### PR TITLE
[Swift] Fix copy/paste error

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/module_search_paths/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/module_search_paths/Makefile
@@ -1,0 +1,11 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules
+
+module:
+	$(SWIFTCC) -g -Onone -emit-module -module-name Module module.swift
+
+cleanup:
+	rm -rf *.swiftdoc *.swiftmodule

--- a/packages/Python/lldbsuite/test/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -1,0 +1,81 @@
+# TestSwiftModuleSearchPaths.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Tests that we can import modules located using target.swift-module-search-paths
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftModuleSearchPaths(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+        system([["make", "module"]])
+        self.addTearDownHook(lambda: system([["make", "cleanup"]]))
+        
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+
+    @decorators.swiftTest
+    def test_swift_module_search_paths(self):
+        """
+        Tests that we can import modules located using
+        target.swift-module-search-paths
+        """
+        
+        # Build and run the dummy target
+        self.build()
+        
+        exe_name = "a.out"
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        a_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', self.main_source_spec)
+        self.assertTrue(a_breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, a_breakpoint)
+
+        self.assertTrue(len(threads) == 1)
+        self.thread = threads[0]
+        self.frame = self.thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+
+        # Add the current working dir to the swift-module-search-paths
+        self.runCmd("settings append target.swift-module-search-paths .")
+        
+        # import the module
+        self.runCmd("e import Module")
+        
+        # Check that we know about the function declared in the module
+        self.match(
+            "e plusTen(10)", "error: Couldn't lookup symbols:", error=True)
+
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/module_search_paths/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/module_search_paths/main.swift
@@ -1,0 +1,17 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+
+func main() {
+    // break here
+}
+main()

--- a/packages/Python/lldbsuite/test/lang/swift/module_search_paths/module.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/module_search_paths/module.swift
@@ -1,0 +1,15 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+public func plusTen(_ val: Int) -> Int {
+  return val + 10
+}

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1872,9 +1872,9 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
             framework_search_paths.GetFileSpecAtIndex(fi).GetPath().c_str());
       }
 
-      for (size_t mi = 0, me = framework_search_paths.GetSize(); mi != me;
+      for (size_t mi = 0, me = module_search_paths.GetSize(); mi != me;
            ++mi) {
-        swift_ast_sp->AddFrameworkSearchPath(
+        swift_ast_sp->AddModuleSearchPath(
             module_search_paths.GetFileSpecAtIndex(mi).GetPath().c_str());
       }
 


### PR DESCRIPTION
These lines look like a simple copy/paste oversight.

I tried the following:
```
lldb --repl
> :settings append target.swift-module-search-paths <path to folder containing Module.swiftmodule>
> import Module
```

Without this patch the `import` will fail with `error: repl.swift:1:8: error: no such module 'Module'`, with this patch, the import succeeds.