### PR TITLE
[TestExec] Unbreak a test which was failing due to a merge mistake.

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/exec/TestExec.py
+++ b/packages/Python/lldbsuite/test/functionalities/exec/TestExec.py
@@ -72,11 +72,7 @@ class ExecTestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
 
         if skip_exec:
-<<<<<<< HEAD
             self.dbg.HandleCommand("settings set target.process.stop-on-exec false")
-=======
-            self.debugger.HandleCommand("settings set target.process.stop-on-exec false")
->>>>>>> b43f294c47d... Add target.process.stop-on-exec setting, and obey it.
             def cleanup():
                 self.runCmd("settings set target.process.stop-on-exec false",
                             check=False)


### PR DESCRIPTION
Another step towards a green `upstream-with-swift`