### PR TITLE
Add back "added tests for SR-2637"

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/A.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/A.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class A: NSObject {
+	public func foo() -> Int {
+	  return 4  // Set breakpoint here
+	}
+}

--- a/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/B.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/B.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc public class B: NSObject {
+	public func bar() -> Int {
+	  return 8  // Set breakpoint here
+	}
+}

--- a/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/Makefile
@@ -1,0 +1,36 @@
+# Build swift modules with debug info
+
+LEVEL=../../../../make
+
+# Don't use 'all' target.  There is a default build rule that will kick in that
+# will be wrong.  WE use 'first' so that the normal 'make' command (without
+# a target) selects the first (but not 'all') target so we avoid the undesired
+# default behavior.
+first: main
+
+SWIFT_OBJC_INTEROP=1
+
+include $(LEVEL)/Makefile.rules
+
+# Add back the SDK settings to the swift flags.  Normally this happens
+# automatically, but since we're overriding the normal swiftc invocation,
+# we're not specifying SWIFT_SOURCES, and thus don't get the SDK.
+SWIFTFLAGS+=-sdk "$(SWIFTSDKROOT)"
+
+# To use the path commented out below, which is what we'd really want to do,
+# we'd also need to require that the Swift standard library be built along
+# with the compiler.  I'd like to avoid that requirement.
+# SWIFT_LIB_DIR=$(dir $(SWIFTCC))../lib
+SWIFT_LIB_DIR="$(shell xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"
+
+main: A.o B.o objc_main.m
+	$(CC) $(CFLAGS) objc_main.m -fobjc-arc -o main A.o B.o -L $(SWIFT_LIB_DIR) -Xlinker -add_ast_path -Xlinker A.swiftmodule -Xlinker -add_ast_path -Xlinker B.swiftmodule -Xlinker -rpath -Xlinker $(SWIFT_LIB_DIR)
+
+A.o: A.swift
+	$(SWIFTCC) $(SWIFTFLAGS) -c -parse-as-library -module-name A -emit-module-path A.swiftmodule -emit-objc-header-path A-Swift.h -output-file-map output_map A.swift
+
+B.o: B.swift
+	$(SWIFTCC) $(SWIFTFLAGS) -c -parse-as-library -module-name B -emit-module-path B.swiftmodule -emit-objc-header-path B-Swift.h -output-file-map output_map B.swift -o B.o
+
+clean::
+	rm -f *.o main *-Swift.h *.swiftmodule *.swiftdoc

--- a/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
+++ b/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
@@ -1,0 +1,114 @@
+# TestSwiftStaticLinkingMacOS.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test that macOS can statically link two separately-compiled Swift modules
+with one Objective-C module, link them through the clang driver, and still
+access debug info for each of the Swift modules.
+"""
+from __future__ import print_function
+
+
+# System imports
+import os
+import commands
+
+# Third-party imports
+
+# LLDB imports
+import lldb
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test import decorators, lldbtest, lldbutil
+
+
+class SwiftStaticLinkingMacOSTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def expect_self_var_available_at_breakpoint(
+            self, process, breakpoint, module_name):
+        # Frame #0 should be at the given breakpoint
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, breakpoint)
+
+        self.assertEquals(1, len(threads))
+        self.thread = threads[0]
+        self.frame = self.thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+
+        patterns = [
+            # Ensure we report a self with an address.
+            r"self\s*=\s*0x[0-9a-fA-F]+",
+            # Ensure we think it is an NSObject.
+            r"ObjectiveC.NSObject"]
+        substrs = [
+            "(%s.%s)" % (module_name, module_name)
+        ]
+        self.expect("frame variable self", patterns=patterns,
+                    substrs=substrs)
+
+    @decorators.skipUnlessDarwin
+    def test_variables_print_from_both_swift_modules(self):
+        """Test that variables from two modules can be accessed."""
+        self.build()
+
+        # I could not find a reasonable way to say "skipUnless(archs=[])".
+        # That would probably be worth adding.
+        if self.getArchitecture() != 'x86_64':
+            self.skipTest("This test requires x86_64 as the architecture "
+                          "for the inferior")
+
+        exe_name = "main"
+        src_a = lldb.SBFileSpec("A.swift")
+        line_a = 5
+        src_b = lldb.SBFileSpec("B.swift")
+        line_b = 5
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, lldbtest.VALID_TARGET)
+
+        # Set the breakpoints
+        # breakpoint_a = target.BreakpointCreateBySourceRegex(
+        #     'Set breakpoint here', src_a)
+        breakpoint_a = target.BreakpointCreateByLocation(
+            src_a, line_a)
+        self.assertTrue(breakpoint_a.GetNumLocations() > 0,
+                        lldbtest.VALID_BREAKPOINT)
+
+        # breakpoint_b = target.BreakpointCreateBySourceRegex(
+        #     'Set breakpoint here', src_b)
+        breakpoint_b = target.BreakpointCreateByLocation(
+            src_b, line_b)
+        self.assertTrue(breakpoint_b.GetNumLocations() > 0,
+                        lldbtest.VALID_BREAKPOINT)
+
+        # Launch the process, and do not stop at the entry point.
+        envp = ['DYLD_FRAMEWORK_PATH=.']
+        process = target.LaunchSimple(None, envp, os.getcwd())
+
+        self.assertTrue(process, lldbtest.PROCESS_IS_VALID)
+
+        # We should be at breakpoint in module A.
+        self.expect_self_var_available_at_breakpoint(
+            process, breakpoint_a, "A")
+
+        # Jump to the next breakpoint
+        process.Continue()
+
+        # We should be at breakpoint in module B.
+        self.expect_self_var_available_at_breakpoint(
+            process, breakpoint_b, "B")
+
+        return

--- a/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/objc_main.m
+++ b/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/objc_main.m
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+#import "A-Swift.h"
+#import "B-Swift.h"
+
+int main(int argc, const char * argv[]) {
+  @autoreleasepool {
+      NSLog(@"Hello, World!");
+      NSLog(@"A = %ld", [[[A alloc] init] foo]);
+      NSLog(@"B = %ld", [[[B alloc] init] bar]);
+  }
+	return 0;
+}

--- a/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/output_map
+++ b/packages/Python/lldbsuite/test/lang/swift/static_linking/macOS/output_map
@@ -1,0 +1,3 @@
+{'A.swift': {'object': 'A.o'},
+ 'B.swift': {'object': 'B.o'},
+}


### PR DESCRIPTION
This commit is intended to address the Objective-C header path issue that showed up on the CI configuration for the new test for SR-2637.  It brings in more of our normal LLDB test inferior logic for setting swiftc and clang flags.

This reverts commit a4630701c013d8e497266ab48b3d19d6f39758d8.