### PR TITLE
Skip TestThreadSpecificBpPlusCondition on Darwin due to timeouts

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
@@ -21,6 +21,7 @@ class ThreadSpecificBreakPlusConditionTestCase(TestBase):
 
     # test frequently times out or hangs
     @skipIf(oslist=['windows', 'freebsd'])
+    @skipIfDarwin
     # hits break in another thread in testrun
     @expectedFailureAll(oslist=['freebsd'], bugnumber='llvm.org/pr18522')
     @add_test_categories(['pyapi'])


### PR DESCRIPTION
Bot failure: https://ci.swift.org/job/oss-lldb-incremental-osx/1104/

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@327731 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit cd49cd49dfbdf689bc51f4da9e213dad8ad50cf1)