### PR TITLE
Set the "debugger typealias" bit on synthesized typealiases.

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1529,7 +1529,10 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
   swift::TypeAliasDecl *type_alias_decl = new (ast_context)
       swift::TypeAliasDecl(source_loc, swift::SourceLoc(), name, source_loc,
                            nullptr, &m_source_file);
-  type_alias_decl->setUnderlyingType(GetSwiftType(type));
+  swift::Type underlying_type = GetSwiftType(type);
+  type_alias_decl->setUnderlyingType(underlying_type);
+  if (underlying_type->hasArchetype())
+    type_alias_decl->markAsDebuggerAlias(true);
 
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
   if (log) {


### PR DESCRIPTION
LLDB creates typealiases that involve archetypes that weren't introduced
in the enclosing context, which violates some of Swift's AST invariants.
Mark such typealiases as "debugger typealiases" so the Swift frontend
can tip-toe around them when needed.

We'll eventually want to rework the LLDB <-> Swift frontend
interaction here, but this allows us to tighten up AST verification in
the Swift frontend without breaking LLDB.