### PR TITLE
[SwiftLanguageRuntime] Remove code accidentally copypasted.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -307,18 +307,6 @@ public:
 
   bool IsSymbolARuntimeThunk(const Symbol &symbol) override;
 
-  // in some cases, compilers will output different names for one same type.
-  // when tht happens, it might be impossible
-  // to construct SBType objects for a valid type, because the name that is
-  // available is not the same as the name that
-  // can be used as a search key in FindTypes(). the equivalents map here is
-  // meant to return possible alternative names
-  // for a type through which a search can be conducted. Currently, this is only
-  // enabled for C++ but can be extended
-  // to ObjC or other languages if necessary
-  static uint32_t FindEquivalentNames(ConstString type_name,
-                                      std::vector<ConstString> &equivalents);
-
   // this call should return true if it could set the name and/or the type
   virtual bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                         lldb::DynamicValueType use_dynamic,

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -713,11 +713,6 @@ const std::string SwiftLanguageRuntime::GetCurrentMangledName(const char *mangle
 #endif
 }
 
-uint32_t SwiftLanguageRuntime::FindEquivalentNames(
-    ConstString type_name, std::vector<ConstString> &equivalents) {
-  return 0;
-}
-
 void SwiftLanguageRuntime::MethodName::Clear() {
   m_full.Clear();
   m_basename = llvm::StringRef();


### PR DESCRIPTION
Presumably from the C++ backend.