### PR TITLE
[cmake] Set the default test compiler to the clang built in-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,20 @@ if(LLDB_INCLUDE_TESTS)
   set(LLDB_DEFAULT_TEST_C_COMPILER "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
   set(LLDB_DEFAULT_TEST_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}")
 
+  # If the build would have failed due to a missing clang target, log some
+  # diagnostics.
+  message(STATUS "lldb: Found SwiftConfig: ${Swift_FOUND}")
+  message(STATUS "lldb: Found ClangConfig: ${Clang_FOUND}")
+  if (TARGET clang)
+    message(STATUS "lldb: Found the clang target.")
+  else()
+    message(WARNING "lldb: Could not find the clang target!")
+    message(STATUS "-> CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+    message(STATUS "-> CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+    message(STATUS "-> LLVM_CONFIG: ${LLVM_CONFIG}")
+    message(STATUS "-> LLDB_PATH_TO_CLANG_SOURCE: ${LLDB_PATH_TO_CLANG_SOURCE}")
+    message(STATUS "-> LLVM_BINARY_DIR: ${LLVM_BINARY_DIR}")
+  endif()
   # END - Swift Mods
 
   set(LLDB_TEST_C_COMPILER "${LLDB_DEFAULT_TEST_C_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,16 +71,15 @@ add_subdirectory(tools)
 option(LLDB_INCLUDE_TESTS "Generate build targets for the LLDB unit tests."
   ${LLVM_INCLUDE_TESTS})
 if(LLDB_INCLUDE_TESTS)
-  # TARGET clang works for a non-standalone build.
-  #
-  # FIXME: This can be avoided by importing the cmake configuration from swift.
-  if (TARGET clang OR LLDB_BUILD_STANDALONE)
-    set(LLDB_DEFAULT_TEST_C_COMPILER "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
-    set(LLDB_DEFAULT_TEST_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}")
-  else()
-    set(LLDB_DEFAULT_TEST_C_COMPILER "")
-    set(LLDB_DEFAULT_TEST_CXX_COMPILER "")
-  endif()
+  # BEGIN - Swift Mods
+  # The clang target is sometimes unavailable (rdar://38935299). Instead of
+  # failing the build when the target is missing, make the in-tree compiler the
+  # default compiler to test.
+
+  set(LLDB_DEFAULT_TEST_C_COMPILER "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
+  set(LLDB_DEFAULT_TEST_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}")
+
+  # END - Swift Mods
 
   set(LLDB_TEST_C_COMPILER "${LLDB_DEFAULT_TEST_C_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
   set(LLDB_TEST_CXX_COMPILER "${LLDB_DEFAULT_TEST_CXX_COMPILER}" CACHE PATH "C++ Compiler to use for building LLDB test inferiors")


### PR DESCRIPTION
The cmake build tries to make sure the `clang` target is available
before setting the test compiler to a clang binary built in-tree.

For reasons we don't understand, the `clang` target is not always
available. This is despite running the exact same build-script and
cmake invocations on the same bot.

As a workaround, in swift-lldb, this change unconditionally makes the
default test compiler be the clang that's built in-tree.

rdar://38935299