### PR TITLE
Update MemoryReader::readBytes API to return int

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1161,7 +1161,7 @@ SwiftLanguageRuntime::GetMemoryReader ()
             return swift::remote::RemoteAddress(nullptr);
         }
         
-        bool
+        int
         readBytes(swift::remote::RemoteAddress address, uint8_t *dest, uint64_t size) override
         {
             if (size > m_max_read_amount)


### PR DESCRIPTION
This function needs to be compatible with C programs, so we can't
use the bool return type.