### PR TITLE
prepend XFAIL/XPASS to the xUnit-reported test method name

### DIFF
--- a/packages/Python/lldbsuite/test_event/formatter/xunit.py
+++ b/packages/Python/lldbsuite/test_event/formatter/xunit.py
@@ -409,7 +409,7 @@ class XunitFormatter(ResultsFormatter):
             with self.lock:
                 self.elements["expected_failures"].append(result)
         elif self.options.xfail == XunitFormatter.RM_SUCCESS:
-            result = self._common_add_testcase_entry(test_event)
+            result = self._common_add_testcase_entry(test_event, test_name_suffix="XFAIL:")
             with self.lock:
                 self.elements["successes"].append(result)
         elif self.options.xfail == XunitFormatter.RM_FAILURE:
@@ -450,7 +450,7 @@ class XunitFormatter(ResultsFormatter):
                 self.elements["unexpected_successes"].append(result)
         elif self.options.xpass == XunitFormatter.RM_SUCCESS:
             # Treat the xpass as a success.
-            result = self._common_add_testcase_entry(test_event)
+            result = self._common_add_testcase_entry(test_event, test_name_suffix="XPASS:")
             with self.lock:
                 self.elements["successes"].append(result)
         elif self.options.xpass == XunitFormatter.RM_FAILURE:
@@ -492,7 +492,7 @@ class XunitFormatter(ResultsFormatter):
         # Call the status handler for the test result.
         self.status_handlers[status](test_event)
 
-    def _common_add_testcase_entry(self, test_event, inner_content=None):
+    def _common_add_testcase_entry(self, test_event, inner_content=None, test_name_suffix=None):
         """Registers a testcase result, and returns the text created.
 
         The caller is expected to manage failure/skip/success counts
@@ -513,6 +513,8 @@ class XunitFormatter(ResultsFormatter):
         # Get elapsed time.
         test_class = test_event.get("test_class", "<no_class>")
         test_name = test_event.get("test_name", "<no_test_method>")
+        if test_name_suffix is not None:
+            test_name = test_name_suffix + test_name
         event_time = test_event["event_time"]
         time_taken = self.elapsed_time_for_test(
             test_class, test_name, event_time)


### PR DESCRIPTION
If the xUnit formatter is instructed to mark XFAIL/XPASS results as
xUnit successes, then prepend XFAIL: or XPASS: to the method name.

Prior to this change and the corresponding change in
swift/utils/build-script-impl to mark XPASS and XFAIL results
as successes, the pretty-ified output from the Jenkins XUnit
plugin did not know anything about XFAILs or XPASSes.
With these two changes, we will see XPASS and XFAIL results
as "passing" in the xUnit results, but we'll be able to distinguish
them by the prefix.

rdar://26769429