### PR TITLE
[ArchSpec] Don't consider Unknown MachO64 as invalid.

### DIFF
--- a/source/Core/ArchSpec.cpp
+++ b/source/Core/ArchSpec.cpp
@@ -984,7 +984,12 @@ void ArchSpec::MergeFrom(const ArchSpec &other) {
     GetTriple().setOS(other.GetTriple().getOS());
   if (GetTriple().getArch() == llvm::Triple::UnknownArch) {
     GetTriple().setArch(other.GetTriple().getArch());
-    UpdateCore();
+
+    // MachO unknown64 isn't really invalid as the debugger can
+    // still obtain information from the binary, e.g. line tables.
+    // As such, we don't update the core here.
+    if (other.GetCore() != eCore_uknownMach64)
+      UpdateCore();
   }
   if (GetTriple().getEnvironment() == llvm::Triple::UnknownEnvironment &&
       !TripleVendorWasSpecified()) {

--- a/unittests/Core/ArchSpecTest.cpp
+++ b/unittests/Core/ArchSpecTest.cpp
@@ -153,3 +153,22 @@ TEST(ArchSpecTest, MergeFrom) {
   EXPECT_EQ(llvm::Triple::OSType::Linux, A.GetTriple().getOS());
   EXPECT_EQ(ArchSpec::eCore_x86_64_x86_64, A.GetCore());
 }
+
+TEST(ArchSpecTest, MergeFromMachOUnknown) {
+  class MyArchSpec : public ArchSpec {
+  public:
+    MyArchSpec() {
+      this->SetTriple("unknown-mach-64");
+      this->m_core = ArchSpec::eCore_uknownMach64;
+      this->m_byte_order = eByteOrderLittle;
+      this->m_flags = 0;
+    }
+  };
+
+  MyArchSpec A;
+  ASSERT_TRUE(A.IsValid());
+  MyArchSpec B;
+  ASSERT_TRUE(B.IsValid());
+  A.MergeFrom(B);
+  ASSERT_EQ(A.GetCore(), ArchSpec::eCore_uknownMach64);
+}


### PR DESCRIPTION
Even without a proper arch we can access line tables, etc..
Fixes <rdar://problem/35778442>