### PR TITLE
Add a test for resolving overloaded == operators with different visibilities.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/Makefile
@@ -1,0 +1,14 @@
+LEVEL = ../../../../make
+
+include $(LEVEL)/Makefile.rules
+
+everything: three fooey
+
+three: fooey three.swift
+	$(SWIFTCC) -g -Onone -L. three.swift -lfooey -I.
+
+fooey: one.swift two.swift
+	$(SWIFTCC) -g -Onone one.swift two.swift -emit-library -module-name fooey -emit-module
+
+cleanup:
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib three

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -31,13 +31,11 @@ class TestUnitTests(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.expectedFailureAll(oslist=['linux'], bugnumber="<rdar://problem/27839009>")
     def test_equality_operators_fileprivate (self):
         """Test that we resolve expression operators correctly"""
         self.buildAll()
         self.do_test("Fooey.CompareEm1", "true", 1)
 
-    @decorators.expectedFailureAll(oslist=['linux'], bugnumber="<rdar://problem/27839009>")
     def test_equality_operators_private (self):
         """Test that we resolve expression operators correctly"""
         self.buildAll()
@@ -73,7 +71,11 @@ class TestUnitTests(TestBase):
         bkpt = target.BreakpointCreateByName(bkpt_name)
         self.assertTrue(bkpt.GetNumLocations() > 0, VALID_BREAKPOINT)
 
-        process = target.LaunchSimple(None, None, os.getcwd())
+        env_arr = None
+        if self.getPlatform() in ('freebsd', 'linux', 'netbsd'):
+            env_arr = ['LD_LIBRARY_PATH=%s'%(os.getcwd())]
+
+        process = target.LaunchSimple(None, env_arr, os.getcwd())
         self.assertTrue(process, PROCESS_IS_VALID)
 
         threads = lldbutil.get_threads_stopped_at_breakpoint (process, bkpt)

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -95,6 +95,12 @@ class TestUnitTests(TestBase):
         counter = value.GetValueAsUnsigned()
         self.assertTrue(counter == counter_value, "Counter value is wrong: %d (expected %d)"%(counter, counter_value))
 
+        # Make sure the presence of these type specific == operators doesn't interfere
+        # with finding other unrelated == operators.
+        value = self.frame.EvaluateExpression("1 == 2", options)
+        self.assertTrue(value.GetError().Success(), "1 == 2 expression couldn't run")
+        self.assertTrue(value.GetSummary() == "false", "1 == 2 didn't return false.")
+
 if __name__ == '__main__':
     import atexit
     lldb.SBDebugger.Initialize()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -71,9 +71,7 @@ class TestUnitTests(TestBase):
         bkpt = target.BreakpointCreateByName(bkpt_name)
         self.assertTrue(bkpt.GetNumLocations() > 0, VALID_BREAKPOINT)
 
-        env_arr = None
-        if self.getPlatform() in ('freebsd', 'linux', 'netbsd'):
-            env_arr = ['LD_LIBRARY_PATH=%s'%(os.getcwd())]
+        env_arr = self.registerSharedLibrariesWithTarget(target, ["fooey"])
 
         process = target.LaunchSimple(None, env_arr, os.getcwd())
         self.assertTrue(process, PROCESS_IS_VALID)

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -1,0 +1,102 @@
+# TestEqualityOperators.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test that we resolve various shadowed equality operators properly
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import unittest2
+
+
+def execute_command (command):
+    (exit_status, output) = commands.getstatusoutput (command)
+    return exit_status
+
+class TestUnitTests(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    def test_equality_operators_fileprivate (self):
+        """Test that we resolve expression operators correctly"""
+        self.buildAll()
+        self.do_test("Fooey.CompareEm1", "true", 1)
+
+    def test_equality_operators_private (self):
+        """Test that we resolve expression operators correctly"""
+        self.buildAll()
+        self.do_test("Fooey.CompareEm2", "false", 2)
+
+    @decorators.expectedFailureAll(bugnumber="rdar://27015195")
+    def test_equality_operators_other_module (self):
+        """Test that we resolve expression operators correctly"""
+        self.buildAll()
+        self.do_test("Fooey.CompareEm3", "false", 3)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    def buildAll(self):
+        execute_command("make everything")
+
+    def do_test(self, bkpt_name, compare_value, counter_value):
+        """Test that we resolve expression operators correctly"""
+        exe_name = "three"
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        def cleanup():
+            execute_command("make cleanup")
+
+        self.addTearDownHook(cleanup)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        bkpt = target.BreakpointCreateByName(bkpt_name)
+        self.assertTrue(bkpt.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        threads = lldbutil.get_threads_stopped_at_breakpoint (process, bkpt)
+
+        self.assertTrue(len(threads) == 1)
+        self.thread = threads[0]
+        self.frame = self.thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+
+        options = lldb.SBExpressionOptions()
+
+        value = self.frame.EvaluateExpression("lhs == rhs", options)
+        self.assertTrue(value.GetError().Success(), "Expression in %s was successful"%(bkpt_name))
+        summary = value.GetSummary()
+        self.assertTrue(summary == compare_value, "Expression in CompareEm has wrong value: %s (expected %s)."%(summary, compare_value))
+
+        # And make sure we got did increment the counter by the right value.
+        value = self.frame.EvaluateExpression("Fooey.GetCounter()", options)
+        self.assertTrue(value.GetError().Success(), "GetCounter worked")
+
+        counter = value.GetValueAsUnsigned()
+        self.assertTrue(counter == counter_value, "Counter value is wrong: %d (expected %d)"%(counter, counter_value))
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -31,11 +31,13 @@ class TestUnitTests(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.expectedFailureAll(oslist=['linux'], bugnumber="<rdar://problem/27839009>")
     def test_equality_operators_fileprivate (self):
         """Test that we resolve expression operators correctly"""
         self.buildAll()
         self.do_test("Fooey.CompareEm1", "true", 1)
 
+    @decorators.expectedFailureAll(oslist=['linux'], bugnumber="<rdar://problem/27839009>")
     def test_equality_operators_private (self):
         """Test that we resolve expression operators correctly"""
         self.buildAll()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/one.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/one.swift
@@ -1,0 +1,38 @@
+public class Fooey
+{
+    static var counter = 0
+
+    public init ()
+    {
+        m_var = 10
+    }
+
+    public class func BumpCounter (_ value : Int)
+    {
+        counter += value
+    }
+    
+    public class func ResetCounter()
+    {
+        counter = 0
+    }
+
+    public class func GetCounter() -> Int
+    {
+        return counter
+    }
+
+    public class func CompareEm1(_ lhs: Fooey, _ rhs : Fooey) -> Bool
+    {
+        return lhs == rhs     
+    }
+
+    public var m_var : Int = 10
+}
+
+fileprivate func == (lhs : Fooey, rhs : Fooey) -> Bool 
+{ 
+    Fooey.BumpCounter(1)
+    return lhs.m_var == rhs.m_var
+}
+

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/three.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/three.swift
@@ -1,0 +1,26 @@
+import fooey
+
+private var counter = 0
+
+func == (lhs : Fooey, rhs : Fooey) -> Bool
+{
+    Fooey.BumpCounter(3)
+    return lhs.m_var == rhs.m_var + 1  
+}
+
+extension Fooey
+{
+    class func CompareEm3(_ lhs : Fooey, _ rhs : Fooey) -> Bool
+    {
+        return lhs == rhs
+    }
+}
+
+var lhs = Fooey()
+var rhs = Fooey()
+
+let result1 = Fooey.CompareEm1(lhs, rhs)
+Fooey.ResetCounter()
+let result2 = Fooey.CompareEm2(lhs, rhs)
+Fooey.ResetCounter()
+let result3 = Fooey.CompareEm3(lhs, rhs)

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/two.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/two.swift
@@ -1,0 +1,14 @@
+private func == (lhs : Fooey, rhs : Fooey) -> Bool 
+{ 
+    Fooey.BumpCounter(2)
+    return lhs.m_var != rhs.m_var // break here for two local operator
+}
+
+extension Fooey
+{
+    public class func CompareEm2(_ lhs : Fooey, _ rhs : Fooey) -> Bool 
+    { 
+        return lhs == rhs
+    }
+}
+


### PR DESCRIPTION
LLDB-side tests for apple/swift#4556, written by @jimingham. Cannot be tested until that PR is merged.

rdar://problem/27015195