### PR TITLE
xfail TestSwiftBridgedArray.py

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
@@ -26,6 +26,7 @@ class TestSwiftBridgedArray(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
+    @decorators.expectedFailureAll(bugnumber="<rdar://problem/32024572>")
     def test_swift_bridged_array(self):
         """Check formatting for Swift.Array<T> that are bridged from ObjC"""
         self.build()


### PR DESCRIPTION
Something changed in the way Swift Numeric types are stored in
bridged NS Arrays.

<rdar://problem/32024572> LLDB test_swift_bridged_array failing

This just xfails the test to get the bots green.