### PR TITLE
Support template template parameters

### DIFF
--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -318,6 +318,9 @@ public:
                           lldb::AccessType access_type, const char *class_name,
                           int kind, const TemplateParameterInfos &infos);
 
+  clang::TemplateTemplateParmDecl *
+  CreateTemplateTemplateParmDecl(const char *template_name);
+
   clang::ClassTemplateSpecializationDecl *CreateClassTemplateSpecializationDecl(
       clang::DeclContext *decl_ctx,
       clang::ClassTemplateDecl *class_template_decl, int kind,

--- a/packages/Python/lldbsuite/test/lang/cpp/template/TestTemplateArgs.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/template/TestTemplateArgs.py
@@ -83,6 +83,34 @@ class TemplateArgsTestCase(TestBase):
             expr_result.GetType().GetName() == "int",
             'expr_result.GetType().GetName() == "int"')
 
+    def test_template_template_args(self):
+        frame = self.prepareProcess()
+
+        c1 = frame.FindVariable('c1')
+        self.assertTrue(
+            c1.IsValid(),
+            'make sure we find a local variabble named "c1"')
+        self.assertTrue(c1.GetType().GetName() == 'C<float, T1>')
+        f1 = c1.GetChildMemberWithName("V").GetChildAtIndex(0).GetChildMemberWithName("f")
+        self.assertTrue(f1.GetType().GetName() == 'float')
+        self.assertTrue(f1.GetValue() == '1.5')
+
+        c2 = frame.FindVariable('c2')
+        self.assertTrue(
+            c2.IsValid(),
+            'make sure we find a local variabble named "c2"')
+        self.assertTrue(c2.GetType().GetName() == 'C<double, T1, T2>')
+        f2 = c2.GetChildMemberWithName("V").GetChildAtIndex(0).GetChildMemberWithName("f")
+        self.assertTrue(f2.GetType().GetName() == 'double')
+        self.assertTrue(f2.GetValue() == '1.5')
+        f3 = c2.GetChildMemberWithName("V").GetChildAtIndex(1).GetChildMemberWithName("f")
+        self.assertTrue(f3.GetType().GetName() == 'double')
+        self.assertTrue(f3.GetValue() == '2.5')
+        f4 = c2.GetChildMemberWithName("V").GetChildAtIndex(1).GetChildMemberWithName("i")
+        self.assertTrue(f4.GetType().GetName() == 'int')
+        self.assertTrue(f4.GetValue() == '42')
+
+
     # Gcc does not generate the necessary DWARF attribute for enum template
     # parameters.
     @expectedFailureAll(bugnumber="llvm.org/pr28354", compiler="gcc")

--- a/packages/Python/lldbsuite/test/lang/cpp/template/main.cpp
+++ b/packages/Python/lldbsuite/test/lang/cpp/template/main.cpp
@@ -6,6 +6,7 @@
 // License. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
+#include <tuple>
 
 template <int Arg>
 class TestObj
@@ -62,11 +63,17 @@ public:
     }    
 };
 
+template <typename FLOAT> struct T1 { FLOAT f = 1.5; };
+template <typename FLOAT> struct T2 { FLOAT f = 2.5; int i = 42; };
+template <typename FLOAT, template <typename> class ...Args> class C { std::tuple<Args<FLOAT>...> V; };
+
 int main(int argc, char **argv)
 {
   TestObj<1> testpos;
   TestObj<-1> testneg;
   EnumTemplate<EnumType::Member> member(123);
   EnumTemplate<EnumType::Subclass> subclass(123*2);
+  C<float, T1> c1;
+  C<double, T1, T2> c2;
   return testpos.getArg() - testneg.getArg() + member.getMember()*2 - subclass.getMember(); // Breakpoint 1
 }

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -43,6 +43,7 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/AST/DeclTemplate.h"
 
 #include <map>
 #include <vector>
@@ -2024,6 +2025,7 @@ bool DWARFASTParserClang::ParseTemplateDIE(
     const DWARFDIE &die,
     ClangASTContext::TemplateParameterInfos &template_param_infos) {
   const dw_tag_t tag = die.Tag();
+  bool is_template_template_argument = false;
 
   switch (tag) {
   case DW_TAG_GNU_template_parameter_pack: {
@@ -2039,11 +2041,15 @@ bool DWARFASTParserClang::ParseTemplateDIE(
     }
     return true;
   }
+  case DW_TAG_GNU_template_template_param:
+    is_template_template_argument = true;
+    LLVM_FALLTHROUGH;
   case DW_TAG_template_type_parameter:
   case DW_TAG_template_value_parameter: {
     DWARFAttributes attributes;
     const size_t num_attributes = die.GetAttributes(attributes);
     const char *name = nullptr;
+    const char *template_name = nullptr;
     CompilerType clang_type;
     uint64_t uval64 = 0;
     bool uval64_valid = false;
@@ -2056,6 +2062,11 @@ bool DWARFASTParserClang::ParseTemplateDIE(
         case DW_AT_name:
           if (attributes.ExtractFormValueAtIndex(i, form_value))
             name = form_value.AsCString();
+          break;
+
+        case DW_AT_GNU_template_name:
+          if (attributes.ExtractFormValueAtIndex(i, form_value))
+            template_name = form_value.AsCString();
           break;
 
         case DW_AT_type:
@@ -2081,7 +2092,7 @@ bool DWARFASTParserClang::ParseTemplateDIE(
       if (!clang_type)
         clang_type = m_ast.GetBasicType(eBasicTypeVoid);
 
-      if (clang_type) {
+      if (!is_template_template_argument) {
         bool is_signed = false;
         if (name && name[0])
           template_param_infos.names.push_back(name);
@@ -2101,7 +2112,10 @@ bool DWARFASTParserClang::ParseTemplateDIE(
               clang::TemplateArgument(ClangUtil::GetQualType(clang_type)));
         }
       } else {
-        return false;
+        auto *tplt_type = m_ast.CreateTemplateTemplateParmDecl(template_name);
+        template_param_infos.names.push_back(name);
+        template_param_infos.args.push_back(
+            clang::TemplateArgument(clang::TemplateName(tplt_type)));
       }
     }
   }
@@ -2129,6 +2143,7 @@ bool DWARFASTParserClang::ParseTemplateParameterInfos(
     case DW_TAG_template_type_parameter:
     case DW_TAG_template_value_parameter:
     case DW_TAG_GNU_template_parameter_pack:
+    case DW_TAG_GNU_template_template_param:
       ParseTemplateDIE(die, template_param_infos);
       break;
 

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -1518,6 +1518,29 @@ ClassTemplateDecl *ClangASTContext::CreateClassTemplateDecl(
   return class_template_decl;
 }
 
+TemplateTemplateParmDecl *
+ClangASTContext::CreateTemplateTemplateParmDecl(const char *template_name) {
+  ASTContext *ast = getASTContext();
+
+  auto *decl_ctx = ast->getTranslationUnitDecl();
+
+  IdentifierInfo &identifier_info = ast->Idents.get(template_name);
+  llvm::SmallVector<NamedDecl *, 8> template_param_decls;
+
+  ClangASTContext::TemplateParameterInfos template_param_infos;
+  TemplateParameterList *template_param_list = CreateTemplateParameterList(
+      ast, template_param_infos, template_param_decls);
+
+  // LLDB needs to create those decls only to be able to display a
+  // type that includes a template template argument. Only the name
+  // matters for this purpose, so we use dummy values for the other
+  // characterisitcs of the type.
+  return TemplateTemplateParmDecl::Create(
+      *ast, decl_ctx, SourceLocation(),
+      /*Depth*/ 0, /*Position*/ 0,
+      /*IsParameterPack*/ false, &identifier_info, template_param_list);
+}
+
 ClassTemplateSpecializationDecl *
 ClangASTContext::CreateClassTemplateSpecializationDecl(
     DeclContext *decl_ctx, ClassTemplateDecl *class_template_decl, int kind,


### PR DESCRIPTION
Summary:
We would fail to resolve (and thus display the value of) any
templated type which contained a template template argument even
though we don't really use template arguments.

This patch adds minimal support for template template arguments,
but I doubt we need any more than that.

rdar://38464962

Reviewers: clayborg, jingham

Subscribers: JDevlieghere, lldb-commits

Differential Revision: https://reviews.llvm.org/D44613

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@328984 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 4f44b1c6ee7a630e852ec78c6af5d34dae687ff8)