### PR TITLE
[ExpressionParser] Fix crash when evaluating invalid expresssions.

### DIFF
--- a/lit/Expr/Inputs/basic.cpp
+++ b/lit/Expr/Inputs/basic.cpp
@@ -1,0 +1,12 @@
+class Patatino {
+private:
+  long tinky;
+
+public:
+  Patatino(long tinky) { this->tinky = tinky; }
+};
+
+int main(void) {
+  Patatino *a = new Patatino(26);
+  return 0;
+}

--- a/lit/Expr/TestCallCppSym.test
+++ b/lit/Expr/TestCallCppSym.test
@@ -1,0 +1,6 @@
+# RUN: %cxx %p/Inputs/basic.cpp -g -o %t && %lldb -b -s %s -- %t 2>&1 | FileCheck %s
+
+breakpoint set --file basic.cpp --line 12
+run
+call (int)_Znwm(23)
+# CHECK: error: use of undeclared identifier '_Znwm'

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -2091,6 +2091,15 @@ void ClangExpressionDeclMap::AddOneFunction(NameSearchContext &context,
       return;
     }
   } else if (symbol) {
+    // Don't insert a generic function decl for C++ symbol names.
+    // Creating a generic function decl is almost surely going to cause troubles
+    // as it breaks Clang/Sema invariants and causes crashes in clang while
+    // we're trying to evaluate the expression.
+    // This means users can't call C++ functions by mangled name when there
+    // are no debug info (as it happens for C symbol, e.g. printf()).
+    if (CPlusPlusLanguage::IsCPPMangledName(
+            symbol->GetMangled().GetMangledName().GetCString()))
+      return;
     fun_address = symbol->GetAddress();
     function_decl = context.AddGenericFunDecl();
     is_indirect_function = symbol->IsIndirect();


### PR DESCRIPTION
Typical example, illformed comparisons (operator== where LHS and
RHS are not compatible). If a symbol matched `operator==` in any
of the object files lldb inserted a generic function declaration
in the ASTContext on which Sema operates. Maintaining the AST
context invariants is fairly tricky and sometimes resulted in
crashes inside clang (or assertions hit).

The real reason why this feature exists in the first place is
that of allowing users to do something like:
(lldb) call printf("patatino")

even if the debug informations for printf() is not available.
Eventually, we might reconsider this feature in its
entirety, but for now we can't remove it as it would break
a bunch of users. Instead, try to limit it to non-C++ symbols,
where getting the invariants right is hopefully easier.

Now you can't do in lldb anymore
(lldb) call _Zsomethingsomething(1,2,3)

but that doesn't seem to be such a big loss.

<rdar://problem/35645893>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@327356 91177308-0d34-0410-b5e6-96231b3b80d8