### PR TITLE
[REPL] Build the dummy executable always with `-g0`.

### DIFF
--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -11,6 +11,13 @@ add_lldb_tool(repl_swift
   main.c
   )
 
+# The dummy repl executable is a C program, but we always look for a mangled
+# swift symbol (corresponding to main). If we build the repl with debug info,
+# the debugger looks at the frame language (looking up the compile unit) and gets
+# confused.
+set_target_properties(repl_swift PROPERTIES
+    COMPILE_FLAGS "-g0")
+
 if (LLDB_BUILD_FRAMEWORK)
   # lldb --repl expects the dummy executable to be located in the framework resource dir,
   # so we copy it.


### PR DESCRIPTION
This is just an implementation detail, and nobody touches it
anyway. Given that's a C program, lldb frame language recognition
gets confused, so the repl malfunctions. It only manifests in
debug builds, that's the reason why nobody noticed (until now).

An alternative would be that of having the dummy executable
being written in swift. At some point this was the case, but
then it was converted to a C program. Eventually we might want
to re-evaluate the choice.

<rdar://problem/38121735>