### PR TITLE
Fix standalone lldb cmake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,10 @@ add_subdirectory(tools)
 option(LLDB_INCLUDE_TESTS "Generate build targets for the LLDB unit tests."
   ${LLVM_INCLUDE_TESTS})
 if(LLDB_INCLUDE_TESTS)
-  if (TARGET clang)
+  # TARGET clang works for a non-standalone build.
+  #
+  # FIXME: This can be avoided by importing the cmake configuration from swift.
+  if (TARGET clang OR LLDB_BUILD_STANDALONE)
     set(LLDB_DEFAULT_TEST_C_COMPILER "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
     set(LLDB_DEFAULT_TEST_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}")
   else()


### PR DESCRIPTION
The code here works in the in-tree version of the lldb cmake build. But when we
do out of tree using llvm-config, we do not have access to the clang target. If
we included llvm's targets directly via the exported llvm cmake configuration,
this would work, but for whatever reason lldb isn't doing that (I thought it
was... but maybe my memory is wrong).