### PR TITLE
Skip more lldb-mi tests which time out on Darwin

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-mi/target/TestMiTarget.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/target/TestMiTarget.py
@@ -18,6 +18,7 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @skipIfLinux  # cannot attach to process on linux
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_target_attach_wait_for(self):
         """Test that 'lldb-mi --interpreter' works for -target-attach -n <name> --waitfor."""
 
@@ -61,6 +62,7 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @skipIfLinux  # cannot attach to process on linux
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_target_attach_name(self):
         """Test that 'lldb-mi --interpreter' works for -target-attach -n <name>."""
 
@@ -97,6 +99,7 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @skipIfLinux  # cannot attach to process on linux
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_target_attach_pid(self):
         """Test that 'lldb-mi --interpreter' works for -target-attach <pid>."""
 


### PR DESCRIPTION
Bot failure: https://ci.swift.org/job/oss-lldb-incremental-osx/1097/testReport/junit/TestMiTarget/MiTargetTestCase/test_lldbmi_target_attach_wait_for/

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@327692 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit ff20c595192d38cbe08666df39844a7d36959793)