### PR TITLE
[lldbinline] Reenable inline tests as part of PR testing.

### DIFF
--- a/packages/Python/lldbsuite/test/lldbinline.py
+++ b/packages/Python/lldbsuite/test/lldbinline.py
@@ -230,14 +230,6 @@ def isEnabled(debug_flavor, target_platform, configuration, decorators):
     # If the debug flavor is skipped, skip the test.
     if debug_flavor in configuration.skipCategories:
         return False
-
-    # If there are any decorators, and we're in swift PR testing mode, skip the
-    # test. We do this because we cannot run x-failed or skipped tests during
-    # PR testing, and we have no other way to prevent this from happening.
-    if configuration.useCategories and 'swiftpr' in configuration.categoriesList:
-        if decorators:
-            return False
-
     return True
 
 def MakeInlineTest(__file, __globals, decorators=None):


### PR DESCRIPTION
We should have more coverage now. We still have one XFAIL,
so this isn't really perfect, but it's much much better than
not running any of these tests at all (hint: they recently
broke).