### PR TITLE
Make use of physical footprint as memory measurement.

### DIFF
--- a/tools/debugserver/source/DNBDefs.h
+++ b/tools/debugserver/source/DNBDefs.h
@@ -347,9 +347,7 @@ enum DNBProfileDataScanType {
 
   eProfileHostMemory = (1 << 5),
 
-  eProfileMemory = (1 << 6), // By default, excludes eProfileMemoryDirtyPage.
-  eProfileMemoryDirtyPage =
-      (1 << 7), // Assume eProfileMemory, get Dirty Page size as well.
+  eProfileMemory = (1 << 6),
   eProfileMemoryAnonymous =
       (1 << 8), // Assume eProfileMemory, get Anonymous memory as well.
 

--- a/tools/debugserver/source/MacOSX/MachVMMemory.h
+++ b/tools/debugserver/source/MacOSX/MachVMMemory.h
@@ -29,34 +29,13 @@ public:
   nub_size_t PageSize(task_t task);
   nub_bool_t GetMemoryRegionInfo(task_t task, nub_addr_t address,
                                  DNBRegionInfo *region_info);
-#if defined(HOST_VM_INFO64_COUNT)
   nub_bool_t GetMemoryProfile(DNBProfileDataScanType scanType, task_t task,
                               struct task_basic_info ti, cpu_type_t cputype,
                               nub_process_t pid, vm_statistics64_data_t &vminfo,
-                              uint64_t &physical_memory, mach_vm_size_t &rprvt,
-                              mach_vm_size_t &rsize, mach_vm_size_t &vprvt,
-                              mach_vm_size_t &vsize, mach_vm_size_t &dirty_size,
-                              mach_vm_size_t &purgeable,
-                              mach_vm_size_t &anonymous);
-#else
-  nub_bool_t GetMemoryProfile(DNBProfileDataScanType scanType, task_t task,
-                              struct task_basic_info ti, cpu_type_t cputype,
-                              nub_process_t pid, vm_statistics_data_t &vminfo,
-                              uint64_t &physical_memory, mach_vm_size_t &rprvt,
-                              mach_vm_size_t &rsize, mach_vm_size_t &vprvt,
-                              mach_vm_size_t &vsize, mach_vm_size_t &dirty_size,
-                              mach_vm_size_t &purgeable,
-                              mach_vm_size_t &anonymous);
-#endif
+                              uint64_t &physical_memory, mach_vm_size_t &anonymous, mach_vm_size_t &phys_footprint);
 
 protected:
   nub_size_t MaxBytesLeftInPage(task_t task, nub_addr_t addr, nub_size_t count);
-
-  uint64_t GetStolenPages(task_t task);
-  void GetRegionSizes(task_t task, mach_vm_size_t &rsize,
-                      mach_vm_size_t &dirty_size);
-  void GetMemorySizes(task_t task, cpu_type_t cputype, nub_process_t pid,
-                      mach_vm_size_t &rprvt, mach_vm_size_t &vprvt);
 
   nub_size_t WriteRegion(task_t task, const nub_addr_t address,
                          const void *data, const nub_size_t data_count);


### PR DESCRIPTION
Remove obsolete measurements.

This check in requires at least 10.11

Reviewed: Jason Molenda, Jim Ingham

<rdar://problem/37047106> Xcode Memory gauge should show the jetsam ledger footprint rather than anonymous

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@324013 91177308-0d34-0410-b5e6-96231b3b80d8