### PR TITLE
[SwiftLangRuntime] Garbage collect now dead code (after recent changes).

### DIFF
--- a/include/lldb/lldb-enumerations.h
+++ b/include/lldb/lldb-enumerations.h
@@ -609,8 +609,6 @@ enum SymbolType {
   eSymbolTypeIVarOffset, // A symbol that contains an offset for an instance
                          // variable
   eSymbolTypeReExported,
-  eSymbolTypeMetadata, // A symbol that contains the location of a direct
-                       // metadata for a type
   eSymbolTypeASTFile   // A symbol whose name is the path to a compiler AST file
 };
 

--- a/scripts/Python/static-binding/LLDBWrapPython.cpp
+++ b/scripts/Python/static-binding/LLDBWrapPython.cpp
@@ -79757,7 +79757,6 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eSymbolTypeObjCIVar",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeObjCIVar)));
   SWIG_Python_SetConstant(d, "eSymbolTypeIVarOffset",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeIVarOffset)));
   SWIG_Python_SetConstant(d, "eSymbolTypeReExported",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeReExported)));
-  SWIG_Python_SetConstant(d, "eSymbolTypeMetadata",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeMetadata)));
   SWIG_Python_SetConstant(d, "eSymbolTypeASTFile",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeASTFile)));
   SWIG_Python_SetConstant(d, "eSectionTypeInvalid",SWIG_From_int(static_cast< int >(lldb::eSectionTypeInvalid)));
   SWIG_Python_SetConstant(d, "eSectionTypeCode",SWIG_From_int(static_cast< int >(lldb::eSectionTypeCode)));

--- a/scripts/Python/static-binding/lldb.py
+++ b/scripts/Python/static-binding/lldb.py
@@ -515,7 +515,6 @@ eSymbolTypeObjCMetaClass = _lldb.eSymbolTypeObjCMetaClass
 eSymbolTypeObjCIVar = _lldb.eSymbolTypeObjCIVar
 eSymbolTypeIVarOffset = _lldb.eSymbolTypeIVarOffset
 eSymbolTypeReExported = _lldb.eSymbolTypeReExported
-eSymbolTypeMetadata = _lldb.eSymbolTypeMetadata
 eSymbolTypeASTFile = _lldb.eSymbolTypeASTFile
 eSectionTypeInvalid = _lldb.eSectionTypeInvalid
 eSectionTypeCode = _lldb.eSectionTypeCode

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -686,8 +686,6 @@ addr_t ClangExpressionDeclMap::GetSymbolAddress(Target &target,
     case eSymbolTypeObjCClass:
     case eSymbolTypeObjCMetaClass:
     case eSymbolTypeObjCIVar:
-    case eSymbolTypeIVarOffset:
-    case eSymbolTypeMetadata:
     case eSymbolTypeASTFile:
       symbol_load_addr = sym_address.GetLoadAddress(&target);
       break;

--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1298,10 +1298,6 @@ AddressClass ObjectFileMachO::GetAddressClass(lldb::addr_t file_addr) {
         return eAddressClassRuntime;
       case eSymbolTypeObjCIVar:
         return eAddressClassRuntime;
-      case eSymbolTypeIVarOffset:
-        return eAddressClassRuntime;
-      case eSymbolTypeMetadata:
-        return eAddressClassRuntime;
       case eSymbolTypeReExported:
         return eAddressClassRuntime;
       case eSymbolTypeASTFile:
@@ -2224,8 +2220,6 @@ static SymbolType GetSymbolType(
             type = eSymbolTypeObjCIVar;
             demangled_is_synthesized = true;
           }
-        } else if (symbol_name_ref.startswith("__TM")) {
-          type = eSymbolTypeMetadata;
         }
       }
     } else if (symbol_sect_name &&
@@ -3612,9 +3606,6 @@ size_t ObjectFileMachO::ParseSymtab() {
                                         type = eSymbolTypeObjCIVar;
                                         demangled_is_synthesized = true;
                                       }
-                                    } else if (symbol_name_ref.startswith(
-                                                   "__TM")) {
-                                      type = eSymbolTypeMetadata;
                                     }
                                   }
                                 } else if (symbol_sect_name &&
@@ -4569,8 +4560,6 @@ size_t ObjectFileMachO::ParseSymtab() {
                           type = eSymbolTypeObjCIVar;
                           demangled_is_synthesized = true;
                         }
-                      } else if (symbol_name_ref.startswith("__TM")) {
-                        type = eSymbolTypeMetadata;
                       }
                     }
                   } else if (symbol_sect_name &&

--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -3706,10 +3706,8 @@ void GDBRemoteCommunicationClient::ServeSymbolLookups(
                       case eSymbolTypeInstrumentation:
                       case eSymbolTypeTrampoline:
                       case eSymbolTypeASTFile:
-                      case eSymbolTypeMetadata:
                         break;
 
-                      case eSymbolTypeIVarOffset:
                       case eSymbolTypeCode:
                       case eSymbolTypeResolver:
                       case eSymbolTypeData:

--- a/source/Symbol/ObjectFile.cpp
+++ b/source/Symbol/ObjectFile.cpp
@@ -448,10 +448,6 @@ AddressClass ObjectFile::GetAddressClass(addr_t file_addr) {
         return eAddressClassRuntime;
       case eSymbolTypeObjCIVar:
         return eAddressClassRuntime;
-      case eSymbolTypeIVarOffset:
-        return eAddressClassRuntime;
-      case eSymbolTypeMetadata:
-        return eAddressClassRuntime;
       case eSymbolTypeReExported:
         return eAddressClassRuntime;
       case eSymbolTypeASTFile:

--- a/source/Symbol/Symbol.cpp
+++ b/source/Symbol/Symbol.cpp
@@ -375,7 +375,6 @@ const char *Symbol::GetTypeAsString() const {
     ENUM_TO_CSTRING(ObjCMetaClass);
     ENUM_TO_CSTRING(ObjCIVar);
     ENUM_TO_CSTRING(IVarOffset);
-    ENUM_TO_CSTRING(Metadata)
     ENUM_TO_CSTRING(ReExported);
   default:
     break;


### PR DESCRIPTION
We should do the same for eSymbolTypeIVarOffset, but there's still
one use that I need to audit separately.