### PR TITLE
When parsing the DBGSourcePathRemapping plist entries

### DIFF
--- a/source/Host/macosx/Symbols.cpp
+++ b/source/Host/macosx/Symbols.cpp
@@ -354,6 +354,7 @@ static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
       // If we see DBGVersion with a value of 2 or higher, this is a new style
       // DBGSourcePathRemapping dictionary
       bool new_style_source_remapping_dictionary = false;
+      bool do_truncate_remapping_names = false;
       std::string original_DBGSourcePath_value = DBGSourcePath;
       cf_str = (CFStringRef)CFDictionaryGetValue((CFDictionaryRef)uuid_dict,
                                                  CFSTR("DBGVersion"));
@@ -364,6 +365,9 @@ static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
           int version_number = atoi(version.c_str());
           if (version_number > 1) {
             new_style_source_remapping_dictionary = true;
+          }
+          if (version_number == 2) {
+            do_truncate_remapping_names = true;
           }
         }
       }
@@ -402,9 +406,24 @@ static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
               FileSpec resolved_source_path(DBGSourcePath.c_str(), true);
               DBGSourcePath = resolved_source_path.GetPath();
             }
+            // With version 2 of DBGSourcePathRemapping, we can chop off the
+            // last two filename parts from the source remapping and get a
+            // more general source remapping that still works. Add this as
+            // another option in addition to the full source path remap.
             module_spec.GetSourceMappingList().Append(
                 ConstString(DBGBuildSourcePath.c_str()),
                 ConstString(DBGSourcePath.c_str()), true);
+            if (do_truncate_remapping_names) {
+              FileSpec build_path(DBGBuildSourcePath.c_str(), false);
+              FileSpec source_path(DBGSourcePath.c_str(), false);
+              build_path.RemoveLastPathComponent();
+              build_path.RemoveLastPathComponent();
+              source_path.RemoveLastPathComponent();
+              source_path.RemoveLastPathComponent();
+              module_spec.GetSourceMappingList().Append(
+                ConstString(build_path.GetPath().c_str()),
+                ConstString(source_path.GetPath().c_str()), true);
+            }
           }
         }
         if (keys)

--- a/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
+++ b/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
@@ -217,6 +217,7 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
                         // the original
                         // gloal DBGSourcePath string.
                         bool new_style_source_remapping_dictionary = false;
+                        bool do_truncate_remapping_names = false;
                         std::string original_DBGSourcePath_value =
                             DBGSourcePath;
                         if (plist_sp->GetAsDictionary()->HasKey("DBGVersion")) {
@@ -230,6 +231,9 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
                             if (version_number > 1) {
                               new_style_source_remapping_dictionary = true;
                             }
+                            if (version_number == 2) {
+                                do_truncate_remapping_names = true;
+                            }
                           }
                         }
 
@@ -239,7 +243,7 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
                                 ->GetAsDictionary();
                         remappings_dict->ForEach(
                             [&module_sp, new_style_source_remapping_dictionary,
-                             original_DBGSourcePath_value](
+                             original_DBGSourcePath_value, do_truncate_remapping_names](
                                 ConstString key,
                                 StructuredData::Object *object) -> bool {
                               if (object && object->GetAsString()) {
@@ -261,6 +265,21 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
                                 }
                                 module_sp->GetSourceMappingList().Append(
                                     key, ConstString(DBGSourcePath), true);
+                                // With version 2 of DBGSourcePathRemapping, we can chop off the
+                                // last two filename parts from the source remapping and get a
+                                // more general source remapping that still works.  Add this as
+                                // another option in addition to the full source path remap.
+                                if (do_truncate_remapping_names) {
+                                  FileSpec build_path(key.AsCString(), false);
+                                  FileSpec source_path(DBGSourcePath.c_str(), false);
+                                  build_path.RemoveLastPathComponent();
+                                  build_path.RemoveLastPathComponent();
+                                  source_path.RemoveLastPathComponent();
+                                  source_path.RemoveLastPathComponent();
+                                  module_sp->GetSourceMappingList().Append(
+                                      ConstString(build_path.GetPath().c_str()),
+                                      ConstString(source_path.GetPath().c_str()), true);
+                                }
                               }
                               return true;
                             });


### PR DESCRIPTION
When parsing the DBGSourcePathRemapping plist entries
in a dSYM, and it's a version 2 DBGSourcePathRemapping,
in addition to the build/source paths specified, add
build/source paths with the last two filename components
removed.  This more generic remapping can sometimes
help lldb to find the correct source file in complex
projects.
<rdar://problem/33973545>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@311622 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 31696925e66879752f1f32cdff3f9f19bccda278)
(cherry picked from commit bdc50e2821f13e5e740c8b9670fa9d0e997d2c06)