### PR TITLE
Remove assertions on invalid input

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -107,22 +107,6 @@
 #include "Plugins/Platform/MacOSX/PlatformDarwin.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 
-#ifdef LLDB_CONFIGURATION_DEBUG
-#define VALID_OR_RETURN(value)                                                 \
-  do {                                                                         \
-    lldbassert(!HasFatalErrors());                                             \
-    if (HasFatalErrors()) {                                                    \
-      return (value);                                                          \
-    }                                                                          \
-  } while (0)
-#define VALID_OR_RETURN_VOID()                                                 \
-  do {                                                                         \
-    lldbassert(!HasFatalErrors());                                             \
-    if (HasFatalErrors()) {                                                    \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
-#else
 #define VALID_OR_RETURN(value)                                                 \
   do {                                                                         \
     if (HasFatalErrors()) {                                                    \
@@ -135,7 +119,6 @@
       return;                                                                  \
     }                                                                          \
   } while (0)
-#endif
 
 using namespace lldb;
 using namespace lldb_private;


### PR DESCRIPTION
As I'm working on testcases that exercise LLDB's behavior with less than optimal input, I noticed that the following use of lldbassert() seems to be wrong. An assertion should only be used when an internal invariant is violated, but these assertions trigger when the SwiftASTContext has developed fatal errors, which can easily happen in the presence of incomplete debug information.