### PR TITLE
Prevent double release of mach ports

### DIFF
--- a/source/Plugins/Process/Darwin/MachException.cpp
+++ b/source/Plugins/Process/Darwin/MachException.cpp
@@ -92,8 +92,6 @@ extern "C" kern_return_t catch_mach_exception_raise_state_identity(
                 (uint64_t)(exc_data_count > 0 ? exc_data[0] : 0xBADDBADD),
                 (uint64_t)(exc_data_count > 1 ? exc_data[1] : 0xBADDBADD));
   }
-  mach_port_deallocate(mach_task_self(), task_port);
-  mach_port_deallocate(mach_task_self(), thread_port);
 
   return KERN_FAILURE;
 }

--- a/tools/debugserver/source/MacOSX/MachException.cpp
+++ b/tools/debugserver/source/MacOSX/MachException.cpp
@@ -86,8 +86,6 @@ extern "C" kern_return_t catch_mach_exception_raise_state_identity(
                    (uint64_t)(exc_data_count > 0 ? exc_data[0] : 0xBADDBADD),
                    (uint64_t)(exc_data_count > 1 ? exc_data[1] : 0xBADDBADD));
   }
-  mach_port_deallocate(mach_task_self(), task_port);
-  mach_port_deallocate(mach_task_self(), thread_port);
 
   return KERN_FAILURE;
 }


### PR DESCRIPTION
Summary:
When a MIG routine returns KERN_FAILURE, the demux function will release any OOL resources like ports. In this case, task_port and thread_port will be released twice, potentially resulting in use after free of the ports.

I don't think we can test this in any useful way
rdar://problem/37331387

Reviewers: jasonmolenda

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D45011

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@328761 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 8f022f17fe6a1579c1ec53c0f3f369fdcbd1a71b)