### PR TITLE
[CompilerType] Expose GetMangledTypeName() to ValueObject.

### DIFF
--- a/include/lldb/Core/ValueObject.h
+++ b/include/lldb/Core/ValueObject.h
@@ -389,6 +389,8 @@ public:
   //------------------------------------------------------------------
   // Subclasses can implement the functions below.
   //------------------------------------------------------------------
+  virtual ConstString GetMangledTypeName();
+
   virtual ConstString GetTypeName();
 
   virtual ConstString GetDisplayTypeName();

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -1717,6 +1717,10 @@ bool ValueObject::GetDeclaration(Declaration &decl) {
   return false;
 }
 
+ConstString ValueObject::GetMangledTypeName() {
+  return GetCompilerType().GetMangledTypeName();
+}
+
 ConstString ValueObject::GetTypeName() {
   return GetCompilerType().GetConstTypeName();
 }


### PR DESCRIPTION
The whole logic was already there, just not exposed yet. This
will be used as we want to pass the mangled type name to remote
mirrors.