### PR TITLE
Reimplement GetDynamicTypeAndAddress_Class using the Remote AST library. 

### DIFF
--- a/lit/SwiftREPL/NSString.test
+++ b/lit/SwiftREPL/NSString.test
@@ -6,7 +6,7 @@
 import Foundation
 var aString = "patatino" as NSString
 // NSSTRING: Welcome to Swift
-// NSSTRING-NEXT: aString: NSTaggedPointerString = "patatino"
+// NSSTRING-NEXT: aString: NSString = "patatino"
 
 aString.substring(to: 3)
 // NSSTRING: $R0: String = "pat"


### PR DESCRIPTION
`GetDynamicTypeAndAddress_Class` hard-coded a fetch of an "isa" pointer and
used the fairly-heavy `GetMetadataPromise` abstraction to immediately
retrieve the type from the remote AST library. Replace both with direct
uses of remote ASTs.