### PR TITLE
Improve Swift's lldb-dotest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,8 +151,7 @@ add_python_test_target(check-lldb
   )
 
 # Generate a wrapper for dotest.py in the bin directory.
-string (REPLACE ";" " " LLDB_DOTEST_ARGS_STR  "${LLDB_DOTEST_ARGS}")
-# We need this to substitute variables.
+# We need configure_file to substitute variables.
 configure_file(
   lldb-dotest.in
   ${CMAKE_CURRENT_BINARY_DIR}/lldb-dotest.configured

--- a/test/lldb-dotest.in
+++ b/test/lldb-dotest.in
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
+import os
 import subprocess
 import sys
 
 dotest_path = '@LLDB_SOURCE_DIR@/test/dotest.py'
 dotest_args_str = '@LLDB_DOTEST_ARGS@'
-swiftc = '@LLDB_SWIFTC@'
+
+swift_build_dir = '@LLDB_PATH_TO_SWIFT_BUILD'
+swift_compiler = os.path.join(swift_build_dir, 'bin', 'swiftc')
+swift_library = os.path.join(swift_build_dir, 'lib', 'swift')
 
 if __name__ == '__main__':
     wrapper_args = sys.argv[1:]
@@ -12,7 +16,8 @@ if __name__ == '__main__':
     # Build dotest.py command.
     cmd = [dotest_path, '-q']
     cmd.extend(dotest_args)
-    cmd.extend(['--swift-compiler', swifc])
+    cmd.extend(['--swift-compiler', swift_compiler])
+    cmd.extend(['--swift-library', swift_library])
     cmd.extend(wrapper_args)
     # Invoke dotest.py
     subprocess.call(cmd)

--- a/test/lldb-dotest.in
+++ b/test/lldb-dotest.in
@@ -1,19 +1,18 @@
 #!/usr/bin/env python
+import subprocess
 import sys
-import os
 
 dotest_path = '@LLDB_SOURCE_DIR@/test/dotest.py'
-dotest_args = '@LLDB_DOTEST_ARGS_STR@'
+dotest_args_str = '@LLDB_DOTEST_ARGS@'
 swiftc = '@LLDB_SWIFTC@'
 
 if __name__ == '__main__':
-    # Wrap arguments in single quotes. This is necessary because we want to
-    # forward the arguments and otherwise we might split up arguments that were
-    # originally wrapped in single quotes.
-    wrapper_args = list("'" + i + "'" for i in sys.argv[1:])
-    # FIXME: It would be nice if we can mimic the approach taken by llvm-lit
-    # and pass a python configuration straight to dotest, rather than going
-    # through the operating system.
-    command = '{} -q {} --swift-compiler {} {}'.format(
-        dotest_path, dotest_args, swiftc, ' '.join(wrapper_args))
-    os.system(command)
+    wrapper_args = sys.argv[1:]
+    dotest_args = dotest_args_str.split(';')
+    # Build dotest.py command.
+    cmd = [dotest_path, '-q']
+    cmd.extend(dotest_args)
+    cmd.extend(['--swift-compiler', swifc])
+    cmd.extend(wrapper_args)
+    # Invoke dotest.py
+    subprocess.call(cmd)


### PR DESCRIPTION
Pull in the latest change from upstream and unify the way we handle the swift compiler and libraries. The latter will allow us to remove the `SWIFTCC` and `SWIFTLIBS` environment variables from the swift build script.