### PR TITLE
Cherry pick rdar38011072 rdar38010986

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break/TestThreadSpecificBreakpoint.py
@@ -13,68 +13,57 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
+def set_thread_id(thread, breakpoint):
+    id = thread.id
+    breakpoint.SetThreadID(id)
+
+def set_thread_name(thread, breakpoint):
+    breakpoint.SetThreadName("main-thread")
 
 class ThreadSpecificBreakTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     @add_test_categories(['pyapi'])
+
     @expectedFailureAll(oslist=["windows"])
     @expectedFailureAll(oslist=['ios', 'watchos', 'tvos', 'bridgeos'], archs=['armv7', 'armv7k'], bugnumber='rdar://problem/34563920') # armv7 ios problem - breakpoint with tid qualifier isn't working
-    def test_python(self):
+    def test_thread_id(self):
+        self.do_test(set_thread_id)
+
+    @skipUnlessDarwin
+    @expectedFailureAll(oslist=['ios', 'watchos', 'tvos', 'bridgeos'], archs=['armv7', 'armv7k'], bugnumber='rdar://problem/34563920') # armv7 ios problem - breakpoint with tid qualifier isn't working
+    def test_thread_name(self):
+        self.do_test(set_thread_name)
+
+    def do_test(self, setter_method):
         """Test that we obey thread conditioned breakpoints."""
         self.build()
-        exe = self.getBuildArtifact("a.out")
+        main_source_spec = lldb.SBFileSpec("main.cpp")
+        (target, process, main_thread, main_breakpoint) = lldbutil.run_to_source_breakpoint(self,
+                "Set main breakpoint here", main_source_spec)
 
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
+        main_thread_id = main_thread.GetThreadID()
 
         # This test works by setting a breakpoint in a function conditioned to stop only on
         # the main thread, and then calling this function on a secondary thread, joining,
         # and then calling again on the main thread.  If the thread specific breakpoint works
         # then it should not be hit on the secondary thread, only on the main
         # thread.
-
-        main_source_spec = lldb.SBFileSpec("main.cpp")
-
-        main_breakpoint = target.BreakpointCreateBySourceRegex(
-            "Set main breakpoint here", main_source_spec)
         thread_breakpoint = target.BreakpointCreateBySourceRegex(
             "Set thread-specific breakpoint here", main_source_spec)
-
-        self.assertTrue(
-            main_breakpoint.IsValid(),
-            "Failed to set main breakpoint.")
-        self.assertGreater(
-            main_breakpoint.GetNumLocations(),
-            0,
-            "main breakpoint has no locations associated with it.")
-        self.assertTrue(
-            thread_breakpoint.IsValid(),
-            "Failed to set thread breakpoint.")
         self.assertGreater(
             thread_breakpoint.GetNumLocations(),
             0,
             "thread breakpoint has no locations associated with it.")
 
-        process = target.LaunchSimple(
-            None, None, self.get_process_working_directory())
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        stopped_threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, main_breakpoint)
-        self.assertEqual(
-            len(stopped_threads),
-            1,
-            "main breakpoint stopped at unexpected number of threads")
-        main_thread = stopped_threads[0]
-        main_thread_id = main_thread.GetThreadID()
-
         # Set the thread-specific breakpoint to only stop on the main thread.  The run the function
         # on another thread and join on it.  If the thread-specific breakpoint works, the next
         # stop should be on the main thread.
-        thread_breakpoint.SetThreadID(main_thread_id)
+
+        main_thread_id = main_thread.GetThreadID()
+        setter_method(main_thread, thread_breakpoint)
 
         process.Continue()
         next_stop_state = process.GetState()

--- a/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break/main.cpp
@@ -12,6 +12,11 @@ int
 main ()
 {
     // Set main breakpoint here.
+
+    #ifdef __APPLE__
+    pthread_setname_np("main-thread");
+    #endif
+
     std::thread t(thread_function);
     t.join();
 

--- a/packages/Python/lldbsuite/test/lang/cpp/dynamic-value-same-basename/Makefile
+++ b/packages/Python/lldbsuite/test/lang/cpp/dynamic-value-same-basename/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../make
+
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/cpp/dynamic-value-same-basename/TestDynamicValueSameBase.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/dynamic-value-same-basename/TestDynamicValueSameBase.py
@@ -1,0 +1,62 @@
+"""
+Make sure if we have two classes with the same base name the
+dynamic value calculator doesn't confuse them
+"""
+
+from __future__ import print_function
+
+
+import os
+import time
+import re
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class RenameThisSampleTestTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    # If your test case doesn't stress debug info, the 
+    # set this to true.  That way it won't be run once for
+    # each debug info format.
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_same_basename_this(self):
+        """Test that the we use the full name to resolve dynamic types."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.cpp")
+        self.sample_test()
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+
+    def sample_test(self):
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                                   "Break here to get started", self.main_source_file) 
+
+        # Set breakpoints in the two class methods and run to them:
+        namesp_bkpt = target.BreakpointCreateBySourceRegex("namesp function did something.", self.main_source_file)
+        self.assertEqual(namesp_bkpt.GetNumLocations(), 1, "Namespace breakpoint invalid")
+
+        virtual_bkpt = target.BreakpointCreateBySourceRegex("Virtual function did something.", self.main_source_file)
+        self.assertEqual(virtual_bkpt.GetNumLocations(), 1, "Virtual breakpoint invalid")
+
+        threads = lldbutil.continue_to_breakpoint(process, namesp_bkpt)
+        self.assertEqual(len(threads), 1, "Didn't stop at namespace breakpoint")
+
+        frame = threads[0].frame[0]
+        namesp_this = frame.FindVariable("this", lldb.eDynamicCanRunTarget)
+        self.assertEqual(namesp_this.GetTypeName(), "namesp::Virtual *", "Didn't get the right dynamic type")
+
+        threads = lldbutil.continue_to_breakpoint(process, virtual_bkpt)
+        self.assertEqual(len(threads), 1, "Didn't stop at virtual breakpoint")
+
+        frame = threads[0].frame[0]
+        virtual_this = frame.FindVariable("this", lldb.eDynamicCanRunTarget)
+        self.assertEqual(virtual_this.GetTypeName(), "Virtual *", "Didn't get the right dynamic type")
+
+        
+

--- a/packages/Python/lldbsuite/test/lang/cpp/dynamic-value-same-basename/main.cpp
+++ b/packages/Python/lldbsuite/test/lang/cpp/dynamic-value-same-basename/main.cpp
@@ -1,0 +1,32 @@
+#include <stdio.h>
+
+namespace namesp
+{
+  class Virtual {
+  public:
+    virtual void doSomething() {
+      printf ("namesp function did something.\n");
+    }
+  }; 
+}
+
+class Virtual {
+  public:
+  virtual void doSomething() {
+    printf("Virtual function did something.\n");
+  }
+};
+
+int
+main()
+{
+  namesp::Virtual my_outer;
+  Virtual my_virtual;
+
+  // Break here to get started
+  my_outer.doSomething();
+  my_virtual.doSomething();
+
+  return 0;
+}
+    

--- a/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -84,6 +84,11 @@ TypeAndOrName ItaniumABILanguageRuntime::GetTypeInfoFromVTableAddress(
             // We are a C++ class, that's good.  Get the class name and look it
             // up:
             const char *class_name = name + strlen(vtable_demangled_prefix);
+            // We know the class name is absolute, so tell FindTypes that by
+            // prefixing it with the root namespace:
+            std::string lookup_name("::");
+            lookup_name.append(class_name);
+            
             type_info.SetName(class_name);
             const bool exact_match = true;
             TypeList class_types;
@@ -94,7 +99,7 @@ TypeAndOrName ItaniumABILanguageRuntime::GetTypeInfoFromVTableAddress(
             llvm::DenseSet<SymbolFile *> searched_symbol_files;
             if (sc.module_sp) {
               num_matches = sc.module_sp->FindTypes(
-                  sc, ConstString(class_name), exact_match, 1,
+                  sc, ConstString(lookup_name), exact_match, 1,
                   searched_symbol_files, class_types);
             }
 
@@ -103,7 +108,7 @@ TypeAndOrName ItaniumABILanguageRuntime::GetTypeInfoFromVTableAddress(
             // as possible
             if (num_matches == 0) {
               num_matches = target.GetImages().FindTypes(
-                  sc, ConstString(class_name), exact_match, UINT32_MAX,
+                  sc, ConstString(lookup_name), exact_match, UINT32_MAX,
                   searched_symbol_files, class_types);
             }
 


### PR DESCRIPTION
<rdar://problem/38010986> If we have two classes with the same base name we get the wrong dynamic type
<rdar://problem/38011072> Breakpoints conditioned by thread name no longer function