### PR TITLE
Add a sanity check to the swift Native Hashed Container data formatter.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/main.swift
@@ -28,6 +28,8 @@ struct A<T> {
     }
 
     mutating func a() -> T? {
+        var adict : [String: Any] = ["key1" : "val1", "key2" : 9999] //% self.expect("frame var adict", "Frame var of uninitialized variable returns.")
+        adict["key3"] = 1.0
         var t : T? = nil
         let c = cs[0]
 
@@ -35,7 +37,7 @@ struct A<T> {
         let k2 = b(t:c) //% self.expect("expression -- c", "Unreadable variable is ignored", substrs = ["= 3"])
         let k3 = b(t:c)
 
-        if let maybeT = process(i:0, k1:k1, k2:k2, k3:k3) {
+        if let maybeT = process(i : adict.count, k1:k1, k2:k2, k3:k3) {
             t = maybeT
         }
 

--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/main.swift
@@ -28,8 +28,9 @@ struct A<T> {
     }
 
     mutating func a() -> T? {
-        var adict : [String: Any] = ["key1" : "val1", "key2" : 9999] //% self.expect("frame var adict", "Frame var of uninitialized variable returns.")
-        adict["key3"] = 1.0
+        var adict : [String: Any]  //% self.expect("frame variable adict", "Frame variable of an uninitialized dict returns")
+        adict = [String: Any]() 
+        adict["key1"] = 1.0
         var t : T? = nil
         let c = cs[0]
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -115,7 +115,7 @@ protected:
 
   virtual bool IsValid();
 
-  bool ReadBitmaskAtIndex(Index);
+  bool ReadBitmaskAtIndex(Index, Status &error);
 
   lldb::addr_t GetLocationOfKeyAtCell(Cell);
 


### PR DESCRIPTION
This checks that we can read the used items bitmask, and if we can't we
don't try to construct children for the container.  The variable can't
be valid if this is not initialized.

<rdar://problem/37475403>