### PR TITLE
 Set DebuggerSupport to true in the ClangImporterOptions.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Bar.framework/Headers/Bar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Bar.framework/Headers/Bar.h
@@ -1,0 +1,2 @@
+struct Foo { int i; };
+#include "conflict.h"

--- a/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Bar.framework/Modules/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Bar.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+framework module Bar {
+  header "Bar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Makefile
@@ -1,0 +1,16 @@
+LEVEL = ../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules
+SWIFTFLAGS += -Xcc -F$(SRCDIR) -I$(SRCDIR)
+
+# Create a nonmodular include by removing the modulemap after building.
+all: a.out
+	rm module.modulemap
+
+a.out: module.modulemap
+
+module.modulemap:
+	echo 'module Baz { header "conflict.h" }' >module.modulemap

--- a/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/TestSwiftNonmodularInclude.py
+++ b/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/TestSwiftNonmodularInclude.py
@@ -1,0 +1,18 @@
+# TestSwiftNonmodularInclude.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
+
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[
+        decorators.add_test_categories(["swiftpr"]),
+        decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/main.swift
@@ -1,0 +1,21 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Bar
+
+func use<T>(_ t: T) {}
+
+func main() {
+  let foo = Foo(i: 42)
+  use(foo) //% self.expect("expr foo", "import worked", ["42"])
+}
+
+main()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2642,6 +2642,7 @@ swift::ClangImporterOptions &SwiftASTContext::GetClangImporterOptions() {
     if (HostInfo::GetLLDBPath(ePathTypeClangDir, clang_dir_spec))
       clang_importer_options.OverrideResourceDir =
           std::move(clang_dir_spec.GetPath());
+    clang_importer_options.DebuggerSupport = true;
   }
   return clang_importer_options;
 }


### PR DESCRIPTION
Swift's ClangImporter is more lenient when this option is set, but
LLDB wasn't passing it correctly to the ClangImporter, only to the
LanguageOptions.

<rdar://problem/37922760>