### PR TITLE
Add gmodules testing

### DIFF
--- a/packages/Python/lldbsuite/support/gmodules.py
+++ b/packages/Python/lldbsuite/support/gmodules.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+# System modules
+import os
+import re
+
+
+GMODULES_SUPPORT_MAP = {}
+GMODULES_HELP_REGEX = re.compile(r"\s-gmodules\s")
+
+
+def is_compiler_clang_with_gmodules(compiler_path):
+    # Before computing the result, check if we already have it cached.
+    if compiler_path in GMODULES_SUPPORT_MAP:
+        return GMODULES_SUPPORT_MAP[compiler_path]
+
+    def _gmodules_supported_internal():
+        compiler = os.path.basename(compiler_path)
+        if "clang" not in compiler:
+            return False
+        else:
+            # Check the compiler help for the -gmodules option.
+            clang_help = os.popen("%s --help" % compiler_path).read()
+            return GMODULES_HELP_REGEX.search(clang_help, re.DOTALL) is not None
+
+    GMODULES_SUPPORT_MAP[compiler_path] = _gmodules_supported_internal()
+    return GMODULES_SUPPORT_MAP[compiler_path]
+
+

--- a/packages/Python/lldbsuite/test/decorators.py
+++ b/packages/Python/lldbsuite/test/decorators.py
@@ -543,15 +543,3 @@ def skipUnlessThreadSanitizer(func):
             return "Compiler cannot compile with -fsanitize=thread"
         return None
     return skipTestIfFn(is_compiler_clang_with_thread_sanitizer)(func)
-
-def skipUnlessClangModules():
-    """Decorate the item to skip test unless Clang -gmodules flag is supported."""
-    def is_compiler_clang_with_gmodules(self):
-        compiler_path = self.getCompiler()
-        compiler = os.path.basename(compiler_path)
-        if compiler != "clang":
-            return "Test requires clang as compiler"
-        clang_help = os.popen("%s --help" % (compiler_path)).read()
-        match = re.match(".* -gmodules ", clang_help, re.DOTALL)
-        return "Clang version doesn't support -gmodules flag" if not match else None
-    return skipTestIfFn(is_compiler_clang_with_gmodules)

--- a/packages/Python/lldbsuite/test/expression_command/top-level/TestTopLevelExprs.py
+++ b/packages/Python/lldbsuite/test/expression_command/top-level/TestTopLevelExprs.py
@@ -50,6 +50,10 @@ class TopLevelExpressionsTestCase(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
 
     @add_test_categories(['pyapi'])
+    @expectedFailureAndroid(api_levels=[21, 22], bugnumber="llvm.org/pr27787")
+    @expectedFailureAll(oslist=["linux"], archs=["arm", "aarch64"], bugnumber="llvm.org/pr27787")
+    @expectedFailureAll(oslist=["macosx"], debug_info="gmodules", bugnumber="llvm.org/pr27864")
+    @skipIf(oslist=["windows"]) # Error in record layout on Windows
     def test_top_level_expressions(self):
         self.build_and_run()
 

--- a/packages/Python/lldbsuite/test/functionalities/dead-strip/TestDeadStrip.py
+++ b/packages/Python/lldbsuite/test/functionalities/dead-strip/TestDeadStrip.py
@@ -18,6 +18,7 @@ class DeadStripTestCase(TestBase):
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @expectedFailureAll(debug_info="dwo", bugnumber="llvm.org/pr25087")
+    @expectedFailureAll(oslist=["linux"], debug_info="gmodules", bugnumber="llvm.org/pr27865")
     @skipIfFreeBSD # The -dead_strip linker option isn't supported on FreeBSD versions of ld.
     def test(self):
         """Test breakpoint works correctly with dead-code stripping."""

--- a/packages/Python/lldbsuite/test/lang/c/global_variables/TestGlobalVariables.py
+++ b/packages/Python/lldbsuite/test/lang/c/global_variables/TestGlobalVariables.py
@@ -20,7 +20,7 @@ class GlobalVariablesTestCase(TestBase):
         self.shlib_names = ["a"]
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
-    @expectedFailureAll("llvm.org/pr25872", oslist=["macosx"], debug_info="dwarf")
+    @expectedFailureAll("llvm.org/pr25872", oslist=["macosx"], debug_info=["dwarf", "gmodules"])
     def test_c_global_variables(self):
         """Test 'frame variable --scope --no-args' which omits args and shows scopes."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/cpp/gmodules/TestWithModuleDebugging.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/gmodules/TestWithModuleDebugging.py
@@ -7,15 +7,9 @@ class TestWithGmodulesDebugInfo(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @add_test_categories(["gmodules"])
     @expectedFailureAll(bugnumber="llvm.org/pr27412")
-    @skipUnlessClangModules()
     def test_specialized_typedef_from_pch(self):
-        clang_help = os.popen("clang --help").read()
-        match = re.match(".* -gmodules ", clang_help, re.DOTALL)
-        if not match:
-            self.skipTest("Clang version doesn't support -gmodules flag")
-            return
-
         self.build()
         cwd = os.getcwd()
 

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods2.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods2.py
@@ -90,6 +90,7 @@ class FoundationTestCase2(TestBase):
             patterns = ["\(int\) \$.* = 3"])
         self.runCmd("process continue")
 
+    @expectedFailureAll(oslist=["macosx"], debug_info="gmodules", bugnumber="llvm.org/pr27861")
     def test_NSString_expr_commands(self):
         """Test expression commands for NSString."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods2.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods2.py
@@ -137,6 +137,7 @@ class FoundationTestCase2(TestBase):
         self.runCmd("process continue")
 
     @expectedFailureAll(archs=["i[3-6]86"])
+    @expectedFailureAll(oslist=["macosx"], debug_info="gmodules", bugnumber="rdar://26557987")
     def test_NSError_po(self):
         """Test that po of the result of an unknown method doesn't require a cast."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestRuntimeTypes.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestRuntimeTypes.py
@@ -17,6 +17,7 @@ class RuntimeTypesTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    @expectedFailureAll(oslist=["macosx"], debug_info="gmodules", bugnumber="llvm.org/pr27862")
     def test_break(self):
         """Test setting objc breakpoints using '_regexp-break' and 'breakpoint set'."""
         if self.getArchitecture() != 'x86_64':

--- a/packages/Python/lldbsuite/test/lang/objc/objc-new-syntax/TestObjCNewSyntax.py
+++ b/packages/Python/lldbsuite/test/lang/objc/objc-new-syntax/TestObjCNewSyntax.py
@@ -27,6 +27,7 @@ class ObjCNewSyntaxTestCase(TestBase):
 
     @skipUnlessDarwin
     @expectedFailureAll(oslist=['macosx'], compiler='clang', compiler_version=['<', '7.0.0'])
+    @expectedFailureAll(oslist=['macosx'], debug_info="gmodules", bugnumber="rdar://26558099")
     @unittest2.skipIf(platform.system() != "Darwin" or StrictVersion('12.0.0') > platform.release(), "Only supported on Darwin 12.0.0+")
     def test_expr(self):
         self.build()

--- a/packages/Python/lldbsuite/test/lang/objc/objc-struct-argument/TestObjCStructArgument.py
+++ b/packages/Python/lldbsuite/test/lang/objc/objc-struct-argument/TestObjCStructArgument.py
@@ -23,6 +23,7 @@ class TestObjCStructArgument(TestBase):
 
     @skipUnlessDarwin
     @add_test_categories(['pyapi'])
+    @expectedFailureAll(oslist=["macosx"], debug_info="gmodules", bugnumber="rdar://26558169")
     def test_with_python_api(self):
         """Test passing structs to Objective-C methods."""
         self.build()

--- a/packages/Python/lldbsuite/test/lldbinline.py
+++ b/packages/Python/lldbsuite/test/lldbinline.py
@@ -13,6 +13,7 @@ import os
 # LLDB modules
 import lldb
 from .lldbtest import *
+from . import configuration
 from . import lldbutil
 from .decorators import *
 
@@ -146,6 +147,12 @@ class InlineTest(TestBase):
         self.buildDwo()
         self.do_test()
 
+    def __test_with_gmodules(self):
+        self.using_dsym = False
+        self.BuildMakefile()
+        self.buildGModules()
+        self.do_test()
+
     def execute_user_command(self, __command):
         exec(__command, globals(), locals())
 
@@ -210,14 +217,14 @@ def MakeInlineTest(__file, __globals, decorators=None):
     test.name = test_name
 
     target_platform = lldb.DBG.GetSelectedPlatform().GetTriple().split('-')[2]
-    supported_categories = [x for x in set(test_categories.debug_info_categories) 
-                            if test_categories.is_supported_on_platform(x, target_platform)]
-    if "dsym" in supported_categories:
+    if test_categories.is_supported_on_platform("dsym", target_platform, configuration.compilers):
         test.test_with_dsym = ApplyDecoratorsToFunction(test._InlineTest__test_with_dsym, decorators)
-    if "dwarf" in supported_categories:
+    if test_categories.is_supported_on_platform("dwarf", target_platform, configuration.compilers):
         test.test_with_dwarf = ApplyDecoratorsToFunction(test._InlineTest__test_with_dwarf, decorators)
-    if "dwo" in supported_categories:
+    if test_categories.is_supported_on_platform("dwo", target_platform, configuration.compilers):
         test.test_with_dwo = ApplyDecoratorsToFunction(test._InlineTest__test_with_dwo, decorators)
+    if test_categories.is_supported_on_platform("gmodules", target_platform, configuration.compilers):
+        test.test_with_gmodules = ApplyDecoratorsToFunction(test._InlineTest__test_with_gmodules, decorators)
 
     # Add the test case to the globals, and hide InlineTest
     __globals.update({test_name : test})

--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -1334,6 +1334,12 @@ class Base(unittest2.TestCase):
         if not module.buildDwo(self, architecture, compiler, dictionary, clean):
             raise Exception("Don't know how to build binary with dwo")
 
+    def buildGModules(self, architecture=None, compiler=None, dictionary=None, clean=True):
+        """Platform specific way to build binaries with gmodules info."""
+        module = builder_module()
+        if not module.buildGModules(self, architecture, compiler, dictionary, clean):
+            raise Exception("Don't know how to build binary with gmodules")
+
     def buildGo(self):
         """Build the default go binary.
         """
@@ -1456,8 +1462,9 @@ class LLDBTestCaseFactory(type):
                 if not categories:
                     categories = all_dbginfo_categories
 
-                supported_categories = [x for x in categories 
-                                        if test_categories.is_supported_on_platform(x, target_platform)]
+                supported_categories = [x for x in categories
+                                        if test_categories.is_supported_on_platform(
+                                            x, target_platform, configuration.compilers)]
                 if "dsym" in supported_categories:
                     @decorators.add_test_categories(["dsym"])
                     @wraps(attrvalue)
@@ -1487,6 +1494,17 @@ class LLDBTestCaseFactory(type):
                     dwo_method_name = attrname + "_dwo"
                     dwo_test_method.__name__ = dwo_method_name
                     newattrs[dwo_method_name] = dwo_test_method
+
+                if "gmodules" in supported_categories:
+                    @decorators.add_test_categories(["gmodules"])
+                    @wraps(attrvalue)
+                    def gmodules_test_method(self, attrvalue=attrvalue):
+                        self.debug_info = "gmodules"
+                        return attrvalue(self)
+                    gmodules_method_name = attrname + "_gmodules"
+                    gmodules_test_method.__name__ = gmodules_method_name
+                    newattrs[gmodules_method_name] = gmodules_test_method
+
             else:
                 newattrs[attrname] = attrvalue
         return super(LLDBTestCaseFactory, cls).__new__(cls, name, bases, newattrs)
@@ -1956,6 +1974,8 @@ class TestBase(Base):
             return self.buildDwarf(architecture, compiler, dictionary, clean)
         elif self.debug_info == "dwo":
             return self.buildDwo(architecture, compiler, dictionary, clean)
+        elif self.debug_info == "gmodules":
+            return self.buildGModules(architecture, compiler, dictionary, clean)
         else:
             self.fail("Can't build for debug info: %s" % self.debug_info)
 

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -258,8 +258,13 @@ ifeq "$(MAKE_DWO)" "YES"
 	CFLAGS += -gsplit-dwarf
 endif
 
+ifeq "$(MAKE_GMODULES)" "YES"
+	CFLAGS += -fmodules -gmodules
+endif
+
 CXXFLAGS += -std=c++11
-CXXFLAGS += $(CFLAGS)
+# FIXME: C++ modules aren't supported on all platforms.
+CXXFLAGS += $(subst -fmodules,, $(CFLAGS))
 LD = $(CC)
 LDFLAGS ?= $(CFLAGS)
 LDFLAGS += $(LD_EXTRAS)
@@ -587,7 +592,7 @@ endif
 $(PCH_OUTPUT) : $(PCH_CXX_SOURCE)
 	$(CXX) $(CXXFLAGS) -x c++-header -o $(PCH_OUTPUT) $(PCH_CXX_SOURCE)
 %.o : %.cpp $(PCH_OUTPUT)
-	$(CXX) $(PCHFLAGS) $(CXXFLAGS) $(CFLAGS) -c -o $@ $<
+	$(CXX) $(PCHFLAGS) $(CXXFLAGS) -c -o $@ $<
 #endif
 
 #----------------------------------------------------------------------

--- a/packages/Python/lldbsuite/test/plugins/builder_base.py
+++ b/packages/Python/lldbsuite/test/plugins/builder_base.py
@@ -156,6 +156,17 @@ def buildDwo(sender=None, architecture=None, compiler=None, dictionary=None, cle
     # True signifies that we can handle building dwo.
     return True
 
+def buildGModules(sender=None, architecture=None, compiler=None, dictionary=None, clean=True):
+    """Build the binaries with dwarf debug info."""
+    commands = []
+    if clean:
+        commands.append([getMake(), "clean", getCmdLine(dictionary)])
+    commands.append([getMake(), "MAKE_DSYM=NO", "MAKE_GMODULES=YES", getArchSpec(architecture), getCCSpec(compiler), getCmdLine(dictionary)])
+
+    lldbtest.system(commands, sender=sender)
+    # True signifies that we can handle building with gmodules.
+    return True
+
 def cleanup(sender=None, dictionary=None):
     """Perform a platform-specific cleanup after the test."""
     #import traceback

--- a/packages/Python/lldbsuite/test/test_categories.py
+++ b/packages/Python/lldbsuite/test/test_categories.py
@@ -11,9 +11,11 @@ import sys
 # Third-party modules
 
 # LLDB modules
+from lldbsuite.support import gmodules
+
 
 debug_info_categories = [
-    'dwarf', 'dwo', 'dsym'
+    'dwarf', 'dwo', 'dsym', 'gmodules'
 ]
 
 all_categories = {
@@ -21,6 +23,7 @@ all_categories = {
     'dwarf'         : 'Tests that can be run with DWARF debug information',
     'dwo'           : 'Tests that can be run with DWO debug information',
     'dsym'          : 'Tests that can be run with DSYM debug information',
+    'gmodules'      : 'Tests that can be run with -gmodules debug information',
     'expression'    : 'Tests related to the expression parser',
     'objc'          : 'Tests related to the Objective-C programming language support',
     'pyapi'         : 'Tests related to the Python API',
@@ -42,12 +45,27 @@ def unique_string_match(yourentry, list):
         candidate = item
     return candidate
 
-def is_supported_on_platform(category, platform):
+
+def is_supported_on_platform(category, platform, compiler_paths):
     if category == "dwo":
         # -gsplit-dwarf is not implemented by clang on Windows.
         return platform in ["linux", "freebsd"]
     elif category == "dsym":
         return platform in ["darwin", "macosx", "ios"]
+    elif category == "gmodules":
+        # First, check to see if the platform can even support gmodules.
+        if platform not in ["linux", "freebsd", "darwin", "macosx", "ios"]:
+            return False
+        # If all compilers specified support gmodules, we'll enable it.
+        for compiler_path in compiler_paths:
+            if not gmodules.is_compiler_clang_with_gmodules(compiler_path):
+                # Ideally in a multi-compiler scenario during a single test run, this would
+                # allow gmodules on compilers that support it and not on ones that don't.
+                # However, I didn't see an easy way for all the callers of this to know
+                # the compiler being used for a test invocation.  As we tend to run with
+                # a single compiler per test run, this shouldn't be a major issue.
+                return False
+        return True
     return True
 
 def validate(categories, exact_match):


### PR DESCRIPTION
Cherry-pick LLVM.org LLDB svn trunk r270848 to enable gmodules testing.

This change also xfails a few tests in GitHub that are not failing upstream.  Radars track those issues.