### PR TITLE
Port swift-lldb to Windows

### DIFF
--- a/cmake/LLDBDependencies.cmake
+++ b/cmake/LLDBDependencies.cmake
@@ -227,9 +227,17 @@ endif()
 
 if(LLDB_BUILT_STANDALONE)
   # this needs to be linked statially
-  list(APPEND LLDB_SYSTEM_LIBS ${PATH_TO_CMARK_BUILD}/src/libcmark.a)
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    list(APPEND LLDB_SYSTEM_LIBS ${PATH_TO_CMARK_BUILD}/src/cmark.lib)
+  else()
+    list(APPEND LLDB_SYSTEM_LIBS ${PATH_TO_CMARK_BUILD}/src/libcmark.a)
+  endif()
 else()
-  list(APPEND LLDB_SYSTEM_LIBS libcmark_static)
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    list(APPEND LLDB_SYSTEM_LIBS ${PATH_TO_CMARK_BUILD}/src/cmark_static.lib)
+  else()
+    list(APPEND LLDB_SYSTEM_LIBS libcmark_static)
+  endif()
 endif()
 
 set(LLVM_LINK_COMPONENTS

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -35,7 +35,7 @@ namespace swift {
 enum class IRGenDebugInfoKind : unsigned;
 class CanType;
 class IRGenOptions;
-class PrintOptions;
+struct PrintOptions;
 class SILModule;
 namespace irgen {
 class FixedTypeInfo;
@@ -43,7 +43,7 @@ class TypeInfo;
 }
 }
 
-class CachedMemberInfo;
+struct CachedMemberInfo;
 class DWARFASTParser;
 class SwiftEnumDescriptor;
 

--- a/source/Core/IOHandler.cpp
+++ b/source/Core/IOHandler.cpp
@@ -28,7 +28,9 @@
 #include "lldb/Core/State.h"
 #include "lldb/Core/StreamFile.h"
 #include "lldb/Core/ValueObjectRegister.h"
+#ifndef LLDB_DISABLE_LIBEDIT
 #include "lldb/Host/Editline.h"
+#endif
 #include "lldb/Interpreter/CommandCompletions.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Symbol/Block.h"
@@ -273,12 +275,16 @@ IOHandlerEditline::IOHandlerEditline(
     IOHandlerDelegate &delegate)
     : IOHandler(debugger, type, input_sp, output_sp, error_sp, flags),
 #ifndef LLDB_DISABLE_LIBEDIT
-      m_editline_ap(), m_delegate(delegate), m_prompt(),
-      m_continuation_prompt(), m_current_lines_ptr(nullptr),
-      m_base_line_number(line_number_start), m_curr_line_idx(UINT32_MAX),
-      m_multi_line(multi_line), m_color_prompts(color_prompts),
-      m_interrupt_exits(true), m_editing(false) {
+      m_editline_ap(),
+#endif
+      m_delegate(delegate), m_prompt(), m_continuation_prompt(),
+      m_current_lines_ptr(nullptr), m_base_line_number(line_number_start),
+      m_curr_line_idx(UINT32_MAX), m_multi_line(multi_line),
+      m_color_prompts(color_prompts), m_interrupt_exits(true),
+      m_editing(false) {
   SetPrompt(prompt);
+
+#ifndef LLDB_DISABLE_LIBEDIT
   bool use_editline = false;
 
   use_editline = m_input_sp->GetFile().GetIsRealTerminal();
@@ -306,7 +312,11 @@ IOHandlerEditline::IOHandlerEditline(
   SetContinuationPrompt(continuation_prompt);
 }
 
-IOHandlerEditline::~IOHandlerEditline() { m_editline_ap.reset(); }
+IOHandlerEditline::~IOHandlerEditline() {
+#ifndef LLDB_DISABLE_LIBEDIT
+  m_editline_ap.reset();
+#endif
+}
 
 void IOHandlerEditline::Activate() {
   IOHandler::Activate();
@@ -319,9 +329,11 @@ void IOHandlerEditline::Deactivate() {
 }
 
 bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
+#ifndef LLDB_DISABLE_LIBEDIT
   if (m_editline_ap) {
     return m_editline_ap->GetLine(line, interrupted);
   } else {
+#endif
     line.clear();
 
     FILE *in = GetInputFILE();
@@ -383,7 +395,9 @@ bool IOHandlerEditline::GetLine(std::string &line, bool &interrupted) {
       SetIsDone(true);
     }
     return false;
+#ifndef LLDB_DISABLE_LIBEDIT
   }
+#endif
 }
 
 #ifndef LLDB_DISABLE_LIBEDIT
@@ -417,16 +431,18 @@ int IOHandlerEditline::AutoCompleteCallback(const char *current_line,
         max_matches, matches);
   return 0;
 }
+#endif
 
 const char *IOHandlerEditline::GetPrompt() {
 #ifndef LLDB_DISABLE_LIBEDIT
-  if (m_editline_ap)
+  if (m_editline_ap) {
     return m_editline_ap->GetPrompt();
-  else if (m_prompt.empty())
-    return nullptr;
-#else
-  if (m_prompt.empty())
-    return nullptr;
+  } else {
+#endif
+    if (m_prompt.empty())
+      return nullptr;
+#ifndef LLDB_DISABLE_LIBEDIT
+  }
 #endif
   return m_prompt.c_str();
 }
@@ -473,6 +489,7 @@ bool IOHandlerEditline::GetLines(StringList &lines, bool &interrupted) {
   m_current_lines_ptr = &lines;
 
   bool success = false;
+#ifndef LLDB_DISABLE_LIBEDIT
   if (m_editline_ap) {
     return m_editline_ap->GetLines(m_base_line_number, lines, interrupted);
   } else {
@@ -501,7 +518,9 @@ bool IOHandlerEditline::GetLines(StringList &lines, bool &interrupted) {
       }
     }
     success = lines.GetSize() > 0;
+#ifndef LLDB_DISABLE_LIBEDIT
   }
+#endif
   m_current_lines_ptr = NULL;
   return success;
 }
@@ -552,14 +571,18 @@ bool IOHandlerEditline::Interrupt() {
   if (m_delegate.IOHandlerInterrupt(*this))
     return true;
 
+#ifndef LLDB_DISABLE_LIBEDIT
   if (m_editline_ap)
     return m_editline_ap->Interrupt();
+#endif
   return false;
 }
 
 void IOHandlerEditline::GotEOF() {
+#ifndef LLDB_DISABLE_LIBEDIT
   if (m_editline_ap)
     m_editline_ap->Interrupt();
+#endif
 }
 
 void IOHandlerEditline::PrintAsync(Stream *stream, const char *s, size_t len) {

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -13,13 +13,6 @@
 #include "lldb/Host/windows/windows.h"
 #include <Dbghelp.h>
 #pragma comment(lib, "dbghelp.lib")
-#define LLDB_USE_BUILTIN_DEMANGLER
-#elif defined(__FreeBSD__)
-#define LLDB_USE_BUILTIN_DEMANGLER
-#elif defined(__GLIBCXX__)
-#define LLDB_USE_BUILTIN_DEMANGLER
-#else
-#include <cxxabi.h>
 #endif
 
 #ifdef LLDB_USE_BUILTIN_DEMANGLER

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -1083,7 +1083,6 @@ private:
   CompilerType m_type;
   bool m_is_program_reference;
   bool m_keep_in_memory;
-  bool m_is_error_result;
 
   lldb::addr_t m_temporary_allocation;
   size_t m_temporary_allocation_size;

--- a/source/Host/common/Socket.cpp
+++ b/source/Host/common/Socket.cpp
@@ -363,7 +363,7 @@ Error Socket::Close() {
   Log *log(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_CONNECTION));
   if (log)
     log->Printf("%p Socket::Close (fd = %i)", static_cast<void *>(this),
-                m_socket);
+                static_cast<int>(m_socket));
 
 #if defined(_WIN32)
   bool success = !!closesocket(m_socket);

--- a/source/Host/windows/Windows.cpp
+++ b/source/Host/windows/Windows.cpp
@@ -32,21 +32,21 @@ int _chdir(const char *path);
 
 namespace {
 bool utf8ToWide(const char *utf8, wchar_t *buf, size_t bufSize) {
-  const llvm::UTF8 *sourceStart = reinterpret_cast<const llvm::UTF8 *>(utf8);
+  const UTF8 *sourceStart = reinterpret_cast<const UTF8 *>(utf8);
   size_t sourceLen = strlen(utf8) + 1 /* convert null too */;
-  llvm::UTF16 *target = reinterpret_cast<llvm::UTF16 *>(buf);
-  llvm::ConversionFlags flags = llvm::strictConversion;
-  return llvm::ConvertUTF8toUTF16(&sourceStart, sourceStart + sourceLen, &target,
-                            target + bufSize, flags) == llvm::conversionOK;
+  UTF16 *target = reinterpret_cast<UTF16 *>(buf);
+  ConversionFlags flags = strictConversion;
+  return ConvertUTF8toUTF16(&sourceStart, sourceStart + sourceLen, &target,
+                            target + bufSize, flags) == conversionOK;
 }
 
 bool wideToUtf8(const wchar_t *wide, char *buf, size_t bufSize) {
-  const llvm::UTF16 *sourceStart = reinterpret_cast<const llvm::UTF16 *>(wide);
+  const UTF16 *sourceStart = reinterpret_cast<const UTF16 *>(wide);
   size_t sourceLen = wcslen(wide) + 1 /* convert null too */;
-  llvm::UTF8 *target = reinterpret_cast<llvm::UTF8 *>(buf);
-  llvm::ConversionFlags flags = llvm::strictConversion;
-  return llvm::ConvertUTF16toUTF8(&sourceStart, sourceStart + sourceLen, &target,
-                            target + bufSize, flags) == llvm::conversionOK;
+  UTF8 *target = reinterpret_cast<UTF8 *>(buf);
+  ConversionFlags flags = strictConversion;
+  return ConvertUTF16toUTF8(&sourceStart, sourceStart + sourceLen, &target,
+                            target + bufSize, flags) == conversionOK;
 }
 }
 

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -362,7 +362,7 @@ private:
   //----------------------------------------------------------------------
   class ParserVars {
   public:
-    ParserVars(ClangExpressionDeclMap &decl_map) : m_decl_map(decl_map) {}
+    ParserVars() {}
 
     Target *GetTarget() {
       if (m_exe_ctx.GetTargetPtr())
@@ -387,7 +387,6 @@ private:
                                               ///that receives new top-level
                                               ///functions.
   private:
-    ClangExpressionDeclMap &m_decl_map;
     DISALLOW_COPY_AND_ASSIGN(ParserVars);
   };
 
@@ -398,7 +397,7 @@ private:
   //----------------------------------------------------------------------
   void EnableParserVars() {
     if (!m_parser_vars.get())
-      m_parser_vars.reset(new ParserVars(*this));
+      m_parser_vars = llvm::make_unique<ParserVars>();
   }
 
   //----------------------------------------------------------------------

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -263,10 +263,9 @@ class EntityREPLPersistentVariable : public Materializer::Entity {
 public:
   EntityREPLPersistentVariable(
       lldb::ExpressionVariableSP &persistent_variable_sp,
-      SwiftREPLMaterializer *parent,
-      Materializer::PersistentVariableDelegate *delegate)
+      SwiftREPLMaterializer *parent)
       : Entity(), m_persistent_variable_sp(persistent_variable_sp),
-        m_parent(parent), m_delegate(delegate) {
+        m_parent(parent) {
     // Hard-coding to maximum size of a pointer since persistent variables are
     // materialized by reference
     m_size = 8;
@@ -443,15 +442,15 @@ public:
 private:
   lldb::ExpressionVariableSP m_persistent_variable_sp;
   SwiftREPLMaterializer *m_parent;
-  Materializer::PersistentVariableDelegate *m_delegate;
 };
 
 uint32_t SwiftREPLMaterializer::AddPersistentVariable(
     lldb::ExpressionVariableSP &persistent_variable_sp,
     PersistentVariableDelegate *delegate, Error &err) {
+  (void)delegate;
   EntityVector::iterator iter = m_entities.insert(m_entities.end(), EntityUP());
   iter->reset(
-      new EntityREPLPersistentVariable(persistent_variable_sp, this, delegate));
+      new EntityREPLPersistentVariable(persistent_variable_sp, this));
   uint32_t ret = AddStructMember(**iter);
   (*iter)->SetOffset(ret);
   return ret;

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -700,7 +700,9 @@ lldb::ExpressionVariableSP SwiftUserExpression::GetResultAfterDematerialization(
 
 SwiftUserExpression::ResultDelegate::ResultDelegate(
     SwiftUserExpression &user_expression, bool is_error)
-    : m_user_expression(user_expression), m_is_error(is_error) {}
+    : m_is_error(is_error) {
+  (void)user_expression;
+}
 
 ConstString SwiftUserExpression::ResultDelegate::GetName() {
   return m_persistent_state->GetNextPersistentVariableName(m_is_error);
@@ -721,8 +723,9 @@ lldb::ExpressionVariableSP &SwiftUserExpression::ResultDelegate::GetVariable() {
 }
 
 SwiftUserExpression::PersistentVariableDelegate::PersistentVariableDelegate(
-    SwiftUserExpression &user_expression)
-    : m_user_expression(user_expression) {}
+    SwiftUserExpression &user_expression) {
+  (void)user_expression;
+}
 
 ConstString SwiftUserExpression::PersistentVariableDelegate::GetName() {
   return ConstString();

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -51,12 +51,11 @@ public:
   class SwiftUserExpressionHelper : public ExpressionTypeSystemHelper {
   public:
     SwiftUserExpressionHelper(Target &target)
-        : ExpressionTypeSystemHelper(eKindSwiftHelper), m_target(target) {}
+        : ExpressionTypeSystemHelper(eKindSwiftHelper) {
+      (void)target;
+    }
 
     ~SwiftUserExpressionHelper() {}
-
-  private:
-    Target &m_target;
   };
 
   //------------------------------------------------------------------
@@ -161,7 +160,6 @@ private:
     lldb::ExpressionVariableSP &GetVariable();
 
   private:
-    SwiftUserExpression &m_user_expression;
     bool m_is_error;
     PersistentExpressionState *m_persistent_state;
     lldb::ExpressionVariableSP m_variable;
@@ -176,9 +174,6 @@ private:
     PersistentVariableDelegate(SwiftUserExpression &);
     ConstString GetName() override;
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
-
-  private:
-    SwiftUserExpression &m_user_expression;
   };
 
   PersistentVariableDelegate m_persistent_variable_delegate;

--- a/source/Plugins/ObjectFile/PECOFF/WindowsMiniDump.cpp
+++ b/source/Plugins/ObjectFile/PECOFF/WindowsMiniDump.cpp
@@ -33,7 +33,7 @@ bool SaveMiniDump(const lldb::ProcessSP &process_sp,
   std::wstring wide_name;
   wide_name.resize(file_name.size() + 1);
   char *result_ptr = reinterpret_cast<char *>(&wide_name[0]);
-  const llvm::UTF8 *error_ptr = nullptr;
+  const UTF8 *error_ptr = nullptr;
   if (!llvm::ConvertUTF8toWide(sizeof(wchar_t), file_name, result_ptr,
                                error_ptr)) {
     error.SetErrorString("cannot convert file name");

--- a/source/Plugins/Process/Windows/Live/ProcessWindowsLive.cpp
+++ b/source/Plugins/Process/Windows/Live/ProcessWindowsLive.cpp
@@ -680,7 +680,7 @@ size_t ProcessWindowsLive::DoReadMemory(lldb::addr_t vm_addr, void *buf,
 
   WINLOG_IFALL(WINDOWS_LOG_MEMORY,
                "DoReadMemory attempting to read %u bytes from address 0x%I64x",
-               size, vm_addr);
+               static_cast<unsigned>(size), vm_addr);
 
   HostProcess process = m_session_data->m_debugger->GetProcess();
   void *addr = reinterpret_cast<void *>(vm_addr);
@@ -699,7 +699,8 @@ size_t ProcessWindowsLive::DoWriteMemory(lldb::addr_t vm_addr, const void *buf,
   llvm::sys::ScopedLock lock(m_mutex);
   WINLOG_IFALL(
       WINDOWS_LOG_MEMORY,
-      "DoWriteMemory attempting to write %u bytes into address 0x%I64x", size,
+      "DoWriteMemory attempting to write %u bytes into address 0x%I64x",
+      static_cast<unsigned>(size),
       vm_addr);
 
   if (!m_session_data) {

--- a/source/Plugins/Process/Windows/MiniDump/ProcessWinMiniDump.cpp
+++ b/source/Plugins/Process/Windows/MiniDump/ProcessWinMiniDump.cpp
@@ -501,17 +501,17 @@ std::string ProcessWinMiniDump::Impl::GetMiniDumpString(RVA rva) const {
   }
   auto md_string = reinterpret_cast<const MINIDUMP_STRING *>(
       static_cast<const char *>(m_base_addr) + rva);
-  auto source_start = reinterpret_cast<const llvm::UTF16 *>(md_string->Buffer);
+  auto source_start = reinterpret_cast<const UTF16 *>(md_string->Buffer);
   const auto source_length = ::wcslen(md_string->Buffer);
   const auto source_end = source_start + source_length;
   result.resize(UNI_MAX_UTF8_BYTES_PER_CODE_POINT *
                 source_length); // worst case length
-  auto result_start = reinterpret_cast<llvm::UTF8 *>(&result[0]);
+  auto result_start = reinterpret_cast<UTF8 *>(&result[0]);
   const auto result_end = result_start + result.size();
-  llvm::ConvertUTF16toUTF8(&source_start, source_end, &result_start, result_end,
-                           llvm::ConversionFlags::strictConversion);
+  ConvertUTF16toUTF8(&source_start, source_end, &result_start, result_end,
+                           ConversionFlags::strictConversion);
   const auto result_size =
-      std::distance(reinterpret_cast<llvm::UTF8 *>(&result[0]), result_start);
+      std::distance(reinterpret_cast<UTF8 *>(&result[0]), result_start);
   result.resize(result_size); // shrink to actual length
   return result;
 }

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2666,6 +2666,8 @@ bool SwiftASTContext::TargetHasNoSDK() {
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpessimizing-move"
 swift::ClangImporterOptions &SwiftASTContext::GetClangImporterOptions() {
   swift::ClangImporterOptions &clang_importer_options =
       GetCompilerInvocation().getClangImporterOptions();
@@ -2678,6 +2680,7 @@ swift::ClangImporterOptions &SwiftASTContext::GetClangImporterOptions() {
   }
   return clang_importer_options;
 }
+#pragma clang diagnostic pop
 
 swift::SearchPathOptions &SwiftASTContext::GetSearchPathOptions() {
   swift::SearchPathOptions &search_path_opts =


### PR DESCRIPTION
This requires some CMake stuff, some upstream cherry-picking, and some modification of swift-specific source code.

Note: the changes in "Fix invalid namespace qualified UTF conversion helpers on Windows" changes lldb code. However: other actual lldb code was changed from `llvm::UTF8` to `UTF8` in `swift-clang`, `swift-llvm` and `swift-lldb`. This just manifests itself now, because we never built these files on non-Windows platforms.

/cc @compnerd @jrose-apple