### PR TITLE
Add a test for swift split debug-info

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/split_debug/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/split_debug/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+SPLIT_DEBUG_SYMBOLS=YES
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/packages/Python/lldbsuite/test/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -1,0 +1,60 @@
+# TestSplitDebug.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test that split debug-info works properly
+"""
+import lldb
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftSplitDebug(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    def test_split_debug_info(self):
+        """Test split debug info"""
+        self.build()
+        self.do_test()
+
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    def check_val(self, var_name, expected_val):
+        value = self.frame.EvaluateExpression(var_name,
+            lldb.eDynamicCanRunTarget)
+
+        self.assertTrue(value.IsValid(), "expr " + var_name + " returned a valid value")
+        self.assertEquals(value.GetValue(), expected_val)
+
+    def do_test(self):
+        """Test the split debug info"""
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+            "Break here in main", self.main_source_spec)
+
+        self.frame = thread.frames[0]
+        self.assertTrue(self.frame.IsValid(), "Frame 0 is valid.")
+
+        self.check_val("c.c_x", "12345")
+        self.check_val("c.c_y", "6789")
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/split_debug/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/split_debug/main.swift
@@ -1,0 +1,24 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+class Class {
+    var c_x : UInt32 = 12345
+    var c_y : UInt32 = 6789
+}
+
+func main() {
+    var c = Class()
+
+    print("hello world") // Break here in main
+}
+
+main()
+

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -358,6 +358,10 @@ ifneq "$(OS)" "Darwin"
     endif
 
     OBJCOPY ?= $(call replace_cc_with,objcopy)
+ifeq ($(wildcard $(OBJCOPY)),)
+    OBJCOPY = objcopy
+endif
+
     ARCHIVER ?= $(call replace_cc_with,ar)
     override AR = $(ARCHIVER)
 endif
@@ -576,7 +580,7 @@ endif
 else
 ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
 	$(OBJCOPY) --only-keep-debug "$(EXE)" "$(DSYM)"
-	$(OBJCOPY) --strip-debug --add-gnu-debuglink="$(DSYM)" "$(EXE)" "$(EXE)"
+	$(OBJCOPY) --remove-section .gnu_debuglink --strip-debug --add-gnu-debuglink="$(DSYM)" "$(EXE)" "$(EXE)"
 endif
 endif
 endif


### PR DESCRIPTION
This is a re-upload of https://github.com/apple/swift-lldb/pull/258, which was reverted due to bot failures. Couldn't figure out a way to re-open that PR, so created a new one.

Falls back to the system `objcopy` if there is no `objcopy` in the directory containing the compiler.