### PR TITLE
[swift-4.0-branch] ThreadSanitizer plugin: Support Swift access races and fix how external races are displayed.

### DIFF
--- a/source/Plugins/InstrumentationRuntime/ThreadSanitizer/ThreadSanitizerRuntime.h
+++ b/source/Plugins/InstrumentationRuntime/ThreadSanitizer/ThreadSanitizerRuntime.h
@@ -77,7 +77,8 @@ private:
                                      std::string &global_name,
                                      std::string &filename, uint32_t &line);
 
-  lldb::addr_t GetFirstNonInternalFramePc(StructuredData::ObjectSP trace);
+  lldb::addr_t GetFirstNonInternalFramePc(StructuredData::ObjectSP trace,
+                                          bool skip_one_frame = false);
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
ThreadSanitizer plugin: Support Swift access races and fix how external races are displayed.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@300416 91177308-0d34-0410-b5e6-96231b3b80d8