### PR TITLE
Print Double.self instead of a double instance

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/TestSwiftMetadataSymbolsType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/TestSwiftMetadataSymbolsType.py
@@ -25,9 +25,6 @@ class TestSwiftMetadataSymbol(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="rdar://problem/30269976")
     def test_swift_metadata_symbol(self):
         """Test that metadata symbols are properly resolved as such"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
@@ -10,12 +10,13 @@
 //
 // -----------------------------------------------------------------------------
 
-func generic_print<T>(_: T) {
-  print("hello world \(T.self)") // Set breakpoint here
+func generic_print<T>(t: T) {
+  print("hello world \(t)") // Set breakpoint here
 }
 
 func main() {
-  generic_print(t)
+  let d = Double(3.1415)
+  generic_print(t:d)
 }
 
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
@@ -10,8 +10,7 @@
 //
 // -----------------------------------------------------------------------------
 func main() {
-  var d: Double = 3.1415
-	print("hello world \(d)") // Set breakpoint here
+  print("hello world \(Double.self)") // Set breakpoint here
 }
 
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
@@ -9,8 +9,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-func main() {
+
+func generic_print<T>(T t) {
   print("hello world \(Double.self)") // Set breakpoint here
+}
+
+func main() {
+  generic_print(t)
 }
 
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/tmd_symbol/main.swift
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-func generic_print<T>(T t) {
-  print("hello world \(Double.self)") // Set breakpoint here
+func generic_print<T>(_: T) {
+  print("hello world \(T.self)") // Set breakpoint here
 }
 
 func main() {


### PR DESCRIPTION
This fixes test/testcases/lang/swift/tmd_symbol by forcing the metadata for Double to be generated in a more reliable way.