### PR TITLE
[semantic-arc] When emitting loads, qualify the load with unqualified ownership.

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftSILManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftSILManipulator.cpp
@@ -98,7 +98,8 @@ swift::SILValue SwiftSILManipulator::emitLValueForVariable(
                                        raw_pointer_type.getAddressType(),
                                        /*isStrict*/ true);
   swift::LoadInst *pointer_to_variable =
-      m_builder.createLoad(null_loc, pointer_to_return_slot);
+      m_builder.createLoad(null_loc, pointer_to_return_slot,
+                           swift::LoadOwnershipQualifier::Unqualified);
   swift::PointerToAddressInst *address_of_variable =
       m_builder.createPointerToAddress(
           null_loc, pointer_to_variable,


### PR DESCRIPTION
[semantic-arc] When emitting loads, qualify the load with unqualified ownership.

This required for changes in Swift.

rdar://28685236