### PR TITLE
Linux / cmake: Install the clang resource directory to the expected P…

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
@@ -1,0 +1,16 @@
+# TestSwiftFoundation.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
+
+# Swift-4.1-branch doesn't have the necessary build-script changes.
+lldbinline.MakeInlineTest(__file__, globals(), decorators=decorators.skipUnlessDarwin)

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
@@ -1,0 +1,22 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Foundation
+
+// Test that importing Foundation and printing a value for which
+// no data formatter exists works consistently on all platforms.
+func main() {
+  var point = NSPoint(x: 23, y: 42)
+  print(point) //% self.expect("frame variable -- point", substrs=['x', '23', 'y', '42'])
+  //% self.expect("expression -- point", substrs=['x', '23', 'y', '42'])
+}
+
+main()

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -482,8 +482,16 @@ endif
 # Check if we need the Swift/ObjC interop features
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_OBJC_INTEROP)" "1"
-	SWIFTFLAGS += -framework Foundation -framework CoreGraphics
-	LDFLAGS +=-lswiftObjectiveC -lswiftFoundation -framework Foundation -framework CoreGraphics
+        ifeq "$(OS)" "Darwin"
+		SWIFTFLAGS += -framework Foundation -framework CoreGraphics
+		LDFLAGS += -lswiftObjectiveC -lswiftFoundation -framework Foundation -framework CoreGraphics
+        else
+                # CFLAGS_EXTRAS is used via "dotest.py -E" to pass the -I and -L paths
+                # for Foundation and libdispatch on Linux.
+                SWIFTFLAGS += $(CFLAGS_EXTRAS)
+                LDFLAGS += $(CFLAGS_EXTRAS)
+        endif
+
 endif
 
 #----------------------------------------------------------------------

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -170,10 +170,11 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(clang_headers_target symlink_clang_headers)
 endif()
 
+# Copy the clang resource directory.
 add_custom_command_target(
     unused_var
-    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang"
-    OUTPUT "${lib_dir}/lldb/clang"
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang/${LLVM_PACKAGE_VERSION}"
+    OUTPUT "${lib_dir}/lldb/clang/${LLVM_PACKAGE_VERSION}"
     VERBATIM
     ALL
     DEPENDS ${clang_headers_target})


### PR DESCRIPTION
…OSIX path.

HostInfoPosix::ComputeClangDirectory() expects the clang resource
directory to be in lib/lldb/clang/$VERSION. This patch fixes the
Swift-specific CMake to install it there instead of in lib/lldb/clang/.

<rdar://problem/37354542>
https://bugs.swift.org/browse/SR-6954

(cherry picked from commit 0f090945431a91eb0a6a89a7c8dd85b0c0d5c1f8)