### PR TITLE
Update call to TypeAliasDecl constructor, added EqualLoc

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1526,7 +1526,7 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
 
   llvm::MutableArrayRef<swift::TypeLoc> inherited;
   swift::TypeAliasDecl *type_alias_decl = new (ast_context)
-      swift::TypeAliasDecl(source_loc, name, source_loc,
+      swift::TypeAliasDecl(source_loc, swift::SourceLoc(), name, source_loc,
                            nullptr, &m_source_file);
   type_alias_decl->setUnderlyingType(GetSwiftType(type));
 


### PR DESCRIPTION
This is an implicit typealias declaration, so doesn't have an
equal '=' token swift::SourceLoc.

This commit requires https://github.com/apple/swift/pull/7393
to be merged in apple/swift.