### PR TITLE
Swift 4.0 branch stringref perf

### DIFF
--- a/include/lldb/Core/UniqueCStringMap.h
+++ b/include/lldb/Core/UniqueCStringMap.h
@@ -17,6 +17,7 @@
 
 // Other libraries and framework includes
 // Project includes
+#include "lldb/Utility/ConstString.h"
 #include "lldb/Core/RegularExpression.h"
 
 namespace lldb_private {
@@ -35,13 +36,17 @@ public:
   struct Entry {
     Entry() {}
 
-    Entry(llvm::StringRef cstr) : cstring(cstr), value() {}
+    Entry(ConstString cstr) : cstring(cstr), value() {}
 
-    Entry(llvm::StringRef cstr, const T &v) : cstring(cstr), value(v) {}
+    Entry(ConstString cstr, const T &v) : cstring(cstr), value(v) {}
 
-    bool operator<(const Entry &rhs) const { return cstring < rhs.cstring; }
+    // This is only for uniqueness, not lexicographical ordering, so we can
+    // just compare pointers.
+    bool operator<(const Entry &rhs) const {
+      return cstring.GetCString() < rhs.cstring.GetCString();
+    }
 
-    llvm::StringRef cstring;
+    ConstString cstring;
     T value;
   };
 
@@ -50,7 +55,7 @@ public:
   // this map, then later call UniqueCStringMap<T>::Sort() before doing
   // any searches by name.
   //------------------------------------------------------------------
-  void Append(llvm::StringRef unique_cstr, const T &value) {
+  void Append(ConstString unique_cstr, const T &value) {
     m_map.push_back(typename UniqueCStringMap<T>::Entry(unique_cstr, value));
   }
 
@@ -62,7 +67,7 @@ public:
   // Call this function to always keep the map sorted when putting
   // entries into the map.
   //------------------------------------------------------------------
-  void Insert(llvm::StringRef unique_cstr, const T &value) {
+  void Insert(ConstString unique_cstr, const T &value) {
     typename UniqueCStringMap<T>::Entry e(unique_cstr, value);
     m_map.insert(std::upper_bound(m_map.begin(), m_map.end(), e), e);
   }
@@ -85,7 +90,7 @@ public:
     return false;
   }
 
-  llvm::StringRef GetCStringAtIndexUnchecked(uint32_t idx) const {
+  ConstString GetCStringAtIndexUnchecked(uint32_t idx) const {
     return m_map[idx].cstring;
   }
 
@@ -99,8 +104,8 @@ public:
     return m_map[idx].value;
   }
 
-  llvm::StringRef GetCStringAtIndex(uint32_t idx) const {
-    return ((idx < m_map.size()) ? m_map[idx].cstring : llvm::StringRef());
+  ConstString GetCStringAtIndex(uint32_t idx) const {
+    return ((idx < m_map.size()) ? m_map[idx].cstring : ConstString());
   }
 
   //------------------------------------------------------------------
@@ -111,7 +116,7 @@ public:
   // T values and only if there is a sensible failure value that can
   // be returned and that won't match any existing values.
   //------------------------------------------------------------------
-  T Find(llvm::StringRef unique_cstr, T fail_value) const {
+  T Find(ConstString unique_cstr, T fail_value) const {
     Entry search_entry(unique_cstr);
     const_iterator end = m_map.end();
     const_iterator pos = std::lower_bound(m_map.begin(), end, search_entry);
@@ -129,15 +134,12 @@ public:
   // The caller is responsible for ensuring that the collection does
   // not change during while using the returned pointer.
   //------------------------------------------------------------------
-  const Entry *FindFirstValueForName(llvm::StringRef unique_cstr) const {
+  const Entry *FindFirstValueForName(ConstString unique_cstr) const {
     Entry search_entry(unique_cstr);
     const_iterator end = m_map.end();
     const_iterator pos = std::lower_bound(m_map.begin(), end, search_entry);
-    if (pos != end) {
-      llvm::StringRef pos_cstr = pos->cstring;
-      if (pos_cstr == unique_cstr)
-        return &(*pos);
-    }
+    if (pos != end && pos->cstring == unique_cstr)
+      return &(*pos);
     return nullptr;
   }
 
@@ -162,7 +164,7 @@ public:
     return nullptr;
   }
 
-  size_t GetValues(llvm::StringRef unique_cstr, std::vector<T> &values) const {
+  size_t GetValues(ConstString unique_cstr, std::vector<T> &values) const {
     const size_t start_size = values.size();
 
     Entry search_entry(unique_cstr);
@@ -184,7 +186,7 @@ public:
 
     const_iterator pos, end = m_map.end();
     for (pos = m_map.begin(); pos != end; ++pos) {
-      if (regex.Execute(pos->cstring))
+      if (regex.Execute(pos->cstring.GetCString()))
         values.push_back(pos->value);
     }
 
@@ -238,7 +240,7 @@ public:
     }
   }
 
-  size_t Erase(llvm::StringRef unique_cstr) {
+  size_t Erase(ConstString unique_cstr) {
     size_t num_removed = 0;
     Entry search_entry(unique_cstr);
     iterator end = m_map.end();

--- a/include/lldb/Core/UniqueCStringMap.h
+++ b/include/lldb/Core/UniqueCStringMap.h
@@ -17,7 +17,7 @@
 
 // Other libraries and framework includes
 // Project includes
-#include "lldb/Utility/ConstString.h"
+#include "lldb/Core/ConstString.h"
 #include "lldb/Core/RegularExpression.h"
 
 namespace lldb_private {

--- a/include/lldb/Symbol/ObjectFile.h
+++ b/include/lldb/Symbol/ObjectFile.h
@@ -805,9 +805,9 @@ public:
   bool IsInMemory() const { return m_memory_addr != LLDB_INVALID_ADDRESS; }
 
   // Strip linker annotations (such as @@VERSION) from symbol names.
-  virtual std::string
+  virtual llvm::StringRef
   StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
-    return symbol_name.str();
+    return symbol_name;
   }
 
   static lldb::SymbolType GetSymbolTypeFromName(

--- a/source/Interpreter/OptionValueEnumeration.cpp
+++ b/source/Interpreter/OptionValueEnumeration.cpp
@@ -37,7 +37,7 @@ void OptionValueEnumeration::DumpValue(const ExecutionContext *exe_ctx,
     const size_t count = m_enumerations.GetSize();
     for (size_t i = 0; i < count; ++i) {
       if (m_enumerations.GetValueAtIndexUnchecked(i).value == m_current_value) {
-        strm.PutCString(m_enumerations.GetCStringAtIndex(i));
+        strm.PutCString(m_enumerations.GetCStringAtIndex(i).GetStringRef());
         return;
       }
     }
@@ -58,8 +58,7 @@ Error OptionValueEnumeration::SetValueFromString(llvm::StringRef value,
   case eVarSetOperationAssign: {
     ConstString const_enumerator_name(value.trim());
     const EnumerationMapEntry *enumerator_entry =
-        m_enumerations.FindFirstValueForName(
-            const_enumerator_name.GetStringRef());
+        m_enumerations.FindFirstValueForName(const_enumerator_name);
     if (enumerator_entry) {
       m_current_value = enumerator_entry->value.value;
       NotifyValueChanged();
@@ -69,10 +68,10 @@ Error OptionValueEnumeration::SetValueFromString(llvm::StringRef value,
       const size_t count = m_enumerations.GetSize();
       if (count) {
         error_strm.Printf(", valid values are: %s",
-                          m_enumerations.GetCStringAtIndex(0).str().c_str());
+                          m_enumerations.GetCStringAtIndex(0).GetCString());
         for (size_t i = 1; i < count; ++i) {
           error_strm.Printf(", %s",
-                            m_enumerations.GetCStringAtIndex(i).str().c_str());
+                            m_enumerations.GetCStringAtIndex(i).GetCString());
         }
       }
       error.SetErrorString(error_strm.GetString());
@@ -99,7 +98,7 @@ void OptionValueEnumeration::SetEnumerations(
       ConstString const_enumerator_name(enumerators[i].string_value);
       EnumeratorInfo enumerator_info = {enumerators[i].value,
                                         enumerators[i].usage};
-      m_enumerations.Append(const_enumerator_name.GetStringRef(),
+      m_enumerations.Append(const_enumerator_name,
                             enumerator_info);
     }
     m_enumerations.Sort();
@@ -119,14 +118,14 @@ size_t OptionValueEnumeration::AutoComplete(
   const uint32_t num_enumerators = m_enumerations.GetSize();
   if (!s.empty()) {
     for (size_t i = 0; i < num_enumerators; ++i) {
-      llvm::StringRef name = m_enumerations.GetCStringAtIndex(i);
+      llvm::StringRef name = m_enumerations.GetCStringAtIndex(i).GetStringRef();
       if (name.startswith(s))
         matches.AppendString(name);
     }
   } else {
     // only suggest "true" or "false" by default
     for (size_t i = 0; i < num_enumerators; ++i)
-      matches.AppendString(m_enumerations.GetCStringAtIndex(i));
+      matches.AppendString(m_enumerations.GetCStringAtIndex(i).GetStringRef());
   }
   return matches.GetSize();
 }

--- a/source/Interpreter/OptionValueProperties.cpp
+++ b/source/Interpreter/OptionValueProperties.cpp
@@ -58,7 +58,7 @@ void OptionValueProperties::Initialize(const PropertyDefinition *defs) {
   for (size_t i = 0; defs[i].name; ++i) {
     Property property(defs[i]);
     assert(property.IsValid());
-    m_name_to_index.Append(property.GetName(), m_properties.size());
+    m_name_to_index.Append(ConstString(property.GetName()), m_properties.size());
     property.GetValue()->SetParent(shared_from_this());
     m_properties.push_back(property);
   }
@@ -77,7 +77,7 @@ void OptionValueProperties::AppendProperty(const ConstString &name,
                                            bool is_global,
                                            const OptionValueSP &value_sp) {
   Property property(name, desc, is_global, value_sp);
-  m_name_to_index.Append(name.GetStringRef(), m_properties.size());
+  m_name_to_index.Append(name, m_properties.size());
   m_properties.push_back(property);
   value_sp->SetParent(shared_from_this());
   m_name_to_index.Sort();
@@ -107,7 +107,7 @@ OptionValueProperties::GetValueForKey(const ExecutionContext *exe_ctx,
                                       const ConstString &key,
                                       bool will_modify) const {
   lldb::OptionValueSP value_sp;
-  size_t idx = m_name_to_index.Find(key.GetStringRef(), SIZE_MAX);
+  size_t idx = m_name_to_index.Find(key, SIZE_MAX);
   if (idx < m_properties.size())
     value_sp = GetPropertyAtIndex(exe_ctx, will_modify, idx)->GetValue();
   return value_sp;
@@ -217,7 +217,7 @@ Error OptionValueProperties::SetSubValue(const ExecutionContext *exe_ctx,
 
 uint32_t
 OptionValueProperties::GetPropertyIndex(const ConstString &name) const {
-  return m_name_to_index.Find(name.GetStringRef(), SIZE_MAX);
+  return m_name_to_index.Find(name, SIZE_MAX);
 }
 
 const Property *
@@ -226,7 +226,7 @@ OptionValueProperties::GetProperty(const ExecutionContext *exe_ctx,
                                    const ConstString &name) const {
   return GetPropertyAtIndex(
       exe_ctx, will_modify,
-      m_name_to_index.Find(name.GetStringRef(), SIZE_MAX));
+      m_name_to_index.Find(name, SIZE_MAX));
 }
 
 const Property *OptionValueProperties::GetPropertyAtIndex(

--- a/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -314,30 +314,27 @@ class CPPRuntimeEquivalents {
 public:
   CPPRuntimeEquivalents() {
     m_impl.Append(ConstString("std::basic_string<char, std::char_traits<char>, "
-                              "std::allocator<char> >")
-                      .GetStringRef(),
+                              "std::allocator<char> >"),
                   ConstString("basic_string<char>"));
 
     // these two (with a prefixed std::) occur when c++stdlib string class
     // occurs as a template argument in some STL container
     m_impl.Append(ConstString("std::basic_string<char, std::char_traits<char>, "
-                              "std::allocator<char> >")
-                      .GetStringRef(),
+                              "std::allocator<char> >"),
                   ConstString("std::basic_string<char>"));
 
     m_impl.Sort();
   }
 
   void Add(ConstString &type_name, ConstString &type_equivalent) {
-    m_impl.Insert(type_name.GetStringRef(), type_equivalent);
+    m_impl.Insert(type_name, type_equivalent);
   }
 
   uint32_t FindExactMatches(ConstString &type_name,
                             std::vector<ConstString> &equivalents) {
     uint32_t count = 0;
 
-    for (ImplData match =
-             m_impl.FindFirstValueForName(type_name.GetStringRef());
+    for (ImplData match = m_impl.FindFirstValueForName(type_name);
          match != nullptr; match = m_impl.FindNextValueForName(match)) {
       equivalents.push_back(match->value);
       count++;
@@ -365,7 +362,7 @@ public:
     size_t items_count = m_impl.GetSize();
 
     for (size_t item = 0; item < items_count; item++) {
-      llvm::StringRef key_cstr = m_impl.GetCStringAtIndex(item);
+      llvm::StringRef key_cstr = m_impl.GetCStringAtIndex(item).GetStringRef();
       if (type_name_cstr.contains(key_cstr)) {
         count += AppendReplacements(type_name_cstr, key_cstr, equivalents);
       }
@@ -394,7 +391,8 @@ private:
 
     uint32_t count = 0;
 
-    for (ImplData match = m_impl.FindFirstValueForName(matching_key);
+    for (ImplData match =
+             m_impl.FindFirstValueForName(ConstString(matching_key));
          match != nullptr; match = m_impl.FindNextValueForName(match)) {
       std::string target(original);
       std::string equiv_class(match->value.AsCString());

--- a/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -156,7 +156,7 @@ size_t ObjectContainerBSDArchive::Archive::ParseObjects() {
       size_t obj_idx = m_objects.size();
       m_objects.push_back(obj);
       // Insert all of the C strings out of order for now...
-      m_object_name_to_index_map.Append(obj.ar_name.GetStringRef(), obj_idx);
+      m_object_name_to_index_map.Append(obj.ar_name, obj_idx);
       offset += obj.ar_file_size;
       obj.Clear();
     } while (data.ValidOffset(offset));
@@ -172,8 +172,7 @@ ObjectContainerBSDArchive::Archive::FindObject(
     const ConstString &object_name,
     const llvm::sys::TimePoint<> &object_mod_time) {
   const ObjectNameToIndexMap::Entry *match =
-      m_object_name_to_index_map.FindFirstValueForName(
-          object_name.GetStringRef());
+      m_object_name_to_index_map.FindFirstValueForName(object_name);
   if (match) {
     if (object_mod_time != llvm::sys::TimePoint<>()) {
       const uint64_t object_date = llvm::sys::toTimeT(object_mod_time);

--- a/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -1742,10 +1742,10 @@ DataExtractor ObjectFileELF::GetSegmentDataByIndex(lldb::user_id_t id) {
                        segment_header->p_filesz);
 }
 
-std::string
+llvm::StringRef
 ObjectFileELF::StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
   size_t pos = symbol_name.find('@');
-  return symbol_name.substr(0, pos).str();
+  return symbol_name.substr(0, pos);
 }
 
 //----------------------------------------------------------------------

--- a/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -152,7 +152,7 @@ public:
   // Returns segment data for the given index.
   lldb_private::DataExtractor GetSegmentDataByIndex(lldb::user_id_t id);
 
-  std::string
+  llvm::StringRef
   StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const override;
 
 private:

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -3909,10 +3909,9 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
         if (src_name) {
           ConstString src_const_name(src_name);
           if (src_die.GetAttributeValueAsUnsigned(DW_AT_artificial, 0))
-            src_name_to_die_artificial.Append(src_const_name.GetStringRef(),
-                                              src_die);
+            src_name_to_die_artificial.Append(src_const_name, src_die);
           else
-            src_name_to_die.Append(src_const_name.GetStringRef(), src_die);
+            src_name_to_die.Append(src_const_name, src_die);
         }
       }
     }
@@ -3929,10 +3928,9 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
         if (dst_name) {
           ConstString dst_const_name(dst_name);
           if (dst_die.GetAttributeValueAsUnsigned(DW_AT_artificial, 0))
-            dst_name_to_die_artificial.Append(dst_const_name.GetStringRef(),
-                                              dst_die);
+            dst_name_to_die_artificial.Append(dst_const_name, dst_die);
           else
-            dst_name_to_die.Append(dst_const_name.GetStringRef(), dst_die);
+            dst_name_to_die.Append(dst_const_name, dst_die);
         }
       }
     }
@@ -4045,7 +4043,7 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
       src_name_to_die.Sort();
 
       for (idx = 0; idx < dst_size; ++idx) {
-        llvm::StringRef dst_name = dst_name_to_die.GetCStringAtIndex(idx);
+        ConstString dst_name = dst_name_to_die.GetCStringAtIndex(idx);
         dst_die = dst_name_to_die.GetValueAtIndexUnchecked(idx);
         src_die = src_name_to_die.Find(dst_name, DWARFDIE());
 
@@ -4100,7 +4098,7 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
     dst_name_to_die_artificial.Sort();
 
     for (idx = 0; idx < src_size_artificial; ++idx) {
-      llvm::StringRef src_name_artificial =
+      ConstString src_name_artificial =
           src_name_to_die_artificial.GetCStringAtIndex(idx);
       src_die = src_name_to_die_artificial.GetValueAtIndexUnchecked(idx);
       dst_die =
@@ -4144,13 +4142,13 @@ bool DWARFASTParserClang::CopyUniqueClassMethodTypes(
 
   if (dst_size_artificial) {
     for (idx = 0; idx < dst_size_artificial; ++idx) {
-      llvm::StringRef dst_name_artificial =
+      ConstString dst_name_artificial =
           dst_name_to_die_artificial.GetCStringAtIndex(idx);
       dst_die = dst_name_to_die_artificial.GetValueAtIndexUnchecked(idx);
       if (log)
         log->Printf("warning: need to create artificial method for 0x%8.8x for "
                     "method '%s'",
-                    dst_die.GetOffset(), dst_name_artificial.str().c_str());
+                    dst_die.GetOffset(), dst_name_artificial.GetCString());
 
       failures.Append(dst_die);
     }

--- a/source/Plugins/SymbolFile/DWARF/NameToDIE.cpp
+++ b/source/Plugins/SymbolFile/DWARF/NameToDIE.cpp
@@ -28,11 +28,11 @@ void NameToDIE::Finalize() {
 }
 
 void NameToDIE::Insert(const ConstString &name, const DIERef &die_ref) {
-  m_map.Append(name.GetStringRef(), die_ref);
+  m_map.Append(name, die_ref);
 }
 
 size_t NameToDIE::Find(const ConstString &name, DIEArray &info_array) const {
-  return m_map.GetValues(name.GetStringRef(), info_array);
+  return m_map.GetValues(name, info_array);
 }
 
 size_t NameToDIE::Find(const RegularExpression &regex,
@@ -55,15 +55,15 @@ size_t NameToDIE::FindAllEntriesForCompileUnit(dw_offset_t cu_offset,
 void NameToDIE::Dump(Stream *s) {
   const uint32_t size = m_map.GetSize();
   for (uint32_t i = 0; i < size; ++i) {
-    llvm::StringRef cstr = m_map.GetCStringAtIndex(i);
+    ConstString cstr = m_map.GetCStringAtIndex(i);
     const DIERef &die_ref = m_map.GetValueAtIndexUnchecked(i);
-    s->Printf("%p: {0x%8.8x/0x%8.8x} \"%s\"\n", (const void *)cstr.data(),
-              die_ref.cu_offset, die_ref.die_offset, cstr.str().c_str());
+    s->Printf("%p: {0x%8.8x/0x%8.8x} \"%s\"\n", (const void *)cstr.GetCString(),
+              die_ref.cu_offset, die_ref.die_offset, cstr.GetCString());
   }
 }
 
 void NameToDIE::ForEach(
-    std::function<bool(llvm::StringRef name, const DIERef &die_ref)> const
+    std::function<bool(ConstString name, const DIERef &die_ref)> const
         &callback) const {
   const uint32_t size = m_map.GetSize();
   for (uint32_t i = 0; i < size; ++i) {

--- a/source/Plugins/SymbolFile/DWARF/NameToDIE.h
+++ b/source/Plugins/SymbolFile/DWARF/NameToDIE.h
@@ -43,7 +43,8 @@ public:
                                       DIEArray &info_array) const;
 
   void
-  ForEach(std::function<bool(llvm::StringRef name, const DIERef &die_ref)> const
+  ForEach(std::function<bool(lldb_private::ConstString name,
+                             const DIERef &die_ref)> const
               &callback) const;
 
 protected:

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -969,75 +969,60 @@ ClangASTContext::GetBasicTypeEnumeration(const ConstString &name) {
     static std::once_flag g_once_flag;
     std::call_once(g_once_flag, []() {
       // "void"
-      g_type_map.Append(ConstString("void").GetStringRef(), eBasicTypeVoid);
+      g_type_map.Append(ConstString("void"), eBasicTypeVoid);
 
       // "char"
-      g_type_map.Append(ConstString("char").GetStringRef(), eBasicTypeChar);
-      g_type_map.Append(ConstString("signed char").GetStringRef(),
-                        eBasicTypeSignedChar);
-      g_type_map.Append(ConstString("unsigned char").GetStringRef(),
-                        eBasicTypeUnsignedChar);
-      g_type_map.Append(ConstString("wchar_t").GetStringRef(), eBasicTypeWChar);
-      g_type_map.Append(ConstString("signed wchar_t").GetStringRef(),
-                        eBasicTypeSignedWChar);
-      g_type_map.Append(ConstString("unsigned wchar_t").GetStringRef(),
+      g_type_map.Append(ConstString("char"), eBasicTypeChar);
+      g_type_map.Append(ConstString("signed char"), eBasicTypeSignedChar);
+      g_type_map.Append(ConstString("unsigned char"), eBasicTypeUnsignedChar);
+      g_type_map.Append(ConstString("wchar_t"), eBasicTypeWChar);
+      g_type_map.Append(ConstString("signed wchar_t"), eBasicTypeSignedWChar);
+      g_type_map.Append(ConstString("unsigned wchar_t"),
                         eBasicTypeUnsignedWChar);
       // "short"
-      g_type_map.Append(ConstString("short").GetStringRef(), eBasicTypeShort);
-      g_type_map.Append(ConstString("short int").GetStringRef(),
-                        eBasicTypeShort);
-      g_type_map.Append(ConstString("unsigned short").GetStringRef(),
-                        eBasicTypeUnsignedShort);
-      g_type_map.Append(ConstString("unsigned short int").GetStringRef(),
+      g_type_map.Append(ConstString("short"), eBasicTypeShort);
+      g_type_map.Append(ConstString("short int"), eBasicTypeShort);
+      g_type_map.Append(ConstString("unsigned short"), eBasicTypeUnsignedShort);
+      g_type_map.Append(ConstString("unsigned short int"),
                         eBasicTypeUnsignedShort);
 
       // "int"
-      g_type_map.Append(ConstString("int").GetStringRef(), eBasicTypeInt);
-      g_type_map.Append(ConstString("signed int").GetStringRef(),
-                        eBasicTypeInt);
-      g_type_map.Append(ConstString("unsigned int").GetStringRef(),
-                        eBasicTypeUnsignedInt);
-      g_type_map.Append(ConstString("unsigned").GetStringRef(),
-                        eBasicTypeUnsignedInt);
+      g_type_map.Append(ConstString("int"), eBasicTypeInt);
+      g_type_map.Append(ConstString("signed int"), eBasicTypeInt);
+      g_type_map.Append(ConstString("unsigned int"), eBasicTypeUnsignedInt);
+      g_type_map.Append(ConstString("unsigned"), eBasicTypeUnsignedInt);
 
       // "long"
-      g_type_map.Append(ConstString("long").GetStringRef(), eBasicTypeLong);
-      g_type_map.Append(ConstString("long int").GetStringRef(), eBasicTypeLong);
-      g_type_map.Append(ConstString("unsigned long").GetStringRef(),
-                        eBasicTypeUnsignedLong);
-      g_type_map.Append(ConstString("unsigned long int").GetStringRef(),
+      g_type_map.Append(ConstString("long"), eBasicTypeLong);
+      g_type_map.Append(ConstString("long int"), eBasicTypeLong);
+      g_type_map.Append(ConstString("unsigned long"), eBasicTypeUnsignedLong);
+      g_type_map.Append(ConstString("unsigned long int"),
                         eBasicTypeUnsignedLong);
 
       // "long long"
-      g_type_map.Append(ConstString("long long").GetStringRef(),
-                        eBasicTypeLongLong);
-      g_type_map.Append(ConstString("long long int").GetStringRef(),
-                        eBasicTypeLongLong);
-      g_type_map.Append(ConstString("unsigned long long").GetStringRef(),
+      g_type_map.Append(ConstString("long long"), eBasicTypeLongLong);
+      g_type_map.Append(ConstString("long long int"), eBasicTypeLongLong);
+      g_type_map.Append(ConstString("unsigned long long"),
                         eBasicTypeUnsignedLongLong);
-      g_type_map.Append(ConstString("unsigned long long int").GetStringRef(),
+      g_type_map.Append(ConstString("unsigned long long int"),
                         eBasicTypeUnsignedLongLong);
 
       // "int128"
-      g_type_map.Append(ConstString("__int128_t").GetStringRef(),
-                        eBasicTypeInt128);
-      g_type_map.Append(ConstString("__uint128_t").GetStringRef(),
-                        eBasicTypeUnsignedInt128);
+      g_type_map.Append(ConstString("__int128_t"), eBasicTypeInt128);
+      g_type_map.Append(ConstString("__uint128_t"), eBasicTypeUnsignedInt128);
 
       // Miscellaneous
-      g_type_map.Append(ConstString("bool").GetStringRef(), eBasicTypeBool);
-      g_type_map.Append(ConstString("float").GetStringRef(), eBasicTypeFloat);
-      g_type_map.Append(ConstString("double").GetStringRef(), eBasicTypeDouble);
-      g_type_map.Append(ConstString("long double").GetStringRef(),
-                        eBasicTypeLongDouble);
-      g_type_map.Append(ConstString("id").GetStringRef(), eBasicTypeObjCID);
-      g_type_map.Append(ConstString("SEL").GetStringRef(), eBasicTypeObjCSel);
-      g_type_map.Append(ConstString("nullptr").GetStringRef(),
-                        eBasicTypeNullPtr);
+      g_type_map.Append(ConstString("bool"), eBasicTypeBool);
+      g_type_map.Append(ConstString("float"), eBasicTypeFloat);
+      g_type_map.Append(ConstString("double"), eBasicTypeDouble);
+      g_type_map.Append(ConstString("long double"), eBasicTypeLongDouble);
+      g_type_map.Append(ConstString("id"), eBasicTypeObjCID);
+      g_type_map.Append(ConstString("SEL"), eBasicTypeObjCSel);
+      g_type_map.Append(ConstString("nullptr"), eBasicTypeNullPtr);
       g_type_map.Sort();
     });
 
-    return g_type_map.Find(name.GetStringRef(), eBasicTypeInvalid);
+    return g_type_map.Find(name, eBasicTypeInvalid);
   }
   return eBasicTypeInvalid;
 }

--- a/source/Symbol/GoASTContext.cpp
+++ b/source/Symbol/GoASTContext.cpp
@@ -596,33 +596,32 @@ GoASTContext::GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) {
     static std::once_flag g_once_flag;
     std::call_once(g_once_flag, []() {
       // "void"
-      g_type_map.Append(ConstString("void").GetStringRef(), eBasicTypeVoid);
+      g_type_map.Append(ConstString("void"), eBasicTypeVoid);
       // "int"
-      g_type_map.Append(ConstString("int").GetStringRef(), eBasicTypeInt);
-      g_type_map.Append(ConstString("uint").GetStringRef(),
-                        eBasicTypeUnsignedInt);
+      g_type_map.Append(ConstString("int"), eBasicTypeInt);
+      g_type_map.Append(ConstString("uint"), eBasicTypeUnsignedInt);
 
       // Miscellaneous
-      g_type_map.Append(ConstString("bool").GetStringRef(), eBasicTypeBool);
+      g_type_map.Append(ConstString("bool"), eBasicTypeBool);
 
       // Others. Should these map to C types?
-      g_type_map.Append(ConstString("byte").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("uint8").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("uint16").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("uint32").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("uint64").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("int8").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("int16").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("int32").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("int64").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("float32").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("float64").GetStringRef(), eBasicTypeOther);
-      g_type_map.Append(ConstString("uintptr").GetStringRef(), eBasicTypeOther);
+      g_type_map.Append(ConstString("byte"), eBasicTypeOther);
+      g_type_map.Append(ConstString("uint8"), eBasicTypeOther);
+      g_type_map.Append(ConstString("uint16"), eBasicTypeOther);
+      g_type_map.Append(ConstString("uint32"), eBasicTypeOther);
+      g_type_map.Append(ConstString("uint64"), eBasicTypeOther);
+      g_type_map.Append(ConstString("int8"), eBasicTypeOther);
+      g_type_map.Append(ConstString("int16"), eBasicTypeOther);
+      g_type_map.Append(ConstString("int32"), eBasicTypeOther);
+      g_type_map.Append(ConstString("int64"), eBasicTypeOther);
+      g_type_map.Append(ConstString("float32"), eBasicTypeOther);
+      g_type_map.Append(ConstString("float64"), eBasicTypeOther);
+      g_type_map.Append(ConstString("uintptr"), eBasicTypeOther);
 
       g_type_map.Sort();
     });
 
-    return g_type_map.Find(name.GetStringRef(), eBasicTypeInvalid);
+    return g_type_map.Find(name, eBasicTypeInvalid);
   }
   return eBasicTypeInvalid;
 }

--- a/source/Symbol/Symtab.cpp
+++ b/source/Symbol/Symtab.cpp
@@ -265,8 +265,8 @@ void Symtab::InitNameIndexes() {
         continue;
 
       const Mangled &mangled = symbol->GetMangled();
-      entry.cstring = mangled.GetMangledName().GetStringRef();
-      if (!entry.cstring.empty()) {
+      entry.cstring = mangled.GetMangledName();
+      if (entry.cstring) {
         m_name_to_index.Append(entry);
 
         // Now try and figure out the basename and figure out if the
@@ -277,26 +277,27 @@ void Symtab::InitNameIndexes() {
           // If the symbol has linker annotations, also add the version without
           // the annotations.
           entry.cstring = ConstString(m_objfile->StripLinkerSymbolAnnotations(
-                                          entry.cstring))
-                              .GetStringRef();
+                                        entry.cstring.GetStringRef()));
           m_name_to_index.Append(entry);
         }
 
         const SymbolType symbol_type = symbol->GetType();
         if (symbol_type == eSymbolTypeCode ||
             symbol_type == eSymbolTypeResolver) {
-          if (name.size() >= 2 && name[0] == '_' && name[1] == 'Z' &&
-              ((name.size() < 3) || (name[2] != 'T' && // avoid virtual table, VTT structure, typeinfo
-                                 // structure, and typeinfo name
-               name[2] != 'G' && // avoid guard variables
-               name[2] != 'Z'))) // named local entities (if we eventually handle
-                                // eSymbolTypeData, we will want this back)
+          llvm::StringRef entry_ref(entry.cstring.GetStringRef());
+          if (entry_ref[0] == '_' && entry_ref[1] == 'Z' &&
+              (entry_ref[2] != 'T' && // avoid virtual table, VTT structure,
+                                      // typeinfo structure, and typeinfo
+                                      // name
+               entry_ref[2] != 'G' && // avoid guard variables
+               entry_ref[2] != 'Z'))  // named local entities (if we
+                                          // eventually handle eSymbolTypeData,
+                                          // we will want this back)
           {
             CPlusPlusLanguage::MethodName cxx_method(
                 mangled.GetDemangledName(lldb::eLanguageTypeC_plus_plus));
-            entry.cstring =
-                ConstString(cxx_method.GetBasename()).GetStringRef();
-            if (!entry.cstring.empty()) {
+            entry.cstring = ConstString(cxx_method.GetBasename());
+            if (entry.cstring) {
               // ConstString objects permanently store the string in the pool so
               // calling
               // GetCString() on the value gets us a const char * that will
@@ -304,7 +305,8 @@ void Symtab::InitNameIndexes() {
               const char *const_context =
                   ConstString(cxx_method.GetContext()).GetCString();
 
-              if (entry.cstring[0] == '~' ||
+              entry_ref = entry.cstring.GetStringRef();
+              if (entry_ref[0] == '~' ||
                   !cxx_method.GetQualifiers().empty()) {
                 // The first character of the demangled basename is '~' which
                 // means we have a class destructor. We can use this information
@@ -360,17 +362,15 @@ void Symtab::InitNameIndexes() {
         }
       }
 
-      entry.cstring =
-          mangled.GetDemangledName(symbol->GetLanguage()).GetStringRef();
-      if (!entry.cstring.empty()) {
+      entry.cstring = mangled.GetDemangledName(symbol->GetLanguage());
+      if (entry.cstring) {
         m_name_to_index.Append(entry);
 
         if (symbol->ContainsLinkerAnnotations()) {
           // If the symbol has linker annotations, also add the version without
           // the annotations.
           entry.cstring = ConstString(m_objfile->StripLinkerSymbolAnnotations(
-                                          entry.cstring))
-                              .GetStringRef();
+                                        entry.cstring.GetStringRef()));
           m_name_to_index.Append(entry);
         }
       }
@@ -378,15 +378,15 @@ void Symtab::InitNameIndexes() {
       // If the demangled name turns out to be an ObjC name, and
       // is a category name, add the version without categories to the index
       // too.
-      ObjCLanguage::MethodName objc_method(entry.cstring, true);
+      ObjCLanguage::MethodName objc_method(entry.cstring.GetStringRef(), true);
       if (objc_method.IsValid(true)) {
-        entry.cstring = objc_method.GetSelector().GetStringRef();
+        entry.cstring = objc_method.GetSelector();
         m_selector_to_index.Append(entry);
 
         ConstString objc_method_no_category(
             objc_method.GetFullNameWithoutCategory(true));
         if (objc_method_no_category) {
-          entry.cstring = objc_method_no_category.GetStringRef();
+          entry.cstring = objc_method_no_category;
           m_name_to_index.Append(entry);
         }
       }
@@ -463,15 +463,14 @@ void Symtab::AppendSymbolNamesToMap(const IndexCollection &indexes,
 
       const Mangled &mangled = symbol->GetMangled();
       if (add_demangled) {
-        entry.cstring =
-            mangled.GetDemangledName(symbol->GetLanguage()).GetStringRef();
-        if (!entry.cstring.empty())
+        entry.cstring = mangled.GetDemangledName(symbol->GetLanguage());
+        if (entry.cstring)
           name_to_index_map.Append(entry);
       }
 
       if (add_mangled) {
-        entry.cstring = mangled.GetMangledName().GetStringRef();
-        if (!entry.cstring.empty())
+        entry.cstring = mangled.GetMangledName();
+        if (entry.cstring)
           name_to_index_map.Append(entry);
       }
     }
@@ -644,7 +643,7 @@ uint32_t Symtab::AppendSymbolIndexesWithName(const ConstString &symbol_name,
     if (!m_name_indexes_computed)
       InitNameIndexes();
 
-    return m_name_to_index.GetValues(symbol_name.GetStringRef(), indexes);
+    return m_name_to_index.GetValues(symbol_name, indexes);
   }
   return 0;
 }
@@ -663,7 +662,7 @@ uint32_t Symtab::AppendSymbolIndexesWithName(const ConstString &symbol_name,
 
     std::vector<uint32_t> all_name_indexes;
     const size_t name_match_count =
-        m_name_to_index.GetValues(symbol_name.GetStringRef(), all_name_indexes);
+        m_name_to_index.GetValues(symbol_name, all_name_indexes);
     for (size_t i = 0; i < name_match_count; ++i) {
       if (CheckSymbolAtIndex(all_name_indexes[i], symbol_debug_type,
                              symbol_visibility))
@@ -1087,8 +1086,6 @@ size_t Symtab::FindFunctionSymbols(const ConstString &name,
   size_t count = 0;
   std::vector<uint32_t> symbol_indexes;
 
-  llvm::StringRef name_cstr = name.GetStringRef();
-
   // eFunctionNameTypeAuto should be pre-resolved by a call to
   // Module::LookupInfo::LookupInfo()
   assert((name_type_mask & eFunctionNameTypeAuto) == 0);
@@ -1126,7 +1123,7 @@ size_t Symtab::FindFunctionSymbols(const ConstString &name,
 
     if (!m_basename_to_index.IsEmpty()) {
       const UniqueCStringMap<uint32_t>::Entry *match;
-      for (match = m_basename_to_index.FindFirstValueForName(name_cstr);
+      for (match = m_basename_to_index.FindFirstValueForName(name);
            match != nullptr;
            match = m_basename_to_index.FindNextValueForName(match)) {
         symbol_indexes.push_back(match->value);
@@ -1140,7 +1137,7 @@ size_t Symtab::FindFunctionSymbols(const ConstString &name,
 
     if (!m_method_to_index.IsEmpty()) {
       const UniqueCStringMap<uint32_t>::Entry *match;
-      for (match = m_method_to_index.FindFirstValueForName(name_cstr);
+      for (match = m_method_to_index.FindFirstValueForName(name);
            match != nullptr;
            match = m_method_to_index.FindNextValueForName(match)) {
         symbol_indexes.push_back(match->value);
@@ -1154,7 +1151,7 @@ size_t Symtab::FindFunctionSymbols(const ConstString &name,
 
     if (!m_selector_to_index.IsEmpty()) {
       const UniqueCStringMap<uint32_t>::Entry *match;
-      for (match = m_selector_to_index.FindFirstValueForName(name_cstr);
+      for (match = m_selector_to_index.FindFirstValueForName(name);
            match != nullptr;
            match = m_selector_to_index.FindNextValueForName(match)) {
         symbol_indexes.push_back(match->value);

--- a/source/Symbol/Symtab.cpp
+++ b/source/Symbol/Symtab.cpp
@@ -272,7 +272,7 @@ void Symtab::InitNameIndexes() {
         // Now try and figure out the basename and figure out if the
         // basename is a method, function, etc and put that in the
         // appropriate table.
-        llvm::StringRef name = entry.cstring;
+        llvm::StringRef name = entry.cstring.GetStringRef();
         if (symbol->ContainsLinkerAnnotations()) {
           // If the symbol has linker annotations, also add the version without
           // the annotations.
@@ -351,7 +351,7 @@ void Symtab::InitNameIndexes() {
                     ExtractFunctionBasenameFromMangled(mangled_name, basename,
                                                        is_method)) {
               if (basename && basename != mangled_name) {
-                entry.cstring = basename.GetCString();
+                entry.cstring = basename;
                 if (is_method)
                   m_method_to_index.Append(entry);
                 else

--- a/tools/argdumper/CMakeLists.txt
+++ b/tools/argdumper/CMakeLists.txt
@@ -4,7 +4,6 @@ add_lldb_tool(lldb-argdumper INCLUDE_IN_FRAMEWORK
   argdumper.cpp
 
   LINK_LIBS
-    lldbCore
-    lldbUtility
+    liblldb
   )
 

--- a/tools/argdumper/CMakeLists.txt
+++ b/tools/argdumper/CMakeLists.txt
@@ -1,9 +1,16 @@
 include(${LLDB_PROJECT_ROOT}/cmake/LLDBDependencies.cmake)
 
+if(NOT LLDB_EXPORT_ALL_SYMBOLS)
+  # if liblldb does not export everything we need to directly link these two
+  # lldb libraries for lldb_private members
+  set(extra_lldb_libs lldbCore lldbUtility)
+endif()
+
 add_lldb_tool(lldb-argdumper INCLUDE_IN_FRAMEWORK
   argdumper.cpp
 
   LINK_LIBS
     liblldb
+    ${extra_lldb_libs}
   )
 

--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -65,7 +65,6 @@ add_lldb_library(lldbDebugserverCommon
   TTYState.cpp
 
   LINK_LIBS
-    lldbHost
     ${COCOA_LIBRARY}
   )
 


### PR DESCRIPTION
This back ports a fix for a severe performance regression in LLDB that was introduced in LLVM 4.0.