### PR TITLE
Cleanup unexpected success for Swift

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -35,29 +35,23 @@ class TestUnitTests(TestBase):
     @decorators.expectedFailureAll(
         oslist=["linux"],
         bugnumber="rdar://28180489")
-    @decorators.expectedFailureAll(
-        oslist=["macosx"],
-       bugnumber="rdar://31515121")
     def test_equality_operators_fileprivate(self):
         """Test that we resolve expression operators correctly"""
         self.buildAll()
         self.do_test("Fooey.CompareEm1", "true", 1)
 
+    @decorators.swiftTest
     @decorators.expectedFailureAll(
         oslist=["linux"],
         bugnumber="rdar://28180489")
-    @decorators.expectedFailureAll(
-        oslist=["macosx"],
-       bugnumber="rdar://31515121")
     def test_equality_operators_private(self):
         """Test that we resolve expression operators correctly"""
         self.buildAll()
         self.do_test("Fooey.CompareEm2", "false", 2)
 
+    @decorators.swiftTest
     @decorators.expectedFailureAll(
-        oslist=[
-            "linux",
-            "macosx"],
+        oslist=["linux"],
         bugnumber="rdar://28180489")
     def test_equality_operators_other_module(self):
         """Test that we resolve expression operators correctly"""

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
@@ -14,4 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -14,6 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.expectedFailureAll(
-                        bugnumber="rdar://problem/32040811"),
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
@@ -14,5 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.expectedFailureDarwin("rdar://35650693"),
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
@@ -14,4 +14,5 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
+        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
@@ -26,7 +26,6 @@ class TestSwiftMixAnyObjectType(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
-    @decorators.expectedFailureDarwin("rdar://35650693")
     def test_any_object_type(self):
         """Test the AnyObject type in different combinations"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -26,7 +26,6 @@ class TestDictionaryNSObjectAnyObject(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
-    @decorators.expectedFailureDarwin("rdar://35650693")
     def test_dictionary_nsobject_any_object(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary<NSObject,AnyObject>"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -31,9 +31,8 @@ class TestIndirectEnumVariables(TestBase):
         self.build()
         self.do_test("indirect case break here")
 
+    @decorators.swiftTest
     @decorators.skipIf(bugnumber='rdar://27568868', oslist=['linux'])
-    @decorators.expectedFailureAll(
-        bugnumber="rdar://29953436")
     def test_indirect_enum_variables(self):
         """Tests that indirect Enum variables display correctly when enum is indirect"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -10,5 +10,8 @@
 #
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), lldbinline.expectedFailureAll(bugnumber="rdar://33860001"))
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[
+    decorators.add_test_categories(["swiftpr"]),
+    decorators.skipUnlessDarwin])


### PR DESCRIPTION
I'm going through the unexpected successes in the test suite. I'm re-enalbing the ones for which the radar suggests they might/are fixed on the condition that they works on all of my machines. Probably some of them will still fail on the bots, which we'll hopefully find out here. 