### PR TITLE
The go OperatingSystem plugin can crash when the application

### DIFF
--- a/source/Plugins/OperatingSystem/Go/OperatingSystemGo.cpp
+++ b/source/Plugins/OperatingSystem/Go/OperatingSystemGo.cpp
@@ -47,7 +47,7 @@ using namespace lldb_private;
 namespace {
 
 static PropertyDefinition g_properties[] = {
-    {"enable", OptionValue::eTypeBoolean, true, true, nullptr, nullptr,
+    {"enable", OptionValue::eTypeBoolean, true, false, nullptr, nullptr,
      "Specify whether goroutines should be treated as threads."},
     {NULL, OptionValue::eTypeInvalid, false, 0, NULL, NULL, NULL}};
 
@@ -451,8 +451,14 @@ OperatingSystemGo::Goroutine
 OperatingSystemGo::CreateGoroutineAtIndex(uint64_t idx, Error &err) {
   err.Clear();
   Goroutine result = {};
-  ValueObjectSP g =
-      m_allg_sp->GetSyntheticArrayMember(idx, true)->Dereference(err);
+  ValueObjectSP child_sp = m_allg_sp->GetSyntheticArrayMember(idx, true);
+  if (!child_sp) {
+    err.SetErrorToGenericError();
+    err.SetErrorString("unable to find goroutines in array");
+    return result;
+  }
+
+  ValueObjectSP g = child_sp->Dereference(err);
   if (err.Fail()) {
     return result;
   }


### PR DESCRIPTION
has some third-party go code linked in to it, possibly created
with a different version of Go than lldb is currently able to
handle.

Disable the automatic creation of threads for goroutines
(plugin.os.goroutines.enable defaults to false) and also harden
the routine that was crashing when the goroutine data structures
weren't as expected.

Go developers can re-enable the goroutines thread creation by
changing the setting.

<rdar://problem/31451900>