### PR TITLE
 Introduce a setting to disable Spotlight while running the test suite

### DIFF
--- a/include/lldb/Core/ModuleList.h
+++ b/include/lldb/Core/ModuleList.h
@@ -81,6 +81,7 @@ public:
 
   FileSpec GetClangModulesCachePath() const;
   bool SetClangModulesCachePath(llvm::StringRef path);
+  bool GetEnableExternalLookup() const;
 }; 
 
 //----------------------------------------------------------------------

--- a/lit/lit-lldb-init
+++ b/lit/lit-lldb-init
@@ -1,0 +1,2 @@
+# LLDB init file for the LIT tests.
+settings set symbols.enable-external-lookup false

--- a/lit/lit.cfg
+++ b/lit/lit.cfg
@@ -55,7 +55,8 @@ config.environment['PYTHON_EXECUTABLE'] = getattr(config, 'python_executable', '
 config.substitutions.append(('%python', config.python_executable))
 
 debugserver = lit.util.which('debugserver', lldb_tools_dir)
-lldb = lit.util.which('lldb', lldb_tools_dir)
+lldb = "%s -S %s/lit-lldb-init" % (lit.util.which('lldb', lldb_tools_dir),
+                               config.test_source_root)
 
 if not os.path.exists(config.cc):
     config.cc = lit.util.which(config.cc, config.environment['PATH'])

--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -1887,12 +1887,17 @@ class TestBase(Base):
         # decorators.
         Base.setUp(self)
 
-        # Set the clang modules cache path.
         if self.child:
+            # Set the clang modules cache path.
             assert(self.getDebugInfo() == 'default')
             mod_cache = os.path.join(self.getBuildDir(), "module-cache")
             self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                         % mod_cache)
+
+            # Disable Spotlight lookup. The testsuite creates
+            # different binaries with the same UUID, because they only
+            # differ in the debug info, which is not being hashed.
+            self.runCmd('settings set symbols.enable-external-lookup false')
 
 
         if "LLDB_MAX_LAUNCH_COUNT" in os.environ:

--- a/source/Core/ModuleList.cpp
+++ b/source/Core/ModuleList.cpp
@@ -69,12 +69,17 @@ static bool KeepLookingInDylinker(SymbolContextList &sc_list, size_t start_idx);
 namespace {
 
 PropertyDefinition g_properties[] = {
+    {"enable-external-lookup", OptionValue::eTypeBoolean, true, true, nullptr,
+     nullptr,
+     "Control the use of external tools or libraries to locate symbol files. "
+     "On macOS, Spotlight is used to locate a matching .dSYM bundle based on "
+     "the UUID of the executable."},
     {"clang-modules-cache-path", OptionValue::eTypeFileSpec, true, 0, nullptr,
      nullptr,
      "The path to the clang modules cache directory (-fmodules-cache-path)."},
     {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
 
-enum { ePropertyClangModulesCachePath };
+enum { ePropertyEnableExternalLookup, ePropertyClangModulesCachePath };
 
 } // namespace
 
@@ -85,6 +90,12 @@ ModuleListProperties::ModuleListProperties() {
   llvm::SmallString<128> path;
   clang::driver::Driver::getDefaultModuleCachePath(path);
   SetClangModulesCachePath(path);
+}
+
+bool ModuleListProperties::GetEnableExternalLookup() const {
+  const uint32_t idx = ePropertyEnableExternalLookup;
+  return m_collection_sp->GetPropertyAtIndexAsBoolean(
+      nullptr, idx, g_properties[idx].default_uint_value != 0);
 }
 
 FileSpec ModuleListProperties::GetClangModulesCachePath() const {

--- a/source/Host/macosx/Symbols.cpp
+++ b/source/Host/macosx/Symbols.cpp
@@ -23,7 +23,7 @@
 #include "Host/macosx/cfcpp/CFCData.h"
 #include "Host/macosx/cfcpp/CFCReleaser.h"
 #include "Host/macosx/cfcpp/CFCString.h"
-#include "lldb/Core/Module.h"
+#include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -55,6 +55,13 @@ CFDictionaryRef DBGCopyDSYMPropertyLists(CFURLRef dsym_url);
 
 int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
                                        ModuleSpec &return_module_spec) {
+  Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
+  if (!ModuleList::GetGlobalModuleListProperties().GetEnableExternalLookup()) {
+    if (log)
+      log->Printf("Spotlight lookup for .dSYM bundles is disabled.");
+    return 0;
+  }
+  
   return_module_spec = module_spec;
   return_module_spec.GetFileSpec().Clear();
   return_module_spec.GetSymbolFileSpec().Clear();
@@ -80,7 +87,6 @@ int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
       if (module_uuid_ref.get()) {
         CFCReleaser<CFURLRef> exec_url;
         const FileSpec *exec_fspec = module_spec.GetFileSpecPtr();
-        Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
         if (exec_fspec) {
           char exec_cf_path[PATH_MAX];
           if (exec_fspec->GetPath(exec_cf_path, sizeof(exec_cf_path)))


### PR DESCRIPTION

This is a more principled approach to disabling Spotlight .dSYM
lookups while running the testsuite, most importantly it also works
for the LIT-based tests, which I overlooked in my initial fix
(renaming the test build dir to lldb-tests.noindex).

Differential Revision: https://reviews.llvm.org/D44342

rdar://problem/38321329

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@327330 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 1a95b60d5aeb50ebba98aef6336b21e6875021c5)