### PR TITLE
[Do not merge yet][SE-0101] Migration

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/private_var/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/private_var/main.swift
@@ -13,7 +13,7 @@
 private var a = 1
 
 func doSomething(b: Int) {
-	a += strideof(b.dynamicType) //% self.expect("expr a", substrs=['Int', '= 1'])
+	a += MemoryLayout.of(b).stride //% self.expect("expr a", substrs=['Int', '= 1'])
 }
 
 doSomething(b:2)


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/3854

[SE-0101](https://github.com/apple/swift-evolution/blob/master/proposals/0101-standardizing-sizeof-naming.md) removes `sizeof`, `sizeofValue` and related functions from the stdlib.
This PR is migrating them to newly introduced `MemoryLayout<T>` values.