### PR TITLE
[unittests] Disable lldb-server tests if an external debug server is …

### DIFF
--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -99,6 +99,7 @@ set(LLDB_CODESIGN_IDENTITY "lldb_codesign"
 
 if(NOT LLDB_CODESIGN_IDENTITY STREQUAL "")
   set(DEBUGSERVER_PATH $<TARGET_FILE:debugserver> CACHE PATH "Path to debugserver.")
+  set(SKIP_DEBUGSERVER OFF CACHE BOOL "Skip building the in-tree debug server")
 else()
   execute_process(
     COMMAND xcode-select -p
@@ -106,7 +107,7 @@ else()
   string(STRIP ${XCODE_DEV_DIR} XCODE_DEV_DIR)
   set(DEBUGSERVER_PATH
     "${XCODE_DEV_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver" CACHE PATH "Path to debugserver.")
-  set(SKIP_DEBUGSERVER True)
+  set(SKIP_DEBUGSERVER ON CACHE BOOL "Skip building the in-tree debug server")
 endif()
 message(STATUS "Path to the lldb debugserver: ${DEBUGSERVER_PATH}")
 
@@ -123,7 +124,7 @@ if (APPLE AND NOT SKIP_DEBUGSERVER)
     find_library(LOCKDOWN_LIBRARY lockdown)
 
     if(NOT BACKBOARD_LIBRARY)
-      set(SKIP_DEBUGSERVER True)
+      set(SKIP_DEBUGSERVER ON CACHE BOOL "Skip building the in-tree debug server" FORCE)
     endif()
   else()
     find_library(COCOA_LIBRARY Cocoa)

--- a/unittests/tools/CMakeLists.txt
+++ b/unittests/tools/CMakeLists.txt
@@ -1,3 +1,8 @@
 if(CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|Linux|NetBSD")
-  add_subdirectory(lldb-server)
+  if (CMAKE_SYSTEM_NAME MATCHES "Darwin" AND SKIP_DEBUGSERVER)
+    # These tests are meant to test lldb-server/debugserver in isolation, and
+    # don't provide any value if run against a server copied from somewhere.
+  else()
+    add_subdirectory(lldb-server)
+  endif()
 endif()


### PR DESCRIPTION
…in use

The lldb-server unit tests don't test the right thing when the debug
server in use is copied from somewhere else. This can lead to spurious
test failures.

Disable these unit tests when an external debug server is in use.

Fixes llvm.org/PR36494.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@326001 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e58ce286ee8dcdb7fca25b31e7f5df2c4c8433db)