### PR TITLE
Revert over-zealous removal of calls to GetReferentType

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1333,14 +1333,13 @@ bool SwiftASTManipulator::AddExternalVariables(
       // The access pattern for these types is the same as for the referent
       // type, so it is fine to
       // just strip it off.
-      // FIXME: If this is a weak managed type, then it could ostensibly go away
-      // out from under us,
-      // but for now we aren't playing with reference counts to keep things
-      // alive in the expression parser.
       SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
           variable.m_type.GetTypeSystem());
 
-      CompilerType referent_type = variable.m_type;
+      CompilerType referent_type;
+
+      if (swift_ast_ctx)
+        referent_type = swift_ast_ctx->GetReferentType(variable.m_type);
 
       // One tricky bit here is that this var may be an argument to the function
       // whose context we are

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -674,6 +674,12 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     if (!imported_self_type.IsValid())
       break;
 
+    // This might be a referenced type, in which case we really want to extend
+    // the referent:
+    imported_self_type =
+        llvm::cast<SwiftASTContext>(imported_self_type.GetTypeSystem())
+            ->GetReferentType(imported_self_type);
+
     // If we are extending a generic class it's going to be a metatype, and we
     // have to grab the instance type:
     imported_self_type =

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5041,6 +5041,10 @@ SwiftASTContext::GetReferentType(const CompilerType &compiler_type) {
   if (compiler_type.IsValid() &&
       llvm::dyn_cast_or_null<SwiftASTContext>(compiler_type.GetTypeSystem())) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(compiler_type));
+    swift::TypeBase *swift_type = swift_can_type.getPointer();
+    if (swift_type && llvm::isa<swift::WeakStorageType>(swift_type))
+      return compiler_type;
+
     auto ref_type = swift_can_type->getReferenceStorageReferent();
     return CompilerType(GetASTContext(), ref_type);
   }


### PR DESCRIPTION
and instead only stop unwrapping weak pointer types.

This fixes an existing bot issue.