### PR TITLE
Add @discardableResult annotation to repl_main()

### DIFF
--- a/tools/repl/swift/main.swift
+++ b/tools/repl/swift/main.swift
@@ -17,6 +17,7 @@
 import Darwin
 #endif
 
+@discardableResult
 func repl_main() -> Int
 {
     return 0


### PR DESCRIPTION
This fixes a compilation warning:

```
lldb/tools/repl/swift/main.swift:57:1: warning: result of call to 'repl_main()' is unused
repl_main()
^        ~~
```

I hope `swift-4.0-branch` is the right home for this.