### PR TITLE
Reapply REPL inline test patch with fixes

### DIFF
--- a/include/lldb/API/SBExpressionOptions.h
+++ b/include/lldb/API/SBExpressionOptions.h
@@ -98,6 +98,12 @@ public:
     
     void
     SetPlaygroundTransformEnabled (bool enable_playground_transform = true);
+    
+    bool
+    GetREPLMode () const;
+    
+    void
+    SetREPLMode (bool enable_repl_mode = true);
 
     bool
     GetGenerateDebugInfo ();

--- a/packages/Python/lldbsuite/test/lldbinrepl.py
+++ b/packages/Python/lldbsuite/test/lldbinrepl.py
@@ -1,0 +1,195 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
+import re
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+import lldbsuite.test.test_categories as test_categories
+# System modules
+import os, sys
+
+# Third-party modules
+
+#LLDB modules
+import lldb
+from .lldbtest import *
+from . import configuration
+from . import lldbutil
+from .decorators import *
+
+def inputFile():
+    return "input.swift"
+
+def mainSourceFile():
+    return "main.swift"
+
+def breakpointMarker():
+    return "Set breakpoint here."
+
+class CommandParser:
+    def __init__(self):
+        self.breakpoint = None
+        self.exprs_and_regexps = []
+
+    def parse_input(self):
+        file_handle = open(inputFile(), 'r')
+        lines = file_handle.readlines()
+        current_expression = None
+        for line in lines:
+            if line.startswith('///'):
+                regexp = line[3:]
+                if current_expression:
+                    self.exprs_and_regexps.append({'expr': current_expression, 'regexps': [regexp.strip()]})
+                    current_expression = None
+                else:
+                    if len(self.exprs_and_regexps):
+                        self.exprs_and_regexps[-1]['regexps'].append(regexp.strip())
+                    else:
+                        sys.exit("Failure parsing test: regexp with no command")
+            else:
+                if current_expression:
+                    current_expression += line
+                else:
+                    current_expression = line
+
+    def set_breakpoint(self, target):
+        self.breakpoint = target.BreakpointCreateBySourceRegex(breakpointMarker(), lldb.SBFileSpec(mainSourceFile()))
+
+    def handle_breakpoint(self, test, thread, breakpoint_id):
+        if self.breakpoint.GetID() == breakpoint_id:
+            frame = thread.GetSelectedFrame()
+            options = lldb.SBExpressionOptions()
+            options.SetLanguage(lldb.eLanguageTypeSwift)
+            options.SetREPLMode(True)
+            options.SetFetchDynamicValue(lldb.eDynamicDontRunTarget)
+
+            for expr_and_regexp in self.exprs_and_regexps:
+                ret = frame.EvaluateExpression(expr_and_regexp['expr'], options)
+                desc_stream = lldb.SBStream()
+                ret.GetDescription(desc_stream)
+                desc = desc_stream.GetData()
+                for regexp in expr_and_regexp['regexps']:
+                    test.assertTrue(re.search(regexp, desc), "Output of REPL input\n" + expr_and_regexp['expr'] + "was\n" + desc + "which didn't match regexp " + regexp)
+                
+            return
+
+class REPLTest(TestBase):
+    # Internal implementation
+
+    def getRerunArgs(self):
+        # The -N option says to NOT run a if it matches the option argument, so
+        # if we are using dSYM we say to NOT run dwarf (-N dwarf) and vice versa.
+        if self.using_dsym is None:
+            # The test was skipped altogether.
+            return ""
+        elif self.using_dsym:
+            return "-N dwarf %s" % (self.mydir)
+        else:
+            return "-N dsym %s" % (self.mydir)
+
+    def BuildSourceFile(self):
+        if os.path.exists(mainSourceFile()):
+            return
+
+        source_file = open(mainSourceFile(), 'w+')
+        source_file.write("func stop_here() {\n")
+        source_file.write("  // " + breakpointMarker() + "\n")
+        source_file.write("}\n")
+        source_file.write("stop_here()\n")
+        source_file.close()
+
+        return
+
+    def BuildMakefile(self):
+        if os.path.exists("Makefile"):
+            return
+
+        makefile = open("Makefile", 'w+')
+
+        level = os.sep.join([".."] * len(self.mydir.split(os.sep))) + os.sep + "make"
+
+        makefile.write("LEVEL = " + level + "\n")
+        makefile.write("SWIFT_SOURCES := " + mainSourceFile() + "\n")
+
+        makefile.write("include $(LEVEL)/Makefile.rules\n")
+        makefile.flush()
+        makefile.close()
+
+    @skipUnlessDarwin
+    def __test_with_dsym(self):
+        return
+
+    def __test_with_dwarf(self):
+        self.using_dsym = False
+        self.BuildSourceFile()
+        self.BuildMakefile()
+        self.buildDwarf()
+        self.do_test()
+
+    def __test_with_dwo(self):
+        return
+
+    def __test_with_gmodules(self):
+        return
+
+    def execute_user_command(self, __command):
+        exec(__command, globals(), locals())
+
+    def do_test(self):
+        exe_name = "a.out"
+        exe = os.path.join(os.getcwd(), exe_name)
+        target = self.dbg.CreateTarget(exe)
+
+        parser = CommandParser()
+        parser.parse_input()
+        parser.set_breakpoint(target)
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        while lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint):
+            thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
+            breakpoint_id = thread.GetStopReasonDataAtIndex (0)
+            parser.handle_breakpoint(self, thread, breakpoint_id)
+            process.Continue()
+
+
+def ApplyDecoratorsToFunction(func, decorators):
+    tmp = func
+    if type(decorators) == list:
+        for decorator in decorators:
+            tmp = decorator(tmp)
+    elif hasattr(decorators, '__call__'):
+        tmp = decorators(tmp)
+    return tmp
+
+
+def MakeREPLTest(__file, __globals, decorators=None):
+    # Adjust the filename if it ends in .pyc.  We want filenames to
+    # reflect the source python file, not the compiled variant.
+    if __file is not None and __file.endswith(".pyc"):
+        # Strip the trailing "c"
+        __file = __file[0:-1]
+
+    # Derive the test name from the current file name
+    file_basename = os.path.basename(__file)
+    REPLTest.mydir = TestBase.compute_mydir(__file)
+
+    test_name, _ = os.path.splitext(file_basename)
+    # Build the test case 
+    test = type(test_name, (REPLTest,), {'using_dsym': None})
+    test.name = test_name
+
+    target_platform = lldb.DBG.GetSelectedPlatform().GetTriple().split('-')[2]
+    if test_categories.is_supported_on_platform("dwarf", target_platform, configuration.compilers):
+        test.test_with_dwarf = ApplyDecoratorsToFunction(test._REPLTest__test_with_dwarf, decorators)
+
+    # Add the test case to the globals, and hide REPLTest
+    __globals.update({test_name : test})
+
+    # Keep track of the original test filename so we report it
+    # correctly in test results.
+    test.test_filename = __file
+    return test
+

--- a/packages/Python/lldbsuite/test/repl/error_return/TestREPLThrowReturn.py
+++ b/packages/Python/lldbsuite/test/repl/error_return/TestREPLThrowReturn.py
@@ -1,35 +1,4 @@
-# TestREPLThrowReturn.py
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See http://swift.org/LICENSE.txt for license information
-# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ------------------------------------------------------------------------------
-"""Test that the REPL correctly handles the case that a called function throws."""
+import lldbsuite.test.lldbinrepl as lldbinrepl
+import lldbsuite.test.lldbtest as lldbtest
 
-import os, time
-import unittest2
-import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
-import lldbsuite.test.decorators as decorators
-
-class REPLThrowReturnTestCase (REPLTest):
-
-    mydir = REPLTest.compute_mydir(__file__)
-
-    @decorators.swiftTest
-    @decorators.skipUnlessDarwin
-    @decorators.no_debug_info_test
-    @decorators.expectedFailureAll(bugnumber="rdar://28559820")
-    def testREPL(self):
-        REPLTest.testREPL(self)
-
-    def doTest(self):
-        self.sendline('import Foundation; Data()')
-        self.sendline('enum VagueProblem: Error { case SomethingWentWrong }; func foo() throws -> Int { throw VagueProblem.SomethingWentWrong }')
-        self.promptSync()
-        self.command('foo()', patterns=['\\$E0', 'SomethingWentWrong'])
+lldbinrepl.MakeREPLTest(__file__, globals(), [])

--- a/packages/Python/lldbsuite/test/repl/error_return/input.swift
+++ b/packages/Python/lldbsuite/test/repl/error_return/input.swift
@@ -1,0 +1,11 @@
+import Foundation
+///
+Data()
+///
+enum VagueProblem: Error { case SomethingWentWrong }
+///
+func foo() throws -> Int { throw VagueProblem.SomethingWentWrong }
+///
+foo()
+///\$E0
+///SomethingWentWrong

--- a/packages/Python/lldbsuite/test/repl/error_return/main.swift
+++ b/packages/Python/lldbsuite/test/repl/error_return/main.swift
@@ -1,0 +1,4 @@
+func stop_here() {
+  // Set breakpoint here.
+}
+stop_here()

--- a/scripts/Python/static-binding/LLDBWrapPython.cpp
+++ b/scripts/Python/static-binding/LLDBWrapPython.cpp
@@ -23491,6 +23491,135 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SBExpressionOptions_GetREPLMode(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBExpressionOptions *arg1 = (lldb::SBExpressionOptions *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:SBExpressionOptions_GetREPLMode",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_lldb__SBExpressionOptions, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBExpressionOptions_GetREPLMode" "', argument " "1"" of type '" "lldb::SBExpressionOptions const *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBExpressionOptions * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (bool)((lldb::SBExpressionOptions const *)arg1)->GetREPLMode();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SBExpressionOptions_SetREPLMode__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBExpressionOptions *arg1 = (lldb::SBExpressionOptions *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:SBExpressionOptions_SetREPLMode",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_lldb__SBExpressionOptions, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBExpressionOptions_SetREPLMode" "', argument " "1"" of type '" "lldb::SBExpressionOptions *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBExpressionOptions * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "SBExpressionOptions_SetREPLMode" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    (arg1)->SetREPLMode(arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SBExpressionOptions_SetREPLMode__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBExpressionOptions *arg1 = (lldb::SBExpressionOptions *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:SBExpressionOptions_SetREPLMode",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_lldb__SBExpressionOptions, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBExpressionOptions_SetREPLMode" "', argument " "1"" of type '" "lldb::SBExpressionOptions *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBExpressionOptions * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    (arg1)->SetREPLMode();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SBExpressionOptions_SetREPLMode(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[3];
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = (int)PyObject_Length(args);
+  for (ii = 0; (ii < argc) && (ii < 2); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_lldb__SBExpressionOptions, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_SBExpressionOptions_SetREPLMode__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_lldb__SBExpressionOptions, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_SBExpressionOptions_SetREPLMode__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number of arguments for overloaded function 'SBExpressionOptions_SetREPLMode'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    SetREPLMode(lldb::SBExpressionOptions *,bool)\n"
+    "    SetREPLMode(lldb::SBExpressionOptions *)\n");
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SBExpressionOptions_SetLanguage(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBExpressionOptions *arg1 = (lldb::SBExpressionOptions *) 0 ;
@@ -68276,6 +68405,11 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBExpressionOptions_SetPlaygroundTransformEnabled", _wrap_SBExpressionOptions_SetPlaygroundTransformEnabled, METH_VARARGS, (char *)"\n"
 		"SetPlaygroundTransformEnabled(bool enable_playground_transform = True)\n"
 		"SBExpressionOptions_SetPlaygroundTransformEnabled(SBExpressionOptions self)\n"
+		""},
+	 { (char *)"SBExpressionOptions_GetREPLMode", _wrap_SBExpressionOptions_GetREPLMode, METH_VARARGS, (char *)"SBExpressionOptions_GetREPLMode(SBExpressionOptions self) -> bool"},
+	 { (char *)"SBExpressionOptions_SetREPLMode", _wrap_SBExpressionOptions_SetREPLMode, METH_VARARGS, (char *)"\n"
+		"SetREPLMode(bool enable_repl = True)\n"
+		"SBExpressionOptions_SetREPLMode(SBExpressionOptions self)\n"
 		""},
 	 { (char *)"SBExpressionOptions_SetLanguage", _wrap_SBExpressionOptions_SetLanguage, METH_VARARGS, (char *)"\n"
 		"SBExpressionOptions_SetLanguage(SBExpressionOptions self, LanguageType language)\n"

--- a/scripts/Python/static-binding/lldb.py
+++ b/scripts/Python/static-binding/lldb.py
@@ -4116,6 +4116,17 @@ class SBExpressionOptions(_object):
         """
         return _lldb.SBExpressionOptions_SetPlaygroundTransformEnabled(self, enable_playground_transform)
 
+    def GetREPLMode(self):
+        """GetREPLMode(self) -> bool"""
+        return _lldb.SBExpressionOptions_GetREPLMode(self)
+
+    def SetREPLMode(self, enable_repl = True):
+        """
+        SetREPLMode(self, bool enable_repl = True)
+        SetREPLMode(self)
+        """
+        return _lldb.SBExpressionOptions_SetREPLMode(self, enable_repl)
+
     def SetLanguage(self, *args):
         """
         SetLanguage(self, LanguageType language)

--- a/scripts/interface/SBExpressionOptions.i
+++ b/scripts/interface/SBExpressionOptions.i
@@ -98,6 +98,12 @@ public:
     void
     SetPlaygroundTransformEnabled (bool enable_playground_transform = true);
 
+    bool
+    GetREPLMode () const;
+    
+    void
+    SetREPLMode (bool enable_repl = true);
+
     %feature ("docstring", "Sets the language that LLDB should assume the expression is written in") SetLanguage;
     void
     SetLanguage (lldb::LanguageType language);

--- a/source/API/SBExpressionOptions.cpp
+++ b/source/API/SBExpressionOptions.cpp
@@ -174,6 +174,18 @@ SBExpressionOptions::SetPlaygroundTransformEnabled (bool enable_playground_trans
 }
 
 bool
+SBExpressionOptions::GetREPLMode () const
+{
+    return m_opaque_ap->GetREPLEnabled();
+}
+
+void
+SBExpressionOptions::SetREPLMode (bool enable_repl_mode)
+{
+    m_opaque_ap->SetREPLEnabled(enable_repl_mode);
+}
+
+bool
 SBExpressionOptions::GetGenerateDebugInfo ()
 {
     return m_opaque_ap->GetGenerateDebugInfo();


### PR DESCRIPTION
This change is by Sean Callanan

Added an "inline-REPL" test case style that allows REPL tests
ithout pexpect.

These test cases simply alternate expressions with (in ///
comment blocks) regexps to be run against the results of those expressions.
They run the LLDB xpression parser in REPL mode.  This eliminates a
dependency on pexpect, which does not provide helpful errors, is harder to debug,
and can be unreliable when the system running the test is under load.