### PR TITLE
Handle swift "indirect enums" correctly.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -32,8 +32,6 @@ class TestIndirectEnumVariables(TestBase):
         self.do_test("indirect case break here")
 
     @decorators.skipIf(bugnumber='rdar://27568868', oslist=['linux'])
-    @decorators.expectedFailureAll(
-        bugnumber="rdar://29953436")
     def test_indirect_enum_variables(self):
         """Tests that indirect Enum variables display correctly when enum is indirect"""
         self.build()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -885,7 +885,8 @@ public:
                    .getPointer());
       case_type = GetFunctionArgumentTuple(case_type.GetFunctionReturnType());
 
-      const bool is_indirect = case_decl->isIndirect();
+      const bool is_indirect = case_decl->isIndirect() 
+          || case_decl->getParentEnum()->isIndirect();
 
       if (log)
         log->Printf("case_name = %s, type = %s, is_indirect = %s",


### PR DESCRIPTION
A swift "indirect enum" is equivalent to an enum where all the payload
elements are indirect.  But swift::EnumElementDecl::isIndirect returns
false in this case and you have to check that the parent is indirect
as well to get the right answer.

<rdar://problem/29953436>