### PR TITLE
Replace getAnyOptionalObjectType with getOptionalObjectType.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5467,7 +5467,7 @@ bool SwiftASTContext::IsOptionalChain(CompilerType type,
             llvm::dyn_cast_or_null<SwiftASTContext>(type.GetTypeSystem())) {
       if (auto swift_ast = ast->GetASTContext()) {
         swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-        if (swift_can_type.getAnyOptionalObjectType())
+        if (swift_can_type.getOptionalObjectType())
           return true;
         return false;
       }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2091,7 +2091,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     lldb::addr_t val_ptr_addr = in_value.GetPointerValue();
     {
       auto swift_type = GetSwiftType(dyn_type);
-      if (swift_type->getAnyOptionalObjectType())
+      if (swift_type->getOptionalObjectType())
         val_ptr_addr = GetProcess()->ReadPointerFromMemory(val_ptr_addr, error);
     }
     address.SetLoadAddress(val_ptr_addr, &m_process->GetTarget());


### PR DESCRIPTION
The former is no longer necessary since we no longer produce
ImplicitlyUnwrappedOptionalType.