### PR TITLE
Add cmake option to choose whether to use the builtin demangler

### DIFF
--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -13,13 +13,6 @@
 #include "lldb/Host/windows/windows.h"
 #include <dbghelp.h>
 #pragma comment(lib, "dbghelp.lib")
-#define LLDB_USE_BUILTIN_DEMANGLER
-#elif defined(__FreeBSD__)
-#define LLDB_USE_BUILTIN_DEMANGLER
-#elif defined(__GLIBCXX__)
-#define LLDB_USE_BUILTIN_DEMANGLER
-#else
-#include <cxxabi.h>
 #endif
 
 #ifdef LLDB_USE_BUILTIN_DEMANGLER


### PR DESCRIPTION
Extracted from #125 - required to fix the Windows build

Summary:
Previously the builting demangler was on for platforms that explicitly set a flag by modifying
Mangled.cpp (windows, freebsd). The Xcode build always used builtin demangler by passing a
compiler flag. This adds a cmake flag (defaulting to ON) to configure the demangling library used
at build time. The flag is only available on non-windows platforms as there the system demangler
is not present (in the form we're trying to use it, at least).
The impact of this change is:
- linux: switches to the builtin demangler
- freebsd, windows: NFC (I hope)
- netbsd: switches to the builtin demangler
- osx cmake build: switches to the builtin demangler (matching the XCode build)

The main motivation for this is the cross-platform case, where it should bring more consistency
by removing the dependency on the host demangler (which can be completely unrelated to the debug
target).

Reviewers: zturner, emaste, krytarowski

Subscribers: emaste, clayborg, lldb-commits

Differential Revision: https://reviews.llvm.org/D23830

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@279808 91177308-0d34-0410-b5e6-96231b3b80d8