### PR TITLE
[lldb-server] Set a more generous timeout when testing gdbremote.

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -33,7 +33,7 @@ class GdbRemoteTestCaseBase(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
-    _TIMEOUT_SECONDS = 7
+    _TIMEOUT_SECONDS = 120
 
     _GDBREMOTE_KILL_PACKET = "$k#6b"
 


### PR DESCRIPTION
One of our downstream bot is struggling under load,  but this
value should be enough for everyone.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@329426 91177308-0d34-0410-b5e6-96231b3b80d8