### PR TITLE
Cleanup unexpected success for C & C++

### DIFF
--- a/packages/Python/lldbsuite/test/lang/c/global_variables/TestGlobalVariables.py
+++ b/packages/Python/lldbsuite/test/lang/c/global_variables/TestGlobalVariables.py
@@ -22,12 +22,6 @@ class GlobalVariablesTestCase(TestBase):
         self.shlib_names = ["a"]
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
-    @expectedFailureAll(
-        "llvm.org/pr25872, <rdar://problem/28725399>",
-        oslist=["macosx"],
-        debug_info=[
-            "dwarf",
-            "gmodules"])
     def test_c_global_variables(self):
         """Test 'frame variable --scope --no-args' which omits args and shows scopes."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/c/register_variables/TestRegisterVariables.py
+++ b/packages/Python/lldbsuite/test/lang/c/register_variables/TestRegisterVariables.py
@@ -99,13 +99,10 @@ class RegisterVariableTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @expectedFailureAll(compiler="clang", compiler_version=['<', '3.5'])
-    @expectedFailureAll(compiler="clang", archs=["i386"])
     @expectedFailureAll(compiler="gcc", compiler_version=[
             '>=', '4.8.2'], archs=["i386"])
     @expectedFailureAll(compiler="gcc", compiler_version=[
             '<', '4.9'], archs=["x86_64"])
-    @expectedFailureAll(oslist=["linux"], bugnumber="bugs.swift.org/SR-2140")
-    @expectedFailureAll(oslist=["macosx"], bugnumber="rdar://28983120")
     def test_and_run_command(self):
         """Test expressions on register values."""
 

--- a/packages/Python/lldbsuite/test/lang/cpp/class_static/TestStaticVariables.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/class_static/TestStaticVariables.py
@@ -24,7 +24,6 @@ class StaticVariableTestCase(TestBase):
         self.line = line_number('main.cpp', '// Set break point at this line.')
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
-    @expectedFailureAll(compiler="clang", bugnumber="rdar://problem/30100567")
     def test_with_run_command(self):
         """Test that file and class static variables display correctly."""
         self.build()


### PR DESCRIPTION
I'm going through the unexpected successes in the test suite. I'm re-enalbing the ones for which the radar suggests they might/are fixed on the condition that they works on all of my machines. 

Actually, all the tests in this PR were already re-enabled upstream, so I'm not expecting any issues at all. 