### PR TITLE
[test] Remove inline tests from the `swiftpr` category

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/date/TestSwiftFoundationTypeDate.py
@@ -13,6 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
-        decorators.skipUnlessDarwin])
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/indexpath/TestSwiftFoundationTypeIndexPath.py
@@ -13,6 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
-        decorators.skipUnlessDarwin])
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
@@ -14,5 +14,4 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
@@ -14,5 +14,4 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
         decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -13,6 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
-        decorators.skipUnlessDarwin])
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/uuid/TestSwiftFoundationTypeUUID.py
@@ -13,6 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
-        decorators.skipUnlessDarwin])
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -13,6 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[
-        decorators.add_test_categories(["swiftpr"]),
-        decorators.skipUnlessDarwin])
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[
-    decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/nested_nsdict/TestSwiftPONestedNSDictionary.py
@@ -15,5 +15,4 @@ import lldbsuite.test.decorators as decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[decorators.skipUnlessDarwin,
-                decorators.add_test_categories(["swiftpr"])])
+    decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/po/ref_types/TestSwiftPORefTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/ref_types/TestSwiftPORefTypes.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/sys_types/TestSwiftPOSysTypes.py
@@ -15,5 +15,4 @@ import lldbsuite.test.decorators as decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[decorators.skipUnlessDarwin,
-                decorators.add_test_categories(["swiftpr"])])
+    decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/uninitialized/TestSwiftPOUninitialized.py
@@ -15,5 +15,4 @@ import lldbsuite.test.decorators as decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[decorators.skipUnlessDarwin,
-                decorators.add_test_categories(["swiftpr"])])
+    decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/po/val_types/TestSwiftPOValTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/po/val_types/TestSwiftPOValTypes.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
+++ b/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
@@ -31,7 +31,6 @@ class TestSwiftReturns(TestBase):
         oslist=["ios"],
         archs=["arm64"],
         bugnumber="rdar://27002915")
-    @decorators.add_test_categories(["swiftpr"])
     def test_swift_returns(self):
         """Test getting return values"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[decorators.add_test_categories(["swiftpr"])])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -13,5 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(__file__, globals(), decorators=[
-    decorators.add_test_categories(["swiftpr"]),
     decorators.skipUnlessDarwin])


### PR DESCRIPTION
The logic to apply decorators to these tests does not quite work
correctly. More tests than intended end up in the `swiftpr` category
when a decorator is added to a single inline test.

Related to r://37173570.