### PR TITLE
Repl swift missing dependency

### DIFF
--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -7,7 +7,7 @@ set(output_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin")
 set(module_cache_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/repl_swift_module_cache")
 
 if(NOT LLDB_BUILT_STANDALONE)
-  set(swift_depends swift)
+  set(swift_depends swift swift-stdlib)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -11,22 +11,22 @@ if(NOT LLDB_BUILT_STANDALONE)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-  add_custom_command_target(
-      repl_swift_target
-      COMMAND "${LLDB_PATH_TO_SWIFT_BUILD}/bin/swiftc" -o "${output_dir}/repl_swift" -module-cache-path "${module_cache_dir}" -Xlinker -rpath -Xlinker \$ORIGIN/../lib/swift/linux "${CMAKE_CURRENT_SOURCE_DIR}/main.swift"
-      OUTPUT "${output_dir}/repl_swift"
-      VERBATIM
-      ALL
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/main.swift" ${swift_depends})
-else()
-  add_custom_command_target(
-      repl_swift_target
-      COMMAND "${LLDB_PATH_TO_SWIFT_BUILD}/bin/swiftc" -o "${output_dir}/repl_swift" -module-cache-path "${module_cache_dir}" "${CMAKE_CURRENT_SOURCE_DIR}/main.swift"
-      OUTPUT "${output_dir}/repl_swift"
-      VERBATIM
-      ALL
-      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/main.swift" ${swift_depends})
+  set(linux_only_flags -Xlinker -rpath -Xlinker \$ORIGIN/../lib/swift/linux)
 endif()
+
+add_custom_command_target(
+    unused_var
+    COMMAND "${LLDB_PATH_TO_SWIFT_BUILD}/bin/swiftc"
+            -o "${output_dir}/repl_swift"
+            -module-cache-path "${module_cache_dir}"
+            ${linux_only_flags} "${CMAKE_CURRENT_SOURCE_DIR}/main.swift"
+    OUTPUT "${output_dir}/repl_swift"
+    VERBATIM
+    ALL
+    CUSTOM_TARGET_NAME repl_swift
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/main.swift"
+            create_swift_module_dir
+            ${swift_depends})
 
 # Ensure we get a fresh, clean module cache for the swift repl run
 # before we build repl_swift.
@@ -44,10 +44,8 @@ add_custom_target(
 add_custom_target(
   create_swift_module_dir
   COMMAND ${CMAKE_COMMAND} -E make_directory "${module_cache_dir}"
+  DEPENDS delete_swift_module_dir
   )
-
-add_dependencies(create_swift_module_dir delete_swift_module_dir)
-add_dependencies(${repl_swift_target} create_swift_module_dir)
 
 install(
   PROGRAMS "${output_dir}/repl_swift"


### PR DESCRIPTION
This PR addresses an issue Sean emailed me about this morning.

There are two commits in this PR. One is a cleanup that I did in order to get a reproducible case for Sean's error, the second is the actual fix.

The fix gives repl_swift a dependency on swift-stdlib.

The cleanup includes the following changes (detailed explanation and description below):

* Move linux-specific flags to a variable that is only set on linux
* Collapse the add_custom_command_target calls into one call
* Remove explicit add_dependencies calls in favor of using DEPENDS arguments
* Wrap COMMAND arguments so that it is easier to read
* Explicitly name the repl_swift target
    
Since CMake variables that are unset expand to nothing I generally encourage the use of variables that are conditionally set to avoid duplicating code wherever possible. In this instance using the linux_only_flags variable allows the add_custom_command_target calls to be collapsed, so modifications to the target or command definition don't need to be duplicated.
    
Also the add_dependencies calls are unnecessary if we use the DEPENDS arguments on the custom command and target calls. In CMake targets do not need to be created in order to setup dependencies, CMake will warn or error at the end of generation if it could not resolve a target dependency.
    
The last change here is providing an explicit name to the repl_swift target. When you do not specify an explicit target name Swift's add_custom_command_target gives you a generated target with an MD5 in it which is completely inscrutable. For debugging the build system and easy incremental builds of the repl_swift tool it is better to have a named target.