### PR TITLE
[PATCH] [test] Introduce the skipUnlessSwiftPR decorator

### DIFF
--- a/packages/Python/lldbsuite/test/configuration.py
+++ b/packages/Python/lldbsuite/test/configuration.py
@@ -36,9 +36,6 @@ skipCategories = ["darwin-log", "frame-diagnose"]
 if platform.system() == 'Linux':
     skipCategories.append('watchpoints')
 
-# use this to track per-category failures
-failuresPerCategory = {}
-
 # The path to LLDB.framework is optional.
 lldbFrameworkPath = None
 

--- a/packages/Python/lldbsuite/test/dotest.py
+++ b/packages/Python/lldbsuite/test/dotest.py
@@ -1387,14 +1387,6 @@ def run_suite():
             " can be found in directory '%s'\n" %
             configuration.sdir_name)
 
-    if configuration.useCategories and len(
-            configuration.failuresPerCategory) > 0:
-        sys.stderr.write("Failures per category:\n")
-        for category in configuration.failuresPerCategory:
-            sys.stderr.write(
-                "%s - %d\n" %
-                (category, configuration.failuresPerCategory[category]))
-
     # Terminate the test suite if ${LLDB_TESTSUITE_FORCE_FINISH} is defined.
     # This should not be necessary now.
     if ("LLDB_TESTSUITE_FORCE_FINISH" in os.environ):

--- a/packages/Python/lldbsuite/test/test_result.py
+++ b/packages/Python/lldbsuite/test/test_result.py
@@ -105,19 +105,6 @@ class LLDBTestResult(unittest2.TextTestResult):
         else:
             return str(test)
 
-    def getCategoriesForTest(self, test):
-        """
-        Gets all the categories for the currently running test method in test case
-        """
-        test_categories = []
-        test_method = getattr(test, test._testMethodName)
-        if test_method is not None and hasattr(test_method, "categories"):
-            test_categories.extend(test_method.categories)
-
-        test_categories.extend(test.getCategories())
-
-        return test_categories
-
     def hardMarkAsSkipped(self, test):
         getattr(test, test._testMethodName).__func__.__unittest_skip__ = True
         getattr(
@@ -133,9 +120,6 @@ class LLDBTestResult(unittest2.TextTestResult):
         return False
 
     def startTest(self, test):
-        if configuration.shouldSkipBecauseOfCategories(
-                self.getCategoriesForTest(test)):
-            self.hardMarkAsSkipped(test)
         if self.checkExclusion(
                 configuration.skip_tests, test.id()):
             self.hardMarkAsSkipped(test)
@@ -238,14 +222,6 @@ class LLDBTestResult(unittest2.TextTestResult):
             self.stream.write(
                 "FAIL: LLDB (%s) :: %s\n" %
                 (self._config_string(test), str(test)))
-        if configuration.useCategories:
-            test_categories = self.getCategoriesForTest(test)
-            for category in test_categories:
-                if category in configuration.failuresPerCategory:
-                    configuration.failuresPerCategory[
-                        category] = configuration.failuresPerCategory[category] + 1
-                else:
-                    configuration.failuresPerCategory[category] = 1
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_failure(test, err))


### PR DESCRIPTION
This determines whether or not a test is skipped due to not being marked
`swiftpr` in the wrapper function, i.e after the test method is called,
instead of before.

This fixes strange issues with categories which resulted in the wrong
set of tests being marked `swiftpr` and running accidentally. It also
fixes discrepancies which arise between the single and multi threaded
test runners due to attempts to edit an attribute on a function instance
shared between multiple inline tests.

Thanks to Vedant Kumar for helping me come up with a solution!