### PR TITLE
Make TestSwiftTupleTypes.py robust against type-sugar changes in the compiler

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -83,11 +83,11 @@ class TestSwiftTupleTypes(TestBase):
         self.expect("frame variable --raw-output --show-types tuple4",
                     substrs=['(p1: ', 'Point, p2: ', '.Point) tuple4',
                              'Point) p1',
-                             '(Builtin.FPIEEE32)', 'value = 1.25',
-                             '(Builtin.FPIEEE32)', 'value = 2.125',
+                             'FPIEEE32)', 'value = 1.25',
+                             'FPIEEE32)', 'value = 2.125',
                              'Point) p2',
-                             '(Builtin.FPIEEE32)', 'value = 4.5',
-                             '(Builtin.FPIEEE32)', 'value = 8.75'])
+                             'FPIEEE32)', 'value = 4.5',
+                             'FPIEEE32)', 'value = 8.75'])
 
 if __name__ == '__main__':
     import atexit


### PR DESCRIPTION
Whether we print the `Builtin` part of the name of something from the builtin module isn't necessarily fixed, since these types aren't really supposed to be exposed to the user anyway.