### PR TITLE
[SwiftTestSuite] A couple of fixes/improvements for our testing.

### DIFF
--- a/packages/Python/lldbsuite/test/decorators.py
+++ b/packages/Python/lldbsuite/test/decorators.py
@@ -10,6 +10,7 @@ import platform
 import re
 import sys
 import tempfile
+import subprocess
 
 # Third-party modules
 import six

--- a/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -26,6 +26,7 @@ class TestDictionaryNSObjectAnyObject(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_dictionary_nsobject_any_object(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary<NSObject,AnyObject>"""
         self.build()


### PR DESCRIPTION
1) Fixup the missing `import` that caused the trivial ABI test
to fail. llvm.org has the `import` bit so it's probably the result
of a merge issue/conflict.

2) Add a dictionary test that Doug found to `swiftpr` category.
It's sensitive to swift frontend changes, so it amkes sense to
adding it here.