### PR TITLE
Addressing issues with 32-bit systems

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -265,7 +265,7 @@ public:
             return m_num_type_params;
         }
         
-        size_t
+        uint64_t
         GetNumWitnessesAtIndex (size_t idx) const
         {
             if (idx >= m_num_type_params)

--- a/packages/Python/lldbsuite/test/issue_verification/Makefile
+++ b/packages/Python/lldbsuite/test/issue_verification/Makefile
@@ -1,0 +1,4 @@
+LEVEL = ../make
+CXX_SOURCES := inline_rerun_inferior.cpp
+CXXFLAGS += -std=c++11
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/issue_verification/TestRerunInline.py.park
+++ b/packages/Python/lldbsuite/test/issue_verification/TestRerunInline.py.park
@@ -1,0 +1,13 @@
+"""Tests that the rerun mechanism respects lldbinline-created tests.
+
+The current implementation of this test is expected to fail both on
+the initial run and on the rerun, assuming --rerun-all-issues is provided
+to the dotest.py run.
+
+This test could be improved by doing something in the test inferior
+C++ program that could look for the "should an issue be raised" marker
+file, and then really pass on the rerun.
+"""
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/issue_verification/inline_rerun_inferior.cpp
+++ b/packages/Python/lldbsuite/test/issue_verification/inline_rerun_inferior.cpp
@@ -1,0 +1,14 @@
+//===-- main.cpp --------------------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+typedef int Foo;
+
+int main() {
+    Foo array[3] = {1,2,3};
+    return 0; //% self.expect("frame variable array --show-types --", substrs = ['(Foo [3]) wrong_type_here = {','(Foo) [0] = 1','(Foo) [1] = 2','(Foo) [2] = 3'])
+}

--- a/packages/Python/lldbsuite/test/lldbinline.py
+++ b/packages/Python/lldbsuite/test/lldbinline.py
@@ -208,5 +208,7 @@ def MakeInlineTest(__file, __globals, decorators=None):
     # Add the test case to the globals, and hide InlineTest
     __globals.update({test_name : test})
 
+    # Store the name of the originating file.o
+    test.test_filename = __file
     return test
 

--- a/packages/Python/lldbsuite/test/python_api/event/TestEvents.py
+++ b/packages/Python/lldbsuite/test/python_api/event/TestEvents.py
@@ -12,6 +12,7 @@ import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 
+@skipIfDarwin  # llvm.org/pr25924, sometimes generating SIGSEGV
 class EventAPITestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)

--- a/packages/Python/lldbsuite/test/result_formatter.py
+++ b/packages/Python/lldbsuite/test/result_formatter.py
@@ -242,11 +242,18 @@ class EventBuilder(object):
         """
         test_class_name, test_name = EventBuilder._get_test_name_info(test)
 
+        # Determine the filename for the test case.  If there is an attribute
+        # for it, use it.  Otherwise, determine from the TestCase class path.
+        if hasattr(test, "test_filename"):
+            test_filename = test.test_filename
+        else:
+            test_filename = inspect.getfile(test.__class__)
+
         event = EventBuilder.bare_event(event_type)
         event.update({
             "test_class": test_class_name,
             "test_name": test_name,
-            "test_filename": inspect.getfile(test.__class__)
+            "test_filename": test_filename
         })
 
         return event

--- a/scripts/Python/prepare_binding_Python.py
+++ b/scripts/Python/prepare_binding_Python.py
@@ -251,17 +251,28 @@ def do_swig_rebuild(options, dependency_file, config_build_dir, settings):
             sys.exit(-10)
 
 
-def copy_static_bindings(options, config_build_dir, settings):
-    """Copies the static Python bindings over to the build dir.
-    """
-
-    # Copy the LLDBWrapPython.cpp C++ binding file impl over.
+def static_binding_paths(options):
+    """Returns the full VCS path to the Python .cpp and .py static bindings."""
     lldb_wrap_python_src_path = os.path.join(
         options.src_root,
         "scripts",
         "Python",
         options.static_binding_dir,
         "LLDBWrapPython.cpp")
+    lldb_py_src_path = os.path.join(
+        options.src_root,
+        "scripts",
+        "Python",
+        options.static_binding_dir,
+        "lldb.py")
+    return (lldb_wrap_python_src_path, lldb_py_src_path)
+
+
+def copy_static_bindings(options, config_build_dir, settings):
+    """Copies the static Python bindings over to the build dir.
+    """
+    lldb_wrap_python_src_path, lldb_py_src_path = static_binding_paths(options)
+    # Copy the LLDBWrapPython.cpp C++ binding file impl over.
     if not os.path.exists(lldb_wrap_python_src_path):
         logging.error(
             "failed to find static Python binding .cpp file at '%s'",
@@ -270,12 +281,6 @@ def copy_static_bindings(options, config_build_dir, settings):
     shutil.copyfile(lldb_wrap_python_src_path, settings.output_file)
 
     # Copy the lldb.py impl over.
-    lldb_py_src_path = os.path.join(
-        options.src_root,
-        "scripts",
-        "Python",
-        options.static_binding_dir,
-        "lldb.py")
     if not os.path.exists(lldb_py_src_path):
         logging.error(
             "failed to find static Python binding .py file at '%s'",
@@ -285,6 +290,49 @@ def copy_static_bindings(options, config_build_dir, settings):
         os.path.dirname(settings.output_file),
         "lldb.py")
     shutil.copyfile(lldb_py_src_path, lldb_py_dest_path)
+
+
+def static_bindings_require_refresh(options, config_build_dir, settings):
+    """Returns whether existing static bindings require an update."""
+    lldb_wrap_python_src_path, lldb_py_src_path = static_binding_paths(options)
+    # Check if LLDBWrapPython.cpp C++ static binding is different than
+    # in the build dir.
+    if not os.path.exists(lldb_wrap_python_src_path):
+        logging.error(
+            "failed to find static Python binding .cpp file at '%s'",
+            lldb_wrap_python_src_path)
+        sys.exit(-12)
+    if not os.path.exists(settings.output_file):
+        # We for sure need an update.
+        # Note this should already be True - we don't check
+        # for a refresh if we already know we have to generate them.
+        return True
+    import filecmp
+    if not filecmp.cmp(
+            lldb_wrap_python_src_path, settings.output_file, shallow=False):
+        return True
+
+    # Check if the lldb.py Python static binding is different than
+    # in the build dir.
+    if not os.path.exists(lldb_py_src_path):
+        logging.error(
+            "failed to find static Python binding .py file at '%s'",
+            lldb_py_src_path)
+        sys.exit(-13)
+    lldb_py_dest_path = os.path.join(
+        os.path.dirname(settings.output_file),
+        "lldb.py")
+    if not os.path.exists(lldb_py_dest_path):
+        # We for sure need an update.
+        # Note this should already be True - we don't check
+        # for a refresh if we already know we have to generate them.
+        return True
+    if not filecmp.cmp(
+            lldb_py_src_path, lldb_py_dest_path, shallow=False):
+        return True
+
+    # If we made it here, we don't need to update.
+    return False
 
 
 def run_python_script(script_and_args):
@@ -449,16 +497,31 @@ def main(options):
             logging.info("__init__.py doesn't exist")
             generate_output = True
 
+    # Figure out if we would be using static bindings
+    use_static_bindings = (
+        not options.swig_executable or
+        not os.path.exists(options.swig_executable))
+    if use_static_bindings and not generate_output:
+        # If the contents of the VCS static binding are different from what
+        # we have in the build dir, we should copy them regardless.
+        if static_bindings_require_refresh(
+                options, config_build_dir, settings):
+            # Force the static bindings to be copied later on, thus preventing
+            # early exit from this method.
+            logging.info("updating static binding due to VCS binding changes")
+            generate_output = True
+
     if not generate_output:
         logging.info(
             "Skipping Python binding generation: everything is up to date")
         return
 
-    # Generate the Python binding with swig, or use the static bindings if no swig.
-    if not options.swig_executable or not os.path.exists(options.swig_executable):
-        # Copy over the static bindings.  We capture the the modified (i.e. post-processed)
-        # binding, so we don't do the modify step here - the modifications have
-        # already been applied.
+    # Generate the Python binding with swig, or use the static bindings if
+    # no swig.
+    if use_static_bindings:
+        # Copy over the static bindings.  We capture the the modified (
+        # i.e. post-processed) binding, so we don't do the modify step
+        # here - the modifications have already been applied.
         copy_static_bindings(options, config_build_dir, settings)
     else:
         # Generate the bindings with swig.

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -64,7 +64,6 @@
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/SIL/SILDebuggerClient.h"
-#include "swift/SIL/SILExternalSource.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6234,7 +6234,7 @@ VisitNodeQualifiedArchetype (SwiftASTContext *ast,
     {
         swift::Demangle::Node::iterator end = cur_node->end();
         VisitNodeResult type_result;
-        size_t index = LLDB_INVALID_ADDRESS;
+        uint64_t index = LLDB_INVALID_ADDRESS;
         for (swift::Demangle::Node::iterator pos = cur_node->begin(); pos != end; ++pos)
         {
             switch (pos->get()->getKind())


### PR DESCRIPTION
There were a few minor issues with this codebase that prevented compilation on 32-bit systems.  These issues have been addressed.  Also, multiple warnings arising from the difference in size_t as used in printf were promoted to unsigned long's to make the %ul match the argument size.