### PR TITLE
[lldb-dotest] Set the --swift-compiler

### DIFF
--- a/test/lldb-dotest.in
+++ b/test/lldb-dotest.in
@@ -4,11 +4,12 @@ import os
 
 dotest_path = '@LLDB_SOURCE_DIR@/test/dotest.py'
 dotest_args = '@LLDB_DOTEST_ARGS_STR@'
+swiftc = '@LLDB_SWIFTC@'
 
 if __name__ == '__main__':
     # FIXME: It would be nice if we can mimic the approach taken by llvm-lit
     # and pass a python configuration straight to dotest, rather than going
     # through the operating system.
-    command = '{} -q {} {}'.format(dotest_path, dotest_args, ' '.join(
-        sys.argv[1:]))
+    command = '{} -q {} --swift-compiler {} {}'.format(
+        dotest_path, dotest_args, swiftc, ' '.join(sys.argv[1:]))
     os.system(command)


### PR DESCRIPTION
This sets the swift compiler in the lldb-dotest wrapper. We have the
path to swiftc avaialable in CMake, so it is just a matter of updating
the python wrapper.