### PR TITLE
[Commands] Add coverage for language swift refcount.

### DIFF
--- a/lit/Swift/Refcount.swift
+++ b/lit/Swift/Refcount.swift
@@ -1,0 +1,31 @@
+// REQUIRES: darwin
+
+// RUN: rm -f %t.cmds %t
+// RUN: echo 'breakpoint set -p "break here"' > %t.cmds
+// RUN: echo 'run' >> %t.cmds
+
+// RUN: echo 'language swift refcount Arg0' >> %t.cmds
+// CHECK: refcount data: (strong = 0, weak = 1)
+
+// RUN: %swiftc %s -g -Onone -o %t && %lldb -b -s %t.cmds -- %t | FileCheck %s
+
+class Patatino {
+  var Foo : String
+
+  init(_ Foo : String) {
+    self.Foo = Foo
+  }
+}
+
+func g(_ Arg0 : Patatino) -> Patatino {
+  return Arg0
+}
+
+func main() -> Patatino {
+  var Arg0 = Patatino("Tinky")
+  var Copy1 = Arg0
+  var Copy2 = g(Copy1)
+  return Copy2 // break here
+}
+
+main()

--- a/lit/Swift/Refcount.swift
+++ b/lit/Swift/Refcount.swift
@@ -1,5 +1,3 @@
-// REQUIRES: darwin
-
 // RUN: rm -f %t.cmds %t
 // RUN: echo 'breakpoint set -p "break here"' > %t.cmds
 // RUN: echo 'run' >> %t.cmds

--- a/lit/Swift/lit.local.cfg
+++ b/lit/Swift/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.swift']

--- a/lit/lit.cfg
+++ b/lit/lit.cfg
@@ -78,6 +78,7 @@ if platform.system() in ['Darwin']:
 
 config.substitutions.append(('%cc', config.cc))
 config.substitutions.append(('%cxx', config.cxx))
+config.substitutions.append(('%swiftc', config.swiftc))
 
 config.substitutions.append(('%lldb', lldb))
 

--- a/lit/lit.site.cfg.in
+++ b/lit/lit.site.cfg.in
@@ -13,6 +13,7 @@ config.python_executable = "@PYTHON_EXECUTABLE@"
 config.cc = "@LLDB_TEST_C_COMPILER@"
 config.cxx = "@LLDB_TEST_CXX_COMPILER@"
 config.have_zlib = @LLVM_ENABLE_ZLIB@
+config.swiftc = "@LLDB_SWIFTC@"
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
To the best of my knowledge this feature was not really tested.
As I'm going to do changes in this area (e.g. adding unowned
printing) I figured I could just add some coverage.

This turned out to be a nice way of experimenting writing
lldb tests in a single file (using lit). Maybe the syntax can
be cleaned up a bit, but I have to say I'm quite happy with the
ending results. Please let me know what you think.

This commit also adds the plumbing to invoke `swiftc` in lit tests,
which I didn't add before because all the swift lit tests were
using the repl.

In preparation for <rdar://30538363>.