### PR TITLE
[SwiftLanguageRuntime] Fail when we can't retrieve the type.

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1437,21 +1437,12 @@ SwiftLanguageRuntime::MetadataPromise::FulfillTypePromise(Status *error) {
       m_remote_ast->getTypeForRemoteTypeMetadata(
           swift::remote::RemoteAddress(m_metadata_location));
 
-  if (result) {
-    m_compiler_type = CompilerType(m_swift_ast, result.getValue().getPointer());
-    if (log)
-      log->Printf("[MetadataPromise] result is type %s",
-                  m_compiler_type->GetTypeName().AsCString());
-    return m_compiler_type.getValue();
-  } else {
-    const auto &failure = result.getFailure();
-    if (error)
-      error->SetErrorStringWithFormat("error in resolving type: %s",
-                                      failure.render().c_str());
-    if (log)
-      log->Printf("[MetadataPromise] failure: %s", failure.render().c_str());
-    return (m_compiler_type = CompilerType()).getValue();
-  }
+  assert(result && "RemoteAST answer is invalid!");
+  m_compiler_type = CompilerType(m_swift_ast, result.getValue().getPointer());
+  if (log)
+    log->Printf("[MetadataPromise] result is type %s",
+                m_compiler_type->GetTypeName().AsCString());
+  return m_compiler_type.getValue();
 }
 
 llvm::Optional<swift::MetadataKind>


### PR DESCRIPTION
This would've made diagnosing other bugs much easier because
we fail immediately instead of going on and producing an
invalid expression. It may seem very brusque to just fail here,
but I think this is good to shake out issues instead of hiding
them.