### PR TITLE
[test] Update the swift stepping behavior test

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
@@ -184,17 +184,9 @@ class TestSwiftStepping(lldbtest.TestBase):
         thread.StepOver()
         self.hit_correct_line(thread, "At point initializer.")
         thread.StepOver()
-        # Due to: <rdar://problem/15888936> we will stop inside the
-        # switch statement instead of at the switch:
-        # self.hit_correct_line (thread, "At the beginning of the switch.")
-        self.hit_correct_line(thread, "case (0, 0):")
+        self.hit_correct_line (thread, "At the beginning of the switch.")
 
         thread.StepOver()
-        self.hit_correct_line(thread, "case (_, 0):")
-        thread.StepInto()
-        self.hit_correct_line(thread, "case (0, _):")
-        thread.StepOver()
-
         stopped_at_case = self.hit_correct_line(
             thread, "case (let x, let y) where", False)
         if stopped_at_case:

--- a/packages/Python/lldbsuite/test/lang/swift/stepping/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/main.swift
@@ -182,7 +182,7 @@ func main () -> Void
 
     switch point  // At the beginning of the switch. 
     {
-        case (0, 0):  // Where swift currently thinks the switch begins...       
+        case (0, 0):
             print("(0, 0) is at the origin")
         case (_, 0):
             print("(\(point.0), 0) is on the x-axis")


### PR DESCRIPTION
apple/swift#15025 fixes the stepping behavior for switches, so we need
to update our test accordingly.

(cherry picked from commit b09f604c4596a89d1c0f4aa3f51cde47c76d91de)