### PR TITLE
Handle the UnicodeScalar type rename to Unicode.Scalar.

### DIFF
--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -576,6 +576,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 "Swift.UnicodeScalar summary provider",
                 ConstString("Swift.UnicodeScalar"), summary_flags);
   AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::UnicodeScalar_SummaryProvider,
+                "Swift.Unicode.Scalar summary provider",
+                ConstString("Swift.Unicode.Scalar"), summary_flags);
+  AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::Character_SummaryProvider,
                 "Swift.Character summary provider",
                 ConstString("Swift.Character"), summary_flags);


### PR DESCRIPTION
Have to adjust the name of the type the formatter matches.  It looks
like you can still spell this UnicodeScalar so I left the old match
in place.

<rdar://problem/32149438>