### PR TITLE
Adjust to return type change of getBaseName in main swift repo

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -509,7 +509,7 @@ void SwiftASTManipulator::FindSpecialNames(
     virtual std::pair<bool, swift::Expr *> walkToExprPre(swift::Expr *expr) {
       if (swift::UnresolvedDeclRefExpr *decl_ref_expr =
               llvm::dyn_cast<swift::UnresolvedDeclRefExpr>(expr)) {
-        swift::Identifier name = decl_ref_expr->getName().getBaseName();
+        swift::Identifier name = decl_ref_expr->getName().getBaseIdentifier();
 
         if (m_prefix.empty() || name.str().startswith(m_prefix))
           m_names.push_back(name);


### PR DESCRIPTION
In the main swift repo, the return type of getBaseName has
changed to `DeclBaseName` so we need to call getBaseIdentifier
now to get a declaration's `Identifier`

This goes hand-in-hand with apple/swift#9321