### PR TITLE
build-swift-cmake.py: use HTTPS instead of SSH to clone Github repositories

### DIFF
--- a/scripts/build-swift-cmake.py
+++ b/scripts/build-swift-cmake.py
@@ -74,45 +74,45 @@ uname = str(subprocess.check_output(["uname", "-s"])).rstrip()
 
 checkout_git(
     "llvm",
-    "ssh://git@github.com/apple/swift-llvm.git",
+    "https://github.com/apple/swift-llvm.git",
     "stable")
 checkout_git(
     "clang",
-    "ssh://git@github.com/apple/swift-clang.git",
+    "https://github.com/apple/swift-clang.git",
     "stable")
-checkout_git("swift", "ssh://git@github.com/apple/swift.git", "master")
-checkout_git("cmark", "ssh://git@github.com/apple/swift-cmark.git", "master")
+checkout_git("swift", "https://github.com/apple/swift.git", "master")
+checkout_git("cmark", "https://github.com/apple/swift-cmark.git", "master")
 checkout_git("ninja", "https://github.com/ninja-build/ninja.git", "master")
 checkout_git(
     "lldb",
-    "ssh://git@github.com/apple/swift-lldb.git",
+    "https://github.com/apple/swift-lldb.git",
     "master")
 
 if args.package:
     checkout_git(
         "llbuild",
-        "ssh://git@github.com/apple/swift-llbuild.git",
+        "https://github.com/apple/swift-llbuild.git",
         "master")
     checkout_git(
         "swiftpm",
-        "ssh://git@github.com/apple/swift-package-manager.git",
+        "https://github.com/apple/swift-package-manager.git",
         "master")
     checkout_git(
         "swift-corelibs-foundation",
-        "ssh://git@github.com/apple/swift-corelibs-foundation.git",
+        "https://github.com/apple/swift-corelibs-foundation.git",
         "master")
     checkout_git(
         "swift-corelibs-xctest",
-        "ssh://git@github.com/apple/swift-corelibs-xctest.git",
+        "https://github.com/apple/swift-corelibs-xctest.git",
         "master")
     checkout_git(
         "swift-integration-tests",
-        "ssh://git@github.com/apple/swift-integration-tests.git",
+        "https://github.com/apple/swift-integration-tests.git",
         "master")
 elif args.foundation:
     checkout_git(
         "swift-corelibs-foundation",
-        "ssh://git@github.com/apple/swift-corelibs-foundation.git",
+        "https://github.com/apple/swift-corelibs-foundation.git",
         "master")
 
 if args.update:


### PR DESCRIPTION
From [Github's documentation](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended):
> SSH URLs provide access to a Git repository via SSH, a secure protocol. To use these URLs, you must generate an SSH keypair on your computer and add the public key to your GitHub account

It makes it easier to use HTTPS URLs instead of SSH URLs in `scripts/build-swift-cmake.py`, especially when building from an environment that has no public key registered on Github. I'm not sure that should be a requirement to build LLDB for Swift.

Signed-off-by: Adrien Duermael <adrien@duermael.com>