### PR TITLE
remove xfail markers for bugs.swift.org/SR-797

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -30,14 +30,12 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @decorators.swiftTest
-    @decorators.expectedFailureAll(bugnumber="bugs.swift.org/SR-797")
     def test_generic_expressions(self):
         """Test expressions in generic contexts"""
         self.build()
         self.do_test()
 
     @decorators.swiftTest
-    @decorators.expectedFailureAll(bugnumber="bugs.swift.org/SR-797")
     def test_ivars_in_generic_expressions(self):
         """Test ivar access through expressions in generic contexts"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -24,7 +24,6 @@ class SwiftDynamicTypeGenericsTest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.expectedFailureAll(bugnumber="bugs.swift.org/SR-797")
     def test_genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""
         self.build()


### PR DESCRIPTION
Adrian Prantl fixed the underlying issue a few months ago.
I'm finally getting around to removing the XFAIL markers.