### PR TITLE
Add new swiftSyntax to LLDBDependencies.cmake

### DIFF
--- a/cmake/LLDBDependencies.cmake
+++ b/cmake/LLDBDependencies.cmake
@@ -180,6 +180,7 @@ else()
     swiftSILOptimizer
     swiftASTSectionImporter
     swiftRemoteAST
+    swiftSyntax
     )
 endif()
 


### PR DESCRIPTION
This fixes the link error currently in master.