### PR TITLE
    xfail the test TestSwiftPartiallyGenericFuncContinuation.py.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
+++ b/packages/Python/lldbsuite/test/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.lldbtest as lldbtest
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[decorators.expectedFailureAll(bugnumber="rdar://31975108")])


### PR DESCRIPTION
    This isn't actually a failure in this test, but rather the debug info has
    changed so that each of the lines in the example have two regions, one of
    which has locals, and one of which has no locals.  The inline tests aren't
    flexible enough for me to work around this in the test.

    <rdar://problem/31975108>