### PR TITLE
[swift-support] Catch up with recent changes in upstream.

### DIFF
--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -384,11 +384,10 @@ public:
   size_t GetNumTemplateArguments() const;
 
   lldb::TemplateArgumentKind GetTemplateArgumentKind(size_t idx) const;
-
   CompilerType GetTypeTemplateArgument(size_t idx) const;
 
-  CompilerType GetBoundGenericType(size_t idx) const;
-  CompilerType GetUnboundGenericType(size_t idx) const;
+  lldb::GenericKind GetGenericKind(size_t idx) const;
+  CompilerType GetGenericType(size_t idx) const;
 
   // Returns the value of the template argument and its type.
   llvm::Optional<IntegralTemplateArgument>

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -384,7 +384,11 @@ public:
   size_t GetNumTemplateArguments() const;
 
   lldb::TemplateArgumentKind GetTemplateArgumentKind(size_t idx) const;
+
   CompilerType GetTypeTemplateArgument(size_t idx) const;
+
+  CompilerType GetBoundGenericType(size_t idx) const;
+  CompilerType GetUnboundGenericType(size_t idx) const;
 
   // Returns the value of the template argument and its type.
   llvm::Optional<IntegralTemplateArgument>

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -386,8 +386,8 @@ public:
   lldb::TemplateArgumentKind GetTemplateArgumentKind(size_t idx) const;
   CompilerType GetTypeTemplateArgument(size_t idx) const;
 
-  lldb::GenericKind GetGenericKind(size_t idx) const;
-  CompilerType GetGenericType(size_t idx) const;
+  lldb::GenericKind GetGenericArgumentKind(size_t idx) const;
+  CompilerType GetGenericArgumentType(size_t idx) const;
 
   // Returns the value of the template argument and its type.
   llvm::Optional<IntegralTemplateArgument>

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -632,11 +632,10 @@ public:
 
   size_t GetNumTemplateArguments(void *type) override;
 
-  lldb::TemplateArgumentKind GetTemplateArgumentKind(void *type,
-                                                     size_t idx) override;
-
-  CompilerType GetUnboundGenericType(void *type, uint32_t idx) override;
-  CompilerType GetBoundGenericType(void *type, uint32_t idx) override;
+  lldb::GenericKind GetGenericKind(void *type, size_t idx);
+  CompilerType GetUnboundGenericType(void *type, size_t idx);
+  CompilerType GetBoundGenericType(void *type, size_t idx);
+  CompilerType GetGenericType(void *type, size_t idx) override;
 
   CompilerType GetTypeForFormatters(void *type) override;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -632,8 +632,11 @@ public:
 
   size_t GetNumTemplateArguments(void *type) override;
 
-  CompilerType GetTemplateArgument(void *type, size_t idx,
-                                   lldb::TemplateArgumentKind &kind) override;
+  lldb::TemplateArgumentKind GetTemplateArgumentKind(void *type,
+                                                     size_t idx) override;
+
+  CompilerType GetUnboundGenericType(void *type, uint32_t idx) override;
+  CompilerType GetBoundGenericType(void *type, uint32_t idx) override;
 
   CompilerType GetTypeForFormatters(void *type) override;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -632,10 +632,10 @@ public:
 
   size_t GetNumTemplateArguments(void *type) override;
 
-  lldb::GenericKind GetGenericKind(void *type, size_t idx);
+  lldb::GenericKind GetGenericArgumentKind(void *type, size_t idx) override;
   CompilerType GetUnboundGenericType(void *type, size_t idx);
   CompilerType GetBoundGenericType(void *type, size_t idx);
-  CompilerType GetGenericType(void *type, size_t idx) override;
+  CompilerType GetGenericArgumentType(void *type, size_t idx) override;
 
   CompilerType GetTypeForFormatters(void *type) override;
 

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -390,7 +390,8 @@ public:
   virtual llvm::Optional<CompilerType::IntegralTemplateArgument>
   GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type, size_t idx);
 
-  virtual CompilerType GetGenericType(void *type, size_t idx);
+  virtual lldb::GenericKind GetGenericArgumentKind(void *type, size_t idx);
+  virtual CompilerType GetGenericArgumentType(void *type, size_t idx);
 
   //----------------------------------------------------------------------
   // Dumping types

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -390,8 +390,7 @@ public:
   virtual llvm::Optional<CompilerType::IntegralTemplateArgument>
   GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type, size_t idx);
 
-  virtual CompilerType GetUnboundGenericType(void *type, uint32_t idx);
-  virtual CompilerType GetBoundGenericType(void *type, uint32_t idx);
+  virtual CompilerType GetGenericType(void *type, size_t idx);
 
   //----------------------------------------------------------------------
   // Dumping types

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -390,6 +390,9 @@ public:
   virtual llvm::Optional<CompilerType::IntegralTemplateArgument>
   GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type, size_t idx);
 
+  virtual CompilerType GetUnboundGenericType(void *type, uint32_t idx);
+  virtual CompilerType GetBoundGenericType(void *type, uint32_t idx);
+
   //----------------------------------------------------------------------
   // Dumping types
   //----------------------------------------------------------------------

--- a/include/lldb/lldb-enumerations.h
+++ b/include/lldb/lldb-enumerations.h
@@ -776,7 +776,12 @@ enum TemplateArgumentKind {
   eTemplateArgumentKindTemplateExpansion,
   eTemplateArgumentKindExpression,
   eTemplateArgumentKindPack,
-  eTemplateArgumentKindNullPtr,
+  eTemplateArgumentKindNullPtr
+};
+
+// Kind of argument for generics, either bound or unbound.
+enum GenericKind {
+  eNullGenericKindType = 0,
   eBoundGenericKindType,
   eUnboundGenericKindType
 };

--- a/include/lldb/lldb-enumerations.h
+++ b/include/lldb/lldb-enumerations.h
@@ -777,6 +777,8 @@ enum TemplateArgumentKind {
   eTemplateArgumentKindExpression,
   eTemplateArgumentKindPack,
   eTemplateArgumentKindNullPtr,
+  eBoundGenericKindType,
+  eUnboundGenericKindType
 };
 
 //----------------------------------------------------------------------

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -74,22 +74,6 @@ void SwiftUserExpression::DidFinishExecuting() {
   }
 }
 
-static CompilerType getBoundOrUnboundType(CompilerType &valobj_type,
-                                          uint32_t idx) {
-  CompilerType key_type;
-  switch (valobj_type.GetTemplateArgumentKind(idx)) {
-  case lldb::eBoundGenericKindType:
-    key_type = valobj_type.GetBoundGenericType(idx);
-    break;
-  case lldb::eUnboundGenericKindType:
-    key_type = valobj_type.GetUnboundGenericType(idx);
-    break;
-  default:
-    break;
-  }
-  return key_type;
-}
-
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
@@ -298,9 +282,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             log->Printf("  [SUE::SC] Class generic arguments:");
 
           for (size_t ai = 0, ae = num_template_args; ai != ae; ++ai) {
-            CompilerType template_arg_type =
-                getBoundOrUnboundType(self_type, ai);
-
+            CompilerType template_arg_type = self_type.GetGenericType(ai);
             ConstString template_arg_name = template_arg_type.GetTypeName();
 
             if (log)
@@ -327,9 +309,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           for (size_t ai = 0, ae = self_unbound_type.GetNumTemplateArguments();
                ai != ae; ++ai) {
-            CompilerType template_arg_type =
-                getBoundOrUnboundType(self_unbound_type, ai);
-
+            CompilerType template_arg_type = self_unbound_type.GetGenericType(ai);
             ConstString template_arg_name = template_arg_type.GetTypeName();
 
             if (log)
@@ -382,9 +362,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
            ai != ae; ++ai) {
         lldb::TemplateArgumentKind template_arg_kind;
 
-        CompilerType template_arg_type =
-            getBoundOrUnboundType(function_type, ai);
-
+        CompilerType template_arg_type = function_type.GetGenericType(ai);
         ConstString template_arg_name = template_arg_type.GetTypeName();
 
         if (log)

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -74,6 +74,22 @@ void SwiftUserExpression::DidFinishExecuting() {
   }
 }
 
+static CompilerType getBoundOrUnboundType(CompilerType &valobj_type,
+                                          uint32_t idx) {
+  CompilerType key_type;
+  switch (valobj_type.GetTemplateArgumentKind(idx)) {
+  case lldb::eBoundGenericKindType:
+    key_type = valobj_type.GetBoundGenericType(idx);
+    break;
+  case lldb::eUnboundGenericKindType:
+    key_type = valobj_type.GetUnboundGenericType(idx);
+    break;
+  default:
+    break;
+  }
+  return key_type;
+}
+
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
@@ -282,10 +298,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             log->Printf("  [SUE::SC] Class generic arguments:");
 
           for (size_t ai = 0, ae = num_template_args; ai != ae; ++ai) {
-            lldb::TemplateArgumentKind template_arg_kind;
-
             CompilerType template_arg_type =
-                self_type.GetTemplateArgument(ai, template_arg_kind);
+                getBoundOrUnboundType(self_type, ai);
 
             ConstString template_arg_name = template_arg_type.GetTypeName();
 
@@ -313,10 +327,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           for (size_t ai = 0, ae = self_unbound_type.GetNumTemplateArguments();
                ai != ae; ++ai) {
-            lldb::TemplateArgumentKind template_arg_kind;
-
             CompilerType template_arg_type =
-                self_unbound_type.GetTemplateArgument(ai, template_arg_kind);
+                getBoundOrUnboundType(self_unbound_type, ai);
 
             ConstString template_arg_name = template_arg_type.GetTypeName();
 
@@ -371,7 +383,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
         lldb::TemplateArgumentKind template_arg_kind;
 
         CompilerType template_arg_type =
-            function_type.GetTemplateArgument(ai, template_arg_kind);
+            getBoundOrUnboundType(function_type, ai);
 
         ConstString template_arg_name = template_arg_type.GetTypeName();
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -282,7 +282,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             log->Printf("  [SUE::SC] Class generic arguments:");
 
           for (size_t ai = 0, ae = num_template_args; ai != ae; ++ai) {
-            CompilerType template_arg_type = self_type.GetGenericType(ai);
+            CompilerType template_arg_type =
+                self_type.GetGenericArgumentType(ai);
             ConstString template_arg_name = template_arg_type.GetTypeName();
 
             if (log)
@@ -309,7 +310,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           for (size_t ai = 0, ae = self_unbound_type.GetNumTemplateArguments();
                ai != ae; ++ai) {
-            CompilerType template_arg_type = self_unbound_type.GetGenericType(ai);
+            CompilerType template_arg_type =
+                self_unbound_type.GetGenericArgumentType(ai);
             ConstString template_arg_name = template_arg_type.GetTypeName();
 
             if (log)
@@ -362,7 +364,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
            ai != ae; ++ai) {
         lldb::TemplateArgumentKind template_arg_kind;
 
-        CompilerType template_arg_type = function_type.GetGenericType(ai);
+        CompilerType template_arg_type =
+            function_type.GetGenericArgumentType(ai);
         ConstString template_arg_name = template_arg_type.GetTypeName();
 
         if (log)

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -331,20 +331,9 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
         valobj.GetCompilerType().GetTypeSystem()));
     SwiftLanguageRuntime::MetadataPromiseSP promise_sp(
         swift_runtime->GetMetadataPromise(argmetadata_ptr, swift_ast_ctx));
-    if (promise_sp) {
-      if (CompilerType type = promise_sp->FulfillTypePromise()) {
-        switch (type.GetTemplateArgumentKind(0)) {
-        case eBoundGenericKindType:
-          argument_type = type.GetBoundGenericType(0);
-          break;
-        case eUnboundGenericKindType:
-          argument_type = type.GetUnboundGenericType(0);
-          break;
-        default:
-          break;
-        }
-      }
-    }
+    if (promise_sp)
+      if (CompilerType type = promise_sp->FulfillTypePromise())
+        argument_type = type.GetGenericType(0);
 
     if (!argument_type.IsValid())
       return nullptr;

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -333,8 +333,16 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
         swift_runtime->GetMetadataPromise(argmetadata_ptr, swift_ast_ctx));
     if (promise_sp) {
       if (CompilerType type = promise_sp->FulfillTypePromise()) {
-        lldb::TemplateArgumentKind kind;
-        argument_type = type.GetTemplateArgument(0, kind);
+        switch (type.GetTemplateArgumentKind(0)) {
+        case eBoundGenericKindType:
+          argument_type = type.GetBoundGenericType(0);
+          break;
+        case eUnboundGenericKindType:
+          argument_type = type.GetUnboundGenericType(0);
+          break;
+        default:
+          break;
+        }
       }
     }
 

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -333,7 +333,7 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
         swift_runtime->GetMetadataPromise(argmetadata_ptr, swift_ast_ctx));
     if (promise_sp)
       if (CompilerType type = promise_sp->FulfillTypePromise())
-        argument_type = type.GetGenericType(0);
+        argument_type = type.GetGenericArgumentType(0);
 
     if (!argument_type.IsValid())
       return nullptr;

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -283,56 +283,75 @@ bool SwiftHashedContainerNativeBufferHandler::IsValid() {
          m_capacity >= m_count;
 }
 
+static CompilerType getBoundOrUnboundType(CompilerType &valobj_type,
+                                          uint32_t idx) {
+  CompilerType key_type;
+  switch (valobj_type.GetTemplateArgumentKind(idx)) {
+  case eBoundGenericKindType:
+    key_type = valobj_type.GetBoundGenericType(idx);
+    break;
+  case eUnboundGenericKindType:
+    key_type = valobj_type.GetUnboundGenericType(idx);
+    break;
+  default:
+    break;
+  }
+  return key_type;
+}
+
 std::unique_ptr<SwiftHashedContainerBufferHandler>
 SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
     ValueObject &valobj, lldb::addr_t storage_ptr, bool fail_on_no_children,
     NativeCreatorFunction Native) {
 
   CompilerType valobj_type(valobj.GetCompilerType());
-  lldb::TemplateArgumentKind kind;
-  CompilerType key_type = valobj_type.GetTemplateArgument(0, kind);
-  CompilerType value_type = valobj_type.GetTemplateArgument(1, kind);
-  
-    static ConstString g_Native("native");
-    static ConstString g_nativeStorage("nativeStorage");
-    static ConstString g_buffer("buffer");
-    
-    Status error;
-    
-    ProcessSP process_sp(valobj.GetProcessSP());
-    if (!process_sp)
-        return nullptr;
+  CompilerType key_type = getBoundOrUnboundType(valobj_type, 0);
+  CompilerType value_type = getBoundOrUnboundType(valobj_type, 1);
 
-    ValueObjectSP native_sp(valobj.GetChildAtNamePath( {g_nativeStorage} ));
-    ValueObjectSP native_buffer_sp(valobj.GetChildAtNamePath( {g_nativeStorage, g_buffer} ));
-    if (!native_sp || !native_buffer_sp)
-    {
-        if (fail_on_no_children)
-            return nullptr;
-        else
-        {
-            lldb::addr_t native_storage_ptr = storage_ptr + (3 * process_sp->GetAddressByteSize());
-            native_storage_ptr = process_sp->ReadPointerFromMemory(native_storage_ptr, error);
-            // (AnyObject,AnyObject)?
-            SwiftASTContext *swift_ast_ctx = process_sp->GetTarget().GetScratchSwiftASTContext(error);
-            if (swift_ast_ctx)
-            {
-                CompilerType element_type(swift_ast_ctx->GetTypeFromMangledTypename(
-                    SwiftLanguageRuntime::GetCurrentMangledName("_TtGSqTPs9AnyObject_PS____").c_str(), error));
-                auto handler = std::unique_ptr<SwiftHashedContainerBufferHandler>(Native(native_sp,
-                                                                                  key_type,
-                                                                                  value_type));
-                if (handler && handler->IsValid())
-                    return handler;
-            }
-            return nullptr;
-        }
+  static ConstString g_Native("native");
+  static ConstString g_nativeStorage("nativeStorage");
+  static ConstString g_buffer("buffer");
+
+  Status error;
+
+  ProcessSP process_sp(valobj.GetProcessSP());
+  if (!process_sp)
+    return nullptr;
+
+  ValueObjectSP native_sp(valobj.GetChildAtNamePath({g_nativeStorage}));
+  ValueObjectSP native_buffer_sp(
+      valobj.GetChildAtNamePath({g_nativeStorage, g_buffer}));
+  if (!native_sp || !native_buffer_sp) {
+    if (fail_on_no_children)
+      return nullptr;
+    else {
+      lldb::addr_t native_storage_ptr =
+          storage_ptr + (3 * process_sp->GetAddressByteSize());
+      native_storage_ptr =
+          process_sp->ReadPointerFromMemory(native_storage_ptr, error);
+      // (AnyObject,AnyObject)?
+      SwiftASTContext *swift_ast_ctx =
+          process_sp->GetTarget().GetScratchSwiftASTContext(error);
+      if (swift_ast_ctx) {
+        CompilerType element_type(swift_ast_ctx->GetTypeFromMangledTypename(
+            SwiftLanguageRuntime::GetCurrentMangledName(
+                "_TtGSqTPs9AnyObject_PS____")
+                .c_str(),
+            error));
+        auto handler = std::unique_ptr<SwiftHashedContainerBufferHandler>(
+            Native(native_sp, key_type, value_type));
+        if (handler && handler->IsValid())
+          return handler;
+      }
+      return nullptr;
+    }
     }
 
     CompilerType child_type(native_sp->GetCompilerType());
-    CompilerType element_type(child_type.GetTemplateArgument(1, kind));
-    if (element_type.IsValid() == false || kind != lldb::eTemplateArgumentKindType)
-        return nullptr;
+    CompilerType element_type(getBoundOrUnboundType(child_type, 1));
+    if (element_type.IsValid() == false ||
+        child_type.GetTemplateArgumentKind(1) != lldb::eBoundGenericKindType)
+      return nullptr;
     lldb::addr_t native_storage_ptr = process_sp->ReadPointerFromMemory(storage_ptr + 2*process_sp->GetAddressByteSize(), error);
     if (error.Fail() || native_storage_ptr == LLDB_INVALID_ADDRESS)
         return nullptr;
@@ -396,9 +415,8 @@ SwiftHashedContainerBufferHandler::CreateBufferHandler(
           valobj_sp->GetChildAtNamePath({g_nativeBuffer, g__storage}));
       if (storage_sp) {
         CompilerType child_type(valobj_sp->GetCompilerType());
-        lldb::TemplateArgumentKind kind;
-        CompilerType key_type(child_type.GetTemplateArgument(0, kind));
-        CompilerType value_type(child_type.GetTemplateArgument(1, kind));
+        CompilerType key_type(getBoundOrUnboundType(child_type, 0));
+        CompilerType value_type(getBoundOrUnboundType(child_type, 1));
 
         auto handler = std::unique_ptr<SwiftHashedContainerBufferHandler>(
             Native(storage_sp, key_type, value_type));
@@ -467,8 +485,8 @@ SwiftHashedContainerBufferHandler::CreateBufferHandler(
 
     CompilerType child_type(valobj.GetCompilerType());
     lldb::TemplateArgumentKind kind;
-    CompilerType key_type(child_type.GetTemplateArgument(0, kind));
-    CompilerType value_type(child_type.GetTemplateArgument(1, kind));
+    CompilerType key_type(getBoundOrUnboundType(child_type, 0));
+    CompilerType value_type(getBoundOrUnboundType(child_type, 1));
 
     auto handler = std::unique_ptr<SwiftHashedContainerBufferHandler>(
         Native(nativeStorage_sp, key_type, value_type));

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -289,8 +289,8 @@ SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
     NativeCreatorFunction Native) {
 
   CompilerType valobj_type(valobj.GetCompilerType());
-  CompilerType key_type = valobj_type.GetGenericType(0);
-  CompilerType value_type = valobj_type.GetGenericType(1);
+  CompilerType key_type = valobj_type.GetGenericArgumentType(0);
+  CompilerType value_type = valobj_type.GetGenericArgumentType(1);
 
   static ConstString g_Native("native");
   static ConstString g_nativeStorage("nativeStorage");
@@ -332,9 +332,9 @@ SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
     }
 
     CompilerType child_type(native_sp->GetCompilerType());
-    CompilerType element_type(child_type.GetGenericType(1));
+    CompilerType element_type(child_type.GetGenericArgumentType(1));
     if (element_type.IsValid() == false ||
-        child_type.GetTemplateArgumentKind(1) != lldb::eBoundGenericKindType)
+        child_type.GetGenericArgumentKind(1) != lldb::eBoundGenericKindType)
       return nullptr;
     lldb::addr_t native_storage_ptr = process_sp->ReadPointerFromMemory(storage_ptr + 2*process_sp->GetAddressByteSize(), error);
     if (error.Fail() || native_storage_ptr == LLDB_INVALID_ADDRESS)
@@ -399,8 +399,8 @@ SwiftHashedContainerBufferHandler::CreateBufferHandler(
           valobj_sp->GetChildAtNamePath({g_nativeBuffer, g__storage}));
       if (storage_sp) {
         CompilerType child_type(valobj_sp->GetCompilerType());
-        CompilerType key_type(child_type.GetGenericType(0));
-        CompilerType value_type(child_type.GetGenericType(1));
+        CompilerType key_type(child_type.GetGenericArgumentType(0));
+        CompilerType value_type(child_type.GetGenericArgumentType(1));
 
         auto handler = std::unique_ptr<SwiftHashedContainerBufferHandler>(
             Native(storage_sp, key_type, value_type));
@@ -469,8 +469,8 @@ SwiftHashedContainerBufferHandler::CreateBufferHandler(
 
     CompilerType child_type(valobj.GetCompilerType());
     lldb::TemplateArgumentKind kind;
-    CompilerType key_type(child_type.GetGenericType(0));
-    CompilerType value_type(child_type.GetGenericType(1));
+    CompilerType key_type(child_type.GetGenericArgumentType(0));
+    CompilerType value_type(child_type.GetGenericArgumentType(1));
 
     auto handler = std::unique_ptr<SwiftHashedContainerBufferHandler>(
         Native(nativeStorage_sp, key_type, value_type));

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -758,9 +758,15 @@ CompilerType CompilerType::GetTypeTemplateArgument(size_t idx) const {
   return CompilerType();
 }
 
-CompilerType CompilerType::GetGenericType(size_t idx) const {
+GenericKind CompilerType::GetGenericArgumentKind(size_t idx) const {
+  if (IsValid())
+    return m_type_system->GetGenericArgumentKind(m_type, idx);
+  return eNullGenericKindType;
+}
+
+CompilerType CompilerType::GetGenericArgumentType(size_t idx) const {
   if (IsValid()) {
-    return m_type_system->GetGenericType(m_type, idx);
+    return m_type_system->GetGenericArgumentType(m_type, idx);
   }
   return CompilerType();
 }

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -758,16 +758,9 @@ CompilerType CompilerType::GetTypeTemplateArgument(size_t idx) const {
   return CompilerType();
 }
 
-CompilerType CompilerType::GetBoundGenericType(size_t idx) const {
+CompilerType CompilerType::GetGenericType(size_t idx) const {
   if (IsValid()) {
-    return m_type_system->GetBoundGenericType(m_type, idx);
-  }
-  return CompilerType();
-}
-
-CompilerType CompilerType::GetUnboundGenericType(size_t idx) const {
-  if (IsValid()) {
-    return m_type_system->GetUnboundGenericType(m_type, idx);
+    return m_type_system->GetGenericType(m_type, idx);
   }
   return CompilerType();
 }

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -758,6 +758,20 @@ CompilerType CompilerType::GetTypeTemplateArgument(size_t idx) const {
   return CompilerType();
 }
 
+CompilerType CompilerType::GetBoundGenericType(size_t idx) const {
+  if (IsValid()) {
+    return m_type_system->GetBoundGenericType(m_type, idx);
+  }
+  return CompilerType();
+}
+
+CompilerType CompilerType::GetUnboundGenericType(size_t idx) const {
+  if (IsValid()) {
+    return m_type_system->GetUnboundGenericType(m_type, idx);
+  }
+  return CompilerType();
+}
+
 llvm::Optional<CompilerType::IntegralTemplateArgument>
 CompilerType::GetIntegralTemplateArgument(size_t idx) const {
   if (IsValid())

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -19,25 +19,25 @@
 #include <sstream>
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/ExistentialLayout.h"
-#include "swift/AST/IRGenOptions.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/IRGenOptions.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/ASTSectionImporter/ASTSectionImporter.h"
-#include "swift/Demangling/Demangle.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterOptions.h"
+#include "swift/Demangling/Demangle.h"
 #include "swift/Driver/Util.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -50,6 +50,7 @@
 #include "clang/Basic/TargetOptions.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
@@ -59,7 +60,6 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
-#include "llvm/Target/TargetSubtargetInfo.h"
 
 #include "swift/../../lib/IRGen/FixedTypeInfo.h"
 #include "swift/../../lib/IRGen/GenEnum.h"
@@ -74,7 +74,6 @@
 
 #include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
 #include "Plugins/ExpressionParser/Swift/SwiftUserExpression.h"
-#include "lldb/Core/ArchSpec.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/DumpDataExtractor.h"
 #include "lldb/Core/Module.h"
@@ -96,11 +95,12 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/CleanUp.h"
-#include "lldb/Utility/Status.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/Status.h"
 
 #include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
@@ -5484,8 +5484,16 @@ bool SwiftASTContext::IsOptionalChain(CompilerType type,
 
   while (is_optional(type)) {
     ++depth;
-    lldb::TemplateArgumentKind kind;
-    type = type.GetTemplateArgument(0, kind);
+    switch (type.GetTemplateArgumentKind(0)) {
+    case eBoundGenericKindType:
+      type = type.GetBoundGenericType(0);
+      break;
+    case eUnboundGenericKindType:
+      type = type.GetUnboundGenericType(0);
+      break;
+    default:
+      break;
+    }
   }
 
   if (depth > 0) {
@@ -7641,35 +7649,52 @@ bool SwiftASTContext::GetSelectedEnumCase(const CompilerType &type,
   return false;
 }
 
-CompilerType
-SwiftASTContext::GetTemplateArgument(void *type, size_t arg_idx,
-                                     lldb::TemplateArgumentKind &kind) {
+lldb::TemplateArgumentKind
+SwiftASTContext::GetTemplateArgumentKind(void *type, size_t idx) {
+  if (type) {
+    swift::CanType swift_can_type(GetCanonicalSwiftType(type));
+    if (auto *unbound_generic_type =
+            swift_can_type->getAs<swift::UnboundGenericType>())
+      return eUnboundGenericKindType;
+    if (auto *bound_generic_type =
+            swift_can_type->getAs<swift::BoundGenericType>())
+      if (idx < bound_generic_type->getGenericArgs().size())
+        return eBoundGenericKindType;
+  }
+  return eTemplateArgumentKindNull;
+}
+
+CompilerType SwiftASTContext::GetBoundGenericType(void *type, uint32_t idx) {
   VALID_OR_RETURN(CompilerType());
 
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
+    if (auto *bound_generic_type =
+            swift_can_type->getAs<swift::BoundGenericType>())
+      if (idx < bound_generic_type->getGenericArgs().size())
+        return CompilerType(
+            GetASTContext(),
+            bound_generic_type->getGenericArgs()[idx].getPointer());
+  }
+  return CompilerType();
+}
 
+CompilerType SwiftASTContext::GetUnboundGenericType(void *type, uint32_t idx) {
+  VALID_OR_RETURN(CompilerType());
+
+  if (type) {
+    swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     if (auto *unbound_generic_type =
           swift_can_type->getAs<swift::UnboundGenericType>()) {
       auto *nominal_type_decl = unbound_generic_type->getDecl();
       swift::GenericSignature *generic_sig =
           nominal_type_decl->getGenericSignature();
-      auto depTy = generic_sig->getGenericParams()[arg_idx];
+      auto depTy = generic_sig->getGenericParams()[idx];
       return CompilerType(GetASTContext(),
                           nominal_type_decl->mapTypeIntoContext(depTy)
                               ->castTo<swift::ArchetypeType>());
     }
-    if (auto *bound_generic_type =
-          swift_can_type->getAs<swift::BoundGenericType>()) {
-      if (arg_idx < bound_generic_type->getGenericArgs().size()) {
-        kind = eTemplateArgumentKindType;
-        return CompilerType(GetASTContext(),
-                            bound_generic_type->getGenericArgs()[arg_idx].getPointer());
-      }
-    }
   }
-
-  kind = eTemplateArgumentKindNull;
   return CompilerType();
 }
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5484,7 +5484,7 @@ bool SwiftASTContext::IsOptionalChain(CompilerType type,
 
   while (is_optional(type)) {
     ++depth;
-    type = type.GetGenericType(0);
+    type = type.GetGenericArgumentType(0);
   }
 
   if (depth > 0) {
@@ -7640,7 +7640,8 @@ bool SwiftASTContext::GetSelectedEnumCase(const CompilerType &type,
   return false;
 }
 
-lldb::GenericKind SwiftASTContext::GetGenericKind(void *type, size_t idx) {
+lldb::GenericKind SwiftASTContext::GetGenericArgumentKind(void *type,
+                                                          size_t idx) {
   if (type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
     if (auto *unbound_generic_type =
@@ -7688,10 +7689,10 @@ CompilerType SwiftASTContext::GetUnboundGenericType(void *type, size_t idx) {
   return CompilerType();
 }
 
-CompilerType SwiftASTContext::GetGenericType(void *type, size_t idx) {
+CompilerType SwiftASTContext::GetGenericArgumentType(void *type, size_t idx) {
   VALID_OR_RETURN(CompilerType());
 
-  switch (GetGenericKind(type, idx)) {
+  switch (GetGenericArgumentKind(type, idx)) {
   case eBoundGenericKindType:
     return GetBoundGenericType(type, idx);
   case eUnboundGenericKindType:

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -119,7 +119,11 @@ CompilerType TypeSystem::GetTypeTemplateArgument(opaque_compiler_type_t type,
   return CompilerType();
 }
 
-CompilerType TypeSystem::GetGenericType(void *type, size_t idx) {
+GenericKind TypeSystem::GetGenericArgumentKind(void *type, size_t idx) {
+  return eNullGenericKindType;
+}
+
+CompilerType TypeSystem::GetGenericArgumentType(void *type, size_t idx) {
   return CompilerType();
 }
 

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -119,11 +119,7 @@ CompilerType TypeSystem::GetTypeTemplateArgument(opaque_compiler_type_t type,
   return CompilerType();
 }
 
-CompilerType TypeSystem::GetUnboundGenericType(void *type, uint32_t idx) {
-  return CompilerType();
-}
-
-CompilerType TypeSystem::GetBoundGenericType(void *type, uint32_t idx) {
+CompilerType TypeSystem::GetGenericType(void *type, size_t idx) {
   return CompilerType();
 }
 

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -119,6 +119,14 @@ CompilerType TypeSystem::GetTypeTemplateArgument(opaque_compiler_type_t type,
   return CompilerType();
 }
 
+CompilerType TypeSystem::GetUnboundGenericType(void *type, uint32_t idx) {
+  return CompilerType();
+}
+
+CompilerType TypeSystem::GetBoundGenericType(void *type, uint32_t idx) {
+  return CompilerType();
+}
+
 llvm::Optional<CompilerType::IntegralTemplateArgument>
 TypeSystem::GetIntegralTemplateArgument(opaque_compiler_type_t type,
                                         size_t idx) {


### PR DESCRIPTION
-> GetTemplateArgument() was replaced by GetTemplateArgumentKind() +
       GetTemplateArgumentKind(). In swift we use this for bound/unbound
       generics so let's introduce two variants to replace.
-> TargetSubtargetInfo.h was moved from Target/ to Codegen/ (in LLVM)
-> Archspec.h was moved from Core/ to Utility/ (in LLDB)

rdar://problem/35752437

I don't know who should actually review this, so I attached the suggested reviewers from GitHub.