### PR TITLE
 Improve inspection of Swift existential types.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -503,6 +503,10 @@ public:
     bool m_is_objc;
     bool m_is_anyobject;
     bool m_is_errortype;
+
+    /// The member index for the error value within an error
+    /// existential.
+    static constexpr unsigned error_instance_index = 0;
   };
 
   static bool GetProtocolTypeInfo(const CompilerType &type,

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -504,6 +504,10 @@ public:
     bool m_is_anyobject;
     bool m_is_errortype;
 
+    /// The superclass bound, which can only be non-null when this is
+    /// a class-bound existential.
+    CompilerType m_superclass;
+
     /// The member index for the error value within an error
     /// existential.
     static constexpr unsigned error_instance_index = 0;

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -510,7 +510,10 @@ public:
 
     /// The member index for the error value within an error
     /// existential.
-    static constexpr unsigned error_instance_index = 0;
+    static constexpr uint32_t error_instance_index = 0;
+
+    /// Retrieve the index at which the instance type occurs.
+    uint32_t GetInstanceTypeIndex() const { return m_num_payload_words; }
   };
 
   static bool GetProtocolTypeInfo(const CompilerType &type,

--- a/packages/Python/lldbsuite/test/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -24,7 +24,6 @@ class TestSwiftProtocolTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.skipIfOutOfTreeDebugserver
     def test_swift_protocol_types(self):
         """Test support for protocol types"""
         self.build()
@@ -66,8 +65,8 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Builtin.RawPointer) instance_type = 0x',
-                             '(Builtin.RawPointer) protocol_witness_0 = 0x'])
+                             '(Any.Type) instance_type = 0x',
+                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
 
         self.expect("frame variable --dynamic-type run-target loc2d",
                     substrs=['Point2D) loc2d =',
@@ -78,8 +77,8 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Builtin.RawPointer) instance_type = 0x',
-                             '(Builtin.RawPointer) protocol_witness_0 = 0x'])
+                             '(Any.Type) instance_type = 0x',
+                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
 
         self.expect(
             "frame variable --dynamic-type run-target loc3d",
@@ -94,22 +93,28 @@ class TestSwiftProtocolTypes(TestBase):
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Builtin.RawPointer) instance_type = 0x',
-                             '(Builtin.RawPointer) protocol_witness_0 = 0x'])
+                             '(Any.Type) instance_type = 0x',
+                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
 
         self.expect("expression --dynamic-type run-target -- loc2d",
                     substrs=['Point2D) $R',
                              'x = 1.25', 'y = 2.5'])
 
-        self.expect("expression --raw-output --show-types -- loc3d",
-                    substrs=['(PointUtils) $R',
-                             '(Builtin.RawPointer) payload_data_0 = 0x',
-                             '(Builtin.RawPointer) payload_data_1 = 0x',
-                             '(Builtin.RawPointer) payload_data_2 = 0x',
-                             '(Builtin.RawPointer) instance_type = 0x',
-                             '(Builtin.RawPointer) protocol_witness_0 = 0x'])
+        self.expect("expression --raw-output --show-types -- loc3dCB",
+                    substrs=['(PointUtils & AnyObject) $R',
+                             '(Builtin.RawPointer) instance = 0x',
+                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
 
-        self.expect("expression --dynamic-type run-target -- loc3d",
+        self.expect("expression --dynamic-type run-target -- loc3dCB",
+                    substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
+
+        self.expect("expression --raw-output --show-types -- loc3dSuper",
+                    substrs=['(a.PointSuperclass & PointUtils) $R',
+                             '(a.PointSuperclass) instance = 0x',
+                             '(Swift.Int) superData = ',
+                             '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
+
+        self.expect("expression --dynamic-type run-target -- loc3dSuper",
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
 
 if __name__ == '__main__':

--- a/packages/Python/lldbsuite/test/lang/swift/variables/protocol/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/protocol/main.swift
@@ -28,7 +28,11 @@ struct Point2D : PointUtils {
     
 }
 
-class Point3D : PointUtils {
+class PointSuperclass {
+  var superData: Int = 17
+}
+
+class Point3D : PointSuperclass, PointUtils {
     var x : Float
     var y : Float
     var z : Float
@@ -46,10 +50,15 @@ class Point3D : PointUtils {
     
 }
 
-func takes_protocol(_ loc2d : PointUtils,_ loc3d : PointUtils) {
+func takes_protocol(_ loc2d : PointUtils,_ loc3d : PointUtils,
+  _ loc3dCB : AnyObject & PointUtils,
+  _ loc3dSuper : PointSuperclass & PointUtils
+) {
     let sum2d = loc2d.sumOfCoordinates()
     let sum3d = loc3d.sumOfCoordinates()
-    print("hello \(sum2d) \(sum3d)") // Set breakpoint here
+    let sum3dCB = loc3dCB.sumOfCoordinates()
+    let sum3dSuper = loc3dSuper.sumOfCoordinates()
+    print("hello \(sum2d) \(sum3d) \(sum3dSuper)") // Set breakpoint here
 }
 
 func main() {
@@ -57,7 +66,7 @@ func main() {
     var loc2d = Point2D(1.25, 2.5)
     var loc3d = Point3D(1.25, 2.5, 1.25)
 
-    takes_protocol (loc2d, loc3d)
+  takes_protocol (loc2d, loc3d, loc3d, loc3d)
 }
 
 main()

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1869,7 +1869,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
     //     (Builtin.RawPointer) payload_data_1 = 0x0000000000000002
     //     (Builtin.RawPointer) payload_data_2 = 0x0000000000000000
     //     (Builtin.RawPointer) instance_type = 0x000000010054c2f8
-    //     (Builtin.RawPointer) protocol_witness_0 = 0x000000010054c100
+    //     (Builtin.RawPointer) witness_table_Proto = 0x000000010054c100
     // }
     // pick &payload_data_0
     // for a pointed-to protocol object, e.g.:
@@ -1878,7 +1878,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
     //     (Builtin.RawPointer) payload_data_1 = 0x0000000000000000
     //     (Builtin.RawPointer) payload_data_2 = 0x0000000000000000
     //     (Builtin.RawPointer) instance_type = 0x000000010054c648
-    //     (Builtin.RawPointer) protocol_witness_0 = 0x000000010054c7b0
+    //     (Builtin.RawPointer) witness_table_Proto = 0x000000010054c7b0
     // }
     // pick the value of payload_data_0
     switch (SwiftASTContext::GetAllocationStrategy(

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1793,7 +1793,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
   MetadataPromiseSP promise_sp;
   ValueObjectSP instance_type_sp(
                   in_value.GetStaticValue()->GetChildAtIndex(
-                                     protocol_info.m_num_payload_words, true));
+                                  protocol_info.GetInstanceTypeIndex(), true));
   if (!instance_type_sp)
     return false;
   ValueObjectSP payload0_sp(

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1509,10 +1509,9 @@ bool SwiftLanguageRuntime::IsValidErrorValue(
   if (!protocol_info.m_is_errortype)
     return false;
 
-  static ConstString g_instance_type_child_name("instance_type");
+  unsigned index = SwiftASTContext::ProtocolInfo::error_instance_index;
   ValueObjectSP instance_type_sp(
-      in_value.GetStaticValue()->GetChildMemberWithName(
-          g_instance_type_child_name, true));
+                  in_value.GetStaticValue()->GetChildAtIndex(index, true));
   if (!instance_type_sp)
     return false;
   lldb::addr_t metadata_location = instance_type_sp->GetValueAsUnsigned(0);
@@ -1792,10 +1791,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
                                               class_type_or_name, address);
 
   MetadataPromiseSP promise_sp;
-  static ConstString g_instance_type_child_name("instance_type");
   ValueObjectSP instance_type_sp(
-      in_value.GetStaticValue()->GetChildMemberWithName(
-          g_instance_type_child_name, true));
+                  in_value.GetStaticValue()->GetChildAtIndex(
+                                     protocol_info.m_num_payload_words, true));
   if (!instance_type_sp)
     return false;
   ValueObjectSP payload0_sp(


### PR DESCRIPTION
Provide better type information for the children of existential types, e.g.,
* If there is a superclass bound, use that type for the instance object
  within the existential
* When printing protocol witness table entries, include the protocol name
  with each entry
* When the child is an instance type, use Any.Type (rather than
  RawPointer) for the type.

We get output more like this now:

```
(a.PointSuperclass & PointUtils) $R4 = {
  (a.PointSuperclass) instance = 0x00007fc618f06780 {
    (Swift.Int) superData = {
      (Int64) _value = 17
    }
  }
  (Builtin.RawPointer) witness_table_PointUtils = 0x0000000106d92168
}
```