### PR TITLE
Cherry pick modules test fixes

### DIFF
--- a/packages/Python/lldbsuite/test/lang/objc/modules-cache/Makefile
+++ b/packages/Python/lldbsuite/test/lang/objc/modules-cache/Makefile
@@ -1,4 +1,3 @@
 LEVEL = ../../../make
 OBJC_SOURCES := main.m
 include $(LEVEL)/Makefile.rules
-CFLAGS += $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(SRCDIR)

--- a/packages/Python/lldbsuite/test/lang/objc/modules-cache/TestClangModulesCache.py
+++ b/packages/Python/lldbsuite/test/lang/objc/modules-cache/TestClangModulesCache.py
@@ -22,6 +22,7 @@ class ObjCModulesTestCase(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
+    @skipUnlessDarwin
     def test_expr(self):
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.m")
@@ -36,5 +37,5 @@ class ObjCModulesTestCase(TestBase):
                     % self.getSourceDir())
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "Set breakpoint here", self.main_source_file)
-        self.runCmd("expr @import Darwin")
+        self.runCmd("expr @import Foo")
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")

--- a/packages/Python/lldbsuite/test/lang/objc/modules-cache/main.m
+++ b/packages/Python/lldbsuite/test/lang/objc/modules-cache/main.m
@@ -1,4 +1,4 @@
-@import Foo;
+#include "f.h"
 int main() {
   f(); // Set breakpoint here.
   return 0;


### PR DESCRIPTION
This eliminates differences between upstream llvm.org and stable for this particular test.

rdar://38550145