### PR TITLE
Swift returns

### DIFF
--- a/include/lldb/API/SBFunction.h
+++ b/include/lldb/API/SBFunction.h
@@ -54,6 +54,8 @@ public:
   lldb::LanguageType GetLanguage();
 
   bool GetIsOptimized();
+  
+  bool GetCanThrow();
 
   bool operator==(const lldb::SBFunction &rhs) const;
 

--- a/include/lldb/Symbol/Function.h
+++ b/include/lldb/Symbol/Function.h
@@ -346,10 +346,14 @@ public:
   ///
   /// @param[in] range
   ///     The section offset based address for this function.
+  ///
+  /// @param[in] can_throw
+  ///     Pass in true if this is a function know to throw
   //------------------------------------------------------------------
   Function(CompileUnit *comp_unit, lldb::user_id_t func_uid,
            lldb::user_id_t func_type_uid, const Mangled &mangled,
-           Type *func_type, const AddressRange &range);
+           Type *func_type, const AddressRange &range,
+           bool can_throw = false);
 
   //------------------------------------------------------------------
   /// Construct with a compile unit, function UID, function type UID,
@@ -381,11 +385,14 @@ public:
   ///
   /// @param[in] range
   ///     The section offset based address for this function.
+  ///
+  /// @param[in] can_throw
+  ///     Pass in true if this is a function know to throw
   //------------------------------------------------------------------
   Function(CompileUnit *comp_unit, lldb::user_id_t func_uid,
            lldb::user_id_t func_type_uid, const char *mangled, Type *func_type,
-           const AddressRange &range);
-
+           const AddressRange &range, bool can_throw = false);
+           
   //------------------------------------------------------------------
   /// Destructor.
   //------------------------------------------------------------------
@@ -595,6 +602,8 @@ public:
   ///     'false' otherwise.
   //------------------------------------------------------------------
   bool IsTopLevelFunction();
+  
+  bool CanThrow() const { return m_flags.Test(flagsFunctionCanThrow); }
 
   lldb::DisassemblerSP GetInstructions(const ExecutionContext &exe_ctx,
                                        const char *flavor,
@@ -606,7 +615,9 @@ public:
 protected:
   enum {
     flagsCalculatedPrologueSize =
-        (1 << 0) ///< Have we already tried to calculate the prologue size?
+        (1 << 0), ///< Have we already tried to calculate the prologue size?
+    flagsFunctionCanThrow =
+        (1 << 1) ///< Do we know whether this function throws?
   };
 
   //------------------------------------------------------------------

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -289,11 +289,14 @@ public:
   CalculateErrorValueFromFirstArgument(lldb::StackFrameSP frame_sp,
                                        ConstString name);
 
-  lldb::ValueObjectSP CalculateErrorValueObjectAtAddress(lldb::addr_t addr,
+  lldb::ValueObjectSP CalculateErrorValueObjectFromValue(Value &value,
                                                          ConstString name,
                                                          bool persistent);
 
-  lldb::addr_t GetErrorReturnLocationForFrame(lldb::StackFrameSP frame_sp);
+  llvm::Optional<Value> GetErrorReturnLocationAfterReturn(lldb::StackFrameSP frame_sp);
+  
+  llvm::Optional<Value> GetErrorReturnLocationBeforeReturn(lldb::StackFrameSP frame_sp,
+                                              bool &need_to_check_after_return);
 
   static void RegisterGlobalError(Target &target, ConstString name,
                                   lldb::addr_t addr);

--- a/include/lldb/Target/ThreadPlanStepOut.h
+++ b/include/lldb/Target/ThreadPlanStepOut.h
@@ -67,7 +67,8 @@ private:
   StackID m_immediate_step_from_id;
   lldb::break_id_t m_return_bp_id;
   lldb::addr_t m_return_addr;
-  lldb::addr_t m_swift_error_return_addr;
+  llvm::Optional<Value> m_swift_error_return;
+  bool m_swift_error_check_after_return;
   bool m_stop_others;
   lldb::ThreadPlanSP m_step_out_to_inline_plan_sp; // This plan implements step
                                                    // out to the real function

--- a/packages/Python/lldbsuite/test/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/errors/TestExpressionErrors.py
@@ -24,6 +24,27 @@ class TestExpressionErrors(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
+    def test_CanThrowError(self):
+        """Tests that swift expressions resolve scoped variables correctly"""
+        self.build()
+        exe_name = "a.out"
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.target = target
+        self.assertTrue(target, VALID_TARGET)
+
+        self.checkCanThrow("IThrowObjectOver10", True)
+        self.checkCanThrow("ClassError.SomeMethod", False)
+ 
+    def checkCanThrow(self, name, expected):
+        sc_list = self.target.FindFunctions(name)
+        self.assertEqual(sc_list.GetSize(), 1, "Error looking for %s"%(name))
+        func = sc_list[0].function
+        self.assertTrue(func.IsValid(), "Couldn't find the function for %s"%(name))
+        self.assertEqual(func.GetCanThrow(), expected,  "GetCanThrow was wrong for %s"%name)
+
     @decorators.swiftTest
     def test_swift_expression_errors(self):
         """Tests that swift expressions that throw report the errors correctly"""

--- a/packages/Python/lldbsuite/test/lang/swift/return/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/return/main.swift
@@ -19,6 +19,45 @@ class Foo {
     }
 }
 
+struct SmallStruct
+{
+    var _a : Int
+    var _b : Int
+    var _c : Int
+    var _d : Int
+    init ()
+    {
+      _a = 22
+      _b = 33
+      _c = 44
+      _d = 55
+    }
+}
+
+struct StructOfClasses
+{
+  var _a : Foo
+  var _b : Foo
+  var _c : Foo
+  init()
+  {
+    _a = Foo()
+    _b = Foo()
+    _c = Foo()
+  }
+}
+
+struct BigStruct
+{
+   var _a : SmallStruct
+   var _b : SmallStruct
+   init ()
+   {
+       _a = SmallStruct()
+       _b = SmallStruct()
+   }
+}
+
 enum MyError : Error
 {
     case TrivialError
@@ -41,6 +80,22 @@ func returnDouble() -> Double {
 func returnClass () -> Foo {
     return Foo() // Set breakpoint here
 }
+
+func returnSmallStruct() -> SmallStruct
+{
+    return SmallStruct() // Set breakpoint here
+}
+
+func returnBigStruct() -> BigStruct
+{
+    return BigStruct() // Set another breakpoint here
+}
+
+func returnStructOfClasses() -> StructOfClasses
+{
+    return StructOfClasses() // Set breakpoint here
+}
+
 func returnString() -> String {
     return "Hello World" // Set breakpoint here
 }
@@ -68,6 +123,8 @@ func main() -> Int {
     let u = returnUInt64()
     let i = returnInt()
     let c = returnClass()
+    let ss = returnSmallStruct()
+    let cs = returnStructOfClasses()
     let s = returnString()
     let dict = getDict()
     let opt_str = getOptionalString()
@@ -83,6 +140,8 @@ func main() -> Int {
     {
         print (err)
     }
+
+    let bs = returnBigStruct()
 
     // TODO: remove the line below when it is no longer needed. Currently extra
     // line table entries will be added after "returnDouble()" and will stop the

--- a/scripts/interface/SBFunction.i
+++ b/scripts/interface/SBFunction.i
@@ -101,6 +101,9 @@ public:
     Returns false if unoptimized, or unknown.") GetIsOptimized;
     bool
     GetIsOptimized();
+    
+    bool
+    GetCanThrow();
 
     bool
     GetDescription (lldb::SBStream &description);

--- a/source/API/SBFunction.cpp
+++ b/source/API/SBFunction.cpp
@@ -220,3 +220,10 @@ bool SBFunction::GetIsOptimized() {
   }
   return false;
 }
+
+bool SBFunction::GetCanThrow() {
+  if (m_opaque_ptr) {
+      return m_opaque_ptr->CanThrow();
+  }
+  return false;
+}

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -215,6 +215,25 @@ Function *DWARFASTParserSwift::ParseFunctionFromDWARF(const SymbolContext &sc,
         func_name.SetValue(ConstString(mangled), true);
       else
         func_name.SetValue(ConstString(name), false);
+      
+      // See if this function can throw.  We can't get that from the
+      // mangled name (even though the information is often there)
+      // because Swift reserves the right to omit it from the name
+      // if it doesn't need it.  So instead we look for the
+      // DW_TAG_thrown_error:
+      
+      bool can_throw = false;
+      
+      DWARFDebugInfoEntry *child(die.GetFirstChild().GetDIE());
+      while (child)
+      {
+        if (child->Tag() == DW_TAG_thrown_type)
+        {
+          can_throw = true;
+          break;
+        }
+        child = child->GetSibling();
+      }
 
       FunctionSP func_sp;
       std::unique_ptr<Declaration> decl_ap;
@@ -227,7 +246,7 @@ Function *DWARFASTParserSwift::ParseFunctionFromDWARF(const SymbolContext &sc,
         const user_id_t func_user_id = die.GetID();
         func_sp.reset(new Function(sc.comp_unit, func_user_id, func_user_id,
                                    func_name, nullptr,
-                                   func_range)); // first address range
+                                   func_range, can_throw)); // first address range
 
         if (func_sp.get() != NULL) {
           if (frame_base.IsValid())

--- a/source/Symbol/Function.cpp
+++ b/source/Symbol/Function.cpp
@@ -134,22 +134,29 @@ size_t InlineFunctionInfo::MemorySize() const {
 //----------------------------------------------------------------------
 Function::Function(CompileUnit *comp_unit, lldb::user_id_t func_uid,
                    lldb::user_id_t type_uid, const Mangled &mangled, Type *type,
-                   const AddressRange &range)
+                   const AddressRange &range, bool canThrow)
     : UserID(func_uid), m_comp_unit(comp_unit), m_type_uid(type_uid),
       m_type(type), m_mangled(mangled), m_block(func_uid), m_range(range),
       m_frame_base(nullptr), m_flags(), m_prologue_byte_size(0) {
   m_block.SetParentScope(this);
+  if (canThrow)
+    m_flags.Set(flagsFunctionCanThrow);
+    
   assert(comp_unit != nullptr);
 }
 
 Function::Function(CompileUnit *comp_unit, lldb::user_id_t func_uid,
                    lldb::user_id_t type_uid, const char *mangled, Type *type,
-                   const AddressRange &range)
+                   const AddressRange &range, bool canThrow)
     : UserID(func_uid), m_comp_unit(comp_unit), m_type_uid(type_uid),
       m_type(type), m_mangled(ConstString(mangled), true), m_block(func_uid),
       m_range(range), m_frame_base(nullptr), m_flags(),
       m_prologue_byte_size(0) {
   m_block.SetParentScope(this);
+
+  if (canThrow)
+    m_flags.Set(flagsFunctionCanThrow);
+
   assert(comp_unit != nullptr);
 }
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -4030,11 +4030,7 @@ llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
     return error_val;
   }
   
-  DataExtractor reg_data;
-  if (!reg_value.GetData(reg_data))
-    return error_val;
-    
-  lldb::addr_t error_addr = reg_data.GetPointer(0);
+  lldb::addr_t error_addr = reg_value.GetAsUInt64();
   if (error_addr == 0)
     return error_val;
 

--- a/source/Target/ThreadPlanStepOut.cpp
+++ b/source/Target/ThreadPlanStepOut.cpp
@@ -302,8 +302,8 @@ bool ThreadPlanStepOut::DoPlanExplainsStop(Event *event_ptr) {
         }
 
         if (done) {
+          CalculateReturnValue();
           if (InvokeShouldStopHereCallback(eFrameCompareOlder)) {
-            CalculateReturnValue();
             SetPlanComplete();
           }
         }
@@ -366,8 +366,8 @@ bool ThreadPlanStepOut::ShouldStop(Event *event_ptr) {
   // and we are done.
 
   if (done) {
+    CalculateReturnValue();
     if (InvokeShouldStopHereCallback(eFrameCompareOlder)) {
-      CalculateReturnValue();
       SetPlanComplete();
     } else {
       m_step_out_further_plan_sp =
@@ -525,7 +525,7 @@ void ThreadPlanStepOut::CalculateReturnValue() {
     if (m_swift_error_return) {
       ConstString name("swift_thrown_error");
 
-      m_return_valobj_sp = swift_runtime->CalculateErrorValueObjectForValue(
+      m_return_valobj_sp = swift_runtime->CalculateErrorValueObjectFromValue(
           m_swift_error_return.getValue(), name, true);
       // Even if we couldn't figure out what the error return was, we
       // were told there was an error, so don't show the user a false return value


### PR DESCRIPTION
The swift calling conventions have changed for swift 4.0, both for regular returns and for error returns.  These changes get lldb to understand the new calling convention.

<rdar://problem/25471028>