### PR TITLE
Revert "Un-xfail a couple of tests that are now passing."

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/load_unload/TestLoadUnload.py
+++ b/packages/Python/lldbsuite/test/functionalities/load_unload/TestLoadUnload.py
@@ -220,6 +220,7 @@ class LoadUnloadTestCase(TestBase):
         triple='.*-android')
     @skipIfFreeBSD  # llvm.org/pr14424 - missing FreeBSD Makefiles/testcase support
     @skipIfWindows  # Windows doesn't have dlopen and friends, dynamic libraries work differently
+    @expectedFailureAll(bugnumber="rdar://38484268")
     def test_lldb_process_load_and_unload_commands(self):
         """Test that lldb process load/unload command work correctly."""
         self.copy_shlibs_to_remote()

--- a/packages/Python/lldbsuite/test/functionalities/process_launch/TestProcessLaunch.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_launch/TestProcessLaunch.py
@@ -85,6 +85,7 @@ class ProcessLaunchTestCase(TestBase):
     # not working?
     @not_remote_testsuite_ready
     @expectedFailureAll(oslist=["linux"], bugnumber="llvm.org/pr20265")
+    @expectedFailureAll(bugnumber="rdar://38484341")
     def test_set_working_dir(self):
         """Test that '-w dir' sets the working dir when running the inferior."""
         d = {'CXX_SOURCES': 'print_cwd.cpp'}


### PR DESCRIPTION
This reverts commit 4853d99005242636f03d96e61f64a4e5207cecad
as these tests are still failing on the CMake bot.