### PR TITLE
Fix Swift dictionary padding with enum keys

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -1,0 +1,96 @@
+# TestSwiftHashedContainerEnum.py
+
+"""
+Test combinations of hashed swift containers with enums as keys/values
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+class TestSwiftHashedContainerEnum(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    def test_any_object_type(self):
+        """Test combinations of hashed swift containers with enums"""
+        self.build()
+        self.do_test()
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    def do_test(self):
+        """Test combinations of hashed swift containers with enums"""
+        exe_name = "a.out"
+        exe = os.path.join(os.getcwd(), exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            '// break here', self.main_source_spec)
+        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        # Launch the process, and do not stop at the entry point.
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # Frame #0 should be at our breakpoint.
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, breakpoint)
+
+        self.assertTrue(len(threads) == 1)
+        self.thread = threads[0]
+        self.frame = self.thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+
+        self.expect(
+            'frame variable -d run -- testA',
+            substrs=[
+                'key = c',
+                'value = 1',
+                'key = b',
+                'value = 2'])
+        self.expect(
+            'expr -d run -- testA',
+            substrs=[
+                'key = c',
+                'value = 1',
+                'key = b',
+                'value = 2'])
+
+        self.expect(
+            'frame variable -d run -- testB',
+            substrs=[
+                'key = "a", value = 1',
+                'key = "b", value = 2'])
+        self.expect(
+            'expr -d run -- testB',
+            substrs=[
+                'key = "a", value = 1',
+                'key = "b", value = 2'])
+
+        self.expect(
+            'frame variable -d run -- testC',
+            substrs=['key = b', 'value = 2'])
+        self.expect(
+            'expr -d run -- testC',
+            substrs=['key = b', 'value = 2'])
+
+        self.expect(
+            'frame variable -d run -- testD',
+            substrs=['[0] = c'])
+        self.expect(
+            'expr -d run -- testD',
+            substrs=['[0] = c'])

--- a/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/main.swift
@@ -1,0 +1,9 @@
+enum Enum {
+    case a, b, c
+}
+
+let testA = [Enum.c: 1, Enum.b: 2]
+let testB = ["a": 1, "b": 2]
+let testC = (key: Enum.b, value: 2)
+let testD = Set([Enum.c])
+print(testA) // break here

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -89,10 +89,10 @@ SwiftHashedContainerNativeBufferHandler::GetElementAtIndex(size_t idx) {
 
       // you found it!!!
       DataBufferSP full_buffer_sp(
-          new DataBufferHeap(m_key_stride + m_value_stride, 0));
+          new DataBufferHeap(m_key_stride_padded + m_value_stride, 0));
       uint8_t *key_buffer_ptr = full_buffer_sp->GetBytes();
       uint8_t *value_buffer_ptr =
-          m_value_stride ? (key_buffer_ptr + m_key_stride) : nullptr;
+          m_value_stride ? (key_buffer_ptr + m_key_stride_padded) : nullptr;
       if (GetDataForKeyAtCell(cell_idx, key_buffer_ptr) &&
           (value_buffer_ptr == nullptr ||
            GetDataForValueAtCell(cell_idx, value_buffer_ptr))) {
@@ -195,7 +195,7 @@ SwiftHashedContainerNativeBufferHandler::
       m_bitmask_ptr(LLDB_INVALID_ADDRESS), m_keys_ptr(LLDB_INVALID_ADDRESS),
       m_values_ptr(LLDB_INVALID_ADDRESS), m_element_type(),
       m_key_stride(key_type.GetByteStride()), m_value_stride(0),
-      m_bitmask_cache() {
+      m_key_stride_padded(m_key_stride), m_bitmask_cache() {
   static ConstString g_initializedEntries("initializedEntries");
   static ConstString g_values("values");
   static ConstString g__rawValue("_rawValue");
@@ -221,6 +221,7 @@ SwiftHashedContainerNativeBufferHandler::
       std::vector<SwiftASTContext::TupleElement> tuple_elements{
           {g_key, key_type}, {g_value, value_type}};
       m_element_type = swift_ast->CreateTupleType(tuple_elements);
+      m_key_stride_padded = m_element_type.GetByteStride() - m_value_stride;
     }
   } else
     m_element_type = key_type;

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -137,6 +137,7 @@ private:
   CompilerType m_element_type;
   uint64_t m_key_stride;
   uint64_t m_value_stride;
+  uint64_t m_key_stride_padded;
   std::map<lldb::addr_t, uint64_t> m_bitmask_cache;
 };
 


### PR DESCRIPTION
When you have a dictionary which has an enum as the key such as:

```
enum Foo: String {
  case a
}

let bar = [Foo.a: 1]
```

The stride of the key is 1 byte. This differs from if you have a tuple
with the same key and value as the dictionary such as:

```
let baz = (Foo.a: 1)
```

In order to read the values from a dictionary we create a tuple which
expects 16 bytes of data (in the case the key is an enum and the value
is an int). Previously because the key was only 1 byte, we only filled
it with 9 bytes, and therefore the offsets were wrong leading to us
printing garbage data. Now instead of just using the stride of the key,
we use the stride based on the tuple type we generate for printing these
values. This works since the buffer is initialized to all 0 and
therefore acts as padding for the key.

This fixes https://bugs.swift.org/browse/SR-6290