### PR TITLE
Fix linux fallout from c++ gmodules enable

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/list/loop/TestDataFormatterLibcxxListLoop.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/list/loop/TestDataFormatterLibcxxListLoop.py
@@ -18,6 +18,7 @@ from lldbsuite.test import lldbutil
 class LibcxxListDataFormatterTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     @add_test_categories(["libc++"])
     @expectedFailureAndroid(bugnumber="llvm.org/pr32592")

--- a/packages/Python/lldbsuite/test/lang/cpp/gmodules-templates/TestGModules.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/gmodules-templates/TestGModules.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
-import lldbsuite.test.decorators
+from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), [
+    expectedFailureAll(oslist=["linux"], bugnumber="llvm.org/pr36107",
+        debug_info="gmodules")])


### PR DESCRIPTION
TestLibcxxListLoop - fails because the evil "define private public"
  trick does not work with gmodules. The purpose of the test is not to
  test debug info parsing so I just mark it as no_debug_info_testcase.
  In the long term it may be interesting to write a mock std::list which
  will allow us to test bad inputs to data formatters more easily.
TestGModules - seems to be a genuine bug. Filed pr36107 and xfailed.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@323520 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 4c11a54e3e22614f7991321995b3d435d7042e48)