### PR TITLE
Fix python build argument

### DIFF
--- a/scripts/build-swift-cmake.py
+++ b/scripts/build-swift-cmake.py
@@ -205,7 +205,7 @@ else:
     elif args.use_system_debugserver:
         build_script_impl_arguments += ['--lldb-use-system-debugserver']
 
-args = ["python" + os.path.join("swift", "utils", "build-script")] + \
+args = ["python", os.path.join("swift", "utils", "build-script")] + \
     build_script_arguments + ["--"] + build_script_impl_arguments
 
 print(" ".join(args))


### PR DESCRIPTION
Previously this concatenated "pythonswift/utils" this was broken in
80e032cb3fc68d1c56ed0c112f1fc81baf1a9454