### PR TITLE
Create one SwiftASTContext per Module if the scratch context fails

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -124,9 +124,11 @@ public:
 
   /// Create a SwiftASTContext from a Module.  This context is used
   /// for frame variable ans uses ClangImporter options specific to
-  /// this lldb::Module.
+  /// this lldb::Module.  The optional target is to create a
+  /// module-specific scract context.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
-                                           Module &module);
+                                           Module &module,
+                                           Target *target = nullptr);
   /// Create a SwiftASTContext from a Target.  This context is global
   /// and used for the expression evaluator.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -1092,6 +1092,9 @@ public:
   GetPersistentExpressionStateForLanguage(lldb::LanguageType language);
 #endif
 
+  SwiftPersistentExpressionState *
+  GetSwiftPersistentExpressionState(ExecutionContextScope &exe_scope);
+
   const TypeSystemMap &GetTypeSystemMap();
 
   // Creates a UserExpression for the given language, the rest of the parameters
@@ -1148,22 +1151,23 @@ public:
 #ifdef __clang_analyzer__
   // See GetScratchTypeSystemForLanguage()
   SwiftASTContext *
-  GetScratchSwiftASTContext(Status &error, bool create_on_demand = true,
+  GetScratchSwiftASTContext(Status &error, ExecutionContextScope &exe_scope,
+                            bool create_on_demand = true,
                             const char *extra_options = nullptr)
       __attribute__((always_inline)) {
-    SwiftASTContext *ret =
-        GetScratchSwiftASTContextImpl(error, create_on_demand, extra_options);
+    SwiftASTContext *ret = GetScratchSwiftASTContextImpl(
+        error, exe_scope, create_on_demand, extra_options);
 
     return ret ? ret : nullptr;
   }
 
   SwiftASTContext *
-  GetScratchSwiftASTContextImpl(Status &error, bool create_on_demand = true,
-                                const char *extra_options = nullptr);
+  GetScratchSwiftASTContextImpl(Status &error, ExecutionContextScope &exe_scope,
+                                bool create_on_demand = true);
 #else
-  SwiftASTContext *
-  GetScratchSwiftASTContext(Status &error, bool create_on_demand = true,
-                            const char *extra_options = nullptr);
+  SwiftASTContext *GetScratchSwiftASTContext(Status &error,
+                                             ExecutionContextScope &exe_scope,
+                                             bool create_on_demand = true);
 #endif
 
   //----------------------------------------------------------------------
@@ -1338,6 +1342,15 @@ public:
 
   void SetREPL(lldb::LanguageType language, lldb::REPLSP repl_sp);
 
+  /// Enable the use of a separate sscratch type system per lldb::Module.
+  void SetUseScratchTypesystemPerModule(bool value) {
+    m_use_scratch_typesystem_per_module = value;
+  }
+  bool UseScratchTypesystemPerModule() const {
+    return m_use_scratch_typesystem_per_module;
+  }
+
+
 protected:
   //------------------------------------------------------------------
   /// Implementing of ModuleList::Notifier.
@@ -1408,6 +1421,11 @@ protected:
   bool m_valid;
   bool m_suppress_stop_hooks;
   bool m_is_dummy_target;
+
+  bool m_use_scratch_typesystem_per_module = false;
+  typedef std::pair<lldb_private::Module *, char> ModuleLanguage;
+  llvm::DenseMap<ModuleLanguage, lldb::TypeSystemSP>
+      m_scratch_typesystem_for_module;
 
   static void ImageSearchPathsChanged(const PathMappingList &path_list,
                                       void *baton);

--- a/lldb.xcodeproj/xcshareddata/xcschemes/desktop.xcscheme
+++ b/lldb.xcodeproj/xcshareddata/xcschemes/desktop.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "DebugClang"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/source/Commands/CommandObjectExpression.cpp
+++ b/source/Commands/CommandObjectExpression.cpp
@@ -405,7 +405,7 @@ bool CommandObjectExpression::EvaluateExpression(const char *expr,
     // We only tell you about the FixIt if we applied it.  The compiler errors
     // will suggest the FixIt if it parsed.
     if (error_stream && !m_fixed_expression.empty() &&
-        target->GetEnableNotifyAboutFixIts()) {
+        (m_fixed_expression != expr) && target->GetEnableNotifyAboutFixIts()) {
       if (success == eExpressionCompleted)
         error_stream->Printf(
             "  Fix-it applied, fixed expression was: \n    %s\n",

--- a/source/Expression/UserExpression.cpp
+++ b/source/Expression/UserExpression.cpp
@@ -391,8 +391,13 @@ UserExpression::Execute(DiagnosticManager &diagnostic_manager,
       diagnostic_manager, exe_ctx, options, shared_ptr_to_me, result_var);
   Target *target = exe_ctx.GetTargetPtr();
   if (options.GetResultIsInternal() && result_var && target) {
-    target->GetPersistentExpressionStateForLanguage(m_language)
-        ->RemovePersistentVariable(result_var);
+    if (m_language == lldb::eLanguageTypeSwift) {
+      if (auto *exe_scope = exe_ctx.GetBestExecutionContextScope())
+        target->GetSwiftPersistentExpressionState(*exe_scope)
+          ->RemovePersistentVariable(result_var);
+    } else
+      target->GetPersistentExpressionStateForLanguage(m_language)
+          ->RemovePersistentVariable(result_var);
   }
   return expr_result;
 }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -149,20 +149,30 @@ private:
   bool PerformAutoImport(swift::SourceFile &source_file, bool user_imports,
                          Status &error);
 
-  Expression &m_expr;   ///< The expression to be parsed
-  std::string m_triple; ///< The triple to use when compiling
-  std::unique_ptr<llvm::LLVMContext>
-      m_llvm_context; ///< The context to use for IR generation
-  std::unique_ptr<llvm::Module> m_module;      ///< The module to build IR into
-  lldb::IRExecutionUnitSP m_execution_unit_sp; ///< The container for the IR, to
-                                               ///be JIT-compiled or interpreted
-  SwiftASTContext
-      *m_swift_ast_context; ///< The AST context to build the expression into
-  SymbolContext m_sc;       ///< The symbol context to use when parsing
-  lldb::StackFrameWP m_stack_frame_wp; ///< The stack frame to use (if possible)
-                                       ///when determining dynamic types.
-  EvaluateExpressionOptions m_options; ///< If true, we are running in REPL mode
+  /// The expression to be parsed.
+  Expression &m_expr;
+  /// The triple to use when compiling.
+  std::string m_triple;
+  /// The context to use for IR generation.
+  std::unique_ptr<llvm::LLVMContext> m_llvm_context;
+  /// The module to build IR into.
+  std::unique_ptr<llvm::Module> m_module;
+  /// The container for the IR, to be JIT-compiled or interpreted.
+  lldb::IRExecutionUnitSP m_execution_unit_sp;
+  /// The AST context to build the expression into.
+  SwiftASTContext *m_swift_ast_context;
+  /// Used to manage the memory of a potential on-off context.
+  //lldb::TypeSystemSP m_typesystem_sp;
+  /// The symbol context to use when parsing.
+  SymbolContext m_sc;
+  // The execution context scope of the expression.
+  ExecutionContextScope *m_exe_scope;
+  /// The stack frame to use (if possible) when determining dynamic
+  /// types.
+  lldb::StackFrameWP m_stack_frame_wp;
+  /// If true, we are running in REPL mode
+  EvaluateExpressionOptions m_options;
 };
-}
+} // namespace lldb_private
 
 #endif // liblldb_SwiftExpressionParser_h_

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -272,8 +272,8 @@ Status SwiftREPL::DoInitialization() {
   Status error;
 
   if (!m_compiler_options.empty()) {
-    (void)m_target.GetScratchSwiftASTContext(error, true,
-                                             m_compiler_options.c_str());
+    (void)m_target.GetScratchTypeSystemForLanguage(
+        &error, eLanguageTypeSwift, true, m_compiler_options.c_str());
   }
 
   return error;
@@ -527,8 +527,8 @@ int SwiftREPL::CompleteCode(const std::string &current_code,
 #define USE_SEPARATE_AST_FOR_COMPLETION
 #if defined(USE_SEPARATE_AST_FOR_COMPLETION)
   if (!m_swift_ast_sp) {
-    SwiftASTContext *target_swift_ast =
-        m_target.GetScratchSwiftASTContext(error);
+    SwiftASTContext *target_swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
+        m_target.GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift));
     if (target_swift_ast)
       m_swift_ast_sp.reset(new SwiftASTContext(*target_swift_ast));
   }

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -26,7 +26,8 @@
 // Project includes
 
 namespace lldb_private {
-
+class SwiftExpressionParser;
+  
 //----------------------------------------------------------------------
 /// @class SwiftUserExpression SwiftUserExpression.h
 /// "lldb/Expression/SwiftUserExpression.h"
@@ -185,6 +186,7 @@ private:
   };
 
   PersistentVariableDelegate m_persistent_variable_delegate;
+  std::unique_ptr<SwiftExpressionParser> m_parser;
 };
 
 } // namespace lldb_private

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -420,8 +420,9 @@ bool lldb_private::formatters::swift::NSContiguousString_SummaryProvider(
 
   DataExtractor data(buffer_sp, process_sp->GetByteOrder(), ptr_size);
 
-  SwiftASTContext *lldb_swift_ast =
-      process_sp->GetTarget().GetScratchSwiftASTContext(error);
+  SwiftASTContext *lldb_swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
+      process_sp->GetTarget().GetScratchTypeSystemForLanguage(
+          &error, eLanguageTypeSwift));
   if (!lldb_swift_ast)
     return false;
   CompilerType string_guts_type = lldb_swift_ast->GetTypeFromMangledTypename(

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -341,8 +341,9 @@ SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
       native_storage_ptr =
           process_sp->ReadPointerFromMemory(native_storage_ptr, error);
       // (AnyObject,AnyObject)?
-      SwiftASTContext *swift_ast_ctx =
-          process_sp->GetTarget().GetScratchSwiftASTContext(error);
+      SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
+          process_sp->GetTarget().GetScratchTypeSystemForLanguage(
+              &error, eLanguageTypeSwift));
       if (swift_ast_ctx) {
         CompilerType element_type(swift_ast_ctx->GetTypeFromMangledTypename(
             SwiftLanguageRuntime::GetCurrentMangledName(

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1324,8 +1324,8 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             if (target) {
               const bool create_on_demand = false;
               Status error;
-              SwiftASTContext *ast_ctx(
-                  target->GetScratchSwiftASTContext(error, create_on_demand));
+              SwiftASTContext *ast_ctx(target->GetScratchSwiftASTContext(
+                  error, *exe_scope, create_on_demand));
               if (ast_ctx) {
                 const bool is_mangled = true;
                 Mangled mangled(ConstString(input), is_mangled);
@@ -1383,8 +1383,8 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             Target *target = exe_scope->CalculateTarget().get();
             const bool create_on_demand = false;
             Status error;
-            SwiftASTContext *ast_ctx(
-                target->GetScratchSwiftASTContext(error, create_on_demand));
+            SwiftASTContext *ast_ctx(target->GetScratchSwiftASTContext(
+                error, *exe_scope, create_on_demand));
             if (ast_ctx) {
               auto iter = ast_ctx->GetModuleCache().begin(),
                    end = ast_ctx->GetModuleCache().end();

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1275,7 +1275,8 @@ static bool DeserializeCompilerFlags(SwiftASTContext &swift_ast, Module &module,
 }
 
 lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
-                                                   Module &module) {
+                                                   Module &module,
+                                                   Target *target) {
   if (!SwiftASTContextSupportsLanguage(language))
     return lldb::TypeSystemSP();
 
@@ -1302,7 +1303,9 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     }
   }
 
-  std::shared_ptr<SwiftASTContext> swift_ast_sp(new SwiftASTContext());
+  std::shared_ptr<SwiftASTContext> swift_ast_sp(
+      target ? (new SwiftASTContextForExpressions(*target))
+             : new SwiftASTContext());
 
   swift_ast_sp->GetLanguageOptions().DebuggerSupport = true;
   swift_ast_sp->GetLanguageOptions().EnableAccessControl = false;
@@ -1748,7 +1751,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                 llvm::dyn_cast_or_null<SwiftASTContext>(
                     sym_file->GetTypeSystemForLanguage(
                         lldb::eLanguageTypeSwift));
-            if (ast_context) {
+            if (ast_context && !ast_context->HasErrors()) {
               if (use_all_compiler_flags ||
                   target.GetExecutableModulePointer() == module_sp.get()) {
                 for (size_t msi = 0,

--- a/source/Target/ABI.cpp
+++ b/source/Target/ABI.cpp
@@ -102,10 +102,15 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
   // work.
 
   if (persistent) {
-    PersistentExpressionState *persistent_expression_state =
-        thread.CalculateTarget()->GetPersistentExpressionStateForLanguage(
-            ast_type.GetMinimumLanguage());
-
+    lldb::LanguageType lang = ast_type.GetMinimumLanguage();
+    PersistentExpressionState *persistent_expression_state;
+    auto target = thread.CalculateTarget();
+    if (lang == lldb::eLanguageTypeSwift)
+        target->GetSwiftPersistentExpressionState(thread);
+    else
+       persistent_expression_state =
+         target->GetPersistentExpressionStateForLanguage(lang);
+    
     if (!persistent_expression_state)
       return ValueObjectSP();
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1182,7 +1182,9 @@ SwiftLanguageRuntime::GetMemoryReader() {
 
 SwiftASTContext *SwiftLanguageRuntime::GetScratchSwiftASTContext() {
   Status error;
-  return m_process->GetTarget().GetScratchSwiftASTContext(error);
+  return llvm::dyn_cast_or_null<SwiftASTContext>(
+      m_process->GetTarget().GetScratchTypeSystemForLanguage(
+          &error, eLanguageTypeSwift));
 }
 
 SwiftLanguageRuntime::MetadataPromise::MetadataPromise(
@@ -2977,7 +2979,9 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
     if (mangled_name.GuessLanguage() == lldb::eLanguageTypeSwift) {
       Status error;
       Target &target = frame.GetThread()->GetProcess()->GetTarget();
-      SwiftASTContext *swift_ast = target.GetScratchSwiftASTContext(error);
+      ExecutionContext exe_ctx(frame);
+      SwiftASTContext *swift_ast =
+          target.GetScratchSwiftASTContext(error, frame);
       if (swift_ast) {
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName().AsCString(), error);
@@ -3095,8 +3099,9 @@ SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
 {
   ValueObjectSP error_valobj_sp;
   Status error;
-  SwiftASTContext *ast_context =
-      m_process->GetTarget().GetScratchSwiftASTContext(error);
+  SwiftASTContext *ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(
+      m_process->GetTarget().GetScratchTypeSystemForLanguage(
+          &error, eLanguageTypeSwift));
   if (!ast_context || error.Fail())
     return error_valobj_sp;
 
@@ -3115,9 +3120,13 @@ SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
   }
 
   if (persistent && error_valobj_sp) {
-    PersistentExpressionState *persistent_state =
-        m_process->GetTarget().GetPersistentExpressionStateForLanguage(
-            eLanguageTypeSwift);
+    ExecutionContext ctx =
+      error_valobj_sp->GetExecutionContextRef().Lock(false);
+    auto *exe_scope = ctx.GetBestExecutionContextScope();
+    if (!exe_scope)
+      return error_valobj_sp;
+    auto *persistent_state =
+        m_process->GetTarget().GetSwiftPersistentExpressionState(*exe_scope);
 
     ConstString persistent_variable_name(
         persistent_state->GetNextPersistentVariableName(true));
@@ -3172,7 +3181,8 @@ ValueObjectSP SwiftLanguageRuntime::CalculateErrorValueFromFirstArgument(
     frame_sp->CalculateExecutionContext(exe_ctx);
     DataExtractor data;
 
-    SwiftASTContext *ast_context = target->GetScratchSwiftASTContext(error);
+    SwiftASTContext *ast_context = target->GetScratchSwiftASTContext(
+        error, *frame_sp);
     if (!ast_context || error.Fail())
       return error_valobj_sp;
 
@@ -3202,8 +3212,9 @@ ValueObjectSP SwiftLanguageRuntime::CalculateErrorValueFromFirstArgument(
 void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
                                                lldb::addr_t addr) {
   Status ast_context_error;
-  SwiftASTContext *ast_context =
-      target.GetScratchSwiftASTContext(ast_context_error);
+  SwiftASTContext *ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(
+      target.GetScratchTypeSystemForLanguage(&ast_context_error,
+                                             eLanguageTypeSwift));
 
   if (ast_context_error.Success() && ast_context &&
       !ast_context->HasFatalErrors()) {


### PR DESCRIPTION
because of irreconcilable module import errors.

When a Swift program contains several dylibs with conflicting
ClangImporter options building the common scratch SwiftASTContext
fails and the expression evaluator is unusable. This patch detects the
situation where an expression fails because of a module import error
and then switches into a mode where one scratch context per
lldb::Module is created, using only the ClangImporter flags for the
module which ideally should have been tested by the Swift compiler
that built that module. This also bifurcates the persistent expression
state, such that each lldb::Module has its own set of return
variables, but it is still a strict improvement over not having access
to the expression evaluator at all.

rdar://problem/38686915