### PR TITLE
lldb running on an ios device is using the _dyld_get_all_image_infos()

### DIFF
--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2179,6 +2179,11 @@ UUID ObjectFileMachO::GetSharedCacheUUID(FileSpec dyld_shared_cache,
            sizeof(uuid_t));
     dsc_uuid.SetBytes(uuid_bytes);
   }
+  Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYMBOLS));
+  if (log && dsc_uuid.IsValid()) {
+    log->Printf("Shared cache %s has UUID %s", dyld_shared_cache.GetPath().c_str(), 
+                dsc_uuid.GetAsString().c_str());
+  }
   return dsc_uuid;
 }
 
@@ -5942,6 +5947,9 @@ UUID ObjectFileMachO::GetProcessSharedCacheUUID(Process *process) {
     dl->GetSharedCacheInformation(load_address, uuid, using_shared_cache,
                                   private_shared_cache);
   }
+  Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYMBOLS | LIBLLDB_LOG_PROCESS));
+  if (log)
+    log->Printf("inferior process shared cache has a UUID of %s", uuid.GetAsString().c_str());
   return uuid;
 }
 
@@ -5972,7 +5980,20 @@ UUID ObjectFileMachO::GetLLDBSharedCacheUUID() {
         uuid.SetBytes(sharedCacheUUID_address);
       }
     }
+  } else {
+    // Exists in macOS 10.12 and later, iOS 10.0 and later - dyld SPI
+    bool *(*dyld_get_shared_cache_uuid)(uuid_t);
+    dyld_get_shared_cache_uuid = (bool *(*)(uuid_t))
+        dlsym(RTLD_DEFAULT, "_dyld_get_shared_cache_uuid");
+    if (dyld_get_shared_cache_uuid) {
+      uuid_t tmp_uuid;
+      if (dyld_get_shared_cache_uuid(tmp_uuid))
+        uuid.SetBytes(tmp_uuid);
+    }
   }
+  Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_SYMBOLS | LIBLLDB_LOG_PROCESS));
+  if (log && uuid.IsValid())
+    log->Printf("lldb's in-memory shared cache has a UUID of %s", uuid.GetAsString().c_str());
 #endif
   return uuid;
 }


### PR DESCRIPTION
SPI call to to find its own shared cache's UUID.  On newer sytems we
need to use the a new SPI which will return the UUID directly.

<rdar://problem/36625871>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@324437 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 63f24576c2deffa02857dd7d2efdcf21df958a66)