### PR TITLE
Cherry pick - LLDB version test fix

### DIFF
--- a/packages/Python/lldbsuite/test/help/TestHelp.py
+++ b/packages/Python/lldbsuite/test/help/TestHelp.py
@@ -91,7 +91,7 @@ class HelpCommandTestCase(TestBase):
         import re
         version_str = self.version_number_string()
         match = re.match('[0-9]+', version_str)
-        search_regexp = ['lldb( version|-' + (version_str if match else '[0-9]+') + ').*\n']
+        search_regexp = ['lldb( version|-' + (version_str if match else '[0-9]+') + '| \(swift-.*\)).*\n']
         search_regexp[0] += '  Swift-\d+\.\d+'
 
         self.expect("version",


### PR DESCRIPTION
This is to support the LLDB release version string print format.