### PR TITLE
Updated inout location to Swift 3 model

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/cgtypes/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/cgtypes/main.swift
@@ -14,7 +14,7 @@ import CoreGraphics
 func main() {
 	var f: CGFloat = CGFloat(1.0)
 	var p: CGPoint = CGPoint(x: 1.0, y: 1.0)
-  var r: CGRect = CGRect()
+	var r: CGRect = CGRect()
 	print("Hello world") // Set breakpoint here
 }
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -125,13 +125,13 @@ SwiftASTManipulator::WrapExpression(lldb_private::Stream &wrapped_stream,
 @_silgen_name ("playground_log_scope_entry") func $builtin_log_scope_entry () -> AnyObject
 @_silgen_name ("playground_log_scope_exit") func $builtin_log_scope_exit () -> AnyObject
 @_silgen_name ("playground_print_T") func $builtin_print<T> (object: T) -> AnyObject
-@_silgen_name ("playground_print_T_stream") func $builtin_print<T, TargetStream : OutputStreamType> (object: T, inout _ stream: TargetStream) -> AnyObject
+@_silgen_name ("playground_print_T_stream") func $builtin_print<T, TargetStream : OutputStreamType> (object: T, _ stream: inout TargetStream) -> AnyObject
 @_silgen_name ("playground_print_T_appendNewline") func $builtin_print<T> (object: T, appendNewline: Bool) -> AnyObject
-@_silgen_name ("playground_print_T_stream_appendNewline") func $builtin_print<T, TargetStream : OutputStreamType> (object: T, inout _ stream: TargetStream, appendNewline: Bool) -> AnyObject
+@_silgen_name ("playground_print_T_stream_appendNewline") func $builtin_print<T, TargetStream : OutputStreamType> (object: T, _ stream: inout TargetStream, appendNewline: Bool) -> AnyObject
 @_silgen_name ("playground_debugPrint_T") func $builtin_debugPrint<T> (object: T) -> AnyObject
-@_silgen_name ("playground_debugPrint_T_stream") func $builtin_debugPrint<T, TargetStream : OutputStreamType> (object: T, inout _ stream: TargetStream) -> AnyObject
+@_silgen_name ("playground_debugPrint_T_stream") func $builtin_debugPrint<T, TargetStream : OutputStreamType> (object: T, _ stream: inout TargetStream) -> AnyObject
 @_silgen_name ("playground_debugPrint_T_appendNewline") func $builtin_debugPrint<T> (object: T, appendNewline: Bool) -> AnyObject
-@_silgen_name ("playground_debugPrint_T_stream_appendNewline") func $builtin_debugPrint<T, TargetStream : OutputStreamType> (object: T, inout _ stream: TargetStream, appendNewline: Bool) -> AnyObject
+@_silgen_name ("playground_debugPrint_T_stream_appendNewline") func $builtin_debugPrint<T, TargetStream : OutputStreamType> (object: T, _ stream: inout TargetStream, appendNewline: Bool) -> AnyObject
 @_silgen_name ("playground_log_postprint") func $builtin_postPrint () -> AnyObject
 @_silgen_name ("DVTSendPlaygroundLogDataToHost") func $builtin_send_data (_ :  AnyObject!, _ : Int, _ : Int, _ : Int, _ : Int)
 $builtin_logger_initialize()


### PR DESCRIPTION
Updates the test cases to change the `inout` location to the new Swift 3 model