### PR TITLE
Log ObjC Runtime messages only in verbose mode

### DIFF
--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1449,8 +1449,8 @@ uint32_t AppleObjCRuntimeV2::ParseClassInfoArray(const DataExtractor &data,
   //        uint32_t hash;
   //    } __attribute__((__packed__));
 
-  Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_PROCESS | LIBLLDB_LOG_TYPES));
-
+  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES 
+                                    | LLDB_LOG_OPTION_VERBOSE));
   uint32_t num_parsed = 0;
 
   // Iterate through all ClassInfo structures


### PR DESCRIPTION
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@328365 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 20094d83dc7e33e1ee811298143866f32eae6999)