### PR TITLE
fix missing import of 'time' in lldbutil.wait_for_file_on_target

### DIFF
--- a/packages/Python/lldbsuite/test/lldbutil.py
+++ b/packages/Python/lldbsuite/test/lldbutil.py
@@ -1061,6 +1061,7 @@ def wait_for_file_on_target(testcase, file_path, max_attempts = 6):
             break
         if i < max_attempts:
             # Exponential backoff!
+            import time
             time.sleep(pow(2, i) * 0.25)
     else:
         testcase.fail("File %s not found even after %d attempts." % (file_path, max_attempts))


### PR DESCRIPTION
This triggers in some timeout scenarios in the LLDB test suite.

Fixes:
https://bugs.swift.org/browse/SR-1193

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@265821 91177308-0d34-0410-b5e6-96231b3b80d8