### PR TITLE
[swift-3.1-branch] Mark ASan and TSan Swift tests as "skipUnlessSwift...Sanitizer"

### DIFF
--- a/packages/Python/lldbsuite/test/decorators.py
+++ b/packages/Python/lldbsuite/test/decorators.py
@@ -24,6 +24,7 @@ from lldbsuite.test_event.event_builder import EventBuilder
 from lldbsuite.support import funcutils
 from lldbsuite.test import lldbplatform
 from lldbsuite.test import lldbplatformutil
+import swift
 
 
 class DecorateMode:
@@ -706,3 +707,35 @@ def skipUnlessAddressSanitizer(func):
             return "Compiler cannot compile with -fsanitize=address"
         return None
     return skipTestIfFn(is_compiler_with_address_sanitizer)(func)
+
+
+def skipUnlessSwiftAddressSanitizer(func):
+    """Decorate the item to skip test unless Swift -sanitize=address is supported."""
+
+    def is_swift_compiler_with_address_sanitizer(self):
+        swiftcc = swift.getSwiftCompiler()
+        f = tempfile.NamedTemporaryFile()
+        cmd = "echo 'print(1)' | %s -o %s -" % (swiftcc, f.name)
+        if os.popen(cmd).close() is not None:
+            return None  # The compiler cannot compile at all, let's *not* skip the test
+        cmd = "echo 'print(1)' | %s -sanitize=address -o %s -" % (swiftcc, f.name)
+        if os.popen(cmd).close() is not None:
+            return "Compiler cannot compile with -sanitize=address"
+        return None
+    return skipTestIfFn(is_swift_compiler_with_address_sanitizer)(func)
+
+
+def skipUnlessSwiftThreadSanitizer(func):
+    """Decorate the item to skip test unless Swift -sanitize=thread is supported."""
+
+    def is_swift_compiler_with_thread_sanitizer(self):
+        swiftcc = swift.getSwiftCompiler()
+        f = tempfile.NamedTemporaryFile()
+        cmd = "echo 'print(1)' | %s -o %s -" % (swiftcc, f.name)
+        if os.popen(cmd).close() is not None:
+            return None  # The compiler cannot compile at all, let's *not* skip the test
+        cmd = "echo 'print(1)' | %s -sanitize=thread -o %s -" % (swiftcc, f.name)
+        if os.popen(cmd).close() is not None:
+            return "Compiler cannot compile with -sanitize=thread"
+        return None
+    return skipTestIfFn(is_swift_compiler_with_thread_sanitizer)(func)

--- a/packages/Python/lldbsuite/test/functionalities/asan/swift/TestAsanSwift.py
+++ b/packages/Python/lldbsuite/test/functionalities/asan/swift/TestAsanSwift.py
@@ -27,7 +27,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
 
     @decorators.swiftTest
     @decorators.skipIfLinux
-    @decorators.skipUnlessThreadSanitizer
+    @decorators.skipUnlessSwiftAddressSanitizer
     def test_asan_swift(self):
         self.build()
         self.do_test()
@@ -72,9 +72,9 @@ class AsanSwiftTestCase(lldbtest.TestBase):
         # ASan will break when a report occurs and we'll try the API then
         self.runCmd("continue")
 
-        # the stop reason of the thread should be a TSan report.
-        self.expect("thread list", "Heap buffer overflow detected", substrs=[
-                    'stopped', 'stop reason = Heap buffer overflow detected'])
+        # the stop reason of the thread should be a ASan report.
+        self.expect("thread list", "Heap buffer overflow", substrs=[
+                    'stopped', 'stop reason = Heap buffer overflow'])
 
         process = self.dbg.GetSelectedTarget().process
         thread = process.GetSelectedThread()

--- a/packages/Python/lldbsuite/test/functionalities/tsan/swift/TestTsanSwift.py
+++ b/packages/Python/lldbsuite/test/functionalities/tsan/swift/TestTsanSwift.py
@@ -27,7 +27,7 @@ class TsanSwiftTestCase(lldbtest.TestBase):
 
     @decorators.swiftTest
     @decorators.skipIfLinux
-    @decorators.skipUnlessThreadSanitizer
+    @decorators.skipUnlessSwiftThreadSanitizer
     def test_tsan_swift(self):
         self.build()
         self.do_test()


### PR DESCRIPTION
This will detect whether the Swift compiler can successfully build with -fsanitize=address/-fsanitize=thread and skip the tests if not.  This should fix the tests when Swift is checked out without the compiler-rt repo.