### PR TITLE
Updated TestExec and TestObjCiVarIMP to use lldbutil.execute_command

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/exec/TestExec.py
+++ b/packages/Python/lldbsuite/test/functionalities/exec/TestExec.py
@@ -12,16 +12,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-
-def execute_command(command):
-    #print('%% %s' % (command))
-    (exit_status, output) = seven.get_command_status_output(command)
-    # if output:
-    #    print(output)
-    #print('status = %u' % (exit_status))
-    return exit_status
-
-
 class ExecTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
@@ -33,15 +23,15 @@ class ExecTestCase(TestBase):
         if self.getArchitecture() == 'x86_64':
             source = os.path.join(os.getcwd(), "main.cpp")
             o_file = os.path.join(os.getcwd(), "main.o")
-            execute_command(
+            lldbutil.execute_command(
                 "'%s' -g -O0 -arch i386 -arch x86_64 '%s' -c -o '%s'" %
                 (os.environ["CC"], source, o_file))
-            execute_command(
+            lldbutil.execute_command(
                 "'%s' -g -O0 -arch i386 -arch x86_64 '%s'" %
                 (os.environ["CC"], o_file))
             if self.debug_info != "dsym":
                 dsym_path = os.path.join(os.getcwd(), "a.out.dSYM")
-                execute_command("rm -rf '%s'" % (dsym_path))
+                lldbutil.execute_command("rm -rf '%s'" % (dsym_path))
         else:
             self.build()
 

--- a/packages/Python/lldbsuite/test/lang/objc/ivar-IMP/TestObjCiVarIMP.py
+++ b/packages/Python/lldbsuite/test/lang/objc/ivar-IMP/TestObjCiVarIMP.py
@@ -15,16 +15,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-
-def execute_command(command):
-    # print('%% %s' % (command))
-    (exit_status, output) = seven.get_command_status_output(command)
-    # if output:
-    #     print(output)
-    # print('status = %u' % (exit_status))
-    return exit_status
-
-
 class ObjCiVarIMPTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
@@ -34,10 +24,10 @@ class ObjCiVarIMPTestCase(TestBase):
     @expectedFailureDarwin("rdar://23590082")
     def test_imp_ivar_type(self):
         """Test that dynamically discovered ivars of type IMP do not crash LLDB"""
-        execute_command("make repro")
+        lldbutil.execute_command("make repro")
 
         def cleanup():
-            execute_command("make cleanup")
+            lldbutil.execute_command("make cleanup")
         self.addTearDownHook(cleanup)
 
         exe = os.path.join(os.getcwd(), "a.out")


### PR DESCRIPTION
This is a follow-up to @jimingham's request in https://github.com/apple/swift-lldb/pull/130