### PR TITLE
Factor out deserialization of compiler flags into a helper function.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -122,10 +122,13 @@ public:
 
   static ConstString GetPluginNameStatic();
 
-  /// Create a SwiftASTContext from a Module.
+  /// Create a SwiftASTContext from a Module.  This context is used
+  /// for frame variable ans uses ClangImporter options specific to
+  /// this lldb::Module.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Module &module);
-  /// Create a SwiftASTContext from a Target.
+  /// Create a SwiftASTContext from a Target.  This context is global
+  /// and used for the expression evaluator.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Target &target,
                                            const char *extra_options);


### PR DESCRIPTION
This is done twice, so it makes sense to have the implementation in
only one place. NFC save for small logging differences.