### PR TITLE
 Answer class/struct queries using the Swift AST and remote AST

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -35,8 +35,10 @@ namespace swift {
 enum class IRGenDebugInfoKind : unsigned;
 class CanType;
 class IRGenOptions;
+class NominalTypeDecl;
 struct PrintOptions;
 class SILModule;
+class VarDecl;
 namespace irgen {
 class FixedTypeInfo;
 class TypeInfo;
@@ -858,6 +860,19 @@ protected:
   ExtraTypeInformation GetExtraTypeInformation(void *type);
 
   CachedMemberInfo *GetCachedMemberInfo(void *type);
+
+  /// Record the set of stored properties for each nominal type declaration
+  /// for which we've asked this question.
+  ///
+  /// All of the information in this DenseMap is easily re-constructed
+  /// with NominalTypeDecl::getStoredProperties(), but we cache the
+  /// result to provide constant-time indexed access.
+  llvm::DenseMap<swift::NominalTypeDecl *, std::vector<swift::VarDecl *>>
+    m_stored_properties;
+
+  /// Retrieve the stored properties for the given nominal type declaration.
+  llvm::ArrayRef<swift::VarDecl *> GetStoredProperties(
+                                               swift::NominalTypeDecl *nominal);
 
   SwiftEnumDescriptor *GetCachedEnumInfo(void *type);
 


### PR DESCRIPTION
Answer all of the various "child" queries for class and struct types
using the Swift AST and (where we have an execution context) remote
AST.

Stop using the "member info" cache for class/struct types, for several
reasons:
* It was getting pre-populated with field offsets formed without
consulting the remote AST, which wouldn't work with resilient struct
types
* It was sharing field offsets across different execution contexts,
which could lead to incorrect results
* Field offsets are already cached within the execution context,
which will have the proper information
* It was storing everything in a global table that will never get
freed, which seems unnecessary
* It duplicated a lot of the information about stored properties
across each instance of a generic class/struct, e.g., all of the
member names and such would be stored for both Foo<Int> and
Foo<String>

Introduce a cache for the stored properties of a nominal type (struct
or class), which provides a constant-time mapping from child indices
into their corresponding stored properties. This is a
per-SwiftASTContext-instance cache where we share the information
across different instances of a generic class/struct and only store
the minimal amount of information needed to reconstruct the rest (a
VarDecl* per stored property).