### PR TITLE
[Swift] Fix 'frame var -O' for inout parameters [4.0]

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
@@ -100,6 +100,8 @@ class TestInOutVariables(TestBase):
                 lldb.eDynamicCanRunTarget)
             message_end = "from FindVariable"
 
+            _ = self.frame.FindVariable("x").description
+
         self.assertTrue(x.IsValid(), "did not find x %s" % (message_end))
         self.assertTrue(
             x.GetNumChildren() == 1,

--- a/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
@@ -100,6 +100,7 @@ class TestInOutVariables(TestBase):
                 lldb.eDynamicCanRunTarget)
             message_end = "from FindVariable"
 
+            # Make sure we can get the object description without crashing
             _ = self.frame.FindVariable("x").description
 
         self.assertTrue(x.IsValid(), "did not find x %s" % (message_end))

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4185,6 +4185,7 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
     case swift::DeclKind::IfConfig:
     case swift::DeclKind::Param:
     case swift::DeclKind::Module:
+    case swift::DeclKind::MissingMember:
       break;
 
     case swift::DeclKind::InfixOperator:

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -365,7 +365,9 @@ static bool GetObjectDescription_ObjectCopy(Process *process, Stream &str,
 
   ValueObjectSP static_sp(object.GetStaticValue());
 
-  CompilerType static_type(static_sp->GetCompilerType().GetNonReferenceType());
+  CompilerType static_type(static_sp->GetCompilerType());
+  if (auto non_reference_type = static_type.GetNonReferenceType())
+    static_type = non_reference_type;
 
   Error error;
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -365,7 +365,7 @@ static bool GetObjectDescription_ObjectCopy(Process *process, Stream &str,
 
   ValueObjectSP static_sp(object.GetStaticValue());
 
-  CompilerType static_type(static_sp->GetCompilerType());
+  CompilerType static_type(static_sp->GetCompilerType().GetNonReferenceType());
 
   Error error;
 


### PR DESCRIPTION
* Description: Fixes a crash when attempting to pass an LValue type to SIL type lowering, which is not allowed. Just unwrap the lvalue type first.

* Scope of the issue: Reported externally.

* Origination: Probably been there for a while, but at one point lldb had a "legal SIL type" check. That's totally wrong, though.

* Risk: Very low.

* Radar: Fixes <rdar://problem/33296509>

* Reviewed by: @jimingham 