### PR TITLE
Allow Linux SDKs in SwiftASTContext.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2148,8 +2148,9 @@ static bool SDKSupportsSwift(const FileSpec &sdk_path, SDKType desired_type) {
         }
       }
 
+      // For non-Darwin SDKs assume Swift is supported
       if (sdk_type == SDKType::unknown)
-        return false;
+        return true;
     } else {
       if (sdk_name.startswith(sdk_strings[(int)desired_type])) {
         version_part =


### PR DESCRIPTION
With this change, cross-compiled Swift binaries can be debugged remotely from Darwin.