### PR TITLE
[Swift] Completely replace Module with ModuleDecl

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -161,7 +161,7 @@ static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {
 
 // Gets the full module name from the module passed in.
 
-static void GetNameFromModule(swift::Module *module, std::string &result) {
+static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
   result.clear();
   if (module) {
     const char *name = module->getName().get();
@@ -198,14 +198,14 @@ bool SwiftExpressionParser::PerformAutoImport(swift::SourceFile &source_file,
   if (compile_unit)
     cu_modules = &compile_unit->GetImportedModules();
 
-  llvm::SmallVector<swift::Module::ImportedModule, 2> imported_modules;
-  llvm::SmallVector<std::pair<swift::Module::ImportedModule,
+  llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> imported_modules;
+  llvm::SmallVector<std::pair<swift::ModuleDecl::ImportedModule,
                               swift::SourceFile::ImportOptions>,
                     2>
       additional_imports;
 
   source_file.getImportedModules(imported_modules,
-                                 swift::Module::ImportFilter::All);
+                                 swift::ModuleDecl::ImportFilter::All);
 
   std::set<ConstString> loaded_modules;
 
@@ -261,10 +261,10 @@ bool SwiftExpressionParser::PerformAutoImport(swift::SourceFile &source_file,
     }
 
     additional_imports.push_back(std::make_pair(
-        std::make_pair(swift::Module::AccessPathTy(), swift_module),
+        std::make_pair(swift::ModuleDecl::AccessPathTy(), swift_module),
         swift::SourceFile::ImportOptions()));
     imported_modules.push_back(
-        std::make_pair(swift::Module::AccessPathTy(), swift_module));
+        std::make_pair(swift::ModuleDecl::AccessPathTy(), swift_module));
 
     return true;
   };
@@ -280,10 +280,10 @@ bool SwiftExpressionParser::PerformAutoImport(swift::SourceFile &source_file,
       }
     }
   } else {
-    llvm::SmallVector<swift::Module::ImportedModule, 2> parsed_imports;
+    llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> parsed_imports;
 
     source_file.getImportedModules(parsed_imports,
-                                   swift::Module::ImportFilter::All);
+                                   swift::ModuleDecl::ImportFilter::All);
 
     SwiftPersistentExpressionState *persistent_expression_state =
         llvm::cast<SwiftPersistentExpressionState>(
@@ -1220,7 +1220,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
            m_options.GetExpressionNumber());
 
   swift::Identifier module_id(ast_context->getIdentifier(expr_name_buf));
-  swift::ModuleDecl *module = swift::Module::create(module_id, *ast_context);
+  swift::ModuleDecl *module = swift::ModuleDecl::create(module_id, *ast_context);
   const swift::SourceFile::ImplicitModuleImportKind implicit_import_kind =
       swift::SourceFile::ImplicitModuleImportKind::Stdlib;
 

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1334,12 +1334,12 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                   [ast_ctx, input, name_parts,
                    &results](swift::ModuleDecl *module) -> void {
 
-                swift::Module::AccessPathTy access_path;
+                swift::ModuleDecl::AccessPathTy access_path;
 
                 module->forAllVisibleModules(
                     access_path, true,
                     [ast_ctx, input, name_parts, &results](
-                        swift::Module::ImportedModule imported_module) -> bool {
+                        swift::ModuleDecl::ImportedModule imported_module) -> bool {
                       auto module = imported_module.second;
                       TypesOrDecls local_results;
                       ast_ctx->FindTypesOrDecls(input, module, local_results,

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3322,7 +3322,7 @@ SwiftASTContext::CreateModule(const ConstString &module_basename,
     if (ast) {
       swift::Identifier module_id(
           ast->getIdentifier(module_basename.GetCString()));
-      module = swift::Module::create(module_id, *ast);
+      module = swift::ModuleDecl::create(module_id, *ast);
       if (module) {
         m_swift_module_cache[module_basename.GetCString()] = module;
         return module;
@@ -3748,7 +3748,7 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
 
   swift_module->forAllVisibleModules({},
                                      true, // includePrivateTopLevel
-                                     [&](swift::Module::ImportedModule import) {
+                                     [&](swift::ModuleDecl::ImportedModule import) {
                                        import.second->collectLinkLibraries(
                                            addLinkLibrary);
                                      });
@@ -4184,7 +4184,7 @@ CompilerType SwiftASTContext::FindQualifiedType(const char *qualified_name) {
       ConstString module_name(qualified_name, dot_pos - qualified_name);
       swift::ModuleDecl *swift_module = GetCachedModule(module_name);
       if (swift_module) {
-        swift::Module::AccessPathTy access_path;
+        swift::ModuleDecl::AccessPathTy access_path;
         llvm::SmallVector<swift::ValueDecl *, 4> decls;
         const char *module_type_name = dot_pos + 1;
         swift_module->lookupValue(access_path, GetIdentifier(module_type_name),
@@ -4409,7 +4409,7 @@ size_t SwiftASTContext::FindTypesOrDecls(const char *name,
   size_t before = results.size();
 
   if (name && name[0] && swift_module) {
-    swift::Module::AccessPathTy access_path;
+    swift::ModuleDecl::AccessPathTy access_path;
     llvm::SmallVector<swift::ValueDecl *, 4> value_decls;
     swift::Identifier identifier(GetIdentifier(name));
     if (strchr(name, '.'))
@@ -4561,7 +4561,7 @@ swift::ModuleDecl *SwiftASTContext::GetScratchModule() {
   VALID_OR_RETURN(nullptr);
 
   if (m_scratch_module == nullptr)
-    m_scratch_module = swift::Module::create(
+    m_scratch_module = swift::ModuleDecl::create(
         GetASTContext()->getIdentifier("__lldb_scratch_module"),
         *GetASTContext());
   return m_scratch_module;
@@ -8888,7 +8888,7 @@ void SwiftASTContext::DumpTypeDescription(void *type, Stream *s,
               if (import_decl) {
                 switch (import_decl->getImportKind()) {
                 case swift::ImportKind::Module: {
-                  swift::Module *imported_module = import_decl->getModule();
+                  swift::ModuleDecl *imported_module = import_decl->getModule();
                   if (imported_module) {
                     s->Printf("import %s\n", imported_module->getName().get());
                   }


### PR DESCRIPTION
The typedef `swift::Module` was a temporary solution in the Swift codebase that allowed `swift::Module` to be renamed to `swift::ModuleDecl` without requiring every single callsite to be modified.

Completely stop using `swift::Module`, in order to then remove the typedef in the Swift codebase.