### PR TITLE
[ObjC] Fix the NSConcreteData formatter and test it

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjC.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjC.py
@@ -244,7 +244,7 @@ class ObjCDataFormatterTestCase(TestBase):
 
     def nsdata_data_formatter_commands(self):
         self.expect(
-            'frame variable immutableData mutableData data_ref mutable_data_ref mutable_string_ref',
+            'frame variable immutableData mutableData data_ref mutable_data_ref mutable_string_ref concreteData concreteMutableData',
             substrs=[
                 '(NSData *) immutableData = ',
                 ' 4 bytes',
@@ -255,7 +255,12 @@ class ObjCDataFormatterTestCase(TestBase):
                 '(CFMutableDataRef) mutable_data_ref = ',
                 '@"5 bytes"',
                 '(CFMutableStringRef) mutable_string_ref = ',
-                ' @"Wish ya knew"'])
+                ' @"Wish ya knew"',
+                '(NSData *) concreteData = ',
+                ' 100000 bytes',
+                '(NSMutableData *) concreteMutableData = ',
+                ' 100000 bytes'])
+
 
     def nsurl_data_formatter_commands(self):
         self.expect(

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/main.m
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/main.m
@@ -398,6 +398,12 @@ int main (int argc, const char * argv[])
 	    NSData *immutableData = [[NSData alloc] initWithBytes:"HELLO" length:4];
 	    NSData *mutableData = [[NSMutableData alloc] initWithBytes:"NODATA" length:6];
 
+	    // No-copy versions of NSData initializers use NSConcreteData if over 2^16 elements are specified.
+	    unsigned concreteLength = 100000;
+	    void *zeroes = calloc(1, concreteLength);
+	    NSData *concreteData = [[NSData alloc] initWithBytesNoCopy:zeroes length:concreteLength];
+	    NSMutableData *concreteMutableData = [[NSMutableData alloc] initWithBytesNoCopy:zeroes length:concreteLength];
+
 	    [mutableData appendBytes:"MOREDATA" length:8];
 
 	    [immutableData length];
@@ -612,6 +618,7 @@ int main (int argc, const char * argv[])
     [molecule setAtoms:nil];
     [molecule setAtoms:[NSMutableArray new]];
 
+    free(zeroes);
     [pool drain];
     return 0;
 }

--- a/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -882,28 +882,34 @@ bool lldb_private::formatters::NSDataSummaryProvider(
 
   uint64_t value = 0;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name = descriptor->GetClassName().GetCString();
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
-  if (!strcmp(class_name, "NSConcreteData") ||
-      !strcmp(class_name, "NSConcreteMutableData") ||
-      !strcmp(class_name, "__NSCFData")) {
-    uint32_t offset = (is_64bit ? 16 : 8);
+  bool isNSConcreteData = class_name == "NSConcreteData";
+  bool isNSConcreteMutableData = class_name == "NSConcreteMutableData";
+  bool isNSCFData = class_name == "__NSCFData";
+  if (isNSConcreteData || isNSConcreteMutableData || isNSCFData) {
+    uint32_t offset;
+    if (isNSConcreteData)
+      offset = is_64bit ? 8 : 4;
+    else
+      offset = is_64bit ? 16 : 8;
+
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(
         valobj_addr + offset, is_64bit ? 8 : 4, 0, error);
     if (error.Fail())
       return false;
-  } else if (!strcmp(class_name, "_NSInlineData")) {
+  } else if (class_name == "_NSInlineData") {
     uint32_t offset = (is_64bit ? 8 : 4);
     Status error;
     value = process_sp->ReadUnsignedIntegerFromMemory(valobj_addr + offset, 2,
                                                       0, error);
     if (error.Fail())
       return false;
-  } else if (!strcmp(class_name, "_NSZeroData")) {
+  } else if (class_name == "_NSZeroData") {
     value = 0;
   } else
     return false;


### PR DESCRIPTION
The length field of an NSConcreteData lives one word past the start of
the object, not two.

rdar://37670464

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@325841 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit ed9fb0ceca0d4e08ab4372eb4cfa9bbbc215272a)