### PR TITLE
Split off the float and double returns into a separate test.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
+++ b/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
@@ -31,11 +31,26 @@ class TestSwiftReturns(TestBase):
         oslist=["ios"],
         archs=["arm64"],
         bugnumber="rdar://27002915")
-    @decorators.skipIfOutOfTreeDebugserver
+    @decorators.expectedFailureAll(
+        bugnumber="rdar://problem/39246943")
     def test_swift_returns(self):
         """Test getting return values"""
         self.build()
         self.do_test()
+
+    @decorators.swiftTest
+    @decorators.skipIfLinux  # bugs.swift.org/SR-841
+    @decorators.expectedFailureAll(
+        oslist=["ios"],
+        archs=["arm64"],
+        bugnumber="rdar://27002915")
+    @decorators.expectedFailureAll(
+        bugnumber="rdar://problem/39246943")
+    @decorators.skipIfOutOfTreeDebugserver
+    def test_swift_float_returns(self):
+        """Test getting float return values"""
+        self.build()
+        self.do_float_tests()
 
     def setUp(self):
         TestBase.setUp(self)
@@ -104,32 +119,7 @@ class TestSwiftReturns(TestBase):
             self.assertTrue(variable)
             self.assertTrue(variable.value is None)
 
-    def do_test(self):
-        """Tests that we can break and display simple types"""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'Set breakpoint here', self.main_source_spec)
-        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        self.process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(self.process, PROCESS_IS_VALID)
-
-        # Frame #0 should be at our breakpoint.
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            self.process, breakpoint)
-
-        self.assertTrue(len(threads) == 1)
-        self.thread = threads[0]
-
+    def do_variables_test(self, breakpoint, variables, invisibles):
         line_before_fin = self.thread.frame[1].line_entry.line
         self.step_out_until_no_breakpoint(breakpoint, False)
 
@@ -142,9 +132,7 @@ class TestSwiftReturns(TestBase):
         # Get a "Swift.Double" return class value
         # Test that the local variable equals return value.
         # Test that none of the later let-bound values are available.
-        variables = ["u", "i", "c", "ss", "cs", "s", "dict", "opt_str", "f", "d"]
-        # FIXME: Enable opt_str below:
-        invisibles = ["i", "c", "s", "dict", "f", "f", "d"]
+
         for var in variables:
             return_value = self.thread.GetStopReturnValue()
             if line_before_fin == self.thread.frame[0].line_entry.line:
@@ -155,6 +143,38 @@ class TestSwiftReturns(TestBase):
                 invisibles.pop(0)
             line_before_fin = self.thread.frame[0].line_entry.line
             self.step_out_until_no_breakpoint(breakpoint, True)
+        
+    def do_float_tests(self):
+        """Tests that we can break and display simple types"""
+        (target, self.process, self.thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 'Set float breakpoint here', self.main_source_spec)
+
+        # Get a "Swift.Float" return class value
+        # Get a "Swift.Double" return class value
+        # Test that the local variable equals return value.
+        # Test that none of the later let-bound values are available.
+        variables = ["f", "d"]
+        # FIXME: Enable opt_str below:
+        invisibles = ["f", "f", "d"]
+        self.do_variables_test(breakpoint, variables, invisibles)
+        
+    def do_test(self):
+        """Tests that we can break and display simple types"""
+        (target, self.process, self.thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 'Set breakpoint here', self.main_source_spec)
+
+        line_before_fin = self.thread.frame[1].line_entry.line
+        self.step_out_until_no_breakpoint(breakpoint, False)
+
+        # Get a "Swift.Int64" return struct value
+        # Get a "main.Foo" return class value
+        # Get a "Swift.String" return class value
+        # Get a "Swift.Dictionary<Swift.Int, Swift.String>" return class value
+        # Get a "Swift.String?" return class value
+        # Test that the local variable equals return value.
+        # Test that none of the later let-bound values are available.
+        variables = ["u", "i", "c", "ss", "cs", "s", "dict", "opt_str", "f", "d"]
+        # FIXME: Enable opt_str below:
+        invisibles = ["i", "c", "s", "dict", "f", "f", "d"]
+        self.do_variables_test(breakpoint, variables, invisibles)
 
         # Call a function that could throw but doesn't and see that it actually
         # gets the result:

--- a/packages/Python/lldbsuite/test/lang/swift/return/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/return/main.swift
@@ -72,10 +72,10 @@ func returnInt() -> Int64 {
     return -123 // Set breakpoint here
 }
 func returnFloat() -> Float {
-    return Float(1.25) // Set breakpoint here
+    return Float(1.25) // Set float breakpoint here
 }
 func returnDouble() -> Double {
-    return 2.125 // Set breakpoint here
+    return 2.125 // Set float breakpoint here
 }
 func returnClass () -> Foo {
     return Foo() // Set breakpoint here


### PR DESCRIPTION
This test was getting skipped for not-in-tree debugserver.  That was an
issue with floating point handling.  So I split off the floating point tests
so the rest of the tests could run with the out-of-tree debugserver.