### PR TITLE
[Gardening] Rename getInOutOrLValueObjectType to getWithoutSpecifierType

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1348,7 +1348,7 @@ bool SwiftASTManipulator::AddExternalVariables(
       // it is inout or not, so we don't have to do anything more to get this to
       // work.
       swift::Type var_type =
-          GetSwiftType(referent_type)->getLValueOrInOutObjectType();
+          GetSwiftType(referent_type)->getWithoutSpecifierType();
       if (is_self) {
         // Another tricky bit is that the Metatype types we get have the
         // "Representation" already attached (i.e.

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -714,7 +714,7 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
 
     swift::Type object_type =
         swift::Type((swift::TypeBase *)(imported_self_type.GetOpaqueQualType()))
-            ->getLValueOrInOutObjectType();
+            ->getWithoutSpecifierType();
 
     if (object_type.getPointer() &&
         (object_type.getPointer() != imported_self_type.GetOpaqueQualType()))

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -227,7 +227,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Error &err) {
 
           swift::Type object_type =
               swift::Type((swift::TypeBase *)(self_type.GetOpaqueQualType()))
-                  ->getLValueOrInOutObjectType();
+                  ->getWithoutSpecifierType();
 
           if (object_type.getPointer() &&
               (object_type.getPointer() != self_type.GetOpaqueQualType()))


### PR DESCRIPTION
Pairs well with apple/swift#10790