### PR TITLE
[SwiftLanguageRuntime] Fix printing of __NSCFString.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/nsarray_code_running_formatter/main.swift
@@ -24,7 +24,7 @@ func main() {
 
   print("second stop") //% self.expect('frame variable -d run -- t', substrs=['t = 0x', 'NSArray = {', 'NSObject = {'])
                        //% self.expect('frame variable -d run -- ta', substrs=['ta = {', '_buffer = {', '_storage =', 'rawValue = 0x'])
-                       //% self.expect('frame variable -d run -- tb', substrs=['tb = 1 value {', '[0] = "abc"'])
+                       //% self.expect('frame variable -d run -- tb', substrs=['tb = 1 value {', '"abc"'])
                        //% self.expect('po t', substrs=['0 : abc'])
                        //% self.expect('po ta', substrs=['0 : abc'])
                        //% self.expect('po tb', substrs=['0 : abc'])

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1844,6 +1844,10 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
     if (!type.IsValid())
       return false;
 
+    lldb::addr_t class_metadata_ptr = payload0_sp->GetAddressOf();
+    if (class_metadata_ptr && class_metadata_ptr != LLDB_INVALID_ADDRESS)
+      address.SetRawAddress(class_metadata_ptr);
+
     class_type_or_name.SetCompilerType(type.GetPointerType());
     return class_type_or_name.GetCompilerType().IsValid();
   }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1844,11 +1844,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
     if (!type.IsValid())
       return false;
 
-    lldb::addr_t class_metadata_ptr = payload0_sp->GetAddressOf();
-    if (class_metadata_ptr == LLDB_INVALID_ADDRESS || class_metadata_ptr == 0)
-      return false;
-    address.SetRawAddress(class_metadata_ptr);
-
     class_type_or_name.SetCompilerType(type.GetPointerType());
     return class_type_or_name.GetCompilerType().IsValid();
   }


### PR DESCRIPTION
The internal store went from being a Swift wrapped string:
Swift._NSContiguousString to just a straight up __NSCFString.

This was broken after the recent String changes, but we
didn't catch this because this test wasn't run as part
of the PR workflow. Eventually we won't need to care about
these details in lldb as everything will be hidden inside
RemoteAST, but for now, we need to fix this case.

<rdar://problem/39006341>