### PR TITLE
Remove intended divergence between the github lldb and llvm.org lldb

### DIFF
--- a/packages/Python/lldbsuite/test/python_api/frame/get-variables/TestGetVariables.py
+++ b/packages/Python/lldbsuite/test/python_api/frame/get-variables/TestGetVariables.py
@@ -44,8 +44,6 @@ class TestGetVariables(TestBase):
             len(copy_names), 0, "%s: we didn't find variables: %s in value list (%s)" %
             (description, copy_names, actual_names))
 
-    @skipUnlessDarwin
-    @expectedFailureAll(oslist=["macosx"], bugnumber="swift.org/SR-1569")
     def test(self):
         self.build()
 
@@ -93,7 +91,7 @@ class TestGetVariables(TestBase):
 
         arg_names = ['argc', 'argv']
         local_names = ['i', 'j', 'k']
-        static_names = ['static_var', 'g_global_var', 'static_var']
+        static_names = ['static_var', 'g_global_var', 'g_static_var']
         breakpoint1_locals = ['i']
         breakpoint1_statics = ['static_var']
         num_args = len(arg_names)

--- a/packages/Python/lldbsuite/test/python_api/frame/get-variables/main.c
+++ b/packages/Python/lldbsuite/test/python_api/frame/get-variables/main.c
@@ -12,8 +12,9 @@ int g_global_var = 123;
 static int g_static_var = 123;
 
 int main (int argc, char const *argv[])
-{                            
+{
     static int static_var = 123;
+    g_static_var = 123; // clang bug. Need to touch this variable, otherwise it disappears.
     int i = 0;                                  // breakpoint 1
     for (i=0; i<1; ++i)
     {


### PR DESCRIPTION
Remove intended divergence between the github lldb and llvm.org lldb
sources.  Todd mis-identified the nature of the failure and xfailed
this, but it has been correctly fixed on llvm.org since then.

(cherry picked from commit 3323f58a7231f530513406b8832cd1d075d1921f)