### PR TITLE
Don't treat DW_AT_const_value as meaning "static" in Swift. (#227)

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/let_int/TestSwiftLetInt.py
+++ b/packages/Python/lldbsuite/test/lang/swift/let_int/TestSwiftLetInt.py
@@ -68,6 +68,16 @@ class TestSwiftLetIntSupport(TestBase):
         lldbutil.check_variable(self, let, False, value="10")
         lldbutil.check_variable(self, var, False, value="10")
 
+        get_arguments = False
+        get_locals = True
+        get_statics = False
+        get_in_scope_only = True
+        local_vars = self.frame.GetVariables(get_arguments, get_locals,
+                                             get_statics, get_in_scope_only)
+        self.assertTrue(local_vars.GetFirstValueByName("x").IsValid())
+        self.assertTrue(local_vars.GetFirstValueByName("y").IsValid())
+        self.assertTrue(not local_vars.GetFirstValueByName("z").IsValid())
+
 if __name__ == '__main__':
     import atexit
     lldb.SBDebugger.Initialize()

--- a/packages/Python/lldbsuite/test/lang/swift/let_int/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/let_int/main.swift
@@ -9,10 +9,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
+
+let z = 10
+
 func main() {
   let x = 10
   var y = 10
-  print(x+y) // Set breakpoint here
+  print(x+y+z) // Set breakpoint here
 }
 
 main()

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -4268,7 +4268,15 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
             }
           }
         } else {
-          if (location_is_const_value_data)
+          // The heuristic for inferring static variables works for Clang's
+          // behavior on C-like languages, which generally does not emit
+          // AT_const_value for locals.
+          //
+          // However, the Swift compiler can and does emit AT_const_value for
+          // locals, and function-level statics don't exist, so we flip the
+          // heuristic here.
+          if (location_is_const_value_data &&
+              !IsSwiftLanguage(sc.comp_unit->GetLanguage()))
             scope = eValueTypeVariableStatic;
           else {
             scope = eValueTypeVariableLocal;


### PR DESCRIPTION
* Don't treat DW_AT_const_value as meaning "static" in Swift.

This is a heuristic that works for code compiled with Clang, but the
Swift language is different (as explained in an added comment).

I've also added a test that checks this, and ensures that global "let"
variables aren't included in the list. 

rdar://31332056