### PR TITLE
[Swift] Update for type reconstruction behavior change with inout parameters

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4089,6 +4089,13 @@ SwiftASTContext::GetTypeFromMangledTypename(const char *mangled_typename,
                      .getPointer();
 
     if (found_type) {
+      // If we have an inout type at the top level, turn it into an lvalue type.
+      // Function parameters that are inout are treated the same as mutable vars
+      // here.
+      if (auto *inout_type = found_type->getAs<swift::InOutType>()) {
+        found_type = swift::LValueType::get(inout_type->getObjectType());
+      }
+
       CacheDemangledType(mangled_name.GetCString(), found_type);
       CompilerType result_type(ast_ctx, found_type);
       if (log)


### PR DESCRIPTION
InOutType comes up here in two cases:

- When a function parameter has InOutType. In this case we want to treat it
  identically to a mutable 'var' local variable, and so it should have
  LValueType.

- Inside the parameter list of a value of function type. Here we want to
  preserve the InOutType.

Previously, type reconstruction only supported the first case by always
returning LValueType. I fixed the second case but broke the first by
always returning InOutType. The correct fix is to check inside LLDB and
special-case an InOutType that appears at the top level only, turning it
into an LValueType.