### PR TITLE
Disable SwiftReturns test case

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
+++ b/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
@@ -25,6 +25,7 @@ class TestSwiftReturns(TestBase):
 
     @decorators.swiftTest
     @decorators.skipIfLinux  # bugs.swift.org/SR-841
+    @decorators.skipIfDarwin # rdar://29481771
     def test_swift_returns(self):
         """Test getting return values"""
         self.build()


### PR DESCRIPTION
With the new calling convention lldb needs to adapt to reading swift error
 
Needed after PR#7237.

rdar://29481771