### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+
 # Swift Debugger and REPL
 
 **Welcome to the Swift Debugger and REPL!**
 
 Swift is a new, high performance systems programming language.  It has a clean
-and modern syntax, and offers seamless access to existing C and Objective-C
+and modern syntax, offers seamless access to existing C and Objective-C
 code and frameworks, and is memory safe (by default).
 
 This repository covers the Swift Debugger and REPL support, built on
@@ -11,7 +12,7 @@ top of the LLDB Debugger.
 
 # Building LLDB for Swift
 
-To build LLDB for Swift, you must have the following pre-requisites
+To build LLDB for Swift, you must have the following prerequisites
 installed on your development system:
 
 * OS X Requirements
@@ -24,11 +25,11 @@ installed on your development system:
 
 * Linux x86_64 (Ubuntu 14.04, Ubuntu 15.10)
 
-  * clang 3.5 or later.
+  * Clang 3.5 or later.
 
   * [Cmake][cmake] (version 2.8.12.2 or later)
 
-  * python 2.7
+  * Python 2.7
 
 Once the pre-requisites are satisfied, follow these steps from a
 bash-like shell:
@@ -52,7 +53,7 @@ LLDB for Swift introduces new dependencies that do not exist with
 core LLDB. In particular, LLDB for Swift makes extensive use of the
 Swift codebase.
 
-Each one of directories listed below underneath the overall
+Each one of the directories listed below underneath the overall
 source_root are backed by a Swift.org repository:
 
 ```
@@ -74,11 +75,11 @@ Details on the contents:
 
 * clang
 
-  contains the stable version of clang used by Swift.
+  Contains the stable version of Clang used by Swift.
 
 * cmark
 
-  contains markdown support used by Swift.
+  Contains markdown support used by Swift.
 
 * lldb
 
@@ -89,17 +90,17 @@ Details on the contents:
 
 * llvm
 
-  Contains the stable version of llvm used by Swift.
+  Contains the stable version of LLVM used by Swift.
 
 * ninja
 
-  Contains the ninja build system.
+  Contains the Ninja build system.
 
 * swift
 
   Contains the Swift Language and Swift Runtime code.
 
-Note if you don't use the build-swift-cmake.py script to do the initial
+Note: If you don't use the build-swift-cmake.py script to do the initial
 clone of the related project repositories, you'll need to manually clone
 them to the names above:
 * [swift-clang][swift-clang] should be cloned as `clang`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Welcome to the Swift Debugger and REPL!**
 
 Swift is a new, high performance systems programming language.  It has a clean
-and modern syntax, offers seamless access to existing C and Objective-C
+and modern syntax, and offers seamless access to existing C and Objective-C
 code and frameworks, and is memory safe (by default).
 
 This repository covers the Swift Debugger and REPL support, built on
@@ -11,7 +11,7 @@ top of the LLDB Debugger.
 
 # Building LLDB for Swift
 
-To build LLDB for Swift, you must have the following prerequisites
+To build LLDB for Swift, you must have the following pre-requisites
 installed on your development system:
 
 * OS X Requirements
@@ -24,11 +24,11 @@ installed on your development system:
 
 * Linux x86_64 (Ubuntu 14.04, Ubuntu 15.10)
 
-  * Clang 3.5 or later.
+  * clang 3.5 or later.
 
   * [Cmake][cmake] (version 2.8.12.2 or later)
 
-  * Python 2.7
+  * python 2.7
 
 Once the pre-requisites are satisfied, follow these steps from a
 bash-like shell:
@@ -52,7 +52,7 @@ LLDB for Swift introduces new dependencies that do not exist with
 core LLDB. In particular, LLDB for Swift makes extensive use of the
 Swift codebase.
 
-Each one of the directories listed below underneath the overall
+Each one of directories listed below underneath the overall
 source_root are backed by a Swift.org repository:
 
 ```
@@ -74,11 +74,11 @@ Details on the contents:
 
 * clang
 
-  Contains the stable version of Clang used by Swift.
+  contains the stable version of clang used by Swift.
 
 * cmark
 
-  Contains markdown support used by Swift.
+  contains markdown support used by Swift.
 
 * lldb
 
@@ -89,17 +89,17 @@ Details on the contents:
 
 * llvm
 
-  Contains the stable version of LLVM used by Swift.
+  Contains the stable version of llvm used by Swift.
 
 * ninja
 
-  Contains the Ninja build system.
+  Contains the ninja build system.
 
 * swift
 
   Contains the Swift Language and Swift Runtime code.
 
-Note: If you don't use the build-swift-cmake.py script to do the initial
+Note if you don't use the build-swift-cmake.py script to do the initial
 clone of the related project repositories, you'll need to manually clone
 them to the names above:
 * [swift-clang][swift-clang] should be cloned as `clang`
@@ -121,8 +121,8 @@ changes should be made to any of these files, follow the standard
 [cmake]: https://cmake.org
 [lldb]: http://lldb.llvm.org "LLDB debugger"
 [llvm]: http://llvm.org "The LLVM Project"
-[swift-clang]: http://github.com/apple/swift-clang
-[swift-cmark]: http://github.com/apple/swift-cmark
-[swift-llvm]: http://github.com/apple/swift-llvm
+[swift-clang]: https://github.com/apple/swift-clang
+[swift-cmark]: https://github.com/apple/swift-cmark
+[swift-llvm]: https://github.com/apple/swift-llvm
 [upstream]: http://swift.org/contributing/#llvm-and-swift "Upstream LLVM changes"
 [xcode-download]: https://developer.apple.com/xcode/download/


### PR DESCRIPTION
HTTPS is so much better 😉 


Was | Now 
--- | --- 
http://github.com/apple/swift-clang | https://github.com/apple/swift-clang 
http://github.com/apple/swift-cmark | https://github.com/apple/swift-cmark 
http://github.com/apple/swift-llvm | https://github.com/apple/swift-llvm 
