### PR TITLE
[stable] Add a testcase for MainThreadCheckerRuntime plugin

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+
+OBJC_SOURCES := main.m
+LDFLAGS = $(CFLAGS) -lobjc -framework Foundation -framework AppKit
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/TestMTCSimple.py
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/TestMTCSimple.py
@@ -1,0 +1,57 @@
+"""
+Tests basic Main Thread Checker support (detecting a main-thread-only violation).
+"""
+
+import os
+import time
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbplatformutil import *
+import json
+
+
+class MTCSimpleTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    def test(self):
+        self.mtc_dylib_path = findMainThreadCheckerDylib()
+        if self.mtc_dylib_path == "":
+            self.skipTest("This test requires libMainThreadChecker.dylib.")
+
+        self.build()
+        self.mtc_tests()
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+
+    def mtc_tests(self):
+        # Load the test
+        exe = os.path.join(os.getcwd(), "a.out")
+        self.expect("file " + exe, patterns=["Current executable set to .*a.out"])
+
+        self.runCmd("env DYLD_INSERT_LIBRARIES=%s" % self.mtc_dylib_path)
+        self.runCmd("run")
+
+        process = self.dbg.GetSelectedTarget().process
+        thread = process.GetSelectedThread()
+        frame = thread.GetSelectedFrame()
+
+        self.expect("thread info", substrs=['stop reason = -[NSView superview] must be called from main thread only'])
+
+        self.expect(
+            "thread info -s",
+            substrs=["instrumentation_class", "api_name", "class_name", "selector", "description"])
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonInstrumentation)
+        output_lines = self.res.GetOutput().split('\n')
+        json_line = '\n'.join(output_lines[2:])
+        data = json.loads(json_line)
+        self.assertEqual(data["instrumentation_class"], "MainThreadChecker")
+        self.assertEqual(data["api_name"], "-[NSView superview]")
+        self.assertEqual(data["class_name"], "NSView")
+        self.assertEqual(data["selector"], "superview")
+        self.assertEqual(data["description"], "-[NSView superview] must be called from main thread only")

--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/main.m
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/main.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+int main() {
+  NSView *view = [[NSView alloc] init];
+  dispatch_group_t g = dispatch_group_create();
+  dispatch_group_enter(g);
+  [NSThread detachNewThreadWithBlock:^{
+    @autoreleasepool {
+      [view superview];
+    }
+    dispatch_group_leave(g);
+  }];
+  dispatch_group_wait(g, DISPATCH_TIME_FOREVER);
+}

--- a/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -8,6 +8,7 @@ import itertools
 import re
 import subprocess
 import sys
+import os
 
 # Third-party modules
 import six
@@ -138,6 +139,19 @@ def getPlatform():
 def platformIsDarwin():
     """Returns true if the OS triple for the selected platform is any valid apple OS"""
     return getPlatform() in getDarwinOSTriples()
+
+
+def findMainThreadCheckerDylib():
+    if not platformIsDarwin():
+        return ""
+
+    with os.popen('xcode-select -p') as output:
+        xcode_developer_path = output.read().strip()
+        mtc_dylib_path = '%s/usr/lib/libMainThreadChecker.dylib' % xcode_developer_path
+        if os.path.isfile(mtc_dylib_path):
+            return mtc_dylib_path
+
+    return ""
 
 
 class _PlatformContext(object):


### PR DESCRIPTION
Cherry-pick of r307170.  This adds a simple testcase for MainThreadCheckerRuntime. The tool (Main Thread Checker) is only available on Darwin, so the test also detects the presence of libMainThreadChecker.dylib and is skipped if the tool is not available.