### PR TITLE
[SwiftRuntime] Add a test for `language swift refcount`.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
@@ -1,0 +1,14 @@
+# TestSwiftReferenceCount.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/main.swift
@@ -1,0 +1,30 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+class Patatino {
+  var meh : Int
+
+  init(_ meh : Int) {
+    self.meh = meh
+  }
+}
+
+func lambda(_ Arg : Patatino) -> Int {
+  return Arg.meh
+}
+
+func main() -> Int {
+  var LiveObj = Patatino(37)
+  var Ret : Int = lambda(LiveObj) // %self.expect('language swift refcount LiveObj', substrs=['strong = 0', 'weak = 0'])
+  return Ret
+}
+
+main()


### PR DESCRIPTION
This was previously untested. As I'm going to make significant
changes here, I figured this should've been exercised somehow.
It's currently broken (prints a strong refcount of zero for
a live object), but hopefully my next commit will fix this.

<rdar://problem/30538363>