### PR TITLE
remove xfails from some now-passing tests

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/inline-stepping/TestInlineStepping.py
+++ b/packages/Python/lldbsuite/test/functionalities/inline-stepping/TestInlineStepping.py
@@ -12,7 +12,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@unittest2.skip("rdar://TestInlineStepping.py")
 class TestInlineStepping(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)

--- a/packages/Python/lldbsuite/test/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
+++ b/packages/Python/lldbsuite/test/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
@@ -40,7 +40,6 @@ class TestSwiftDifferentClangFlags(TestBase):
     @decorators.skipIf(
         debug_info=decorators.no_match("dsym"),
         bugnumber="This test requires a stripped binary and a dSYM")
-    @decorators.skipIf(oslist=["macosx"], bugnumber="rdar://26051347")
     def test_swift_different_clang_flags(self):
         """Test that we use the right compiler flags when debugging"""
         self.buildAll()


### PR DESCRIPTION
These tests are:
TestInlineStepping.py
TestSwiftDifferentClangFlags.py

rdar://23611922
rdar://26051347