### PR TITLE
Add a testcase that uses a pure-ObjC main executable and two Swift

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar.swift
@@ -1,0 +1,11 @@
+import CBar
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Bar : NSObject {
+  @objc public func f() {
+    let baz = Baz(i_am_from_Bar: 42)
+    use(baz) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar/Baz.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar/Baz.h
@@ -1,0 +1,1 @@
+struct Baz { int i_am_from_Bar; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar/CBar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar/CBar.h
@@ -1,0 +1,1 @@
+#include <Baz.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module CBar {
+  header "CBar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo.swift
@@ -1,0 +1,11 @@
+import CFoo
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Foo : NSObject {
+  @objc public func f() {
+    let baz = Baz(i_am_from_Foo: 23)
+    use(baz) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo/Baz.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo/Baz.h
@@ -1,0 +1,1 @@
+struct Baz { int i_am_from_Foo; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo/CFoo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo/CFoo.h
@@ -1,0 +1,1 @@
+#include <Baz.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module CFoo {
+  header "CFoo.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
@@ -1,0 +1,17 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+# This test builds an Objective-C main program that imports two Swift
+# .dylibs with conflicting ClangImporter search paths.
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.m libFoo.dylib libBar.dylib
+	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<
+
+lib%.dylib: %.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(shell basename $< .swift) $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -1,0 +1,72 @@
+# TestSwiftObjCMainConflictingDylibs.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftObjCMainConflictingDylibs(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        # To ensure we hit the rebuild problem remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.build()
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        bar_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Bar.swift'))
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        # This is failing because the Target-SwiftASTContext uses the
+        # amalgamated target header search options from all dylibs.
+        self.expect("p baz", "wrong baz", substrs=["i_am_from_Foo"])
+        # This works because it is using the Module-SwiftASTContext
+        # with only this the dylib's search paths.
+        self.expect("fr var baz", "correct baz", substrs=["i_am_from_Bar"])
+        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Foo.swift'))
+        process.Continue()
+        self.expect("p baz", "correct baz", substrs=["i_am_from_Foo"])
+        self.expect("fr var baz", "correct baz", substrs=["i_am_from_Foo"])
+        
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/main.m
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/main.m
@@ -1,0 +1,9 @@
+@import Foundation;
+#include "Foo.h"
+#include "Bar.h"
+
+int main(int argc, char **argv) {
+  [[[Bar alloc] init] f];
+  [[[Foo alloc] init] f];
+  return 0;
+}


### PR DESCRIPTION
dylibs with conflicting modules. This one neatly demonstrates the
difference between the Module- and the Target-SwiftASTContext.

<rdar://problem/38686915>