### PR TITLE
Support for the new Array implementation in swift stdlib.

### DIFF
--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -393,9 +393,16 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
     ValueObjectSP buffer_sp(valobj.GetNonSyntheticValue()->GetChildAtNamePath(
         {g_buffer, g__storage, g_rawValue}));
 
+    // For the old Array version which using ManagedBufferPointer.
+    // TODO: this can be removed eventually.
     if (!buffer_sp)
       buffer_sp = valobj.GetNonSyntheticValue()->GetChildAtNamePath(
           {g_buffer, g___bufferPointer, g__nativeBuffer});
+
+    // For the new Array version which uses SIL tail-allocated arrays.
+    if (!buffer_sp)
+      buffer_sp = valobj.GetNonSyntheticValue()->GetChildAtNamePath(
+          {g_buffer, g__storage});
 
     if (!buffer_sp)
       return nullptr;


### PR DESCRIPTION
The old implementation (using ManagedBufferPointer) still works bug can be removed eventually.