### PR TITLE
delete this pr too

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -37,6 +37,7 @@
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/SymbolVendor.h"
+#include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
 #include "llvm/ADT/STLExtras.h"
@@ -1944,4 +1945,80 @@ PlatformDarwin::LaunchProcess(lldb_private::ProcessLaunchInfo &launch_info) {
 
   // Let our parent class do the real launching.
   return PlatformPOSIX::LaunchProcess(launch_info);
+}
+
+lldb_private::Error
+PlatformDarwin::FindBundleBinaryInExecSearchPaths (const ModuleSpec &module_spec, Process *process, 
+                                                   ModuleSP &module_sp, 
+                                                   const FileSpecList *module_search_paths_ptr, 
+                                                   ModuleSP *old_module_sp_ptr, bool *did_create_ptr)
+{
+  const FileSpec &platform_file = module_spec.GetFileSpec();
+  // See if the file is present in any of the module_search_paths_ptr directories.
+  if (!module_sp && module_search_paths_ptr && platform_file) {
+    // create a vector of all the file / directory names in platform_file
+    // e.g. this might be
+    // /System/Library/PrivateFrameworks/UIFoundation.framework/UIFoundation
+    //
+    // We'll need to look in the module_search_paths_ptr directories for
+    // both "UIFoundation" and "UIFoundation.framework" -- most likely the
+    // latter will be the one we find there.
+
+    FileSpec platform_pull_apart(platform_file);
+    std::vector<std::string> path_parts;
+    ConstString unix_root_dir("/");
+    while (true) {
+      ConstString part = platform_pull_apart.GetLastPathComponent();
+      platform_pull_apart.RemoveLastPathComponent();
+      if (part.IsEmpty() || part == unix_root_dir)
+        break;
+      path_parts.push_back(part.AsCString());
+    }
+    const size_t path_parts_size = path_parts.size();
+
+    size_t num_module_search_paths = module_search_paths_ptr->GetSize();
+    for (size_t i = 0; i < num_module_search_paths; ++i) {
+      Log *log_verbose = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
+      if (log_verbose)
+          log_verbose->Printf ("PlatformRemoteDarwinDevice::GetSharedModule searching for binary in search-path %s", module_search_paths_ptr->GetFileSpecAtIndex(i).GetPath().c_str());
+      // Create a new FileSpec with this module_search_paths_ptr
+      // plus just the filename ("UIFoundation"), then the parent
+      // dir plus filename ("UIFoundation.framework/UIFoundation")
+      // etc - up to four names (to handle "Foo.framework/Contents/MacOS/Foo")
+
+      for (size_t j = 0; j < 4 && j < path_parts_size - 1; ++j) {
+        FileSpec path_to_try(module_search_paths_ptr->GetFileSpecAtIndex(i));
+
+        // Add the components backwards.  For
+        // .../PrivateFrameworks/UIFoundation.framework/UIFoundation
+        // path_parts is
+        //   [0] UIFoundation
+        //   [1] UIFoundation.framework
+        //   [2] PrivateFrameworks
+        //
+        // and if 'j' is 2, we want to append path_parts[1] and then
+        // path_parts[0], aka
+        // 'UIFoundation.framework/UIFoundation', to the module_search_paths_ptr
+        // path.
+
+        for (int k = j; k >= 0; --k) {
+          path_to_try.AppendPathComponent(path_parts[k]);
+        }
+
+        if (path_to_try.Exists()) {
+          ModuleSpec new_module_spec(module_spec);
+          new_module_spec.GetFileSpec() = path_to_try;
+          Error new_error(Platform::GetSharedModule(
+              new_module_spec, process, module_sp, NULL, old_module_sp_ptr,
+              did_create_ptr));
+
+          if (module_sp) {
+            module_sp->SetPlatformFileSpec(path_to_try);
+            return new_error;
+          }
+        }
+      }
+    }
+  }
+  return Error();
 }

--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -141,9 +141,15 @@ protected:
                                              std::vector<std::string> &options,
                                              SDKType sdk_type);
 
+  const char *GetDeveloperDirectory();
+
+  lldb_private::Error
+  FindBundleBinaryInExecSearchPaths (const lldb_private::ModuleSpec &module_spec, lldb_private::Process *process,
+                                     lldb::ModuleSP &module_sp, const lldb_private::FileSpecList *module_search_paths_ptr, 
+                                     lldb::ModuleSP *old_module_sp_ptr, bool *did_create_ptr);
+
   std::string m_developer_directory;
 
-  const char *GetDeveloperDirectory();
 
 private:
   DISALLOW_COPY_AND_ASSIGN(PlatformDarwin);

--- a/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -340,5 +340,9 @@ lldb_private::Error PlatformMacOSX::GetSharedModule(
       }
     }
   }
+
+  if (!module_sp) {
+      error = FindBundleBinaryInExecSearchPaths (module_spec, process, module_sp, module_search_paths_ptr, old_module_sp_ptr, did_create_ptr);
+  }
   return error;
 }

--- a/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -623,72 +623,12 @@ Error PlatformRemoteDarwinDevice::GetSharedModule(
 
   // See if the file is present in any of the module_search_paths_ptr
   // directories.
-  if (!module_sp && module_search_paths_ptr && platform_file) {
-    // create a vector of all the file / directory names in platform_file
-    // e.g. this might be
-    // /System/Library/PrivateFrameworks/UIFoundation.framework/UIFoundation
-    //
-    // We'll need to look in the module_search_paths_ptr directories for
-    // both "UIFoundation" and "UIFoundation.framework" -- most likely the
-    // latter will be the one we find there.
+  if (!module_sp)
+    error = PlatformDarwin::FindBundleBinaryInExecSearchPaths (module_spec, process, module_sp,
+            module_search_paths_ptr, old_module_sp_ptr, did_create_ptr);
 
-    FileSpec platform_pull_apart(platform_file);
-    std::vector<std::string> path_parts;
-    ConstString unix_root_dir("/");
-    while (true) {
-      ConstString part = platform_pull_apart.GetLastPathComponent();
-      platform_pull_apart.RemoveLastPathComponent();
-      if (part.IsEmpty() || part == unix_root_dir)
-        break;
-      path_parts.push_back(part.AsCString());
-    }
-    const size_t path_parts_size = path_parts.size();
-
-    size_t num_module_search_paths = module_search_paths_ptr->GetSize();
-    for (size_t i = 0; i < num_module_search_paths; ++i) {
-      Log *log_verbose = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST |
-                                                    LIBLLDB_LOG_VERBOSE);
-      if (log_verbose)
-          log_verbose->Printf ("PlatformRemoteDarwinDevice::GetSharedModule searching for binary in search-path %s", module_search_paths_ptr->GetFileSpecAtIndex(i).GetPath().c_str());
-      // Create a new FileSpec with this module_search_paths_ptr
-      // plus just the filename ("UIFoundation"), then the parent
-      // dir plus filename ("UIFoundation.framework/UIFoundation")
-      // etc - up to four names (to handle "Foo.framework/Contents/MacOS/Foo")
-
-      for (size_t j = 0; j < 4 && j < path_parts_size - 1; ++j) {
-        FileSpec path_to_try(module_search_paths_ptr->GetFileSpecAtIndex(i));
-
-        // Add the components backwards.  For
-        // .../PrivateFrameworks/UIFoundation.framework/UIFoundation
-        // path_parts is
-        //   [0] UIFoundation
-        //   [1] UIFoundation.framework
-        //   [2] PrivateFrameworks
-        //
-        // and if 'j' is 2, we want to append path_parts[1] and then
-        // path_parts[0], aka
-        // 'UIFoundation.framework/UIFoundation', to the module_search_paths_ptr
-        // path.
-
-        for (int k = j; k >= 0; --k) {
-          path_to_try.AppendPathComponent(path_parts[k]);
-        }
-
-        if (path_to_try.Exists()) {
-          ModuleSpec new_module_spec(module_spec);
-          new_module_spec.GetFileSpec() = path_to_try;
-          Error new_error(Platform::GetSharedModule(
-              new_module_spec, process, module_sp, NULL, old_module_sp_ptr,
-              did_create_ptr));
-
-          if (module_sp) {
-            module_sp->SetPlatformFileSpec(path_to_try);
-            return new_error;
-          }
-        }
-      }
-    }
-  }
+  if (error.Success())
+    return error;
 
   const bool always_create = false;
   error = ModuleList::GetSharedModule(


### PR DESCRIPTION
When lldb is debugging a process on a remote system, it may need to look in the target.exec-search-paths setting to find a binary on the remote host which is not present on the debug host system. If the binary is in a Darwin bundle, like com.apple.sbd.xpc/com.apple.sbd, and lldb is looking for a binary called "com.apple.sbd", it needs to know to (1) look for "com.apple.sbd.xpc" in the target.exec-search-paths, and (2) to look for "com.apple.sbd.xpc.dSYM" next to that bundle to get the debug information correctly.

The old algorithm for testing the parent directories was using the dot's in the filenames to strip off filename components.

rdar://problem/31825940
