### PR TITLE
Copy clang and swift resources into LLDB.framework

### DIFF
--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -191,7 +191,8 @@ if(LLDB_BUILD_FRAMEWORK)
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:liblldb>/Versions/${LLDB_FRAMEWORK_VERSION}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${LLDB_SOURCE_DIR}/include/lldb/API $<TARGET_FILE_DIR:liblldb>/Headers
     COMMAND ${CMAKE_COMMAND} -E create_symlink Versions/Current/Headers ${CMAKE_BINARY_DIR}/${LLDB_FRAMEWORK_INSTALL_DIR}/LLDB.framework/Headers 
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/clang/${LLDB_VERSION} $<TARGET_FILE_DIR:liblldb>/Resources/Clang
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CLANG_RESOURCE_PATH} $<TARGET_FILE_DIR:liblldb>/Resources/Clang
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${LLDB_PATH_TO_SWIFT_BUILD}/lib/swift $<TARGET_FILE_DIR:liblldb>/Resources/Swift
     )
 endif()
 


### PR DESCRIPTION
This fixes building LLDB with CMake + LLDB_BUILD_FRAMEWORK. Previously
no resources were copied into the final framework's resources. This now
follows the same behavior as building from the build scripts which
copies clang and swift resources into the final framework through the
target's build phases.