### PR TITLE
Add a testcase where the expression evaluator fails with a module

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar.swift
@@ -1,0 +1,11 @@
+import CBar
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Bar : NSObject {
+  @objc public func f() {
+    let bar = CBar(j: 42)
+    use(bar) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar/Baz.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar/Baz.h
@@ -1,0 +1,1 @@
+typedef int BazBar;

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar/CBar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar/CBar.h
@@ -1,0 +1,5 @@
+#include <Baz.h>
+
+struct CBar {
+  BazBar j;
+};

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module CBar {
+  header "CBar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo.swift
@@ -1,0 +1,11 @@
+import CFoo
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Foo : NSObject {
+  @objc public func f() {
+    let foo = CFoo(i: 23)
+    use(foo) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo/Baz.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo/Baz.h
@@ -1,0 +1,1 @@
+typedef int BazFoo;

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo/CFoo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo/CFoo.h
@@ -1,0 +1,5 @@
+#include <Baz.h>
+
+struct CFoo {
+  BazFoo i;
+};

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module CFoo {
+  header "CFoo.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
@@ -1,0 +1,17 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+# This test builds an Objective-C main program that imports two Swift
+# .dylibs with conflicting ClangImporter search paths.
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.m libFoo.dylib libBar.dylib
+	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<
+
+lib%.dylib: %.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(shell basename $< .swift) $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -1,0 +1,78 @@
+# TestSwiftObjCMainConflictingDylibsFailingImport.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        # To ensure we hit the rebuild problem remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.build()
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        bar_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Bar.swift'))
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        # This is failing because the Target-SwiftASTContext uses the
+        # amalgamated target header search options from all dylibs.
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, bar_breakpoint)
+        frame = threads[0].GetFrameAtIndex(0)
+        value = frame.EvaluateExpression("bar")
+        self.assertFalse(value.GetError().Success())
+        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+
+        # This works becaue the Module-SwiftASTContext uses the dylib flags.
+        self.expect("fr var bar", "expected result", substrs=["42"])
+
+        # This works by accident because the search paths are in the right order.
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Foo.swift'))
+        process.Continue()
+        self.assertFalse(value.GetError().Success())
+        self.expect("p foo", "expected result", substrs=["23"])
+        # This works becaue the Module-SwiftASTContext uses the dylib flags.
+        self.expect("fr var foo", "expected result", substrs=["23"])
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/main.m
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/main.m
@@ -1,0 +1,9 @@
+@import Foundation;
+#include "Foo.h"
+#include "Bar.h"
+
+int main(int argc, char **argv) {
+  [[[Bar alloc] init] f];
+  [[[Foo alloc] init] f];
+  return 0;
+}


### PR DESCRIPTION
build error, but frame variable still works.

rdar://problem/38686915