### PR TITLE
[test] Tighten up a dictionary test

### DIFF
--- a/lit/SwiftREPL/Dict.test
+++ b/lit/SwiftREPL/Dict.test
@@ -38,10 +38,12 @@ var x = $R0
 
 x.updateValue(8, forKey : 4)
 x
+// DICT-LABEL: $R5: [Int : Int] = 4 key/value pairs
 // DICT: key = 4
 // DICT-NEXT: value = 8
 
 x[3] = 5
 x
+// DICT-LABEL: $R6: [Int : Int] = 4 key/value pairs
 // DICT: key = 3
 // DICT-NEXT: value = 5


### PR DESCRIPTION
This test isn't stringent enough.

It looks like DICT: key = 4 can match, then DICT: key = 3 can match, all before
"x[3] = 5" happens.

rdar://38459944