### PR TITLE
[SwiftLanguageRuntime] Delete unused demangler functionality.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -215,10 +215,6 @@ public:
   
   static bool IsSwiftClassName(const char *name);
   
-  static bool IsMetadataSymbol(const char *symbol);
-  
-  static bool IsIvarOffsetSymbol(const char *symbol);
-  
   static const std::string GetCurrentMangledName(const char *mangled_name);
 
   struct SwiftErrorDescriptor {

--- a/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2403,9 +2403,6 @@ unsigned ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
         mangled.SetDemangledName(ConstString((demangled_name + suffix).str()));
     }
 
-    if (SwiftLanguageRuntime::IsMetadataSymbol(symbol_name))
-      symbol_type = eSymbolTypeMetadata;
-
     // In ELF all symbol should have a valid size but it is not true for some
     // function symbols
     // coming from hand written assembly. As none of the function symbol should

--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -3892,14 +3892,6 @@ size_t ObjectFileMachO::ParseSymtab() {
                                       nlist.n_type << 16 | nlist.n_desc);
                                   sym[sym_idx].Clear();
                                   continue;
-                                } else {
-                                  if (SwiftLanguageRuntime::IsSwiftSymbol(symbol_name) {
-                                    if (SwiftLanguageRuntime::IsIvarOffset(symbol_name) {
-                                      type = eSymbolTypeIVarOffset;
-                                    } else if (SwiftLanguageRuntime::IsMetadataSymbol(symbol_name) {
-                                      type = eSymbolTypeMetadata;
-                                    }
-                                  }
                                 }
                               }
                             }
@@ -4043,12 +4035,6 @@ size_t ObjectFileMachO::ParseSymtab() {
             // correctly.  To do this right, we should coalesce all the GSYM &
             // global symbols that have the
             // same address.
-            if (symbol_name && symbol_name[0] == '_' && symbol_name[1] == '_'
-                && SwiftLanguageRuntime::IsMetadataSymbol(symbol_name+1)) {
-              add_nlist = false;
-              break;
-            }
-
             is_gsym = true;
             sym[sym_idx].SetExternal(true);
 
@@ -4823,24 +4809,8 @@ size_t ObjectFileMachO::ParseSymtab() {
                     // symbol table
                     sym[GSYM_sym_idx].SetFlags(nlist.n_type << 16 |
                                                nlist.n_desc);
-                    if (SwiftLanguageRuntime::IsSwiftMangledName(gsym_name)) {
-                      if (SwiftLanguageRuntime::IsIvarOffsetSymbol(gsym_name)) {
-                        sym[GSYM_sym_idx].SetType(eSymbolTypeIVarOffset);
-                      } else if (SwiftLanguageRuntime::IsMetadataSymbol(gsym_name)) {
-                        sym[GSYM_sym_idx].SetType(eSymbolTypeMetadata);
-                      }
-                    }
-
                     sym[sym_idx].Clear();
                     continue;
-                  } else {
-                    if (SwiftLanguageRuntime::IsSwiftMangledName(symbol_name)) { 
-                      if (SwiftLanguageRuntime::IsIvarOffsetSymbol(symbol_name)) {
-                        type = eSymbolTypeIVarOffset;
-                      } else if (SwiftLanguageRuntime::IsMetadataSymbol(symbol_name)) {
-                        type = eSymbolTypeMetadata;
-                      }
-                    }
                   }
                 }
               }

--- a/source/Symbol/ObjectFile.cpp
+++ b/source/Symbol/ObjectFile.cpp
@@ -642,14 +642,7 @@ lldb::SymbolType
 ObjectFile::GetSymbolTypeFromName(llvm::StringRef name,
                                   lldb::SymbolType symbol_type_hint) {
   if (!name.empty()) {
-    std::string name_str = name.str();
-    if (SwiftLanguageRuntime::IsSwiftMangledName(name_str.c_str())) {
-      // Swift
-      if (SwiftLanguageRuntime::IsMetadataSymbol(name_str.c_str()))
-        return lldb::eSymbolTypeMetadata;
-      if (SwiftLanguageRuntime::IsIvarOffsetSymbol(name_str.c_str()))
-        return lldb::eSymbolTypeIVarOffset;
-    } else if (name.startswith("_OBJC_")) {
+    if (name.startswith("_OBJC_")) {
       // ObjC
       if (name.startswith("_OBJC_CLASS_$_"))
         return lldb::eSymbolTypeObjCClass;

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -596,62 +596,6 @@ bool SwiftLanguageRuntime::IsSwiftClassName(const char *name)
   return swift::Demangle::isClass(name);
 }
 
-bool SwiftLanguageRuntime::IsMetadataSymbol(const char *symbol) {
-  if (!symbol)
-    return false;
-
-  swift::Demangle::Context demangle_ctx;
-  swift::Demangle::NodePointer node_ptr =
-    demangle_ctx.demangleSymbolAsNode(symbol);
-  if (!node_ptr)
-    return false;
-
-  size_t num_children = node_ptr->getNumChildren();
-  
-  if (num_children != 1)
-    return false;
-    
-  if (node_ptr->getKind() != swift::Demangle::Node::Kind::Global)
-    return false;
-  
-  num_children = node_ptr->getNumChildren();
-  if (num_children != 1)
-    return false;
-  swift::Demangle::NodePointer type_meta_ptr = node_ptr->getFirstChild();
-  if (type_meta_ptr->getKind() != swift::Demangle::Node::Kind::TypeMetadata)
-    return false;
-  else
-    return true;
-  
-  return true;
-}
-
-bool SwiftLanguageRuntime::IsIvarOffsetSymbol(const char *symbol)
-{
-  if (!symbol) 
-    return false;
-  swift::Demangle::Context demangle_ctx;
-  swift::Demangle::NodePointer node_pointer = 
-    demangle_ctx.demangleSymbolAsNode(symbol);
-  if (!node_pointer)
-    return false;
-
-  size_t num_children = node_pointer->getNumChildren();
-  if (num_children < 2)
-    return false;
-  if (node_pointer->getChild(0)->getKind() != swift::Demangle::Node::Kind::Global)
-    return false;
-  swift::Demangle::NodePointer field_offset = node_pointer->getChild(1);
-  if (field_offset->getKind() != swift::Demangle::Node::Kind::FieldOffset)
-    return false;
-  if (node_pointer->getNumChildren() < 1)
-    return false;
-  if (node_pointer->getChild(0)->getKind() != swift::Demangle::Node::Kind::Directness)
-    return false;
-    
-  return true;
-}
-
 const std::string SwiftLanguageRuntime::GetCurrentMangledName(const char *mangled_name)
 {
 #ifndef USE_NEW_MANGLING


### PR DESCRIPTION
I originally thought this should live in the compiler, to then
realize, this is actually unused. Jim tells me this was needed
at some point, but it's not anymore, so let's nuke this.

It was the last bit of demangler functionality in the debugger,
now everything has been moved to the compiler or removed.

<rdar://problem/37710513>