### PR TITLE
Replace getAnyOptionalObjectType and remove TypeKind::ImplicitlyUnwrappedOptional

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -478,7 +478,6 @@ CachedMemberInfo *SwiftASTContext::GetCachedMemberInfo(void *type) {
       break;
 
     case swift::TypeKind::Optional:
-    case swift::TypeKind::ImplicitlyUnwrappedOptional:
     case swift::TypeKind::NameAlias:
     case swift::TypeKind::Paren:
     case swift::TypeKind::Dictionary:
@@ -5717,7 +5716,6 @@ SwiftASTContext::GetTypeInfo(void *type,
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -5822,7 +5820,6 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(void *type) {
     return lldb::eTypeClassOther;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -6295,7 +6292,6 @@ lldb::Encoding SwiftASTContext::GetEncoding(void *type, uint64_t &count) {
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -6380,7 +6376,6 @@ lldb::Format SwiftASTContext::GetFormat(void *type) {
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -6480,7 +6475,6 @@ uint32_t SwiftASTContext::GetNumChildren(void *type,
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -6594,7 +6588,6 @@ uint32_t SwiftASTContext::GetNumFields(void *type) {
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -6733,7 +6726,6 @@ CompilerType SwiftASTContext::GetFieldAtIndex(void *type, size_t idx,
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -6836,7 +6828,6 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(void *type) {
     return 0;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -7244,7 +7235,6 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:
@@ -7428,7 +7418,6 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
       break;
 
     case swift::TypeKind::Optional:
-    case swift::TypeKind::ImplicitlyUnwrappedOptional:
     case swift::TypeKind::NameAlias:
     case swift::TypeKind::Paren:
     case swift::TypeKind::Dictionary:
@@ -7561,7 +7550,6 @@ SwiftASTContext::GetIndexOfChildWithName(void *type, const char *name,
       break;
 
     case swift::TypeKind::Optional:
-    case swift::TypeKind::ImplicitlyUnwrappedOptional:
     case swift::TypeKind::NameAlias:
     case swift::TypeKind::Paren:
     case swift::TypeKind::Dictionary:
@@ -7888,7 +7876,6 @@ bool SwiftASTContext::DumpTypeValue(
     break;
 
   case swift::TypeKind::Optional:
-  case swift::TypeKind::ImplicitlyUnwrappedOptional:
   case swift::TypeKind::NameAlias:
   case swift::TypeKind::Paren:
   case swift::TypeKind::Dictionary:

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5467,7 +5467,7 @@ bool SwiftASTContext::IsOptionalChain(CompilerType type,
             llvm::dyn_cast_or_null<SwiftASTContext>(type.GetTypeSystem())) {
       if (auto swift_ast = ast->GetASTContext()) {
         swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-        if (swift_can_type.getAnyOptionalObjectType())
+        if (swift_can_type.getOptionalObjectType())
           return true;
         return false;
       }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2091,7 +2091,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     lldb::addr_t val_ptr_addr = in_value.GetPointerValue();
     {
       auto swift_type = GetSwiftType(dyn_type);
-      if (swift_type->getAnyOptionalObjectType())
+      if (swift_type->getOptionalObjectType())
         val_ptr_addr = GetProcess()->ReadPointerFromMemory(val_ptr_addr, error);
     }
     address.SetLoadAddress(val_ptr_addr, &m_process->GetTarget());


### PR DESCRIPTION
ImplicitlyUnwrappedOptionalType<Wrapped> is now a type alias for Optional<Wrapped>, so we're replacing getAnyOptionalObjectType() with getOptionalObjectType() in the compiler, and removing TypeKind::ImplicitlyUnwrappedOptional.