### PR TITLE
Fix typo which broke debugging on older OSX systems after r285172.

### DIFF
--- a/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -1137,7 +1137,7 @@ bool DynamicLoaderDarwin::UseDYLDSPI(Process *process) {
 
     // macOS 10.12 and newer
     if (os_type == llvm::Triple::MacOSX &&
-        (major >= 10 || (major == 10 && minor >= 12))) {
+        (major > 10 || (major == 10 && minor >= 12))) {
       use_new_spi_interface = true;
     }
 


### PR DESCRIPTION
Reviewed by: jasonmolenda
Subscribers: lldb-commits
Differential Revision: http://reviews.llvm.org/D26260

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@285858 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 1aeb08951525a9d8072f3d2fe8dd5da160401fb4)