### PR TITLE
fix a race is the LLDB test suite results collection

### DIFF
--- a/packages/Python/lldbsuite/test/dosep.py
+++ b/packages/Python/lldbsuite/test/dosep.py
@@ -59,12 +59,8 @@ from . import result_formatter
 
 from .result_formatter import EventBuilder
 
-
-# Todo: Convert this folder layout to be relative-import friendly and
-# don't hack up sys.path like this
-sys.path.append(os.path.join(os.path.dirname(__file__), "test_runner", "lib"))
-import lldb_utils
-import process_control
+from .test_runner import lldb_utils
+from .test_runner import process_control
 
 # Status codes for running command with timeout.
 eTimedOut, ePassed, eFailed = 124, 0, 1
@@ -109,13 +105,17 @@ def setup_global_variables(
         global GET_WORKER_INDEX
         GET_WORKER_INDEX = get_worker_index_use_pid
 
-def report_test_failure(name, command, output):
+def report_test_failure(name, command, output, timeout):
     global output_lock
     with output_lock:
         if not (RESULTS_FORMATTER and RESULTS_FORMATTER.is_using_terminal()):
             print(file=sys.stderr)
             print(output, file=sys.stderr)
-            print("[%s FAILED]" % name, file=sys.stderr)
+            if timeout:
+                timeout_str = " (TIMEOUT)"
+            else:
+                timeout_str = ""
+            print("[%s FAILED]%s" % (name, timeout_str), file=sys.stderr)
             print("Command invoked: %s" % ' '.join(command), file=sys.stderr)
         update_progress(name)
 
@@ -173,7 +173,7 @@ class DoTestProcessDriver(process_control.ProcessDriver):
         super(DoTestProcessDriver, self).__init__(
             soft_terminate_timeout=soft_terminate_timeout)
         self.output_file = output_file
-        self.output_lock = lldb_utils.OptionalWith(output_file_lock)
+        self.output_lock = lldb_utils.optional_with(output_file_lock)
         self.pid_events = pid_events
         self.results = None
         self.file_name = file_name
@@ -211,7 +211,7 @@ class DoTestProcessDriver(process_control.ProcessDriver):
             # only stderr does.
             report_test_pass(self.file_name, output[1])
         else:
-            report_test_failure(self.file_name, command, output[1])
+            report_test_failure(self.file_name, command, output[1], was_timeout)
 
         # Save off the results for the caller.
         self.results = (
@@ -310,6 +310,10 @@ def send_events_to_collector(events, command):
     # Send the events: the port-based event just pickles the content
     # and sends over to the server side of the socket.
     for event in events:
+        # print("sending event ({}:{}) to formatter (type={})".format(
+        #     event.get("event", "{unknown}"),
+        #     event.get("status", "{unknown}"),
+        #     type(formatter_spec.formatter)), file=sys.stderr)
         formatter_spec.formatter.handle_event(event)
 
     # Cleanup
@@ -346,6 +350,7 @@ def send_inferior_post_run_events(
 
     # Handle signal/exceptional exits.
     if process_driver.is_exceptional_exit():
+        # print("\n** post-process events: sending exceptional exit test_event", file=sys.stderr)
         (code, desc) = process_driver.exceptional_exit_details()
         post_events.append(
             EventBuilder.event_for_job_exceptional_exit(
@@ -358,6 +363,7 @@ def send_inferior_post_run_events(
 
     # Handle timeouts.
     if process_driver.is_timeout():
+        # print("\n** post-process events: sending timeout test_event", file=sys.stderr)
         post_events.append(EventBuilder.event_for_job_timeout(
             process_driver.pid,
             worker_index,
@@ -365,6 +371,7 @@ def send_inferior_post_run_events(
             command))
 
     if len(post_events) > 0:
+        # print("\n** post-process events: sending queued events", file=sys.stderr)
         send_events_to_collector(post_events, command)
 
 

--- a/packages/Python/lldbsuite/test/dotest_channels.py
+++ b/packages/Python/lldbsuite/test/dotest_channels.py
@@ -55,6 +55,14 @@ class UnpicklingForwardingReaderChannel(asyncore.dispatcher):
             # unpickled results.
             raise Exception("forwarding function must be set")
 
+        # Initiate all connections by sending an ack.  This allows
+        # the initiators of the socket to await this to ensure
+        # that this end is up and running (and therefore already
+        # into the async map).
+        ack_bytes = bytearray()
+        ack_bytes.append(chr(42))
+        file_object.send(ack_bytes)
+
     def deserialize_payload(self):
         """Unpickles the collected input buffer bytes and forwards."""
         if len(self.ibuffer) > 0:

--- a/packages/Python/lldbsuite/test/issue_verification/TestRerunTimeout.py.park
+++ b/packages/Python/lldbsuite/test/issue_verification/TestRerunTimeout.py.park
@@ -3,19 +3,21 @@ from __future__ import print_function
 
 import time
 
-import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.decorators as decorators
 import rerun_base
 
 
 class RerunTimeoutTestCase(rerun_base.RerunBaseTestCase):
-    @lldbtest.no_debug_info_test
+    @decorators.no_debug_info_test
     def test_timeout_rerun_succeeds(self):
-        """Tests that timeout logic kicks in and is picked up."""
+        """Tests that the timeout logic kicks in and that this timeout is picked up."""
         if not self.should_generate_issue():
             # We pass this time.
             return
+
         # We time out this time.
         while True:
+            # noinspection PyBroadException
             try:
                 time.sleep(1)
             except:

--- a/packages/Python/lldbsuite/test/result_formatter.py
+++ b/packages/Python/lldbsuite/test/result_formatter.py
@@ -76,6 +76,18 @@ def create_results_formatter(config):
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(("localhost", port))
+
+        # Wait for the ack from the listener side.
+        # This is needed to prevent a race condition
+        # in the main dosep.py processing loop: we
+        # can't allow a worker queue thread to die
+        # that has outstanding messages to a listener
+        # socket before the listener socket asyncore
+        # listener socket gets spun up; otherwise,
+        # we lose the test result info.
+        read_bytes = sock.recv(1)
+        # print("\n** socket creation: received ack: {}".format(ord(read_bytes[0])), file=sys.stderr)
+
         return (sock, lambda: socket_closer(sock))
 
     default_formatter_name = None

--- a/packages/Python/lldbsuite/test/test_runner/__init__.py
+++ b/packages/Python/lldbsuite/test/test_runner/__init__.py
@@ -1,0 +1,2 @@
+import lldb_utils
+import process_control

--- a/packages/Python/lldbsuite/test/test_runner/lldb_utils.py
+++ b/packages/Python/lldbsuite/test/test_runner/lldb_utils.py
@@ -8,11 +8,11 @@ Provides classes used by the test results reporting infrastructure
 within the LLDB test suite.
 
 
-This module contains utilities used by the lldb test framwork.
+This module contains utilities used by the lldb test framework.
 """
 
 
-class OptionalWith(object):
+class optional_with(object):
     # pylint: disable=too-few-public-methods
     # This is a wrapper - it is not meant to provide any extra methods.
     """Provides a wrapper for objects supporting "with", allowing None.
@@ -22,13 +22,13 @@ class OptionalWith(object):
 
     e.g.
 
-    wrapped_lock = OptionalWith(thread.Lock())
+    wrapped_lock = optional_with(thread.Lock())
     with wrapped_lock:
         # Do something while the lock is obtained.
         pass
 
     might_be_none = None
-    wrapped_none = OptionalWith(might_be_none)
+    wrapped_none = optional_with(might_be_none)
     with wrapped_none:
         # This code here still works.
         pass
@@ -40,13 +40,13 @@ class OptionalWith(object):
         lock.acquire()
 
     try:
-        code_fragament_always_run()
+        code_fragment_always_run()
     finally:
         if lock:
             lock.release()
 
     And I'd posit it is safer, as it becomes impossible to
-    forget the try/finally using OptionalWith(), since
+    forget the try/finally using optional_with(), since
     the with syntax can be used.
     """
     def __init__(self, wrapped_object):

--- a/packages/Python/lldbsuite/test/test_runner/process_control.py
+++ b/packages/Python/lldbsuite/test/test_runner/process_control.py
@@ -9,7 +9,7 @@ within the LLDB test suite.
 
 
 This module provides process-management support for the LLDB test
-running infrasructure.
+running infrastructure.
 """
 
 # System imports
@@ -302,7 +302,7 @@ class UnixProcessHelper(ProcessHelper):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True, # Elicits automatic byte -> string decoding in Py3
+            universal_newlines=True,  # Elicits automatic byte -> string decoding in Py3
             close_fds=True,
             preexec_fn=preexec_func)
 
@@ -410,7 +410,8 @@ class UnixProcessHelper(ProcessHelper):
         signo = -popen_status
         signal_names_by_number = self._signal_names_by_number()
         signal_name = signal_names_by_number.get(signo, "")
-        return (signo, signal_name)
+        return signo, signal_name
+
 
 class WindowsProcessHelper(ProcessHelper):
     """Provides a Windows implementation of the ProcessHelper class."""
@@ -429,7 +430,7 @@ class WindowsProcessHelper(ProcessHelper):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True, # Elicits automatic byte -> string decoding in Py3
+            universal_newlines=True,  # Elicits automatic byte -> string decoding in Py3
             creationflags=creation_flags)
 
     def was_hard_terminate(self, returncode):


### PR DESCRIPTION
The race boiled down to this:

If a test worker queue is able to run the test inferior and
clean up before the dosep.py listener socket is spun up, and
the worker queue is the last one (as would be the case when
there's only one test rerunning in the rerun queue), then
the test suite will exit the main loop before having a chance
to process any test events coming from the test inferior or
the worker queue job control.

I found this race to be far more likely on fast hardware.
Our Linux CI is one such example.

Addresses an issue (maybe the only issue) causing the
following bug:
https://bugs.swift.org/browse/SR-1220