### PR TITLE
[Swift] Make classes and members of classes 'open' instead of 'public' [4.0]

### DIFF
--- a/packages/Python/lldbsuite/test/repl/breakpoints/TestREPLBreakpoints.py
+++ b/packages/Python/lldbsuite/test/repl/breakpoints/TestREPLBreakpoints.py
@@ -16,12 +16,12 @@ import time
 import unittest2
 import lldb
 import lldbsuite.test.decorators as decorators
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLBreakpointsTestCase (REPLTest):
+class REPLBreakpointsTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     @decorators.swiftTest
     @decorators.no_debug_info_test

--- a/packages/Python/lldbsuite/test/repl/closures/TestREPLClosure.py
+++ b/packages/Python/lldbsuite/test/repl/closures/TestREPLClosure.py
@@ -15,12 +15,12 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLClosureTestCase (REPLTest):
+class REPLClosureTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     def doTest(self):
         self.command(

--- a/packages/Python/lldbsuite/test/repl/dictionary/TestREPLDictionary.py
+++ b/packages/Python/lldbsuite/test/repl/dictionary/TestREPLDictionary.py
@@ -15,13 +15,13 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 import lldbsuite.test.decorators as decorators
 
 
-class REPLDictionaryTestCase (REPLTest):
+class REPLDictionaryTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     @decorators.swiftTest
     @decorators.no_debug_info_test

--- a/packages/Python/lldbsuite/test/repl/dyntype/TestREPLDynamicType.py
+++ b/packages/Python/lldbsuite/test/repl/dyntype/TestREPLDynamicType.py
@@ -15,12 +15,12 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLDynamicTypeTestCase (REPLTest):
+class REPLDynamicTypeTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     def doTest(self):
         self.command('type(of: 1)', patterns=['\\$R0: Int.Type = Int'])

--- a/packages/Python/lldbsuite/test/repl/func_definition/TestREPLFunctionDefinition.py
+++ b/packages/Python/lldbsuite/test/repl/func_definition/TestREPLFunctionDefinition.py
@@ -15,12 +15,12 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLFuncDefinitionTestCase (REPLTest):
+class REPLFuncDefinitionTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     def doTest(self):
         self.command(

--- a/packages/Python/lldbsuite/test/repl/int_vars/TestREPLIntVars.py
+++ b/packages/Python/lldbsuite/test/repl/int_vars/TestREPLIntVars.py
@@ -16,12 +16,12 @@ import time
 import unittest2
 import lldb
 import lldbsuite.test.decorators as decorators
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLIntVarsTestCase (REPLTest):
+class REPLIntVarsTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     @decorators.swiftTest
     @decorators.no_debug_info_test

--- a/packages/Python/lldbsuite/test/repl/multilevelarrays/TestMultilevelArrays.py
+++ b/packages/Python/lldbsuite/test/repl/multilevelarrays/TestMultilevelArrays.py
@@ -15,12 +15,12 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLNestedArrayTestCase (REPLTest):
+class REPLNestedArrayTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     def doTest(self):
         self.command('[[1,2,3,4],[1,2,3],[1,2],[],[1]]', patterns=[

--- a/packages/Python/lldbsuite/test/repl/nsobject_subclass/TestNSObjectSubclass.py
+++ b/packages/Python/lldbsuite/test/repl/nsobject_subclass/TestNSObjectSubclass.py
@@ -15,14 +15,14 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 import lldbsuite.test.decorators as decorators
 import lldbsuite.test.lldbtest as lldbtest
 
 
-class REPLNSObjectSubclassTest (REPLTest):
+class REPLNSObjectSubclassTest (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     @decorators.swiftTest
     @decorators.skipUnlessDarwin

--- a/packages/Python/lldbsuite/test/repl/nsstring/TestREPLNSString.py
+++ b/packages/Python/lldbsuite/test/repl/nsstring/TestREPLNSString.py
@@ -16,12 +16,12 @@ import time
 import unittest2
 import lldb
 import lldbsuite.test.decorators as decorators
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 
 
-class REPLNSStringTestCase (REPLTest):
+class REPLNSStringTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     @decorators.swiftTest
     @decorators.skipUnlessDarwin

--- a/packages/Python/lldbsuite/test/repl/quicklookobject/TestREPLQuickLookObject.py
+++ b/packages/Python/lldbsuite/test/repl/quicklookobject/TestREPLQuickLookObject.py
@@ -15,13 +15,13 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 import lldbsuite.test.lldbtest as lldbtest
 
 
-class REPLQuickLookTestCase (REPLTest):
+class REPLQuickLookTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
     def doTest(self):
         self.command(

--- a/packages/Python/lldbsuite/test/repl/subclassing/TestREPLSubclassing.py
+++ b/packages/Python/lldbsuite/test/repl/subclassing/TestREPLSubclassing.py
@@ -15,24 +15,21 @@ import os
 import time
 import unittest2
 import lldb
-from lldbsuite.test.lldbrepl import REPLTest, load_tests
+import lldbsuite.test.lldbrepl as lldbrepl
 from lldbsuite.test import decorators
 
 
-class REPLSubclassingTestCase (REPLTest):
+class REPLSubclassingTestCase (lldbrepl.REPLTest):
 
-    mydir = REPLTest.compute_mydir(__file__)
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
 
-    @decorators.expectedFailureAll(
-        oslist=["macosx"],
-        bugnumber="rdar://26768714")
     def doTest(self):
         self.command('class A {init(a: Int) {}}')
         self.command(
-            'class B : A {let x: Int; init() { x = 10; super.init(a: x) } }')
+            'class B : A {let x: Int; init() { x = 5 + 5; super.init(a: x) } }')
         self.command('print(B().x)', patterns=['10'])
         self.command(
-            'extension B : CustomStringConvertible { var description:String { return "class B is a subclass of class A"} }')
+            'extension B : CustomStringConvertible { public var description:String { return "class B\(x) is a subclass of class A"} }')
         self.command(
             'print(B())',
-            patterns=['class B is a subclass of class A'])
+            patterns=['class B(10) is a subclass of class A'])

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -835,10 +835,16 @@ void SwiftASTManipulator::MakeDeclarationsPublic() {
     virtual bool walkToDeclPre(swift::Decl *decl) {
       if (swift::ValueDecl *value_decl =
               llvm::dyn_cast<swift::ValueDecl>(decl)) {
-        value_decl->overwriteAccessibility(swift::Accessibility::Public);
+        auto access = swift::Accessibility::Public;
+        if (swift::isa<swift::ClassDecl>(value_decl) ||
+            swift::isa<swift::ClassDecl>(value_decl->getDeclContext())) {
+          access = swift::Accessibility::Open;
+        }
+
+        value_decl->overwriteAccessibility(access);
         if (swift::AbstractStorageDecl *var_decl =
                 llvm::dyn_cast<swift::AbstractStorageDecl>(decl))
-          var_decl->overwriteSetterAccessibility(swift::Accessibility::Public);
+          var_decl->overwriteSetterAccessibility(access);
       }
 
       return true;


### PR DESCRIPTION
Fixes <rdar://problem/29039602>.