### PR TITLE
Add a testcase where the ClangImporter fails because of search path

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Bar/Bar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Bar/Bar.h
@@ -1,0 +1,1 @@
+#include <Foo.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Bar/Foo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Bar/Foo.h
@@ -1,0 +1,1 @@
+struct FooBar { int j; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Bar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Foo/Foo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Foo/Foo.h
@@ -1,0 +1,1 @@
+struct FooFoo { int i; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Foo/Outer.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Foo/Outer.h
@@ -1,0 +1,1 @@
+#include <Foo.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "Outer.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/Makefile
@@ -1,0 +1,22 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+# This test builds a .dylib whose .swiftmodule imports a Clang module
+# which uses a header file "Foo.h". The main swift program also
+# imports a Clang module that imports a header file called "Foo.h",
+# but it is in a different directory. We are differen -Xcc -I paths to
+# switch between the two versions of "Foo.h" during build time.
+
+all: libDylib.dylib a.out
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.swift
+	$(SWIFTC) -g -Onone $^ -lDylib -L$(shell pwd) -o $@ $(SWIFTFLAGS) -Xcc -I$(SRCDIR)/Bar -I. -Xcc -I$(SRCDIR)/Foo
+
+libDylib.dylib: dylib.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name Dylib -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/Foo $(SWIFTFLAGS)
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -1,0 +1,74 @@
+# TestSwiftHeadermapConflict.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftIncludeConflict(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        # To ensure we hit the rebuild problem remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.build()
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        a_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('main.swift'))
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        # This is expected to succeed because ClangImporter was set up
+        # with the flags from the main executable.
+        self.expect("expr foo", "expected result", substrs=["42"])
+        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+
+        b_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('dylib.swift'))
+
+        process.Continue()
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, b_breakpoint)
+        frame = threads[0].GetFrameAtIndex(0)
+        value = frame.EvaluateExpression("foo")
+        # This is expected to fail because ClangImporter is *still*
+        # set up with the flags from the main executable.
+        self.assertFalse(value.GetError().Success())
+        
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/dylib.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/dylib.swift
@@ -1,0 +1,8 @@
+import Foo
+
+func use<T>(_ t: T) {}
+
+public func f() {
+  let foo = FooFoo(i: 23)
+  use(foo) // break here
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/main.swift
@@ -1,0 +1,23 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Bar
+import Dylib
+
+func use<T>(_ t: T) {}
+
+func main() {
+  let foo = FooBar(j: 42)
+  f() // break here
+  use(foo)
+}
+
+main()


### PR DESCRIPTION
mismatches.

<rdar://problem/38686915>