### PR TITLE
Swift: Form NameAliasTypes for references to type aliases.

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -74,20 +74,20 @@ class TestSwiftTypeAliasFormatters(TestBase):
         self.expect("frame variable f", substrs=['Foo) f = (value = 12)'])
         self.expect("frame variable b", substrs=['Bar) b = (value = 24)'])
 
-        self.runCmd('type summary add a.Foo -v -s "hello"')
+        self.runCmd('type summary add Foo -v -s "hello"')
         self.expect("frame variable f", substrs=['Foo) f = hello'])
         self.expect("frame variable b", substrs=['Bar) b = hello'])
 
-        self.runCmd('type summary add a.Bar -v -s "hi"')
+        self.runCmd('type summary add Bar -v -s "hi"')
         self.expect("frame variable f", substrs=['Foo) f = hello'])
         self.expect("frame variable b", substrs=['Bar) b = hi'])
 
-        self.runCmd("type summary delete a.Foo")
+        self.runCmd("type summary delete Foo")
         self.expect("frame variable f", substrs=['Foo) f = (value = 12)'])
         self.expect("frame variable b", substrs=['Bar) b = hi'])
 
-        self.runCmd("type summary delete a.Bar")
-        self.runCmd("type summary add -C no -v a.Foo -s hello")
+        self.runCmd("type summary delete Bar")
+        self.runCmd("type summary add -C no -v Foo -s hello")
         self.expect("frame variable f", substrs=['Foo) f = hello'])
         self.expect("frame variable b", substrs=['Bar) b = (value = 24)'])
 

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -29,6 +29,7 @@ class TestSwiftTypeAliasFormatters(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""
         self.build()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4102,7 +4102,11 @@ static CompilerType ValueDeclToType(swift::ValueDecl *decl,
     case swift::DeclKind::TypeAlias: {
       swift::TypeAliasDecl *alias_decl = swift::cast<swift::TypeAliasDecl>(decl);
       if (alias_decl->hasInterfaceType()) {
-        swift::Type swift_type = alias_decl->getDeclaredInterfaceType();
+        swift::Type swift_type =
+          swift::NameAliasType::get(
+                                  alias_decl, swift::Type(),
+                                  swift::SubstitutionMap(),
+                                  alias_decl->getUnderlyingTypeLoc().getType());
         return CompilerType(ast, swift_type.getPointer());
       }
       break;
@@ -4186,7 +4190,11 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
       swift::TypeAliasDecl *alias_decl =
           swift::cast<swift::TypeAliasDecl>(decl);
       if (alias_decl->hasInterfaceType()) {
-        swift::Type swift_type = alias_decl->getDeclaredInterfaceType();
+        swift::Type swift_type =
+          swift::NameAliasType::get(
+                                  alias_decl, swift::Type(),
+                                  swift::SubstitutionMap(),
+                                  alias_decl->getUnderlyingTypeLoc().getType());
         return CompilerType(ast, swift_type.getPointer());
       }
     } break;


### PR DESCRIPTION
The declared interface type of a typealias declaration is not necessarily
a sugared type; make sure that we do form a sugared type. Update the test
case to not refer to the model name when adding type summary information
to a typealias.