### PR TITLE
react to upgrading #line to error in swift

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/nested_arrays/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/nested_arrays/main.swift
@@ -14,7 +14,8 @@ class C {
   let m_counter: Int
   private init(_ val: Int) { m_counter = val }
   class func Create() -> C {
-    return C(++Nested.g_counter)
+    Nested.g_counter += 1
+    return C(Nested.g_counter)
   }
 }
 

--- a/packages/Python/lldbsuite/test/lang/swift/variables/globals/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/globals/main.swift
@@ -14,7 +14,7 @@ var g_counter = 1
 
 class Foo {
 	var x : Int
-	init () { x = g_counter++ }
+	init () { x = g_counter; g_counter += 1 }
 }
 
 var my_foo = Foo()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/inout/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/inout/main.swift
@@ -40,12 +40,12 @@ struct Struct {
 
 func foo (_ x: inout Class) {
 	print(x.ivar)
-	x.ivar++ // Set breakpoint here for Class access
+	x.ivar += 1 // Set breakpoint here for Class access
 }
 
 func foo(_ x: inout Struct) {
 	print(x.ivar)
-	x.ivar++ // Set breakpoint here for Struct access
+	x.ivar += 1 // Set breakpoint here for Struct access
 }
 
 func foo (_ x: inout String) {

--- a/source/Expression/ExpressionSourceCode.cpp
+++ b/source/Expression/ExpressionSourceCode.cpp
@@ -393,7 +393,14 @@ ExpressionSourceCode::GetText (std::string &text,
         StreamString pound_body;
         if (pound_file && pound_line)
         {
-            pound_body.Printf("#line %u \"%s\"\n%s", pound_line, pound_file, body);
+            if (wrapping_language == lldb::eLanguageTypeSwift)
+            {
+                pound_body.Printf("#sourceLocation(file: \"%s\", line: %u)\n%s", pound_file, pound_line, body);
+            }
+            else
+            {
+                pound_body.Printf("#line %u \"%s\"\n%s", pound_line, pound_file, body);
+            }
             body = pound_body.GetString().c_str();
         }
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -129,7 +129,7 @@ $builtin_logger_initialize()
 )";
         if (pound_file && pound_line)
         {
-            wrapped_stream.Printf("%s#line %u \"%s\"\n%s\n#line\n", playground_prefix, pound_line, pound_file, orig_text);
+            wrapped_stream.Printf("%s#sourceLocation(file: \"%s\", line: %u)\n%s\n", playground_prefix, pound_file, pound_line, orig_text);
             first_body_line = 1;
         }
         else
@@ -143,7 +143,7 @@ $builtin_logger_initialize()
     {
         if (pound_file && pound_line)
         {
-            wrapped_stream.Printf("#line %u \"%s\"\n%s\n#line\n", pound_line, llvm::sys::path::filename(pound_file).data(), orig_text);
+            wrapped_stream.Printf("#sourceLocation(file: \"%s\", line:  %u)\n%s\n", llvm::sys::path::filename(pound_file).data(), pound_line, orig_text);
         }
         else
         {
@@ -158,14 +158,14 @@ $builtin_logger_initialize()
 
     if (pound_file && pound_line)
     {
-        fixed_text.Printf("#line %u \"%s\"\n%s\n#line\n", pound_line, pound_file, orig_text);
+        fixed_text.Printf("#sourceLocation(file: \"%s\", line: %u)\n%s\n", pound_file, pound_line, orig_text);
         text = fixed_text.GetString().c_str();
     }
     else if (generate_debug_info)
     {
         if (ExpressionSourceCode::SaveExpressionTextToTempFile(orig_text, options, expr_source_path))
         {
-            fixed_text.Printf("#line 1 \"%s\"\n%s\n#line\n", expr_source_path.c_str(), orig_text);
+            fixed_text.Printf("#sourceLocation(file: \"%s\", line: 1)\n%s\n", expr_source_path.c_str(), orig_text);
             text = fixed_text.GetString().c_str();
         }
     }
@@ -350,7 +350,7 @@ $builtin_logger_initialize()
         }
     }
     
-    // The first source line will be 1 if we used the #line directive
+    // The first source line will be 1 if we used the #sourceLocation directive
     if (!expr_source_path.empty() || (pound_file && pound_line))
         first_body_line = 1;
 }


### PR DESCRIPTION
LLDB synthesizes quite a bit of Swift.  We were using #line still,
which became an error with:
https://github.com/apple/swift/commit/183ae242495e0b9542f10b8f7123626bc2f7d11f

Change usage of #line to #sourceLocation.