### PR TITLE
Use test-specific module caches to avoid stale header conflicts

### DIFF
--- a/packages/Python/lldbsuite/test/lang/objc/modules-auto-import/TestModulesAutoImport.py
+++ b/packages/Python/lldbsuite/test/lang/objc/modules-auto-import/TestModulesAutoImport.py
@@ -27,7 +27,6 @@ class ObjCModulesAutoImportTestCase(TestBase):
 
     @skipUnlessDarwin
     @skipIf(macos_version=["<", "10.12"], debug_info=no_match(["gmodules"]))
-    @expectedFailureAll(debug_info="dsym") # rdar://36914859
     def test_expr(self):
         self.build()
         exe = os.path.join(os.getcwd(), "a.out")


### PR DESCRIPTION
Stale global module caches cause problems for the bots. The modules
become invalid when clang headers are updated by version control, and
tests which use these modules fail to compile, e.g:

  fatal error: file '.../__stddef_max_align_t.h' has been modified since the module file '/var/.../Darwin.pcm' was built
  note: please rebuild precompiled header '/var/.../Darwin.pcm'

Eventually we should transition to having just a single module cache to speed
tests up. This patch should be just enough to fix the spurious bot failures due
to stale caches.

rdar://36479805, also related to llvm.org/PR36048

Differential Revision: https://reviews.llvm.org/D42277

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@323450 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit efc6461947107e26e236bb43a5ae026db5945b7e)