### PR TITLE
temporarily increase the test suite timeout

### DIFF
--- a/packages/Python/lldbsuite/test/dosep.py
+++ b/packages/Python/lldbsuite/test/dosep.py
@@ -1167,6 +1167,11 @@ def getDefaultTimeout(platform_name):
     if os.getenv("LLDB_TEST_TIMEOUT"):
         return os.getenv("LLDB_TEST_TIMEOUT")
 
+    # https://bugs.swift.org/browse/SR-1220
+    # Temporary work-around for timeout rerun issues.
+    # Remove this as soon as SR-1220 is resolved.
+    return "10m"
+
     if platform_name is None:
         platform_name = sys.platform
 


### PR DESCRIPTION
This is a temporarily measure until the following issue is resolved:
https://bugs.swift.org/browse/SR-1220