### PR TITLE
fix lldb tests for Swift language changes

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/optionset/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/optionset/main.swift
@@ -17,9 +17,9 @@ struct Options : OptionSet {
 
 func main() {
   var user_option = Options(rawValue: 123456)
-  var sdk_option_exhaustive: NSBinarySearchingOptions = [.firstEqual, .insertionIndex]
-  var sdk_option_nonexhaustive = NSBinarySearchingOptions(rawValue: 257)
-  var sdk_option_nonevalid = NSBinarySearchingOptions(rawValue: 12)
+  var sdk_option_exhaustive: BinarySearchingOptions = [.firstEqual, .insertionIndex]
+  var sdk_option_nonexhaustive = BinarySearchingOptions(rawValue: 257)
+  var sdk_option_nonevalid = BinarySearchingOptions(rawValue: 12)
   print("break here and do test") //%self.expect('frame variable user_option', substrs=['rawValue = 123456'])
   //%self.expect('expression user_option', substrs=['rawValue = 123456'])
   //%self.expect('frame variable sdk_option_exhaustive', substrs=['[.firstEqual, .insertionIndex]'])

--- a/packages/Python/lldbsuite/test/lang/swift/po/sys_types/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/po/sys_types/main.swift
@@ -22,7 +22,7 @@ func main() {
   var any: Any = 1234 //% self.expect("po nsobject", substrs = ['<NSObject: 0x']) # may change depending on OS/platform
   //% self.expect("script lldb.frame.FindVariable('nsobject').GetObjectDescription()", substrs = ['<NSObject: 0x']) # may change depending on OS/platform
   var anyobject: AnyObject = 1234 as NSNumber //% self.expect("po any", substrs = ['1234'])
-  var notification = NSNotification(name: "JustANotification", object: nil)
+  var notification = NSNotification(name: "JustANotification" as NSNotification.Name, object: nil)
   print("yay I am done!") //% self.expect("po notification", substrs=['JustANotification'])
    //% self.expect("po notification", matching=False, substrs=['super'])
 }

--- a/packages/Python/lldbsuite/test/lang/swift/po/sys_types/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/po/sys_types/main.swift
@@ -22,7 +22,7 @@ func main() {
   var any: Any = 1234 //% self.expect("po nsobject", substrs = ['<NSObject: 0x']) # may change depending on OS/platform
   //% self.expect("script lldb.frame.FindVariable('nsobject').GetObjectDescription()", substrs = ['<NSObject: 0x']) # may change depending on OS/platform
   var anyobject: AnyObject = 1234 as NSNumber //% self.expect("po any", substrs = ['1234'])
-  var notification = NSNotification(name: "JustANotification" as NSNotification.Name, object: nil)
+  var notification = Notification(name: "JustANotification" as Notification.Name, object: nil)
   print("yay I am done!") //% self.expect("po notification", substrs=['JustANotification'])
    //% self.expect("po notification", matching=False, substrs=['super'])
 }


### PR DESCRIPTION
Fix up a couple LLDB swift-language tests that need adjustments based on Swift 3.0 preview-1 changes.