### PR TITLE
[4.0] Main Thread Checker: When in Swift, and the report is describing a call to an setter or getter of a property, use the property name instead of the method name

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+
+OBJC_SOURCES := main.m
+LDFLAGS = $(CFLAGS) -lobjc -framework Foundation -framework AppKit
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/TestMTCSimple.py
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/TestMTCSimple.py
@@ -1,0 +1,57 @@
+"""
+Tests basic Main Thread Checker support (detecting a main-thread-only violation).
+"""
+
+import os
+import time
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbplatformutil import *
+import json
+
+
+class MTCSimpleTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    def test(self):
+        self.mtc_dylib_path = findMainThreadCheckerDylib()
+        if self.mtc_dylib_path == "":
+            self.skipTest("This test requires libMainThreadChecker.dylib.")
+
+        self.build()
+        self.mtc_tests()
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+
+    def mtc_tests(self):
+        # Load the test
+        exe = os.path.join(os.getcwd(), "a.out")
+        self.expect("file " + exe, patterns=["Current executable set to .*a.out"])
+
+        self.runCmd("env DYLD_INSERT_LIBRARIES=%s" % self.mtc_dylib_path)
+        self.runCmd("run")
+
+        process = self.dbg.GetSelectedTarget().process
+        thread = process.GetSelectedThread()
+        frame = thread.GetSelectedFrame()
+
+        self.expect("thread info", substrs=['stop reason = -[NSView superview] must be called from main thread only'])
+
+        self.expect(
+            "thread info -s",
+            substrs=["instrumentation_class", "api_name", "class_name", "selector", "description"])
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonInstrumentation)
+        output_lines = self.res.GetOutput().split('\n')
+        json_line = '\n'.join(output_lines[2:])
+        data = json.loads(json_line)
+        self.assertEqual(data["instrumentation_class"], "MainThreadChecker")
+        self.assertEqual(data["api_name"], "-[NSView superview]")
+        self.assertEqual(data["class_name"], "NSView")
+        self.assertEqual(data["selector"], "superview")
+        self.assertEqual(data["description"], "-[NSView superview] must be called from main thread only")

--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/TestMTCSimple.py
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/TestMTCSimple.py
@@ -41,7 +41,7 @@ class MTCSimpleTestCase(TestBase):
         thread = process.GetSelectedThread()
         frame = thread.GetSelectedFrame()
 
-        self.expect("thread info", substrs=['stop reason = -[NSView superview] must be called from main thread only'])
+        self.expect("thread info", substrs=['stop reason = -[NSView superview] must be used from main thread only'])
 
         self.expect(
             "thread info -s",
@@ -54,4 +54,4 @@ class MTCSimpleTestCase(TestBase):
         self.assertEqual(data["api_name"], "-[NSView superview]")
         self.assertEqual(data["class_name"], "NSView")
         self.assertEqual(data["selector"], "superview")
-        self.assertEqual(data["description"], "-[NSView superview] must be called from main thread only")
+        self.assertEqual(data["description"], "-[NSView superview] must be used from main thread only")

--- a/packages/Python/lldbsuite/test/functionalities/mtc/simple/main.m
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/simple/main.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+int main() {
+  NSView *view = [[NSView alloc] init];
+  dispatch_group_t g = dispatch_group_create();
+  dispatch_group_enter(g);
+  [NSThread detachNewThreadWithBlock:^{
+    @autoreleasepool {
+      [view superview];
+    }
+    dispatch_group_leave(g);
+  }];
+  dispatch_group_wait(g, DISPATCH_TIME_FOREVER);
+}

--- a/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/Makefile
@@ -1,0 +1,4 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+TRIPLE_SWIFTFLAGS := -target x86_64-apple-macosx10.12
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/TestMTCSwiftProperty.py
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/TestMTCSwiftProperty.py
@@ -1,5 +1,5 @@
 """
-Tests Main Thread Checker support on Swift code.
+Tests Main Thread Checker support on Swift properties.
 """
 
 import os
@@ -12,7 +12,7 @@ from lldbsuite.test.lldbplatformutil import *
 import json
 
 
-class MTCSwiftTestCase(TestBase):
+class MTCSwiftPropertyTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
@@ -41,7 +41,7 @@ class MTCSwiftTestCase(TestBase):
         thread = process.GetSelectedThread()
         frame = thread.GetSelectedFrame()
 
-        self.expect("thread info", substrs=['stop reason = NSView.removeFromSuperview() must be used from main thread only'])
+        self.expect("thread info", substrs=['stop reason = NSView.superview must be used from main thread only'])
 
         self.expect(
             "thread info -s",
@@ -51,7 +51,7 @@ class MTCSwiftTestCase(TestBase):
         json_line = '\n'.join(output_lines[2:])
         data = json.loads(json_line)
         self.assertEqual(data["instrumentation_class"], "MainThreadChecker")
-        self.assertEqual(data["api_name"], "NSView.removeFromSuperview()")
+        self.assertEqual(data["api_name"], "NSView.superview")
         self.assertEqual(data["class_name"], "NSView")
-        self.assertEqual(data["selector"], "removeFromSuperview")
-        self.assertEqual(data["description"], "NSView.removeFromSuperview() must be used from main thread only")
+        self.assertEqual(data["selector"], "superview")
+        self.assertEqual(data["description"], "NSView.superview must be used from main thread only")

--- a/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/main.swift
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/swift-property/main.swift
@@ -18,7 +18,7 @@ let g = DispatchGroup()
 g.enter()
 Thread.detachNewThread {
   autoreleasepool {
-    view.removeFromSuperview()
+    let _ = view.superview
   }
   g.leave()
 }

--- a/packages/Python/lldbsuite/test/functionalities/mtc/swift/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/swift/Makefile
@@ -1,0 +1,4 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+TRIPLE_SWIFTFLAGS := -target x86_64-apple-macosx10.12
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/mtc/swift/TestMTCSwift.py
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/swift/TestMTCSwift.py
@@ -1,0 +1,57 @@
+"""
+Tests Main Thread Checker support on Swift code.
+"""
+
+import os
+import time
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbplatformutil import *
+import json
+
+
+class MTCSwiftTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    def test(self):
+        self.mtc_dylib_path = findMainThreadCheckerDylib()
+        if self.mtc_dylib_path == "":
+            self.skipTest("This test requires libMainThreadChecker.dylib.")
+
+        self.build()
+        self.mtc_tests()
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+
+    def mtc_tests(self):
+        # Load the test
+        exe = os.path.join(os.getcwd(), "a.out")
+        self.expect("file " + exe, patterns=["Current executable set to .*a.out"])
+
+        self.runCmd("env DYLD_INSERT_LIBRARIES=%s" % self.mtc_dylib_path)
+        self.runCmd("run")
+
+        process = self.dbg.GetSelectedTarget().process
+        thread = process.GetSelectedThread()
+        frame = thread.GetSelectedFrame()
+
+        self.expect("thread info", substrs=['stop reason = NSView.superview() must be called from main thread only'])
+
+        self.expect(
+            "thread info -s",
+            substrs=["instrumentation_class", "api_name", "class_name", "selector", "description"])
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonInstrumentation)
+        output_lines = self.res.GetOutput().split('\n')
+        json_line = '\n'.join(output_lines[2:])
+        data = json.loads(json_line)
+        self.assertEqual(data["instrumentation_class"], "MainThreadChecker")
+        self.assertEqual(data["api_name"], "NSView.superview()")
+        self.assertEqual(data["class_name"], "NSView")
+        self.assertEqual(data["selector"], "superview")
+        self.assertEqual(data["description"], "NSView.superview() must be called from main thread only")

--- a/packages/Python/lldbsuite/test/functionalities/mtc/swift/main.swift
+++ b/packages/Python/lldbsuite/test/functionalities/mtc/swift/main.swift
@@ -1,0 +1,24 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+import Foundation
+import AppKit
+
+let view = NSView()
+let g = DispatchGroup()
+g.enter()
+Thread.detachNewThread {
+  autoreleasepool {
+    let _ = view.superview
+  }
+}
+g.wait()

--- a/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -8,6 +8,7 @@ import itertools
 import re
 import subprocess
 import sys
+import os
 
 # Third-party modules
 import six
@@ -138,6 +139,19 @@ def getPlatform():
 def platformIsDarwin():
     """Returns true if the OS triple for the selected platform is any valid apple OS"""
     return getPlatform() in getDarwinOSTriples()
+
+
+def findMainThreadCheckerDylib():
+    if not platformIsDarwin():
+        return ""
+
+    with os.popen('xcode-select -p') as output:
+        xcode_developer_path = output.read().strip()
+        mtc_dylib_path = '%s/usr/lib/libMainThreadChecker.dylib' % xcode_developer_path
+        if os.path.isfile(mtc_dylib_path):
+            return mtc_dylib_path
+
+    return ""
 
 
 class _PlatformContext(object):

--- a/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
@@ -123,8 +123,8 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
         // We need to loadAllMembers(), otherwise 'isAccessor' returns false.
         if (auto extension = clang::dyn_cast<swift::ExtensionDecl>(funcCtx)) {
           extension->loadAllMembers();
-        }
-        if (auto nominal = clang::dyn_cast<swift::NominalTypeDecl>(funcCtx)) {
+        } else if (auto nominal =
+                       clang::dyn_cast<swift::NominalTypeDecl>(funcCtx)) {
           nominal->loadAllMembers();
         }
 

--- a/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
@@ -109,7 +109,7 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
                            swift::DeclVisibilityKind Reason) {
       if (result)
         return; // Take the first result.
-      swift::ClassDecl *cls = clang::dyn_cast<swift::ClassDecl>(VD);
+      swift::ClassDecl *cls = llvm::dyn_cast<swift::ClassDecl>(VD);
       if (!cls)
         return;
       auto funcs = cls->lookupDirect(selectorToLookup, true);
@@ -118,13 +118,13 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
 
       // If the decl is actually an accessor, use the property name instead.
       swift::AbstractFunctionDecl *decl = funcs.front();
-      if (auto func = clang::dyn_cast<swift::FuncDecl>(decl)) {
+      if (auto func = llvm::dyn_cast<swift::FuncDecl>(decl)) {
         swift::DeclContext *funcCtx = func->getParent();
         // We need to loadAllMembers(), otherwise 'isAccessor' returns false.
-        if (auto extension = clang::dyn_cast<swift::ExtensionDecl>(funcCtx)) {
+        if (auto extension = llvm::dyn_cast<swift::ExtensionDecl>(funcCtx)) {
           extension->loadAllMembers();
         } else if (auto nominal =
-                       clang::dyn_cast<swift::NominalTypeDecl>(funcCtx)) {
+                       llvm::dyn_cast<swift::NominalTypeDecl>(funcCtx)) {
           nominal->loadAllMembers();
         }
 

--- a/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
@@ -109,12 +109,32 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
                            swift::DeclVisibilityKind Reason) {
       if (result)
         return; // Take the first result.
-      if (swift::ClassDecl *cls = clang::dyn_cast<swift::ClassDecl>(VD)) {
-        auto funcs = cls->lookupDirect(selectorToLookup, true);
-        if (funcs.size() > 0) {
-          result = funcs.front()->getFullName();
+      swift::ClassDecl *cls = clang::dyn_cast<swift::ClassDecl>(VD);
+      if (!cls)
+        return;
+      auto funcs = cls->lookupDirect(selectorToLookup, true);
+      if (funcs.size() == 0)
+        return;
+
+      // If the decl is actually an accessor, use the property name instead.
+      swift::AbstractFunctionDecl *decl = funcs.front();
+      if (auto func = clang::dyn_cast<swift::FuncDecl>(decl)) {
+        swift::DeclContext *funcCtx = func->getParent();
+        // We need to loadAllMembers(), otherwise 'isAccessor' returns false.
+        if (auto extension = clang::dyn_cast<swift::ExtensionDecl>(funcCtx)) {
+          extension->loadAllMembers();
+        }
+        if (auto nominal = clang::dyn_cast<swift::NominalTypeDecl>(funcCtx)) {
+          nominal->loadAllMembers();
+        }
+
+        if (func->isAccessor()) {
+          result = func->getAccessorStorageDecl()->getFullName();
+          return;
         }
       }
+
+      result = decl->getFullName();
     }
   };
 
@@ -211,7 +231,7 @@ MainThreadCheckerRuntime::RetrieveReportData(ExecutionContextRef exe_ctx_ref) {
   d->AddStringItem("class_name", className);
   d->AddStringItem("selector", selector);
   d->AddStringItem("description",
-                   apiName + " must be called from main thread only");
+                   apiName + " must be used from main thread only");
   d->AddIntegerItem("tid", thread_sp->GetIndexID());
   d->AddItem("trace", trace_sp);
   return dict_sp;


### PR DESCRIPTION
This is cherry-pick of  28ad4cf into swift-4.0-branch:  Main Thread Checker: When in Swift, and the report is describing a call to an setter or getter of a property, use the property name instead of the method name. We currently report things like NSView.setFrame(_:), which isn't correct: The call is user's code looks like myview.frame = .... Let's look up the actual property name and use it in the message instead.