### PR TITLE
Temporarily disable TestCallStopAndContinue.test on Linux

### DIFF
--- a/lit/Expr/TestCallStopAndContinue.test
+++ b/lit/Expr/TestCallStopAndContinue.test
@@ -1,5 +1,7 @@
 # XFAIL: windows
 # -> llvm.org/pr24489
+# REQUIRES: darwin
+# -> Temporarily disable this test on the Swift Linux builders, due to flakiness (rdar://38378404).
 
 # RUN: %cxx %p/Inputs/call-function.cpp -g -o %t && %lldb -b -s %s -o continue -o "thread list" -- %t 2>&1 | FileCheck %s
 


### PR DESCRIPTION
This is a workaround to unblock the Swift Linux builders. It's unclear
why, but this test is sporadically failing.

rdar://38378404