### PR TITLE
Fix swift AST section name for COFF objects

### DIFF
--- a/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -697,7 +697,7 @@ void ObjectFilePECOFF::CreateSections(SectionList &unified_section_list) {
         static ConstString g_sect_name_dwarf_debug_ranges(".debug_ranges");
         static ConstString g_sect_name_dwarf_debug_str(".debug_str");
         static ConstString g_sect_name_eh_frame(".eh_frame");
-        static ConstString g_sect_name_swift_ast(".swift_ast");
+        static ConstString g_sect_name_swift_ast("swiftast");
         static ConstString g_sect_name_go_symtab(".gosymtab");
         SectionType section_type = eSectionTypeOther;
         if (m_sect_headers[idx].flags & llvm::COFF::IMAGE_SCN_CNT_CODE &&


### PR DESCRIPTION
According to: `swift/include/swift/Basic/Dwarf.h`,
the correct AST section name for COFF is "swiftast".