### PR TITLE
Fix up swift stepping in the new mangling

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -164,6 +164,9 @@ public:
   virtual bool GetIRPasses(LLVMUserExpression::IRPasses &custom_passes) {
     return false;
   }
+  
+  static bool
+  IsSymbolAnyRuntimeThunk(lldb::ProcessSP process, Symbol &symbol);
 
 protected:
   //------------------------------------------------------------------

--- a/include/lldb/Target/Thread.h
+++ b/include/lldb/Target/Thread.h
@@ -777,6 +777,13 @@ public:
       LazyBool step_in_avoids_code_without_debug_info = eLazyBoolCalculate,
       LazyBool step_out_avoids_code_without_debug_info = eLazyBoolCalculate);
 
+  virtual lldb::ThreadPlanSP QueueThreadPlanForStepInRangeNoShouldStop(
+      bool abort_other_plans, const AddressRange &range,
+      const SymbolContext &addr_context, const char *step_in_target,
+      lldb::RunMode stop_other_threads,
+      LazyBool step_in_avoids_code_without_debug_info = eLazyBoolCalculate,
+      LazyBool step_out_avoids_code_without_debug_info = eLazyBoolCalculate);
+
   // Helper function that takes a LineEntry to step, insted of an AddressRange.
   // This may combine multiple
   // LineEntries of the same source line number to step over a longer address

--- a/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
@@ -26,7 +26,6 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.expectedFailureAll(bugnumber="rdar://31515444")
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
@@ -289,11 +289,12 @@ class TestSwiftStepping(lldbtest.TestBase):
         # Step out of the protocol function, one step out should also
         # get us past any dispatch thunk.
         thread.StepOut()
-        self.hit_correct_line(thread, "indirect.protocol_func(20)")
-
+        stop_on_caller = self.hit_correct_line(thread, "indirect.protocol_func(20)", False)
+        
         # And one step over is necessary because step out doesn't
         # finish off the line.
-        thread.StepOver()
+        if stop_on_caller:
+            thread.StepOver()
         self.hit_correct_line(thread, "doSomethingWithFunction(cd_maker, 10)")
 
         thread.StepInto()

--- a/source/Target/LanguageRuntime.cpp
+++ b/source/Target/LanguageRuntime.cpp
@@ -342,3 +342,25 @@ LanguageRuntime::GuessLanguageForSymbolByName(Target &target,
   else
     return eLanguageTypeUnknown;
 }
+
+bool
+LanguageRuntime::IsSymbolAnyRuntimeThunk(ProcessSP process_sp, Symbol &symbol)
+{
+  if (!process_sp)
+    return false;
+    
+  enum LanguageType languages_to_try[] = {
+      eLanguageTypeSwift, eLanguageTypeObjC, eLanguageTypeC_plus_plus};
+
+  LanguageRuntime *language_runtime;
+  for (enum LanguageType language : languages_to_try) {
+    language_runtime = process_sp->GetLanguageRuntime(language);
+    if (language_runtime) {
+        if (language_runtime->IsSymbolARuntimeThunk(symbol))
+          return true;
+    }
+  }
+  return false;
+}
+
+

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2781,13 +2781,12 @@ GetThunkKind(llvm::StringRef symbol_name)
   if (num_global_children == 0)
     return ThunkKind::Unknown;
 
-  swift::Demangle::NodePointer global_node_ptr = nodes->getFirstChild();
-  if (global_node_ptr->getKind() != swift::Demangle::Node::Kind::Global)
+  if (nodes->getKind() != swift::Demangle::Node::Kind::Global)
     return ThunkKind::Unknown;
-  if (global_node_ptr->getNumChildren() == 0)
+  if (nodes->getNumChildren() == 0)
     return ThunkKind::Unknown;
 
-  swift::Demangle::NodePointer node_ptr = global_node_ptr->getFirstChild();
+  swift::Demangle::NodePointer node_ptr = nodes->getFirstChild();
   kind = node_ptr->getKind();
   switch (kind)
   {
@@ -2803,6 +2802,8 @@ GetThunkKind(llvm::StringRef symbol_name)
     break;
   case swift::Demangle::Node::Kind::ReabstractionThunkHelper:
     return ThunkKind::Reabstraction;
+  case swift::Demangle::Node::Kind::PartialApplyForwarder:
+    return ThunkKind::PartialApply;
   case swift::Demangle::Node::Kind::Allocator:
     if (node_ptr->getNumChildren() == 0)
       return ThunkKind::Unknown;
@@ -2848,7 +2849,7 @@ GetThunkAction (ThunkKind kind)
       case ThunkKind::ObjCAttribute:
         return ThunkAction::GetThunkTarget;
       case ThunkKind::Reabstraction:
-        return ThunkAction::GetThunkTarget;
+        return ThunkAction::StepThrough;
       case ThunkKind::ProtocolConformance:
         return ThunkAction::StepIntoConformance;
     }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2901,7 +2901,9 @@ bool SwiftLanguageRuntime::GetTargetOfPartialApply(SymbolContext &curr_sc,
 bool SwiftLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
 
   llvm::StringRef symbol_name = symbol.GetMangled().GetMangledName().GetStringRef();
-  
+  if (symbol_name.empty())
+    return false;
+
   swift::Demangle::Context demangle_ctx;
   return demangle_ctx.isThunkSymbol(symbol_name);
 }

--- a/source/Target/Thread.cpp
+++ b/source/Target/Thread.cpp
@@ -1391,6 +1391,28 @@ ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
   return thread_plan_sp;
 }
 
+ThreadPlanSP Thread::QueueThreadPlanForStepInRangeNoShouldStop(
+    bool abort_other_plans, const AddressRange &range,
+    const SymbolContext &addr_context, const char *step_in_target,
+    lldb::RunMode stop_other_threads,
+    LazyBool step_in_avoids_code_without_debug_info,
+    LazyBool step_out_avoids_code_without_debug_info) {
+  ThreadPlanSP thread_plan_sp(
+      new ThreadPlanStepInRange(*this, range, addr_context, stop_other_threads,
+                                step_in_avoids_code_without_debug_info,
+                                step_out_avoids_code_without_debug_info));
+  ThreadPlanStepInRange *plan =
+      static_cast<ThreadPlanStepInRange *>(thread_plan_sp.get());
+
+  if (step_in_target)
+    plan->SetStepInTarget(step_in_target);
+    
+  plan->ClearShouldStopHereCallbacks();
+
+  QueueThreadPlan(thread_plan_sp, abort_other_plans);
+  return thread_plan_sp;
+}
+
 // Call the QueueThreadPlanForStepInRange method which takes an address range.
 ThreadPlanSP Thread::QueueThreadPlanForStepInRange(
     bool abort_other_plans, const LineEntry &line_entry,

--- a/source/Target/ThreadPlanStepOut.cpp
+++ b/source/Target/ThreadPlanStepOut.cpp
@@ -372,6 +372,15 @@ bool ThreadPlanStepOut::ShouldStop(Event *event_ptr) {
     } else {
       m_step_out_further_plan_sp =
           QueueStepOutFromHerePlan(m_flags, eFrameCompareOlder);
+      if (m_step_out_further_plan_sp->GetKind() == eKindStepOut)
+      {
+        // If we are planning to step out further, then the frame we are going
+        // to step out to is about to go away, so we need to reset the frame
+        // we are stepping out to to the one our step out plan is aiming for.
+        ThreadPlanStepOut *as_step_out 
+          = static_cast<ThreadPlanStepOut *>(m_step_out_further_plan_sp.get());
+        m_step_out_to_id = as_step_out->m_step_out_to_id;
+      }
       done = false;
     }
   }


### PR DESCRIPTION
I got the swift stepping test running with an intermediate version of the new mangling, but something changed on the swift side and broke these tests.  This gets them running again.

The stepping out also ran into some additional difficulties because we have debug info for the swift standard library, which the stepping tests also have to successfully get out of.  I fixed a few places in the step out from here generation to make this more robust.