### PR TITLE
[testsuite] Restore two Linux tests which were partially deleted

### DIFF
--- a/packages/Python/lldbsuite/test/linux/add-symbols/TestTargetSymbolsAddCommand.py
+++ b/packages/Python/lldbsuite/test/linux/add-symbols/TestTargetSymbolsAddCommand.py
@@ -18,12 +18,12 @@ class TargetSymbolsAddCommand(TestBase):
 
     @no_debug_info_test  # Prevent the genaration of the dwarf version of this test
     @skipUnlessPlatform(['linux'])
-    @expectedFailureAll(bugnumber="rdar://problem/33684210") # no llvm-objcopy yet
+    @skipIf(bugnumber="rdar://38550275")
     def test_target_symbols_add(self):
         """Test that 'target symbols add' can load the symbols
         even if gnu.build-id and gnu_debuglink are not present in the module.
         Similar to test_add_dsym_mid_execution test for macos."""
-        self.build(clean=True)
+        self.build()
         exe = self.getBuildArtifact("stripped.out")
 
         self.target = self.dbg.CreateTarget(exe)

--- a/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/Makefile
+++ b/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/Makefile
@@ -1,0 +1,10 @@
+LEVEL := ../../make
+
+C_SOURCES := a.c b.c
+a.o: CFLAGS_EXTRAS += -gsplit-dwarf
+
+include $(LEVEL)/Makefile.rules
+
+.PHONY: clean
+clean::
+	$(RM) -f a.dwo a.o b.o main

--- a/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/TestMixedDwarfBinary.py
+++ b/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/TestMixedDwarfBinary.py
@@ -16,6 +16,7 @@ class TestMixedDwarfBinary(TestBase):
     @no_debug_info_test  # Prevent the genaration of the dwarf version of this test
     @add_test_categories(["dwo"])
     @skipUnlessPlatform(["linux"])
+    @skipIf(bugnumber="rdar://38550275")
     def test_mixed_dwarf(self):
         """Test that 'frame variable' works
         for the executable built from two source files compiled

--- a/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/a.c
+++ b/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/a.c
@@ -1,0 +1,3 @@
+int f() {
+  return 1;
+}

--- a/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/b.c
+++ b/packages/Python/lldbsuite/test/linux/mix-dwo-and-regular-objects/b.c
@@ -1,0 +1,11 @@
+extern int f();
+
+void g() {
+  int y = 14;
+  int x = f();
+}
+
+int main() {
+  g();
+  return 0;
+}

--- a/packages/Python/lldbsuite/test/linux/sepdebugsymlink/Makefile
+++ b/packages/Python/lldbsuite/test/linux/sepdebugsymlink/Makefile
@@ -1,0 +1,20 @@
+LEVEL = ../../make
+C_SOURCES := main.c
+
+all: dirsymlink
+
+dirreal: a.out
+	$(RM) -r $@
+	mkdir $@
+	$(OBJCOPY) --only-keep-debug $< $@/stripped.debug
+	$(OBJCOPY) --strip-all --add-gnu-debuglink=$@/stripped.debug $< $@/stripped.out
+
+dirsymlink: dirreal
+	$(RM) -r $@
+	mkdir $@
+	ln -s ../$</stripped.out $@/stripped.symlink
+
+clean::
+	$(RM) -r dirreal dirsymlink
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/linux/sepdebugsymlink/TestTargetSymbolsSepDebugSymlink.py
+++ b/packages/Python/lldbsuite/test/linux/sepdebugsymlink/TestTargetSymbolsSepDebugSymlink.py
@@ -16,8 +16,9 @@ class TestTargetSymbolsSepDebugSymlink(TestBase):
     @skipUnlessPlatform(['linux'])
     @skipIf(hostoslist=["windows"])
     @skipIfRemote # llvm.org/pr36237
+    @skipIf(bugnumber="rdar://38550275")
     def test_target_symbols_sepdebug_symlink_case(self):
-        self.build(clean=True)
+        self.build()
         exe = self.getBuildArtifact("dirsymlink/stripped.symlink")
 
         lldbutil.run_to_name_breakpoint(self, "main", exe_name = exe)

--- a/packages/Python/lldbsuite/test/linux/sepdebugsymlink/main.c
+++ b/packages/Python/lldbsuite/test/linux/sepdebugsymlink/main.c
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}


### PR DESCRIPTION
The mix-dwo-and-regular-objects and sepdebugsymlink were partially
deleted internally. This caused build failures: rdar://38550275.

Restore the tests and skip them for now.