### PR TITLE
Updated the Swift expression parser to handle NULL IR modules

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1782,7 +1782,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
   if (!m_module) {
     diagnostic_manager.PutCString(
-        DiagnosticSeverity.Error,
+        eDiagnosticSeverityError,
         "Couldn't IRGen expression, no additional error");
     return 1;
   }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1780,6 +1780,10 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     return 1;
   }
 
+  if (!m_module) {
+    diagnostic_manager.PutCString(DiagnosticSeverity.Error, "Couldn't IRGen expression, no additional error");
+  }
+
   if (log) {
     std::string s;
     llvm::raw_string_ostream ss(s);

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1781,7 +1781,10 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   }
 
   if (!m_module) {
-    diagnostic_manager.PutCString(DiagnosticSeverity.Error, "Couldn't IRGen expression, no additional error");
+    diagnostic_manager.PutCString(
+        DiagnosticSeverity.Error,
+        "Couldn't IRGen expression, no additional error");
+    return 1;
   }
 
   if (log) {


### PR DESCRIPTION
Updated the Swift expression parser to handle NULL IR modules.
    
    IRGen in rare cases can produce a NULL module without reporting an error.
    LLDB should report an error here but it should not crash.  This fixes the
    problem.
    
    Swift is still looking into what scenarios this occurs in.  Once we know that,
    we can add a testcase.
    
    <rdar://problem/28979704>