### PR TITLE
[SwiftASTContext] Remove IsOptionalChain.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -503,9 +503,6 @@ public:
   static bool GetProtocolTypeInfo(const CompilerType &type,
                                   ProtocolInfo &protocol_info);
 
-  static bool IsOptionalChain(CompilerType type, CompilerType &payload_type,
-                              uint32_t &depth);
-
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
 
   static TypeAllocationStrategy GetAllocationStrategy(const CompilerType &type);

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5433,37 +5433,6 @@ bool SwiftASTContext::GetProtocolTypeInfo(const CompilerType &type,
   return false;
 }
 
-bool SwiftASTContext::IsOptionalChain(CompilerType type,
-                                      CompilerType &payload_type,
-                                      uint32_t &depth) {
-  auto is_optional = [](const CompilerType &type) -> bool {
-    if (auto ast =
-            llvm::dyn_cast_or_null<SwiftASTContext>(type.GetTypeSystem())) {
-      if (auto swift_ast = ast->GetASTContext()) {
-        swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-        if (swift_can_type.getOptionalObjectType())
-          return true;
-        return false;
-      }
-    }
-    return false;
-  };
-
-  depth = 0;
-
-  while (is_optional(type)) {
-    ++depth;
-    lldb::TemplateArgumentKind kind;
-    type = type.GetTemplateArgument(0, kind);
-  }
-
-  if (depth > 0) {
-    payload_type = type;
-    return true;
-  } else
-    return false;
-}
-
 SwiftASTContext::TypeAllocationStrategy
 SwiftASTContext::GetAllocationStrategy(const CompilerType &type) {
   if (auto ast =


### PR DESCRIPTION
Unused, and unneeded. Found by inspection (when looking at stuffs that can be moved to `RemoteMirrors`).