### PR TITLE
Improve support for debugging Swift code built on a different machine.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -865,6 +865,10 @@ protected:
   SwiftEnumDescriptor *GetCachedEnumInfo(void *type);
 
   friend class CompilerType;
+
+  /// Apply a PathMappingList dictionary on all search paths in the
+  /// ClangImporterOptions.
+  void RemapClangImporterOptions(const PathMappingList &path_map);
 };
 
 class SwiftASTContextForExpressions : public SwiftASTContext {

--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -9387,6 +9387,7 @@
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
 					"-DLLDB_USE_BUILTIN_DEMANGLER",
+					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
 				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = (
@@ -13629,6 +13630,7 @@
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
 					"-DLLDB_USE_BUILTIN_DEMANGLER",
+					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
 				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = (
@@ -14230,6 +14232,7 @@
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
 					"-DLLDB_USE_BUILTIN_DEMANGLER",
+					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
 				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = (

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo.swift
@@ -1,0 +1,13 @@
+import CFoo
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Foo : NSObject {
+  @objc public func f() {
+    let foo = CFoo(x: 23)
+    let bar = FromBridgingHeader(y: 42)
+    use(foo) // break here
+    use(bar)
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo/CFoo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo/CFoo.h
@@ -1,0 +1,1 @@
+struct CFoo { int x; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo/bridge.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo/bridge.h
@@ -1,0 +1,1 @@
+struct FromBridgingHeader { int y; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module CFoo {
+  header "CFoo.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -1,0 +1,40 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+include $(LEVEL)/Makefile.rules
+
+BUILDDIR := $(realpath $(shell pwd))
+BOTDIR := $(BUILDDIR)/buildbot
+USERDIR := $(BUILDDIR)/user
+
+a.out: main.m libFoo.dylib
+	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -L$(shell pwd) -o $@ $<
+	mv $(BOTDIR) $(USERDIR)
+
+libFoo.dylib: Foo.swift
+	mkdir -p $(BOTDIR)
+	cp -r $(SRCDIR)/Foo $(BOTDIR)/
+	$(SWIFTC) -g -Onone $^ -emit-library \
+            -module-name $(shell basename $< .swift) -emit-module \
+            -Xlinker -install_name -Xlinker @executable_path/$@ \
+            -Xcc -I$(BOTDIR)/Foo $(SWIFTFLAGS) -emit-objc-header-path Foo.h \
+            -sdk "$(SWIFTSDKROOT)" -import-objc-header $(BOTDIR)/Foo/bridge.h
+	UUID=$$(dwarfdump --uuid "$@.dSYM" | awk '{ print $$2 }') ; \
+	echo "UUID = $$UUID" ; \
+	PLIST="$@.dSYM/Contents/Resources/$$UUID.plist" ; \
+	echo "Generating $$PLIST ..."; \
+	echo '<?xml version="1.0" encoding="UTF-8"?>'>$$PLIST; \
+	echo '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'>>$$PLIST; \
+	echo '<plist version="1.0">'>>$$PLIST; \
+	echo '<dict>'>>$$PLIST; \
+	echo '  <key>DBGSourcePathRemapping</key>'>>$$PLIST; \
+	echo '  <dict>'>>$$PLIST; \
+	echo "    <key>$(BOTDIR)</key>">>$$PLIST; \
+	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
+	echo '  </dict>'>>$$PLIST; \
+	echo '</dict>'>>$$PLIST; \
+	echo '</plist>'>>$$PLIST
+
+clean::
+	rm -rf $(USERDIR) rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -1,0 +1,101 @@
+# TestSwiftRewriteClangPaths.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftRewriteClangPaths(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def testWithRemap(self):
+        self.dotest(True)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def testWithoutRemap(self):
+        self.dotest(False)
+
+    def find_plist(self):
+        import glob
+        plist = self.getBuildArtifact("libFoo.dylib.dSYM/Contents/Resources/*.plist")
+        lst = glob.glob(plist)
+        self.assertTrue(len(lst) == 1)
+        return lst[0]
+        
+    def dotest(self, remap):
+        self.build()
+        # To ensure the module is rebuilt remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+
+        botdir = os.path.realpath(self.getBuildArtifact("buildbot"))
+        userdir = os.path.realpath(self.getBuildArtifact("user"))
+        self.assertFalse(os.path.isdir(botdir))
+        self.assertTrue(os.path.isdir(userdir))
+        plist = self.find_plist()
+        self.assertTrue(os.path.isfile(plist))
+        if remap:
+            self.runCmd("settings set target.source-map %s %s" %
+                        (botdir, userdir))
+        else:
+            # Also delete the remapping plist from the .dSYM to verify
+            # that this doesn't work by happy accident without it.
+            os.remove(plist)
+            
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Foo.swift'))
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        if remap:
+            comment = "returns correct value"
+            self.expect("p foo", comment, substrs=["x", "23"])
+            self.expect("p bar", comment, substrs=["y", "42"])
+            self.expect("fr var foo", comment, substrs=["x", "23"])
+            self.expect("fr var bar", comment, substrs=["y", "42"])
+            self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+        else:
+            threads = lldbutil.get_threads_stopped_at_breakpoint(
+                process, foo_breakpoint)
+            frame = threads[0].GetFrameAtIndex(0)
+            value = frame.EvaluateExpression("foo")
+            self.assertFalse(value.GetError().Success())
+        
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/main.m
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/main.m
@@ -1,0 +1,7 @@
+@import Foundation;
+#include "Foo.h"
+
+int main(int argc, char **argv) {
+  [[[Foo alloc] init] f];
+  return 0;
+}


### PR DESCRIPTION
The patch does two things:

- If present, applies the target.source-map setting to the
  ClangImporter options of the scratch AST context.

- If present, applies the DBGSourcePathRemapping dictionary from the
  .dSYM bundle to the per-lldb::Module SwiftASTContext.

This allows the ClangImporter to find Clang module maps in a new
location on the machine that LLDB is running on.

This also fixes an oversight in the xcode project file uncovered by
this change: it now sets the libxml2 -D definition for the custom
swift targets, too.

rdar://problem/36032144
(cherry picked from commit 677798b0781387b5f6be39a7d80245b4cce9cacb)