### PR TITLE
Add a missing return in SBPlatform::IsConnected and test

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/platform/TestPlatformPython.py
+++ b/packages/Python/lldbsuite/test/functionalities/platform/TestPlatformPython.py
@@ -51,6 +51,14 @@ class PlatformPythonTestCase(TestBase):
 
     @add_test_categories(['pyapi'])
     @no_debug_info_test
+    def test_host_is_connected(self):
+        # We've already tested that this one IS the host platform.
+        host_platform = self.dbg.GetPlatformAtIndex(0)
+        self.assertTrue(host_platform.IsConnected(), "The host platform is always connected")
+
+
+    @add_test_categories(['pyapi'])
+    @no_debug_info_test
     def test_available_platform_list(self):
         """Test SBDebugger::GetNumAvailablePlatforms() and GetAvailablePlatformInfoAtIndex() API"""
         num_platforms = self.dbg.GetNumAvailablePlatforms()

--- a/source/API/SBPlatform.cpp
+++ b/source/API/SBPlatform.cpp
@@ -271,7 +271,7 @@ void SBPlatform::DisconnectRemote() {
 bool SBPlatform::IsConnected() {
   PlatformSP platform_sp(GetSP());
   if (platform_sp)
-    platform_sp->IsConnected();
+    return platform_sp->IsConnected();
   return false;
 }
 


### PR DESCRIPTION
for the behavior - using the fact that the Host platform
is always present & connected.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@327448 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 0a70baf276505ccfe4bce1acc4017c44565011d7)