### PR TITLE
[SwiftASTContext] Start pruning unused and presumably stale functions.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -748,9 +748,6 @@ public:
   bool IsReferenceType(void *type, CompilerType *pointee_type,
                        bool *is_rvalue) override;
 
-  static bool IsInoutType(const CompilerType &compiler_type,
-                          CompilerType *original_type);
-
   bool
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) override;
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5221,31 +5221,6 @@ bool SwiftASTContext::IsReferenceType(void *type, CompilerType *pointee_type,
   return false;
 }
 
-bool SwiftASTContext::IsInoutType(const CompilerType &compiler_type,
-                                  CompilerType *original_type) {
-  if (compiler_type.IsValid()) {
-    if (auto ast = llvm::dyn_cast_or_null<SwiftASTContext>(
-            compiler_type.GetTypeSystem())) {
-      swift::CanType swift_can_type(GetCanonicalSwiftType(compiler_type));
-      swift::LValueType *lvalue = swift_can_type->getAs<swift::LValueType>();
-      if (lvalue) {
-        if (original_type)
-          *original_type =
-          CompilerType(ast, lvalue->getObjectType().getPointer());
-        return true;
-      }
-      swift::InOutType *inout = swift_can_type->getAs<swift::InOutType>();
-      if (inout) {
-        if (original_type)
-          *original_type =
-          CompilerType(ast, inout->getObjectType().getPointer());
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 bool SwiftASTContext::IsFloatingPointType(void *type, uint32_t &count,
                                           bool &is_complex) {
   if (type) {


### PR DESCRIPTION
If somebody needs this functionality in the future, it should go
through remote mirrors.