### PR TITLE
Add string and dictionary tests to 'swiftpr' catergory

### DIFF
--- a/packages/Python/lldbsuite/test/decorators.py
+++ b/packages/Python/lldbsuite/test/decorators.py
@@ -305,13 +305,16 @@ def add_test_categories(cat):
         if isinstance(func, type) and issubclass(func, unittest2.TestCase):
             raise Exception(
                 "@add_test_categories can only be used to decorate a test method")
-        if hasattr(func, "categories"):
-            cat.extend(func.categories)
-        # For instance methods, the attribute must be set on the actual function.
-        if inspect.ismethod(func):
-            func.__func__.categories = cat
-        else:
-            func.categories = cat
+
+        # Update or set the categories attribute. For instance methods, the
+        # attribute must be set on the actual function.
+        func_for_attr = func
+        if inspect.ismethod(func_for_attr):
+            func_for_attr = func.__func__
+        if hasattr(func_for_attr, "categories"):
+            cat.extend(func_for_attr.categories)
+        setattr(func_for_attr, "categories", cat)
+
         return func
 
     return impl

--- a/packages/Python/lldbsuite/test/decorators.py
+++ b/packages/Python/lldbsuite/test/decorators.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 # System modules
 from distutils.version import LooseVersion, StrictVersion
 from functools import wraps
+import inspect
 import os
 import platform
 import re
@@ -306,7 +307,11 @@ def add_test_categories(cat):
                 "@add_test_categories can only be used to decorate a test method")
         if hasattr(func, "categories"):
             cat.extend(func.categories)
-        func.categories = cat
+        # For instance methods, the attribute must be set on the actual function.
+        if inspect.ismethod(func):
+            func.__func__.categories = cat
+        else:
+            func.categories = cat
         return func
 
     return impl
@@ -526,7 +531,7 @@ def skipIfNoSBHeaders(func):
                 'LLDB.h')
             if os.path.exists(header):
                 return None
-        
+
         header = os.path.join(
             os.environ["LLDB_SRC"],
             "include",

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
@@ -14,4 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -14,4 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -14,4 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[
+    decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
@@ -15,4 +15,5 @@ import lldbsuite.test.decorators as decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=decorators.skipUnlessDarwin)
+    decorators=[decorators.skipUnlessDarwin,
+                decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/po/ref_types/TestSwiftPORefTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/ref_types/TestSwiftPORefTypes.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
@@ -15,4 +15,5 @@ import lldbsuite.test.decorators as decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=decorators.skipUnlessDarwin)
+    decorators=[decorators.skipUnlessDarwin,
+                decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
@@ -10,9 +10,10 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
-import lldbsuite.test.decorators
+import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=lldbsuite.test.decorators.skipUnlessDarwin)
+    decorators=[decorators.skipUnlessDarwin,
+                decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/po/val_types/TestSwiftPOValTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/val_types/TestSwiftPOValTypes.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -10,5 +10,7 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])

--- a/packages/Python/lldbsuite/test/repl/subclassing/TestREPLSubclassing.py
+++ b/packages/Python/lldbsuite/test/repl/subclassing/TestREPLSubclassing.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinrepl as lldbinrepl
 import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.decorators as decorators
 
-lldbinrepl.MakeREPLTest(__file__, globals(), [])
+lldbinrepl.MakeREPLTest(__file__, globals(),
+        decorators=[decorators.add_test_categories(["swiftpr"])])


### PR DESCRIPTION
Now that the Swift String and Dictionary formatters are fixed we want to
move those tests into the `switpr` category.