### PR TITLE
[SwiftLanguage] Enforce a valid ASTContext when resolving archetypes.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -319,9 +319,8 @@ public:
 
   bool IsRuntimeSupportValue(ValueObject &valobj) override;
 
-  virtual CompilerType
-  DoArchetypeBindingForType(StackFrame &stack_frame, CompilerType base_type,
-                            SwiftASTContext *ast_context = nullptr);
+  virtual CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,
+                                                 CompilerType base_type);
 
   virtual CompilerType GetConcreteType(ExecutionContextScope *exe_scope,
                                        ConstString abstract_type_name) override;

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -942,7 +942,6 @@ public:
     if (lang == lldb::eLanguageTypeSwift) {
       SwiftLanguageRuntime *language_runtime =
           process_sp->GetSwiftLanguageRuntime();
-
       if (language_runtime && frame_sp)
         m_type = language_runtime->DoArchetypeBindingForType(*frame_sp, m_type);
     }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -931,7 +931,7 @@ static void CountLocals(
 
       if (language_runtime && stack_frame_sp)
         target_type = language_runtime->DoArchetypeBindingForType(
-            *stack_frame_sp, target_type, &ast_context);
+            *stack_frame_sp, target_type);
 
       // If we couldn't fully realize the type, then we aren't going to get very
       // far making a local out of it,


### PR DESCRIPTION
The callers now have to provide an AST all the time. In case they
don't we still bail out instead of crashing, but at least in assert
build we notice the violation sooner rather than later.