### PR TITLE
Fix weak symbol linkage in SBStructuredData, update docs.

### DIFF
--- a/include/lldb/API/SBStructuredData.h
+++ b/include/lldb/API/SBStructuredData.h
@@ -13,6 +13,8 @@
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBModule.h"
 
+class StructuredDataImpl;
+
 namespace lldb {
 
 class SBStructuredData {
@@ -36,8 +38,7 @@ public:
   lldb::SBError GetDescription(lldb::SBStream &stream) const;
 
 private:
-  class Impl;
-  std::unique_ptr<Impl> m_impl_up;
+  std::unique_ptr<StructuredDataImpl> m_impl_up;
 };
 }
 

--- a/www/SB-api-coding-rules.html
+++ b/www/SB-api-coding-rules.html
@@ -36,7 +36,7 @@
 
                                       <p>You also need to choose the ivars for the class with care, since you can't add or remove ivars
                                         without breaking binary compatibility.  In some cases, the SB class is a thin wrapper around
-                                        an interal lldb_private object.  In that case, the class can have a single ivar, which is 
+                                        an internal lldb_private object.  In that case, the class can have a single ivar, which is
                                         either a pointer, shared_ptr or unique_ptr to the object in the lldb_private API.  All the
                                         lldb_private classes that get used this way are declared as opaque classes in lldb_forward.h,
                                         which is included in SBDefines.h.  So if you need an SB class to wrap an lldb_private class
@@ -47,8 +47,9 @@
                                         as a direct ivar in the SB Class.  Instead, make an Impl class in the SB's .cpp file, and then
                                         make the SB object hold a shared or unique pointer to the Impl object.  The theory behind this is
                                         that if you need more state in the SB object, those needs are likely to change over time, 
-                                        and this way the impl class can pick up members without changing the size of the object.
-                                        An example of this is the SBValue class.
+                                        and this way the Impl class can pick up members without changing the size of the object.
+                                        An example of this is the SBValue class.  Please note that you should not put this Impl class
+                                        in the lldb namespace.  Failure to do so leads to leakage of weak-linked symbols in the SBAPI.
                                         
                                       <p>In order to fit into the Python API's, we need to be able to default construct all the SB objects.
                                         Since the ivars of the classes are all pointers of one sort or other, this can easily be done, but


### PR DESCRIPTION
Summary:
This change fixes an issue where I was leaking a weakly-linked symbol in
the SBAPI. It also updates the docs to call out what I did wrong.

Fixes:
rdar://28882483

Reviewers: jingham

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D26470

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@286413 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 752ca9d6fea6e3eb31c7480b7be94d1aa8c7edc3)