### PR TITLE
Cleanup unexpected success for Objective-C

### DIFF
--- a/packages/Python/lldbsuite/test/lang/objc/objc-new-syntax/TestObjCNewSyntax.py
+++ b/packages/Python/lldbsuite/test/lang/objc/objc-new-syntax/TestObjCNewSyntax.py
@@ -47,12 +47,6 @@ class ObjCNewSyntaxTestCase(TestBase):
                     substrs=[' resolved, hit count = 1'])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_read_array(self):
@@ -69,12 +63,6 @@ class ObjCNewSyntaxTestCase(TestBase):
             substrs=["foo"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_update_array(self):
@@ -91,12 +79,6 @@ class ObjCNewSyntaxTestCase(TestBase):
             substrs=["bar"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_read_dictionary(self):
@@ -113,12 +95,6 @@ class ObjCNewSyntaxTestCase(TestBase):
             substrs=["value"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     @expectedFailureAll(debug_info="gmodules",
@@ -137,12 +113,6 @@ class ObjCNewSyntaxTestCase(TestBase):
             substrs=["object"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_array_literal(self):
@@ -157,12 +127,6 @@ class ObjCNewSyntaxTestCase(TestBase):
                 "bar"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     @expectedFailureAll(debug_info="gmodules",
@@ -178,12 +142,6 @@ class ObjCNewSyntaxTestCase(TestBase):
                 "object"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_char_literal(self):
@@ -193,12 +151,6 @@ class ObjCNewSyntaxTestCase(TestBase):
                     VARIABLES_DISPLAYED_CORRECTLY, substrs=[str(ord('a'))])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_integer_literals(self):
@@ -230,12 +182,6 @@ class ObjCNewSyntaxTestCase(TestBase):
             substrs=["1"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_float_literal(self):
@@ -245,12 +191,6 @@ class ObjCNewSyntaxTestCase(TestBase):
                     substrs=["NSNumber", "123.45"])
 
     @skipUnlessDarwin
-    @expectedFailureAll(
-        oslist=['macosx'],
-        compiler='clang',
-        compiler_version=[
-            '<',
-            '7.0.0'])
     @skipIf(macos_version=["<", "10.12"])
     @expectedFailureAll(archs=["i[3-6]86"])
     def test_expressions_in_literals(self):

--- a/packages/Python/lldbsuite/test/lang/objc/objc-struct-argument/TestObjCStructArgument.py
+++ b/packages/Python/lldbsuite/test/lang/objc/objc-struct-argument/TestObjCStructArgument.py
@@ -25,10 +25,6 @@ class TestObjCStructArgument(TestBase):
 
     @skipUnlessDarwin
     @add_test_categories(['pyapi'])
-    @expectedFailureAll(
-        oslist=["macosx"],
-        debug_info="gmodules",
-        bugnumber="rdar://26558169,bugs.swift.org/SR-1766")
     @skipIf(debug_info=no_match(["gmodules"]), oslist=['ios', 'watchos', 'tvos', 'bridgeos'], archs=['armv7', 'arm64'])  # this test program only builds for ios with -gmodules
     def test_with_python_api(self):
         """Test passing structs to Objective-C methods."""


### PR DESCRIPTION
I'm going through the unexpected successes in the test suite. I'm re-enalbing the ones for which the radar suggests they might/are fixed on the condition that they works on all of my machines. Probably some of them will still fail on the bots, which we'll hopefully find out here.