### PR TITLE
Fix assertion in ObjectFileELF

### DIFF
--- a/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -3504,6 +3504,7 @@ size_t ObjectFileELF::ReadSectionData(Section *section,
   if (!Decompressor) {
     LLDB_LOG(log, "Unable to initialize decompressor for section {0}: {1}",
              section->GetName(), llvm::toString(Decompressor.takeError()));
+    consumeError(Decompressor.takeError());
     return result;
   }
   auto buffer_sp =
@@ -3513,6 +3514,7 @@ size_t ObjectFileELF::ReadSectionData(Section *section,
            size_t(buffer_sp->GetByteSize())})) {
     LLDB_LOG(log, "Decompression of section {0} failed: {1}",
              section->GetName(), llvm::toString(std::move(Error)));
+    consumeError(std::move(Error));
     return result;
   }
   section_data.SetData(buffer_sp);


### PR DESCRIPTION
In D40616 I (mistakenly) assumed that logging an llvm::Error would clear
it. This of course is only true if logging is actually enabled.

This fixes the assertion by manually clearing the error, but it raises
the point of whether we need a special error-clearing logging primitive.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@322664 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 9436395663f0baa4a0e52c2af0c0dbc7aefe4c37)