### PR TITLE
[lldb-dotest] Wrap arguments in single quotes

### DIFF
--- a/test/lldb-dotest.in
+++ b/test/lldb-dotest.in
@@ -7,9 +7,13 @@ dotest_args = '@LLDB_DOTEST_ARGS_STR@'
 swiftc = '@LLDB_SWIFTC@'
 
 if __name__ == '__main__':
+    # Wrap arguments in single quotes. This is necessary because we want to
+    # forward the arguments and otherwise we might split up arguments that were
+    # originally wrapped in single quotes.
+    wrapper_args = list("'" + i + "'" for i in sys.argv[1:])
     # FIXME: It would be nice if we can mimic the approach taken by llvm-lit
     # and pass a python configuration straight to dotest, rather than going
     # through the operating system.
     command = '{} -q {} --swift-compiler {} {}'.format(
-        dotest_path, dotest_args, swiftc, ' '.join(sys.argv[1:]))
+        dotest_path, dotest_args, swiftc, ' '.join(wrapper_args))
     os.system(command)


### PR DESCRIPTION
If we don't wrap arguments to the wrapper in single quotes, combined
arguments, for example for -E, don't reach dotest.py as a unit but as
separate arguments, causing the latter to fail.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@328020 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 17e38ad863d0cd1baff9149848d92a5f304ee21b)