### PR TITLE
Include header instead of cpp in SwiftLanguage.cpp

### DIFF
--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -28,7 +28,7 @@
 
 #include "lldb/Target/SwiftLanguageRuntime.h"
 
-#include "ObjCRuntimeSyntheticProvider.cpp"
+#include "ObjCRuntimeSyntheticProvider.h"
 #include "SwiftFormatters.h"
 
 #include <functional>


### PR DESCRIPTION
This caused linker errors on Windows