### PR TITLE
Align use of LLVM_PRETTY_FUNCTION with upstream llvm

### DIFF
--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1809,11 +1809,7 @@ lldb::addr_t AppleObjCRuntimeV2::GetSharedCacheReadOnlyAddress() {
 void AppleObjCRuntimeV2::UpdateISAToDescriptorMapIfNeeded() {
   Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_PROCESS | LIBLLDB_LOG_TYPES));
 
-#if !defined(_MSC_VER)
-  Timer scoped_timer(__PRETTY_FUNCTION__, __PRETTY_FUNCTION__);
-#else
-  Timer scoped_timer(__FUNCSIG__, __FUNCSIG__);
-#endif
+  Timer scoped_timer(LLVM_PRETTY_FUNCTION, LLVM_PRETTY_FUNCTION);
 
   // Else we need to check with our process to see when the map was updated.
   Process *process = GetProcess();


### PR DESCRIPTION
This prevents merge issues when pulling from upstream llvm