### PR TITLE
Pass defines from compile flags to swift clang importer

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1475,6 +1475,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                 swift_ast_sp->AddClangArgumentPair("-iquote",
                                                    cc_options[i + 1].c_str());
               }
+
+              if (!cc_options[i].compare(0, 2, "-D")) {
+                swift_ast_sp->AddClangArgument(cc_options[i].c_str());
+              }
             }
           }
         }


### PR DESCRIPTION
Since the clang importer will preprocess the module headers,
it will need access to any defines that the user supplied
when building those headers.