### PR TITLE
[SwiftASTContext] Remove now always failing caching of common demangl…

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3062,21 +3062,6 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
     }
 
     GetASTMap().Insert(m_ast_context_ap.get(), this);
-
-    // Store common useful manglings for quick lookup - this also ensures that
-    // types that didn't come out of the visitor (e.g. fallback ObjCPointers)
-    // still exist in our tables for later mangled name retrieval
-    // (the expression parser needs to do this).
-    CacheDemangledType(ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtBO").c_str()).GetCString(),
-                       m_ast_context_ap->TheUnknownObjectType.getPointer());
-    CacheDemangledType(ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtBp").c_str()).GetCString(),
-                       m_ast_context_ap->TheRawPointerType.getPointer());
-    CacheDemangledType(ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtBb").c_str()).GetCString(),
-                       m_ast_context_ap->TheBridgeObjectType.getPointer());
-    CacheDemangledType(ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtBo").c_str()).GetCString(),
-                       m_ast_context_ap->TheNativeObjectType.getPointer());
-    CacheDemangledType(ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtT_").c_str()).GetCString(),
-                       m_ast_context_ap->TheEmptyTupleType.getPointer());
   }
 
   VALID_OR_RETURN(nullptr);


### PR DESCRIPTION
…ing.

This never kicks in because the mangling prefix changed from `_T` to
`$S`. Also, it's not the debugger job to decide which names are more common,
and it's unsure whether this decision should be static.

I plan to remove this cache altogether, my first set of measurements
show this is not a time sink, and this mechanism exhibits some fragility.

I think a better way of handling this situation is either:
a) Speed up the demangler if it turns out to be slow
b) Have a mechanism in the demangler library that transparently
caches results (and implements some suitable cache evition policy).
This way, the debugger can dynamically communicate what are the set
of symbols more commonly demangled, and the library can decide to
cache them accordingly. This avoids the hardcoding problem and
makes the whole thing more robust.