### PR TITLE
Remove special handling for undefined LLDB_REVISION

### DIFF
--- a/source/lldb.cpp
+++ b/source/lldb.cpp
@@ -26,19 +26,10 @@ using namespace lldb_private;
 
 static const char *GetLLDBRevision() {
 #ifdef LLDB_REVISION
-  static const char *s_revision = LLDB_REVISION;
+  return LLDB_REVISION;
 #else
-  static const char *s_revision = nullptr;
+  return nullptr;
 #endif
-
-  // If LLDB_REVISION is defined but isn't set to a string, it
-  // can still be the equivalent of NULL.  Hence we always do
-  // this check below and return an empty string when we don't
-  // otherwise have a valid const string for it.
-  if (s_revision != nullptr)
-    return s_revision;
-  else
-    return "";
 }
 
 static const char *GetLLDBRepository() {


### PR DESCRIPTION
Returning empty string instead of nullptr is unnecessary with the refactored code here, and it actually causes some odd version printing.