### PR TITLE
Remove weak-linked symbols for SBBreakpointListImpl

### DIFF
--- a/include/lldb/API/SBBreakpoint.h
+++ b/include/lldb/API/SBBreakpoint.h
@@ -12,6 +12,8 @@
 
 #include "lldb/API/SBDefines.h"
 
+class SBBreakpointListImpl;
+
 namespace lldb {
 
 class LLDB_API SBBreakpoint {
@@ -145,8 +147,6 @@ private:
 
   lldb::BreakpointSP m_opaque_sp;
 };
-
-class SBBreakpointListImpl;
 
 class LLDB_API SBBreakpointList {
 public:

--- a/include/lldb/API/SBTarget.h
+++ b/include/lldb/API/SBTarget.h
@@ -830,7 +830,7 @@ public:
 protected:
   friend class SBAddress;
   friend class SBBlock;
-  friend class SBBreakpointListImpl;
+  friend class SBBreakpointList;
   friend class SBDebugger;
   friend class SBExecutionContext;
   friend class SBFunction;

--- a/source/API/SBBreakpoint.cpp
+++ b/source/API/SBBreakpoint.cpp
@@ -712,11 +712,11 @@ SBBreakpoint::GetNumBreakpointLocationsFromEvent(const lldb::SBEvent &event) {
 }
 
 // This is simple collection of breakpoint id's and their target.
-class lldb::SBBreakpointListImpl {
+class SBBreakpointListImpl {
 public:
-  SBBreakpointListImpl(SBTarget &target) : m_target_wp() {
-    if (target.IsValid())
-      m_target_wp = target.GetSP();
+  SBBreakpointListImpl(lldb::TargetSP target_sp) : m_target_wp() {
+    if (target_sp && target_sp->IsValid())
+      m_target_wp = target_sp;
   }
 
   ~SBBreakpointListImpl() = default;
@@ -796,7 +796,7 @@ private:
 };
 
 SBBreakpointList::SBBreakpointList(SBTarget &target)
-    : m_opaque_sp(new lldb::SBBreakpointListImpl(target)) {}
+    : m_opaque_sp(new SBBreakpointListImpl(target.GetSP())) {}
 
 SBBreakpointList::~SBBreakpointList() {}
 


### PR DESCRIPTION
Summary:
Similar to SBStructuredData's Impl class, SBBreakpointListImpl was
getting weak-link exported in the lldb namespace. This change list fixes
that by moving out of the lldb public namespace, which removes it from
public export visibility.

Fixes:
rdar://28960344

Reviewers: jingham

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D26553

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@286631 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 8819ba16f8089e4d34502df8eae8c870ef90aeb1)