### PR TITLE
[CMake] For Darwin rpath $ORIGIN should be @loader_path

### DIFF
--- a/cmake/modules/AddLLDB.cmake
+++ b/cmake/modules/AddLLDB.cmake
@@ -101,7 +101,13 @@ endmacro(add_lldb_library)
 macro(add_lldb_executable name)
   add_llvm_executable(${name} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
   set_target_properties(${name} PROPERTIES FOLDER "lldb executables")
-  set_target_properties(${name} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
+  # $ORIGIN is only 
+  if(APPLE)
+    set(rpath_prefix "@loader_path")
+  else()
+    set(rpath_prefix "$ORIGIN")
+  endif()
+  set_target_properties(${name} PROPERTIES INSTALL_RPATH "${rpath_prefix}/../lib")
 endmacro(add_lldb_executable)
 
 # Support appending linker flags to an existing target.

--- a/cmake/modules/AddLLDB.cmake
+++ b/cmake/modules/AddLLDB.cmake
@@ -101,7 +101,9 @@ endmacro(add_lldb_library)
 macro(add_lldb_executable name)
   add_llvm_executable(${name} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
   set_target_properties(${name} PROPERTIES FOLDER "lldb executables")
-  # $ORIGIN is only 
+  # ELF and Mach-O loaders have different ways of expressing that an rpath
+  # should be relative to the binary being loaded. Mach-O uses @loader_path, and
+  # ELF uses $ORIGIN.
   if(APPLE)
     set(rpath_prefix "@loader_path")
   else()


### PR DESCRIPTION
This allows lldb builds on darwin with CMake to have the correct rpath.

Without this patch all binaries were getting $ORIGIN-based rpaths, which are invalid on Darwin.