### PR TITLE
[testsuite] UnXFAIL a bunch of tests that are passing.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,7 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        decorators.expectedFailureAll(
-                        bugnumber="rdar://problem/32040811"),
-        decorators.skipUnlessDarwin])
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -11,4 +11,4 @@
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
 
-lldbinline.MakeInlineTest(__file__, globals(), lldbinline.expectedFailureAll(bugnumber="rdar://33860001"))
+lldbinline.MakeInlineTest(__file__, globals())


### PR DESCRIPTION
These are currently reported as Unexpected successes, and
this is wrong. This is the first step towards a green `upstream-with-swift` branch in lldb.