### PR TITLE
[CMake] Search for llvm-config in LLDB_PATH_TO_LLVM_BUILD first

### DIFF
--- a/cmake/modules/LLDBStandalone.cmake
+++ b/cmake/modules/LLDBStandalone.cmake
@@ -17,7 +17,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(FIND_PATHS "${LLDB_PATH_TO_LLVM_BUILD}/bin")
   endif()
   find_program(LLVM_CONFIG "llvm-config"
-    PATHS ${FIND_PATHS})
+    HINTS ${FIND_PATHS})
 
   if(LLVM_CONFIG)
     message(STATUS "Found LLVM_CONFIG as ${LLVM_CONFIG}")


### PR DESCRIPTION
Add NO_DEFAULT_PATH to cmake's find_program() so we don't pick up
llvm-config in cmake or system paths.

My local build as been failing as it picked up llvm-config in my build compiler since it is on the $PATH.