### PR TITLE
[SR-2757][Swift] Use new capture list VarDecl initializer

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -56,12 +56,15 @@ public:
     swift::Identifier GetName() const { return m_name; }
     swift::VarDecl *GetDecl() const { return m_decl; }
     bool GetIsLet() const;
+    bool GetIsCaptureList() const;
 
     VariableInfo() : m_type(), m_name(), m_metadata() {}
 
     VariableInfo(CompilerType &type, swift::Identifier name,
-                 VariableMetadataSP metadata, bool is_let = false)
-        : m_type(type), m_name(name), m_is_let(is_let), m_metadata(metadata) {}
+                 VariableMetadataSP metadata, bool is_let = false,
+                 bool is_capture_list = false)
+        : m_type(type), m_name(name), m_is_let(is_let),
+          m_is_capture_list(is_capture_list), m_metadata(metadata) {}
 
     template <class T> bool MetadataIs() const {
       return (m_metadata && m_metadata->GetType() == T::Type());
@@ -78,6 +81,7 @@ public:
     swift::Identifier m_name;
     swift::VarDecl *m_decl = nullptr;
     bool m_is_let = false;
+    bool m_is_capture_list = false;
 
   public:
     VariableMetadataSP m_metadata;

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -3146,9 +3146,10 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
     if (module_creation_error.Success() && module_decl) {
       const bool is_static = false;
       const bool is_let = true;
+      const bool is_capture_list = false;
 
       swift::VarDecl *var_decl = new (*ast_context->GetASTContext())
-          swift::VarDecl(is_static, is_let, swift::SourceLoc(),
+          swift::VarDecl(is_static, is_let, is_capture_list, swift::SourceLoc(),
                          ast_context->GetIdentifier(name.GetCString()),
                          GetSwiftType(ast_context->GetErrorType()),
                          module_decl);


### PR DESCRIPTION
Addresses SR-2757.

https://github.com/apple/swift/pull/6490 modified the VarDecl to add a boolean parameter to specify whether the variable was an element in a closure capture list, in order to improve diagnostics in the Swift compiler. Use this new parameter.