### PR TITLE
Handle typeof() expressions

### DIFF
--- a/lit/Expr/TestTypeOfDeclTypeExpr.test
+++ b/lit/Expr/TestTypeOfDeclTypeExpr.test
@@ -1,0 +1,13 @@
+# RUN: %lldb -b -s %s | FileCheck %s
+
+expression int i; __typeof__(i) j = 1; j
+# CHECK: (lldb) expression int i; __typeof__(i) j = 1; j
+# CHECK-NEXT: (typeof (i)) {{.*}} = 1
+
+expression int i; typeof(i) j = 1; j
+# CHECK: (lldb) expression int i; typeof(i) j = 1; j
+# CHECK-NEXT: (typeof (i)) {{.*}} = 1
+
+expression int i; decltype(i) j = 1; j
+# CHECK: (lldb) expression int i; decltype(i) j = 1; j
+# CHECK-NEXT: (decltype(i)) {{.*}} = 1


### PR DESCRIPTION
Before this patch, LLDB was not able to evaluate expressions that
resulted in a value with a typeof- or decltype-type. This patch fixes
that.

Before:
  (lldb) p int i; __typeof__(i) j = 1; j
  (typeof (i)) $0 =

After:
  (lldb) p int i; __typeof__(i) j = 1; j
  (typeof (i)) $0 = 1

Differential revision: https://reviews.llvm.org/D43471

rdar://37461520

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@325568 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 98516a2168f6d61fee2c1e53ec48b26674ba9659)