### PR TITLE
Explicitly import subprocess

### DIFF
--- a/packages/Python/lldbsuite/test/lang/cpp/trivial_abi/TestTrivialABI.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/trivial_abi/TestTrivialABI.py
@@ -9,6 +9,7 @@ import os
 import time
 import re
 import lldb
+import subprocess
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import decorators


### PR DESCRIPTION
For some reason on one of our bots subprocess wasn't already
imported. Do so explicitly.


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@328715 91177308-0d34-0410-b5e6-96231b3b80d8