### PR TITLE
Don't crash when trying to capture persistent variables in a block.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/c/blocks/TestBlocks.py
+++ b/packages/Python/lldbsuite/test/lang/c/blocks/TestBlocks.py
@@ -57,8 +57,10 @@ class BlocksTestCase(TestBase):
         self.launch_common()
 
         self.runCmd("expression int (^$add)(int, int) = ^int(int a, int b) { return a + b; };")
-
         self.expect("expression $add(2,3)", VARIABLES_DISPLAYED_CORRECTLY, substrs = [" = 5"])
+
+        self.runCmd("expression int $a = 3")
+        self.expect("expression int (^$addA)(int) = ^int(int b) { return $a + b; };", "Proper error is reported on capture", error=True)
     
     def wait_for_breakpoint(self):
         if self.is_started == False:

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -894,7 +894,7 @@ ClangExpressionParser::PrepareForExecution (lldb::addr_t &func_addr,
 
         Process *process = exe_ctx.GetProcessPtr();
 
-        if (execution_policy != eExecutionPolicyAlways && execution_policy != eExecutionPolicyTopLevel)
+        if (execution_policy != eExecutionPolicyAlways && execution_policy != eExecutionPolicyTopLevel && ir_can_run)
         {
             lldb_private::Error interpret_error;
 

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -332,7 +332,7 @@ ClangExpressionParser::ClangExpressionParser (ExecutionContextScope *exe_scope,
     target_sp = exe_scope->CalculateTarget();
     if (!target_sp)
     {
-        lldb_assert(exe_scope, "Can't make an expression parser with a null target.", __FUNCTION__, __FILE__, __LINE__);
+        lldb_assert(target_sp.get(), "Can't make an expression parser with a null target.", __FUNCTION__, __FILE__, __LINE__);
         return;
     }
     

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -891,9 +891,15 @@ ClangExpressionParser::PrepareForExecution (lldb::addr_t &func_addr,
 
         bool ir_can_run = ir_for_target.runOnModule(*execution_unit_sp->GetModule());
 
+        if (!ir_can_run)
+        {
+            err.SetErrorString("The expression could not be prepared to run in the target");
+            return err;
+        }
+
         Process *process = exe_ctx.GetProcessPtr();
 
-        if (execution_policy != eExecutionPolicyAlways && execution_policy != eExecutionPolicyTopLevel && ir_can_run)
+        if (execution_policy != eExecutionPolicyAlways && execution_policy != eExecutionPolicyTopLevel)
         {
             lldb_private::Error interpret_error;
 
@@ -907,12 +913,6 @@ ClangExpressionParser::PrepareForExecution (lldb::addr_t &func_addr,
                 err.SetErrorStringWithFormat("Can't run the expression locally: %s", interpret_error.AsCString());
                 return err;
             }
-        }
-
-        if (!ir_can_run)
-        {
-            err.SetErrorString("The expression could not be prepared to run in the target");
-            return err;
         }
 
         if (!process && execution_policy == eExecutionPolicyAlways)

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -884,10 +884,9 @@ ClangExpressionParser::PrepareForExecution (lldb::addr_t &func_addr,
     {
         Stream *error_stream = NULL;
         Target *target = exe_ctx.GetTargetPtr();
-        if (target)
-            error_stream = target->GetDebugger().GetErrorFile().get();
+        error_stream = target->GetDebugger().GetErrorFile().get();
 
-        IRForTarget ir_for_target(decl_map, m_expr.NeedsVariableResolution(), *execution_unit_sp, error_stream,
+        IRForTarget ir_for_target(decl_map, m_expr.NeedsVariableResolution(), *execution_unit_sp, *error_stream,
                                   function_name.AsCString());
 
         bool ir_can_run = ir_for_target.runOnModule(*execution_unit_sp->GetModule());

--- a/source/Plugins/ExpressionParser/Clang/IRForTarget.h
+++ b/source/Plugins/ExpressionParser/Clang/IRForTarget.h
@@ -101,7 +101,7 @@ public:
     IRForTarget(lldb_private::ClangExpressionDeclMap *decl_map,
                 bool resolve_vars,
                 lldb_private::IRExecutionUnit &execution_unit,
-                lldb_private::Stream *error_stream,
+                lldb_private::Stream &error_stream,
                 const char* func_name = "$__lldb_expr");
     
     //------------------------------------------------------------------
@@ -563,7 +563,7 @@ private:
     llvm::Constant *m_sel_registerName;   ///< The address of the function sel_registerName, cast to the appropriate
                                           ///function pointer type
     llvm::IntegerType *m_intptr_ty;       ///< The type of an integer large enough to hold a pointer.
-    lldb_private::Stream *m_error_stream; ///< If non-NULL, the stream on which errors should be printed
+    lldb_private::Stream &m_error_stream; ///< The stream on which errors should be printed
     lldb_private::IRExecutionUnit &m_execution_unit; ///< The execution unit containing the IR being created.
 
     llvm::StoreInst *m_result_store; ///< If non-NULL, the store instruction that writes to the result variable.  If
@@ -615,7 +615,7 @@ private:
                     llvm::Function *llvm_function,
                     FunctionValueCache &value_maker,
                     FunctionValueCache &entry_instruction_finder,
-                    lldb_private::Stream *error_stream);
+                    lldb_private::Stream &error_stream);
     
     //------------------------------------------------------------------
     /// Construct a reference to m_reloc_placeholder with a given type

--- a/source/Plugins/ExpressionParser/Clang/IRForTarget.h
+++ b/source/Plugins/ExpressionParser/Clang/IRForTarget.h
@@ -611,9 +611,11 @@ private:
     FunctionValueCache m_entry_instruction_finder;
     
     static bool
-    UnfoldConstant (llvm::Constant *old_constant, 
+    UnfoldConstant (llvm::Constant *old_constant,
+                    llvm::Function *llvm_function,
                     FunctionValueCache &value_maker,
-                    FunctionValueCache &entry_instruction_finder);
+                    FunctionValueCache &entry_instruction_finder,
+                    lldb_private::Stream *error_stream);
     
     //------------------------------------------------------------------
     /// Construct a reference to m_reloc_placeholder with a given type


### PR DESCRIPTION
Don't crash when trying to capture persistent variables in a block.

Reports an error instead.  We can fix this later to make persistent variables work, but right now we hit an LLVM assertion if we get this wrong.  This patch also makes the error stream easier to use, and ensures it is never NULL.  It also fixes some of the logic in ClangExpressionParser to allow expressions to error out if IRForTarget fails.

This fixes <rdar://problem/27770298>