### PR TITLE
Updated SwiftASTContext to find a single module with Swift flags.

### DIFF
--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -142,8 +142,6 @@ public:
 
   bool GetEnableAutoImportClangModules() const;
 
-  bool GetUseAllCompilerFlags() const;
-
   bool GetEnableAutoApplyFixIts() const;
 
   bool GetEnableNotifyAboutFixIts() const;

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3423,9 +3423,6 @@ static PropertyDefinition g_properties[] = {
     {"auto-import-clang-modules", OptionValue::eTypeBoolean, false, true,
      nullptr, nullptr,
      "Automatically load Clang modules referred to by the program."},
-    {"use-all-compiler-flags", OptionValue::eTypeBoolean, false, false, nullptr,
-     nullptr, "Try to use compiler flags for all modules when setting up the "
-              "Swift expression parser, not just the main executable."},
     {"auto-apply-fixits", OptionValue::eTypeBoolean, false, true, nullptr,
      nullptr, "Automatically apply fix-it hints to expressions."},
     {"notify-about-fixits", OptionValue::eTypeBoolean, false, true, nullptr,
@@ -3560,7 +3557,6 @@ enum {
   ePropertySwiftFrameworkSearchPaths,
   ePropertySwiftModuleSearchPaths,
   ePropertyAutoImportClangModules,
-  ePropertyUseAllCompilerFlags,
   ePropertyAutoApplyFixIts,
   ePropertyNotifyAboutFixIts,
   ePropertySaveObjects,
@@ -4006,12 +4002,6 @@ bool TargetProperties::GetEnableAutoImportClangModules() const {
   const uint32_t idx = ePropertyAutoImportClangModules;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
       nullptr, idx, g_properties[idx].default_uint_value != 0);
-}
-
-bool TargetProperties::GetUseAllCompilerFlags() const {
-  const uint32_t idx = ePropertyUseAllCompilerFlags;
-  return m_collection_sp->GetPropertyAtIndexAsBoolean(
-      NULL, idx, g_properties[idx].default_uint_value != 0);
 }
 
 bool TargetProperties::GetEnableAutoApplyFixIts() const {


### PR DESCRIPTION
This makes LLDB get flags from the following sources (in order of preference):

  - the main executable;
  - a unit test bundle; or
  - the first module that has a Swift AST.

We used to take the union of all the Swift flags if the first two cases didn't apply.
This was a bad approach and caused a lot of user frustration (mostly of the form
"po doesn't work.")

<rdar://problem/29906378>