### PR TITLE
Allow .swift_ast ELF section to be stored in external debug info

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/split_ast/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/split_ast/Makefile
@@ -1,0 +1,9 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+SPLIT_DEBUG_SYMBOLS=YES
+
+SPLIT_SWIFT_AST=YES
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/split_ast/TestSwiftSplitAST.py
+++ b/packages/Python/lldbsuite/test/lang/swift/split_ast/TestSwiftSplitAST.py
@@ -1,0 +1,61 @@
+# TestSplitAST.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test that split ast works properly
+"""
+import lldb
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftSplitAST(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test_split_ast_info(self):
+        """Test split ast"""
+        self.build()
+        self.do_test()
+
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    def check_val(self, var_name, expected_val):
+        value = self.frame.EvaluateExpression(var_name,
+            lldb.eDynamicCanRunTarget)
+
+        self.assertTrue(value.IsValid(), "expr " + var_name + " returned a valid value")
+        self.assertEquals(value.GetValue(), expected_val)
+
+    def do_test(self):
+        """Test the split ast"""
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+            "Break here in main", self.main_source_spec)
+
+        self.frame = thread.frames[0]
+        self.assertTrue(self.frame.IsValid(), "Frame 0 is valid.")
+
+        self.check_val("c.c_x", "12345")
+        self.check_val("c.c_y", "6789")
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/split_ast/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/split_ast/main.swift
@@ -1,0 +1,24 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+class Class {
+    var c_x : UInt32 = 12345
+    var c_y : UInt32 = 6789
+}
+
+func main() {
+    var c = Class()
+
+    print("hello world") // Break here in main
+}
+
+main()
+

--- a/packages/Python/lldbsuite/test/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/packages/Python/lldbsuite/test/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -25,6 +25,7 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_split_debug_info(self):
         """Test split debug info"""
         self.build()

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -573,6 +573,17 @@ endif
 #----------------------------------------------------------------------
 # Make the dSYM file from the executable if $(MAKE_DSYM) != "NO"
 #----------------------------------------------------------------------
+ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
+  OBJCOPY_COPY_ARGS =
+  ifneq "$(SPLIT_SWIFT_AST)" "YES"
+    OBJCOPY_COPY_ARGS += --only-keep-debug
+  endif
+  OBJCOPY_STRIP_ARGS = --remove-section .gnu_debuglink --strip-debug --add-gnu-debuglink="$(DSYM)"
+  ifeq "$(SPLIT_SWIFT_AST)" "YES"
+    OBJCOPY_STRIP_ARGS += --remove-section .swift_ast
+  endif
+endif
+
 ifneq "$(DYLIB_ONLY)" "YES"
 $(DSYM) : $(EXE)
 ifeq "$(OS)" "Darwin"
@@ -581,8 +592,8 @@ ifneq "$(MAKE_DSYM)" "NO"
 endif
 else
 ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
-	$(OBJCOPY) --only-keep-debug "$(EXE)" "$(DSYM)"
-	$(OBJCOPY) --remove-section .gnu_debuglink --strip-debug --add-gnu-debuglink="$(DSYM)" "$(EXE)" "$(EXE)"
+	$(OBJCOPY) $(OBJCOPY_COPY_ARGS) "$(EXE)" "$(DSYM)"
+	$(OBJCOPY) $(OBJCOPY_STRIP_ARGS) "$(EXE)" "$(EXE)"
 endif
 endif
 endif

--- a/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2033,7 +2033,7 @@ void ObjectFileELF::CreateSections(SectionList &unified_section_list) {
         SectionType section_type = g_sections[idx];
         SectionSP section_sp(
             elf_section_list->FindSectionByType(section_type, true));
-        if (section_sp) {
+        if (section_sp && section_sp->GetFileSize()) {
           SectionSP module_section_sp(
               unified_section_list.FindSectionByType(section_type, true));
           if (module_section_sp)

--- a/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2026,6 +2026,7 @@ void ObjectFileELF::CreateSections(SectionList &unified_section_list) {
           eSectionTypeDWARFDebugPubNames,   eSectionTypeDWARFDebugPubTypes,
           eSectionTypeDWARFDebugRanges,     eSectionTypeDWARFDebugStr,
           eSectionTypeDWARFDebugStrOffsets, eSectionTypeELFSymbolTable,
+          eSectionTypeSwiftModules,
       };
       SectionList *elf_section_list = m_sections_ap.get();
       for (size_t idx = 0; idx < sizeof(g_sections) / sizeof(g_sections[0]);

--- a/source/Plugins/SymbolVendor/ELF/SymbolVendorELF.cpp
+++ b/source/Plugins/SymbolVendor/ELF/SymbolVendorELF.cpp
@@ -140,7 +140,7 @@ SymbolVendorELF::CreateInstance(const lldb::ModuleSP &module_sp,
             SectionType section_type = g_sections[idx];
             SectionSP section_sp(
                 objfile_section_list->FindSectionByType(section_type, true));
-            if (section_sp) {
+            if (section_sp && section_sp->GetFileSize()) {
               SectionSP module_section_sp(
                   module_section_list->FindSectionByType(section_type, true));
               if (module_section_sp)

--- a/source/Plugins/SymbolVendor/ELF/SymbolVendorELF.cpp
+++ b/source/Plugins/SymbolVendor/ELF/SymbolVendorELF.cpp
@@ -134,6 +134,7 @@ SymbolVendorELF::CreateInstance(const lldb::ModuleSP &module_sp,
               eSectionTypeDWARFDebugPubNames,   eSectionTypeDWARFDebugPubTypes,
               eSectionTypeDWARFDebugRanges,     eSectionTypeDWARFDebugStr,
               eSectionTypeDWARFDebugStrOffsets, eSectionTypeELFSymbolTable,
+              eSectionTypeSwiftModules,
           };
           for (size_t idx = 0; idx < sizeof(g_sections) / sizeof(g_sections[0]);
                ++idx) {


### PR DESCRIPTION
Like the other DWARF sections, the swift ast should be loaded if present only in separate debug-info files.