### PR TITLE
Bool summary should ignore spare bits

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/bool/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bool/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bool/TestSwiftBool.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bool/TestSwiftBool.py
@@ -1,0 +1,84 @@
+# TestSwiftBool.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test that we can inspect Swift Bools - they are 8 bit entities with only the
+LSB significant.  Make sure that works.
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftBool(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    def test_swift_bool(self):
+        """Test that we can inspect various Swift bools"""
+        self.build()
+        self.do_test()
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    def do_test(self):
+        """Tests that we can break and display simple types"""
+        exe_name = "a.out"
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'Set breakpoint here', self.main_source_spec)
+        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        # Launch the process, and do not stop at the entry point.
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # Frame #0 should be at our breakpoint.
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, breakpoint)
+
+        self.assertTrue(len(threads) == 1)
+        thread = threads[0]
+        
+        frame = thread.frames[0]
+        self.assertTrue(frame.IsValid(), "Couldn't get a frame.")
+        
+        true_vars = ["reg_true", "odd_true", "odd_true_works", "odd_false_works"]
+        for name in true_vars:
+            var = frame.FindVariable(name)
+            summary = var.GetSummary()
+            self.assertTrue(summary == "true", "%s should be true, was: %s"%(name, summary))
+
+        false_vars = ["reg_false", "odd_false"]
+        for name in false_vars:
+            var = frame.FindVariable(name)
+            summary = var.GetSummary()
+            self.assertTrue(summary == "false", "%s should be false, was: %s"%(name, summary))
+
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bool/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bool/main.swift
@@ -1,0 +1,29 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+func main() -> Int {
+    let short_five : Int8 = 5
+    let short_four : Int8 = 4
+
+    var reg_true : Bool   = true
+    var reg_false : Bool  = false
+    var odd_true : Bool   = unsafeBitCast(short_five, to: Bool.self)
+    var odd_false : Bool  = unsafeBitCast(short_four, to: Bool.self)
+
+    var odd_true_works = reg_true == odd_true
+    var odd_false_works = reg_false == odd_false
+
+    print("stop here") // Set breakpoint here
+    return 0
+}
+
+main()

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -383,7 +383,7 @@ bool lldb_private::formatters::swift::Bool_SummaryProvider(
   // But at present CompilerType has no way to represent that information.
   // So for now we hard code it.
   uint64_t value = value_child->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-  uint64_t mask = 1 << 0;
+  const uint64_t mask = 1 << 0;
   value &= mask;
   
   switch (value) {

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -376,7 +376,16 @@ bool lldb_private::formatters::swift::Bool_SummaryProvider(
   ValueObjectSP value_child(valobj.GetChildMemberWithName(g_value, true));
   if (!value_child)
     return false;
-  auto value = value_child->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+    
+  // Swift Bools are stored in a byte, but only the LSB of the byte is
+  // significant.  The swift::irgen::FixedTypeInfo structure represents
+  // this information by providing a mask of the "extra bits" for the type.
+  // But at present CompilerType has no way to represent that information.
+  // So for now we hard code it.
+  uint64_t value = value_child->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+  uint64_t mask = 1 << 0;
+  value &= mask;
+  
   switch (value) {
   case 0:
     stream.Printf("false");


### PR DESCRIPTION
The swift Bool only considers the LSB significant.  So the formatter should mask off all the other bits before interpreting the value.