### PR TITLE
Fix a couple of more tests to not create files in the source tree

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/TestAttachDenied.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/TestAttachDenied.py
@@ -18,6 +18,7 @@ exe_name = 'AttachDenied'  # Must match Makefile
 class AttachDeniedTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfWindows
     @skipIfiOSSimulator
@@ -28,7 +29,7 @@ class AttachDeniedTestCase(TestBase):
         exe = self.getBuildArtifact(exe_name)
 
         # Use a file as a synchronization point between test and inferior.
-        pid_file_path = lldbutil.append_to_process_working_directory(
+        pid_file_path = lldbutil.append_to_process_working_directory(self,
             "pid_file_%d" % (int(time.time())))
         self.addTearDownHook(
             lambda: self.run_platform_command(

--- a/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 class ChangeProcessGroupTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     NO_DEBUG_INFO_TESTCASE = True
 
@@ -32,7 +33,7 @@ class ChangeProcessGroupTestCase(TestBase):
         exe = self.getBuildArtifact("a.out")
 
         # Use a file as a synchronization point between test and inferior.
-        pid_file_path = lldbutil.append_to_process_working_directory(
+        pid_file_path = lldbutil.append_to_process_working_directory(self,
             "pid_file_%d" % (int(time.time())))
         self.addTearDownHook(
             lambda: self.run_platform_command(

--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -368,8 +368,8 @@ class _RemoteProcess(_BaseProcess):
     def launch(self, executable, args):
         if self._install_remote:
             src_path = executable
-            dst_path = lldbutil.append_to_process_working_directory(
-                os.path.basename(executable))
+            dst_path = lldbutil.join_remote_paths(
+                    lldb.remote_platform.GetWorkingDirectory(), os.path.basename(executable))
 
             dst_file_spec = lldb.SBFileSpec(dst_path, False)
             err = lldb.remote_platform.Install(
@@ -1987,7 +1987,7 @@ class TestBase(Base):
             if lldb.remote_platform:
                 # We must set the remote install location if we want the shared library
                 # to get uploaded to the remote target
-                remote_shlib_path = lldbutil.append_to_process_working_directory(
+                remote_shlib_path = lldbutil.append_to_process_working_directory(self,
                     os.path.basename(local_shlib_path))
                 shlib_module.SetRemoteInstallFileSpec(
                     lldb.SBFileSpec(remote_shlib_path, False))

--- a/packages/Python/lldbsuite/test/lldbutil.py
+++ b/packages/Python/lldbsuite/test/lldbutil.py
@@ -1281,11 +1281,11 @@ def join_remote_paths(*paths):
     return os.path.join(*paths).replace(os.path.sep, '/')
 
 
-def append_to_process_working_directory(*paths):
+def append_to_process_working_directory(test, *paths):
     remote = lldb.remote_platform
     if remote:
         return join_remote_paths(remote.GetWorkingDirectory(), *paths)
-    return os.path.join(os.getcwd(), *paths)
+    return os.path.join(test.getBuildDir(), *paths)
 
 # ==================================================
 # Utility functions to get the correct signal number

--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteModuleInfo.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteModuleInfo.py
@@ -20,7 +20,7 @@ class TestGdbRemoteModuleInfo(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         self.test_sequence.add_log_lines([
             'read packet: $jModulesInfo:[{"file":"%s","triple":"%s"}]]#00' % (
-                lldbutil.append_to_process_working_directory("a.out"),
+                lldbutil.append_to_process_working_directory(self, "a.out"),
                 info["triple"].decode('hex')),
             {"direction": "send",
              "regex": r'^\$\[{(.*)}\]\]#[0-9A-Fa-f]{2}',

--- a/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -550,7 +550,7 @@ class GdbRemoteTestCaseBase(TestBase):
                 inferior_exe_path = self.getBuildArtifact("a.out")
 
             if lldb.remote_platform:
-                remote_path = lldbutil.append_to_process_working_directory(
+                remote_path = lldbutil.append_to_process_working_directory(self,
                     os.path.basename(inferior_exe_path))
                 remote_file_spec = lldb.SBFileSpec(remote_path, False)
                 err = lldb.remote_platform.Install(lldb.SBFileSpec(
@@ -1611,7 +1611,7 @@ class GdbRemoteTestCaseBase(TestBase):
         exe_path = self.getBuildArtifact("a.out")
         if not lldb.remote_platform:
             return [exe_path]
-        remote_path = lldbutil.append_to_process_working_directory(
+        remote_path = lldbutil.append_to_process_working_directory(self,
             os.path.basename(exe_path))
         remote_file_spec = lldb.SBFileSpec(remote_path, False)
         err = lldb.remote_platform.Install(lldb.SBFileSpec(exe_path, True),


### PR DESCRIPTION
Summary:
These were not being flaky, but they're still making the tree dirty.

These tests were using lldbutil.append_to_process_working_directory to
derive the file path so I fix them by modifying the function to return
the build directory for local tests.

Technically, now the path returned by this function does not point to
the process working directory for local tests, but I think it makes
sense to keep the function name, as I think we should move towards
launching the process in the build directory (and I intend to change
this for the handful of inferiors that actually care about their PWD,
for example because they need to create files there).

Reviewers: davide, aprantl

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D43506

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@325690 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 6d2b66f2740b2600b5afef8ba704245ce47a4343)