### PR TITLE
[Repl] Don't crash when passing additional arguments.

### DIFF
--- a/lit/SwiftREPL/CrashArgs.test
+++ b/lit/SwiftREPL/CrashArgs.test
@@ -1,0 +1,4 @@
+// Make sure we don't crash if we pass args to the repl.
+
+// RUN: %lldb --repl="-some-argument" | FileCheck %s --check-prefix=SWIFT
+// SWIFT: Welcome to Swift version {{.*}} (LLVM {{.*}}, Clang {{.*}}, Swift {{.*}})

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1900,7 +1900,6 @@ static lldb::TypeSystemSP CreateTypeSystemInstance(lldb::LanguageType language,
     return SwiftASTContext::CreateInstance(language, *module);
   } else if (target) {
     assert(!module);
-    assert(StringRef(extra_options).empty());
     return SwiftASTContext::CreateInstance(language, *target, extra_options);
   }
 }


### PR DESCRIPTION
The assertion was overly aggressive, we can actually
have a non-empty set of options in this codepath. While
here, add a test to make sure this doesn't regress.

<rdar://38042866>