### PR TITLE
[SwiftLanguageRuntime] Remove unused helpers.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -111,18 +111,6 @@ public:
 
     llvm::StringRef GetBasename();
 
-    llvm::StringRef GetContext();
-
-    llvm::StringRef GetMetatypeReference();
-
-    llvm::StringRef GetTemplateArguments();
-
-    llvm::StringRef GetArguments();
-
-    llvm::StringRef GetQualifiers();
-
-    llvm::StringRef GetReturnType();
-
     static bool ExtractFunctionBasenameFromMangled(const ConstString &mangled,
                                                    ConstString &basename,
                                                    bool &is_method);

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1102,42 +1102,6 @@ llvm::StringRef SwiftLanguageRuntime::MethodName::GetBasename() {
   return m_basename;
 }
 
-llvm::StringRef SwiftLanguageRuntime::MethodName::GetContext() {
-  if (!m_parsed)
-    Parse();
-  return m_context;
-}
-
-llvm::StringRef SwiftLanguageRuntime::MethodName::GetArguments() {
-  if (!m_parsed)
-    Parse();
-  return m_arguments;
-}
-
-llvm::StringRef SwiftLanguageRuntime::MethodName::GetQualifiers() {
-  if (!m_parsed)
-    Parse();
-  return m_qualifiers;
-}
-
-llvm::StringRef SwiftLanguageRuntime::MethodName::GetMetatypeReference() {
-  if (!m_parsed)
-    Parse();
-  return m_qualifiers;
-}
-
-llvm::StringRef SwiftLanguageRuntime::MethodName::GetTemplateArguments() {
-  if (!m_parsed)
-    Parse();
-  return m_template_args;
-}
-
-llvm::StringRef SwiftLanguageRuntime::MethodName::GetReturnType() {
-  if (!m_parsed)
-    Parse();
-  return m_return_type;
-}
-
 const CompilerType &SwiftLanguageRuntime::GetBoxMetadataType() {
   if (m_box_metadata_type.IsValid())
     return m_box_metadata_type;


### PR DESCRIPTION
This opens the path for more simplification in this file.