### PR TITLE
Fix compile errors in s390x build

### DIFF
--- a/source/Plugins/Process/Linux/NativeRegisterContextLinux_s390x.cpp
+++ b/source/Plugins/Process/Linux/NativeRegisterContextLinux_s390x.cpp
@@ -10,7 +10,7 @@
 #if defined(__s390x__) && defined(__linux__)
 
 #include "NativeRegisterContextLinux_s390x.h"
-
+#include "Plugins/Process/Linux/NativeProcessLinux.h"
 #include "lldb/Core/RegisterValue.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/DataBufferHeap.h"


### PR DESCRIPTION
Fix linux s390x build (pr36694)

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@327379 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d768f36b02dce5d9b2d58de886bf76646bb79925)