### PR TITLE
Remove use of getImplicitlyUnwrappedOptionalDecl.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1002,16 +1002,6 @@ SwiftEnumDescriptor::CreateDescriptor(swift::ASTContext *ast,
   assert(swift_can_type.getPointer());
   SwiftASTContext *swift_ast_ctx = SwiftASTContext::GetSwiftASTContext(ast);
   assert(swift_ast_ctx);
-  if (enum_decl == ast->getImplicitlyUnwrappedOptionalDecl()) {
-    swift::EnumDecl *optional_decl = ast->getOptionalDecl();
-    swift::CanType bound_optional_can_type =
-        swift::BoundGenericType::get(
-            optional_decl,
-            swift::Type(),
-            swift::cast<swift::BoundGenericType>(swift_can_type)
-                ->getGenericArgs())->getCanonicalType();
-    return CreateDescriptor(ast, bound_optional_can_type, optional_decl);
-  }
   swift::irgen::IRGenModule &irgen_module = swift_ast_ctx->GetIRGenModule();
   const swift::irgen::EnumImplStrategy &enum_impl_strategy =
       swift::irgen::getEnumImplStrategy(irgen_module, swift_can_type);


### PR DESCRIPTION
As of https://github.com/apple/swift/pull/14299, we should effectively
no longer see this decl since we no longer generate IUO types.

A follow-on PR actually removes this API completely:
  https://github.com/apple/swift/pull/14364