### PR TITLE
Revert "Add new swiftSyntax to LLDBDependencies.cmake"

### DIFF
--- a/cmake/LLDBDependencies.cmake
+++ b/cmake/LLDBDependencies.cmake
@@ -180,7 +180,6 @@ else()
     swiftSILOptimizer
     swiftASTSectionImporter
     swiftRemoteAST
-    swiftSyntax
     )
 endif()
 


### PR DESCRIPTION
The commits creating this library are temporarily deleted
in Swift.

This reverts commit 513630b6677e67183a9329c759f9dc404de2f203.

This revert depends on https://github.com/apple/swift/pull/5864,
which is now in the tree.