### PR TITLE
Weak link libswiftCore.dylib from repl_swift (#136)

### DIFF
--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -9278,12 +9278,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -11166,12 +11162,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -11210,12 +11202,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -11249,12 +11237,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -11289,13 +11273,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "-DXCODE_BUILD_ME";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -12545,12 +12525,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -13483,12 +13459,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -14067,12 +14039,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "${REPL_SWIFT_RPATH}";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-Wparentheses";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"${REPL_SWIFT_LINKER_FLAGS}",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_LINKER_FLAGS = "-L${BUILT_PRODUCTS_DIR}/LLDB.framework/Resources/Swift/macosx -L${TOOLCHAIN_DIR}/usr/lib/swift/macosx/  -lswiftCore";
 				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/tools/repl/swift/main.c
+++ b/tools/repl/swift/main.c
@@ -14,12 +14,9 @@
 #include <mach/mach_time.h>
 #endif
 
-// forces loading of libswiftCore
-extern int swift_retain;
-
-int __attribute__ ((used)) _repl_swift_caller() {
-  return swift_retain;
-}
+#ifdef __APPLE__
+#include <dlfcn.h>
+#endif
 
 #define REPL_MAIN _TF10repl_swift9repl_mainFT_Si
 
@@ -28,8 +25,10 @@ int REPL_MAIN() {
 }
 
 int main() {
-  volatile int _repl_swift_result = _repl_swift_caller();
-  (void)_repl_swift_result;
+#ifdef __APPLE__
+  // Force loading of libswiftCore.dylib, which is not linked at build time.
+  dlopen("@rpath/libswiftCore.dylib", RTLD_LAZY);
+#endif
   
 #ifdef __APPLE__
   // This code will be run when running the REPL. A breakpoint will be set at


### PR DESCRIPTION
* Weak link libswiftCore.dylib from repl_swift to sever a build dependency on OS X.
* In repl_swift.c, open libswiftCore lazily, and only look in the rpath.

(cherry picked from commit e587c38476dc053bb31d5ffa33d8848a5305d09a)