### PR TITLE
[Swift] Use llvm casts instead of looking at {Decl,TypeBase}::getKind()

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -432,8 +432,8 @@ CachedMemberInfo *SwiftASTContext::GetCachedMemberInfo(void *type) {
           }
 
           for (auto decl : nominal_decl->getMembers()) {
-            if (decl->getKind() == swift::DeclKind::Var) {
-              swift::VarDecl *var_decl = swift::cast<swift::VarDecl>(decl);
+            if (swift::isa<swift::VarDecl>(decl)) {
+              swift::VarDecl *var_decl = llvm::cast<swift::VarDecl>(decl);
               if (var_decl->hasStorage() && !var_decl->isStatic()) {
                 MemberInfo member_info(MemberType::Field);
                 member_info.clang_type = CompilerType(
@@ -493,8 +493,8 @@ CachedMemberInfo *SwiftASTContext::GetCachedMemberInfo(void *type) {
 
           for (auto decl : t_decl->getMembers()) {
             // Find ivars that aren't properties
-            if (decl->getKind() == swift::DeclKind::Var) {
-              swift::VarDecl *var_decl = swift::cast<swift::VarDecl>(decl);
+            if (swift::isa<swift::VarDecl>(decl)) {
+              swift::VarDecl *var_decl = llvm::cast<swift::VarDecl>(decl);
               if (var_decl->hasStorage() && !var_decl->isStatic()) {
                 MemberInfo member_info(MemberType::Field);
                 swift::Type member_type = swift_can_type->getTypeOfMember(
@@ -4051,13 +4051,7 @@ ConstString SwiftASTContext::GetMangledTypeName(swift::TypeBase *type_base) {
 
   swift::Type swift_type(type_base);
 
-  bool has_archetypes = false;
-
-  swift_type.visit([&has_archetypes](swift::Type part_type) -> void {
-    if (part_type->getKind() == swift::TypeKind::Archetype) {
-      has_archetypes = true;
-    }
-  });
+  bool has_archetypes = swift_type->hasArchetype();
 
   if (!has_archetypes) {
     swift::Mangle::ASTMangler mangler(true);


### PR DESCRIPTION
For some reason this patch was in upstream-with-swift but not in the stable branch. Cherry-pick it over.