### PR TITLE
Fix a copy of a fixed length, possibly non-nul terminated, string

### DIFF
--- a/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -665,7 +665,7 @@ llvm::Error ProcessElfCore::parseLinuxNotes(llvm::ArrayRef<CoreNote> notes) {
       Status status = prpsinfo.Parse(note.data, arch);
       if (status.Fail())
         return status.ToError();
-      thread_data.name = prpsinfo.pr_fname;
+      thread_data.name.assign (prpsinfo.pr_fname, strnlen (prpsinfo.pr_fname, sizeof (prpsinfo.pr_fname)));
       SetID(prpsinfo.pr_pid);
       break;
     }


### PR DESCRIPTION
into a std::string so we don't run off the end of the array when
there is no nul byte in ProcessElfCore::parseLinuxNotes.
Found with ASAN testing.

<rdar://problem/37134319>

Differential revision: https://reviews.llvm.org/D42828

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@324156 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 01cf28c211cd32c850bbe8f8110bf28d221fc54b)