### PR TITLE
[Swift language runtime] Cache member variable offsets.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -452,6 +452,10 @@ protected:
   std::unordered_map<const char *, lldb::SyntheticChildrenSP>
       m_bridged_synthetics_map;
 
+  /// Cached member variable offsets.
+  typename KeyHasher<const swift::TypeBase *, const char *, uint64_t>::MapType
+    m_member_offsets;
+
   CompilerType m_box_metadata_type;
 
 


### PR DESCRIPTION
Lazily cache the offsets of member variables within the Swift language
runtime interface, since they might be queried repeatedly.