### PR TITLE
Implement support for most of the new string ABI

### DIFF
--- a/docs/code-signing.txt
+++ b/docs/code-signing.txt
@@ -1,6 +1,11 @@
-On MacOSX lldb needs to be code signed. The Debug, DebugClang and Release 
-builds  are set to code sign using a code signing certificate named 
-"lldb_codesign". 
+To use the in-tree debug server on macOS, lldb needs to be code signed. The
+Debug, DebugClang and Release builds are set to code sign using a code signing
+certificate named "lldb_codesign". This document explains how to set up the
+signing certificate.
+
+Note that it's possible to build and use lldb on macOS without setting up code
+signing by using the system's debug server. To configure lldb in this way with
+cmake, specify -DLLDB_CODESIGN_IDENTITY=''.
 
 If you have re-installed a new OS, please delete all old lldb_codesign items
 from your keychain. There will be a code signing certification and a public

--- a/packages/Python/lldbsuite/test/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/packages/Python/lldbsuite/test/lang/swift/address_of/TestSwiftAddressOf.py
@@ -26,6 +26,7 @@ class TestSwiftAddressOf(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_any_type(self):
         """Test the Any type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/packages/Python/lldbsuite/test/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -25,6 +25,7 @@ class SwiftPartialBreakTest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_partial_break(self):
         """Tests that we can break on a partial name of a Swift function"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/fixits/TestSwiftFixIts.py
+++ b/packages/Python/lldbsuite/test/lang/swift/fixits/TestSwiftFixIts.py
@@ -24,6 +24,7 @@ class TestSwiftFixIts(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_fixits(self):
         """Test applying fixits to expressions"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/packages/Python/lldbsuite/test/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -24,6 +24,7 @@ class SwiftGetValueAsUnsignedAPITest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_get_value_as_unsigned_sbapi(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -26,6 +26,7 @@ class TestSwiftCGImportedTypes(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_cg_imported_types(self):
         """Test that we are able to deal with ObjC-imported types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -33,6 +33,7 @@ class TestSwiftModuleSearchPaths(TestBase):
 
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_module_search_paths(self):
         """
         Tests that we can import modules located using

--- a/packages/Python/lldbsuite/test/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -25,6 +25,7 @@ class TestSwiftMultipayloadEnum(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/packages/Python/lldbsuite/test/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -26,6 +26,7 @@ class TestSwiftAtObjCIvars(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_at_objc_ivars(self):
         """Check that we correctly find offsets for ivars of Swift @objc types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -25,6 +25,7 @@ class TestSwiftOneCaseEnum(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/packages/Python/lldbsuite/test/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -26,6 +26,7 @@ class TestSwiftTypeLookup(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -25,6 +25,7 @@ class TestSwiftRangeType(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -25,6 +25,7 @@ class TestSwiftReferenceStorageTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
+++ b/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
@@ -31,6 +31,7 @@ class TestSwiftReturns(TestBase):
         oslist=["ios"],
         archs=["arm64"],
         bugnumber="rdar://27002915")
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_returns(self):
         """Test getting return values"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
@@ -25,6 +25,7 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/struct_init_display/TestSwiftStructInit.py
+++ b/packages/Python/lldbsuite/test/lang/swift/struct_init_display/TestSwiftStructInit.py
@@ -25,6 +25,7 @@ class TestSwiftStructInit(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_struct_init(self):
         """Test that we display self correctly for an inline-initialized struct"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/tuple/TestSwiftTuple.py
+++ b/packages/Python/lldbsuite/test/lang/swift/tuple/TestSwiftTuple.py
@@ -25,6 +25,7 @@ class TestSwiftTuple(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/array/TestSwiftArrayType.py
@@ -31,6 +31,7 @@ class TestSwiftArrayType(lldbtest.TestBase):
 
     @decorators.swiftTest
     @decorators.skipIf(bugnumber='rdar://30663811', oslist=['linux'])
+    @decorators.add_test_categories(["swiftpr"])
     def test_array(self):
         """Check formatting for Swift.Array<T>"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bool/TestSwiftBool.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bool/TestSwiftBool.py
@@ -25,6 +25,7 @@ class TestSwiftBool(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_bool(self):
         """Test that we can inspect various Swift bools"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -41,30 +41,9 @@ class TestSwiftBridgedStringVariables(TestBase):
 
     def do_test(self):
         """Test that Swift.String formats properly"""
-        exe_name = "a.out"
-        exe = os.path.join(os.getcwd(), exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'Set breakpoint here', self.main_source_spec)
-        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, breakpoint)
-
-        self.assertTrue(len(threads) == 1)
-        self.thread = threads[0]
-        self.frame = self.thread.frames[0]
+        (_, _, thread, _) = lldbutil.run_to_source_breakpoint(self,
+                "Set breakpoint here", self.main_source_spec)
+        self.frame = thread.frames[0]
         self.assertTrue(self.frame, "Frame 0 is valid.")
 
         s1 = self.frame.FindVariable("s1")

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -29,7 +29,6 @@ class TestSwiftBridgedStringVariables(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
-    @decorators.expectedFailureAll # rdar://36744510
     def test_swift_bridged_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -67,11 +67,15 @@ class TestSwiftBridgedStringVariables(TestBase):
         self.frame = self.thread.frames[0]
         self.assertTrue(self.frame, "Frame 0 is valid.")
 
+        s1 = self.frame.FindVariable("s1")
+        s2 = self.frame.FindVariable("s2")
         s3 = self.frame.FindVariable("s3")
         s4 = self.frame.FindVariable("s4")
         s5 = self.frame.FindVariable("s5")
         s6 = self.frame.FindVariable("s6")
 
+        lldbutil.check_variable(self, s1, summary='"Hello world"')
+        lldbutil.check_variable(self, s2, summary='"ΞΕΛΛΘ"')
         lldbutil.check_variable(self, s3, summary='"Hello world"')
         lldbutil.check_variable(self, s4, summary='"ΞΕΛΛΘ"')
         lldbutil.check_variable(self, s5, use_dynamic=True, summary='"abc"')

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/main.swift
@@ -13,12 +13,12 @@ import Foundation
 
 func main()
 {
-	var s1 = "Hello world"
-	var s2 = "ΞΕΛΛΘ"
-	var s3 = s1 as NSString
-	var s4 = s2 as NSString
-	var s5 = "abc" as NSString
-	var s6 = String(s5)
+	let s1 = "Hello world"
+	let s2 = "ΞΕΛΛΘ"
+	let s3 = s1 as NSString
+	let s4 = s2 as NSString
+	let s5 = "abc" as NSString
+	let s6 = String(s5)
 	print(s1) // Set breakpoint here
 }
 

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -25,6 +25,7 @@ class TestBulkyEnumVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -25,6 +25,7 @@ class TestSwiftClassTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_class_types(self):
         """Test swift Class types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/enums/TestEnumVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/enums/TestEnumVariables.py
@@ -25,6 +25,7 @@ class TestEnumVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -25,6 +25,7 @@ class TestSwiftGlobals(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -26,6 +26,7 @@ class TestSwiftObjCOptionalType(TestBase):
 
     @decorators.swiftTest
     @decorators.skipUnlessDarwin
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_objc_optional_type(self):
         """Check formatting for T? and T! when T is an ObjC type"""
         self.buildDsym()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -25,6 +25,7 @@ class TestSwiftOptionalType(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_optional_type(self):
         """Check formatting for T? and T!"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -28,6 +28,7 @@ class TestSwiftStaticStringVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_static_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -28,6 +28,7 @@ class TestSwiftStringVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/swift/TestSwiftTypes.py
@@ -24,6 +24,7 @@ class TestSwiftTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -24,6 +24,7 @@ class TestSwiftTupleTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_tuple_types(self):
         """Test support for tuple types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
@@ -25,6 +25,7 @@ class TestSwiftValueOfOptionalType(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_value_optional_type(self):
         """Check that trying to read an optional's numeric value doesn't crash LLDB"""
         self.build()

--- a/packages/Python/lldbsuite/test/test_categories.py
+++ b/packages/Python/lldbsuite/test/test_categories.py
@@ -19,6 +19,7 @@ debug_info_categories = [
 ]
 
 all_categories = {
+    'swiftpr': 'Tests that may run as a part of Swift pull-request testing',
     'dataformatters': 'Tests related to the type command and the data formatters subsystem',
     'dwarf': 'Tests that can be run with DWARF debug information',
     'dwo': 'Tests that can be run with DWO debug information',

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -325,13 +325,6 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
     bool is_utf_16 = objectAddr & (1ULL << 60);
     uint64_t payloadAddr = objectAddr & ((1ULL << 56) - 1);
 
-    // FIXME: Remove printf debugging.
-    // stream.Printf("payload address = %llu\n", payloadAddr);
-    // stream.Printf("t (is-a-value) = %d\n", is_a_value);
-    // stream.Printf("v (sub-variant) = %d\n", is_Cocoa_or_small);
-    // stream.Printf("o (opaque) = %d\n", is_opaque);
-    // stream.Printf("w (width) = %d\n", is_utf_16);
-
     if (!is_opaque && ((is_a_value && !is_Cocoa_or_small) ||
                        (!is_a_value && !is_Cocoa_or_small))) {
       uint64_t count = otherBits_sp->GetValueAsUnsigned(0) & ((1ULL << 48) - 1);

--- a/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -39,13 +39,6 @@ bool Character_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool UnicodeScalar_SummaryProvider(ValueObject &valobj, Stream &stream,
                                    const TypeSummaryOptions &options);
 
-bool StringCore_SummaryProvider(ValueObject &valobj, Stream &stream,
-                                const TypeSummaryOptions &options);
-
-bool StringCore_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &,
-    StringPrinter::ReadStringAndDumpToStreamOptions);
-
 bool StringGuts_SummaryProvider(ValueObject &valobj, Stream &stream,
                                 const TypeSummaryOptions &options);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,9 @@ if(TARGET lldb-server)
 endif()
   
 if(TARGET debugserver)
-  list(APPEND LLDB_TEST_DEPS debugserver)
+  if(NOT CMAKE_HOST_APPLE OR LLDB_CODESIGN_IDENTITY)
+    list(APPEND LLDB_TEST_DEPS debugserver)
+  endif()
 endif()
 
 if(TARGET lldb-mi)
@@ -107,7 +109,18 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows|Darwin")
 endif()
 
 if(CMAKE_HOST_APPLE)
-  list(APPEND LLDB_TEST_COMMON_ARGS --server $<TARGET_FILE:debugserver>)
+  if(LLDB_CODESIGN_IDENTITY)
+    set(DEBUGSERVER_PATH $<TARGET_FILE:debugserver>)
+  else()
+    execute_process(
+      COMMAND xcode-select -p
+      OUTPUT_VARIABLE XCODE_DEV_DIR)
+    string(STRIP ${XCODE_DEV_DIR} XCODE_DEV_DIR)
+    set(DEBUGSERVER_PATH
+      "${XCODE_DEV_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver")
+  endif()
+  message(STATUS "Path to the lldb debugserver: ${DEBUGSERVER_PATH}")
+  list(APPEND LLDB_TEST_COMMON_ARGS --server ${DEBUGSERVER_PATH})
 endif()
 
 set(LLDB_DOTEST_ARGS ${LLDB_TEST_COMMON_ARGS};${LLDB_TEST_USER_ARGS})


### PR DESCRIPTION
This teaches the string data formatter about some additional bits of the new ABI related to bridged NSStrings. Support for the 32-bit ABI is still WIP.