### PR TITLE
Update test for SE-0107.

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/asan/swift/main.swift
+++ b/packages/Python/lldbsuite/test/functionalities/asan/swift/main.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-let ptr = UnsafeMutablePointer<UInt8>.init(allocatingCapacity: 10)
+let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: 10)
 print(ptr)  // breakpoint
 ptr[11] = 42
 


### PR DESCRIPTION
UnsafeMutablePointer.init(allocatingCapacity:) has been replaced by .allocate(capacity:). Update this lldb test to match that change.