### PR TITLE
[lldb-dotest] Check that swif compiler and libs path exists.

### DIFF
--- a/test/lldb-dotest.in
+++ b/test/lldb-dotest.in
@@ -5,10 +5,8 @@ import sys
 
 dotest_path = '@LLDB_SOURCE_DIR@/test/dotest.py'
 dotest_args_str = '@LLDB_DOTEST_ARGS@'
-
-swift_build_dir = '@LLDB_PATH_TO_SWIFT_BUILD'
-swift_compiler = os.path.join(swift_build_dir, 'bin', 'swiftc')
-swift_library = os.path.join(swift_build_dir, 'lib', 'swift')
+swift_compiler = '@LLDB_SWIFTC'
+swift_library = '@LLDB_SWIFT_LIBS'
 
 if __name__ == '__main__':
     wrapper_args = sys.argv[1:]
@@ -16,8 +14,10 @@ if __name__ == '__main__':
     # Build dotest.py command.
     cmd = [dotest_path, '-q']
     cmd.extend(dotest_args)
-    cmd.extend(['--swift-compiler', swift_compiler])
-    cmd.extend(['--swift-library', swift_library])
+    if os.path.exists(swift_compiler):
+        cmd.extend(['--swift-compiler', swift_compiler])
+    if os.path.exists(swift_library):
+        cmd.extend(['--swift-library', swift_library])
     cmd.extend(wrapper_args)
     # Invoke dotest.py
     subprocess.call(cmd)


### PR DESCRIPTION
The @LLDB_PATH_TO_SWIFT_BUILD variable is not known at configuration
time so we need to read LLDB_SWIFTC and LLDB_SWIFT_LIBS which are (will
be) set by the build script.