### PR TITLE
Swift 4.0 branch with exclusivity suppression

### DIFF
--- a/include/lldb/Expression/Expression.h
+++ b/include/lldb/Expression/Expression.h
@@ -110,6 +110,16 @@ public:
   //------------------------------------------------------------------
   lldb::addr_t StartAddress() { return m_jit_start_addr; }
 
+  //------------------------------------------------------------------
+  /// Called to notify the expression that it is about to be executed.
+  //------------------------------------------------------------------
+  virtual void WillStartExecuting() {}
+
+  //------------------------------------------------------------------
+  /// Called to notify the expression that its execution has finished.
+  //------------------------------------------------------------------
+  virtual void DidFinishExecuting() {}
+
   struct SwiftGenericInfo {
     struct Binding {
       const char *name;

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -386,6 +386,9 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
+  void WillStartExecutingUserExpression();
+  void DidFinishExecutingUserExpression();
+
 protected:
   //------------------------------------------------------------------
   // Classes that inherit from SwiftLanguageRuntime can see and modify these
@@ -444,6 +447,7 @@ protected:
   AppleObjCRuntimeV2 *GetObjCRuntime();
 
   void SetupSwiftError();
+  void SetupExclusivity();
 
   const CompilerType &GetBoxMetadataType();
 
@@ -484,6 +488,12 @@ protected:
       m_bridged_synthetics_map;
 
   CompilerType m_box_metadata_type;
+
+  std::mutex m_active_user_expr_mutex;
+  uint32_t m_active_user_expr_count = 0;
+  llvm::Optional<lldb::addr_t> m_dynamic_exclusivity_flag_addr =
+    llvm::Optional<lldb::addr_t>();
+  bool m_original_dynamic_exclusivity_flag_state = false;
 
 private:
   DISALLOW_COPY_AND_ASSIGN(SwiftLanguageRuntime);

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -489,6 +489,12 @@ protected:
 
   CompilerType m_box_metadata_type;
 
+
+  // These members are used to track and toggle the state of the "dynamic
+  // exclusivity enforcement flag" in the swift runtime. This flag is set to
+  // true when an LLDB expression starts running, and reset to its original
+  // state after that expression (and any other concurrently running
+  // expressions) terminates.
   std::mutex m_active_user_expr_mutex;
   uint32_t m_active_user_expr_count = 0;
   llvm::Optional<lldb::addr_t> m_dynamic_exclusivity_flag_addr =

--- a/include/lldb/Target/ThreadPlanCallFunction.h
+++ b/include/lldb/Target/ThreadPlanCallFunction.h
@@ -122,7 +122,7 @@ protected:
                         lldb::addr_t &start_load_addr,
                         lldb::addr_t &function_load_addr);
 
-  void DoTakedown(bool success);
+  virtual void DoTakedown(bool success);
 
   void SetBreakpoints();
 

--- a/include/lldb/Target/ThreadPlanCallUserExpression.h
+++ b/include/lldb/Target/ThreadPlanCallUserExpression.h
@@ -35,6 +35,8 @@ public:
 
   void GetDescription(Stream *s, lldb::DescriptionLevel level) override;
 
+  void DidPush() override;
+
   void WillPop() override;
 
   lldb::StopInfoSP GetRealStopInfo() override;
@@ -48,6 +50,7 @@ public:
   }
 
 protected:
+  void DoTakedown(bool success) override;
 private:
   lldb::UserExpressionSP
       m_user_expression_sp; // This is currently just used to ensure the

--- a/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/Makefile
@@ -1,0 +1,11 @@
+LEVEL = ../../../../make
+
+include $(LEVEL)/Makefile.rules
+
+everything: main
+
+main: main.swift
+	$(SWIFTCC) -g -Onone -enforce-exclusivity=checked -o main main.swift
+
+cleanup:
+	rm -rf main *.dSYM lib*.dylib *~

--- a/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -90,7 +90,6 @@ class TestExclusivitySuppression(TestBase):
 
         self.assertTrue(len(threads) == 1)
         thread = threads[0]
-        self.assertTrue(frame, "Frame 0 is valid.")
 
         opts = lldb.SBExpressionOptions()
         opts.SetIgnoreBreakpoints(False)

--- a/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -1,0 +1,145 @@
+# TestExclusivitySuppression.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test suppression of dynamic exclusivity enforcement
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+def execute_command(command):
+    (exit_status, output) = commands.getstatusoutput(command)
+    return exit_status
+
+class TestExclusivitySuppression(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
+    # a failure due to exclusivity
+    @decorators.swiftTest
+    def test_basic_exclusivity_suppression(self):
+        """Test that exclusively owned values can still be accessed"""
+
+        self.buildAll()
+
+        target = self.create_target()
+
+        # Set the breakpoints
+        bp1 = target.BreakpointCreateBySourceRegex('Breakpoint 1',
+                                                   self.main_source_spec)
+        self.assertTrue(bp1.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        # Launch the process, and do not stop at the entry point.
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # Frame #0 should be at our breakpoint.
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, bp1)
+
+        self.assertTrue(len(threads) == 1)
+        thread = threads[0]
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        self.check_expression(frame, "w.s.i", "8", use_summary=False)
+
+    # Test that we properly handle nested expression evaluations by:
+    # (1) Breaking at breakpoint 1
+    # (2) Running 'expr get()' (which will hit breakpoint 2)
+    # (3) Evaluating w.s.i at breakpoint 2 (this is a nested evaluation)
+    # (4) Contininging the evaluation of 'expr get()' to return to bp 1
+    # (5) Evaluating w.s.i again to check that finishing the nested expression
+    #     did not prematurely re-enable exclusivity checks.
+    @decorators.swiftTest
+    def test_exclusivity_suppression_for_concurrent_expressions(self):
+        """Test that exclusively owned values can still be accessed"""
+        self.buildAll()
+
+        target = self.create_target()
+
+        bp1 = target.BreakpointCreateBySourceRegex('Breakpoint 1',
+                                                   self.main_source_spec)
+        self.assertTrue(bp1.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        bp2 = target.BreakpointCreateBySourceRegex('Breakpoint 2',
+                                                   self.main_source_spec)
+        self.assertTrue(bp2.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        # Launch the process, and do not stop at the entry point.
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # Frame #0 should be at our breakpoint.
+        threads = lldbutil.get_threads_stopped_at_breakpoint(process, bp1)
+
+        self.assertTrue(len(threads) == 1)
+        thread = threads[0]
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        self.check_expression(frame, "w.s.i", "8", use_summary=False)
+
+
+    @decorators.swiftTest
+    def test_exclusivity_suppression_on_expression_bailout(self):
+        """Test that exclusively owned values can still be accessed"""
+        self.buildAll()
+
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    def buildAll(self):
+        execute_command("make everything")
+        def cleanup():
+            execute_command("make cleanup")
+
+        self.addTearDownHook(cleanup)
+
+    def check_expression(self, frame, expression, expected_result, use_summary=True):
+        value = frame.EvaluateExpression(expression)
+        self.assertTrue(value.IsValid(), expression + "returned a valid value")
+        if self.TraceOn():
+            print value.GetSummary()
+            print value.GetValue()
+        if use_summary:
+            answer = value.GetSummary()
+        else:
+            answer = value.GetValue()
+        report_str = "%s expected: %s got: %s" % (
+            expression, expected_result, answer)
+        self.assertTrue(answer == expected_result, report_str)
+
+    def create_target(self):
+        exe_name = "main"
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        return target
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/main.swift
@@ -1,0 +1,38 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+struct S {
+  var i = 7
+
+  func get() -> Int {
+    // Breakpoint 2
+    return i
+  }
+
+  // Mutating function inc will acquire write access to i.
+  mutating func inc() {
+    i += 1
+
+    // Breakpoint 1
+  }
+}
+
+// We wrap our test class C so that we're reading a member variable, not a
+// global. LLDB accesses globals via unsafe pointers, which aren't subject to
+// dynamic exclusivity checks, and we need to actually hit these checks to
+// verify that enforcement is suppressed.
+class Wrapper {
+  var s = S()
+}
+
+let w = Wrapper()
+w.s.inc()

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -55,6 +55,20 @@ SwiftUserExpression::SwiftUserExpression(
 
 SwiftUserExpression::~SwiftUserExpression() {}
 
+void SwiftUserExpression::WillStartExecuting() {
+  // Can we assert that the process weak-ptr is non-null here?
+  // What's the 'retry_if_fail' argument to GetSwiftLanguageRuntime?
+  // Can the runtime ever come back as null?
+  if (auto process = m_jit_process_wp.lock())
+    process->GetSwiftLanguageRuntime()->WillStartExecutingUserExpression();
+}
+
+void SwiftUserExpression::DidFinishExecuting() {
+  // Same questions as above.
+  if (auto process = m_jit_process_wp.lock())
+    process->GetSwiftLanguageRuntime()->DidFinishExecutingUserExpression();
+}
+
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Error &err) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -59,14 +59,23 @@ void SwiftUserExpression::WillStartExecuting() {
   // Can we assert that the process weak-ptr is non-null here?
   // What's the 'retry_if_fail' argument to GetSwiftLanguageRuntime?
   // Can the runtime ever come back as null?
-  if (auto process = m_jit_process_wp.lock())
-    process->GetSwiftLanguageRuntime()->WillStartExecutingUserExpression();
+  if (auto process = m_jit_process_wp.lock()) {
+    if (auto *swift_runtime = process->GetSwiftLanguageRuntime())
+      swift_runtime->WillStartExecutingUserExpression();
+    else
+      llvm_unreachable("Can't execute a swift expression without a runtime");
+  } else
+    llvm_unreachable("Can't execute an expression without a process");
 }
 
 void SwiftUserExpression::DidFinishExecuting() {
-  // Same questions as above.
-  if (auto process = m_jit_process_wp.lock())
-    process->GetSwiftLanguageRuntime()->DidFinishExecutingUserExpression();
+  if (auto process = m_jit_process_wp.lock()) {
+    if (auto swift_runtime = process->GetSwiftLanguageRuntime())
+      swift_runtime->DidFinishExecutingUserExpression();
+    else
+      llvm_unreachable("Can't execute a swift expression without a runtime");
+  } else
+    llvm_unreachable("Can't execute an expression without a process");
 }
 
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Error &err) {

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -56,9 +56,6 @@ SwiftUserExpression::SwiftUserExpression(
 SwiftUserExpression::~SwiftUserExpression() {}
 
 void SwiftUserExpression::WillStartExecuting() {
-  // Can we assert that the process weak-ptr is non-null here?
-  // What's the 'retry_if_fail' argument to GetSwiftLanguageRuntime?
-  // Can the runtime ever come back as null?
   if (auto process = m_jit_process_wp.lock()) {
     if (auto *swift_runtime = process->GetSwiftLanguageRuntime())
       swift_runtime->WillStartExecutingUserExpression();
@@ -74,8 +71,7 @@ void SwiftUserExpression::DidFinishExecuting() {
       swift_runtime->DidFinishExecutingUserExpression();
     else
       llvm_unreachable("Can't execute a swift expression without a runtime");
-  } else
-    llvm_unreachable("Can't execute an expression without a process");
+  }
 }
 
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Error &err) {

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -136,6 +136,9 @@ public:
   lldb::ExpressionVariableSP
   GetResultAfterDematerialization(ExecutionContextScope *exe_scope) override;
 
+  void WillStartExecuting() override;
+  void DidFinishExecuting() override;
+
 private:
   //------------------------------------------------------------------
   /// Populate m_in_cplusplus_method and m_in_objectivec_method based on the

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -86,6 +86,7 @@ SwiftLanguageRuntime::SwiftLanguageRuntime(Process *process)
       m_SwiftNativeNSErrorISA(), m_memory_reader_sp(), m_promises_map(),
       m_resolvers_map(), m_bridged_synthetics_map(), m_box_metadata_type() {
   SetupSwiftError();
+  SetupExclusivity();
 }
 
 static llvm::Optional<lldb::addr_t>
@@ -131,6 +132,23 @@ void SwiftLanguageRuntime::SetupSwiftError() {
   m_SwiftNativeNSErrorISA = FindSymbolForSwiftObject(
       target, g_SwiftNativeNSError, eSymbolTypeObjCClass);
 }
+
+void SwiftLanguageRuntime::SetupExclusivity() {
+  Target &target(m_process->GetTarget());
+
+  ConstString g_disableExclusivityChecking("_swift_disableExclusivityChecking");
+
+  m_dynamic_exclusivity_flag_addr = FindSymbolForSwiftObject(
+      target, g_disableExclusivityChecking, eSymbolTypeData);
+
+  Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+
+  if (log)
+    log->Printf("SwiftLanguageRuntime: _swift_disableExclusivityChecking = %p",
+                m_dynamic_exclusivity_flag_addr ?
+                *m_dynamic_exclusivity_flag_addr : 0);
+}
+
 
 void SwiftLanguageRuntime::ModulesDidLoad(const ModuleList &module_list) {}
 
@@ -3870,6 +3888,83 @@ SwiftLanguageRuntime::GetBridgedSyntheticChildProvider(ValueObject &valobj) {
   }
 
   return nullptr;
+}
+
+void SwiftLanguageRuntime::WillStartExecutingUserExpression() {
+  std::lock_guard<std::mutex> lock(m_active_user_expr_mutex);
+  Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+
+  if (m_active_user_expr_count == 0 &&
+      m_dynamic_exclusivity_flag_addr) {
+    // We're executing the first user expression. Toggle the flag.
+    Error error;
+    size_t bytes_read =
+      m_process->DoReadMemory(*m_dynamic_exclusivity_flag_addr,
+                              &m_original_dynamic_exclusivity_flag_state,
+                              sizeof(m_original_dynamic_exclusivity_flag_state),
+                              error);
+
+    if (bytes_read != sizeof(m_original_dynamic_exclusivity_flag_state)) {
+      if (log)
+        log->Printf("SwiftLanguageRuntime: Unable to read "
+                    "disableExclusivityChecking flag state");
+    } else {
+      bool new_flag_state = true;
+      size_t bytes_written =
+        m_process->DoWriteMemory(
+                              *m_dynamic_exclusivity_flag_addr,
+                              &new_flag_state,
+                              sizeof(m_original_dynamic_exclusivity_flag_state),
+                              error);
+      if (bytes_written != sizeof(m_original_dynamic_exclusivity_flag_state)) {
+        if (log)
+          log->Printf("SwiftLanguageRuntime: Unable to set "
+                      "disableExclusivityChecking flag state");
+      } else {
+        if (log)
+          log->Printf("SwiftLanguageRuntime: Changed "
+                      "disableExclusivityChecking flag state from %u to %u",
+                      m_original_dynamic_exclusivity_flag_state,
+                      new_flag_state);
+      }
+    }
+  }
+  ++m_active_user_expr_count;
+
+  if (log)
+    log->Printf("SwiftLanguageRuntime: starting user expression. "
+                "Number active: %u", m_active_user_expr_count);
+}
+
+void SwiftLanguageRuntime::DidFinishExecutingUserExpression() {
+  std::lock_guard<std::mutex> lock(m_active_user_expr_mutex);
+  Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+
+  --m_active_user_expr_count;
+  if (log)
+    log->Printf("SwiftLanguageRuntime: finished user expression. "
+                "Number active: %u", m_active_user_expr_count);
+
+  if (m_active_user_expr_count == 0 &&
+      m_dynamic_exclusivity_flag_addr) {
+    Error error;
+    size_t bytes_written =
+      m_process->DoWriteMemory(
+                              *m_dynamic_exclusivity_flag_addr,
+                              &m_original_dynamic_exclusivity_flag_state,
+                              sizeof(m_original_dynamic_exclusivity_flag_state),
+                              error);
+    if (bytes_written != sizeof(m_original_dynamic_exclusivity_flag_state)) {
+      if (log)
+        log->Printf("SwiftLanguageRuntime: Unable to reset "
+                    "disableExclusivityChecking flag state");
+    } else {
+      if (log)
+        log->Printf("SwiftLanguageRuntime: Changed "
+                    "disableExclusivityChecking flag state back to %u",
+                    m_original_dynamic_exclusivity_flag_state);
+    }
+  }
 }
 
 lldb::addr_t SwiftLanguageRuntime::GetErrorReturnLocationForFrame(

--- a/source/Target/ThreadPlanCallUserExpression.cpp
+++ b/source/Target/ThreadPlanCallUserExpression.cpp
@@ -60,6 +60,12 @@ void ThreadPlanCallUserExpression::GetDescription(
     ThreadPlanCallFunction::GetDescription(s, level);
 }
 
+void ThreadPlanCallUserExpression::DidPush() {
+  ThreadPlanCallFunction::DidPush();
+  if (m_user_expression_sp)
+    m_user_expression_sp->WillStartExecuting();
+}
+
 void ThreadPlanCallUserExpression::WillPop() {
   ThreadPlanCallFunction::WillPop();
   if (m_user_expression_sp)
@@ -112,4 +118,9 @@ StopInfoSP ThreadPlanCallUserExpression::GetRealStopInfo() {
   }
 
   return stop_info_sp;
+}
+
+void ThreadPlanCallUserExpression::DoTakedown(bool success) {
+  ThreadPlanCallFunction::DoTakedown(success);
+  m_user_expression_sp->DidFinishExecuting();
 }


### PR DESCRIPTION
Explanation:

These two commits teach LLDB to temporarily suppress enforcement of exclusivity during evaluation of swift expressions. This is necessary to allow debugger expressions to access variables that are exclusively owned in the original program in the context where the expression is to be evaluated.

Scope: Affects evaluation of swift expressions in LLDB. Will disable exclusivity enforcement by the swift runtime while each expression is executed, then re-enable it afterwards. This will suppress exclusivity errors in expressions, but should not affect expression evaluation otherwise.  

Radar (and possibly SR Issue): <rdar://problem/31715465>

Risk: Affects evaluation of swift expressions under LLDB only. Low risk.

Testing: Some testing by hand, plus test cases for:
(1) a single expression accessing an exclusively owned variable, and
(2) two nested expressions accessing an exclusively owned variable
