### PR TITLE
[Swift] Make this test more robust relaxing output checks.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -25,6 +25,7 @@ class TestSwiftAnyObjectType(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_any_object_type(self):
         """Test the Any type"""
         self.build()
@@ -68,7 +69,7 @@ class TestSwiftAnyObjectType(TestBase):
             self,
             var_object,
             use_dynamic=False,
-            typename="Swift.AnyObject")
+            typename="AnyObject")
         lldbutil.check_variable(
             self,
             var_object,


### PR DESCRIPTION
It was just too strict and matches what Doug did for another test.
While I'm here add it to `@swiftpr` so that we notice if this
regresses again during PR testing.