### PR TITLE
[SwiftLanguageRuntime] Fix language refcount.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -343,9 +343,6 @@ public:
 
   ConstString GetStandardLibraryBaseName();
 
-  virtual bool GetReferenceCounts(ValueObject &valobj, size_t &strong,
-                                  size_t &weak);
-
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 

--- a/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_reference_counting/main.swift
@@ -17,13 +17,16 @@ class Patatino {
   }
 }
 
+struct Tinky {}
+
 func lambda(_ Arg : Patatino) -> Int {
   return Arg.meh
 }
 
 func main() -> Int {
-  var LiveObj = Patatino(37)
-  var Ret : Int = lambda(LiveObj) // %self.expect('language swift refcount LiveObj', substrs=['strong = 0', 'weak = 0'])
+  var LiveObj = Patatino(37) //%self.expect('language swift refcount Blah', substrs=['unresolved identifier \'Blah\''], error=True)
+  var Ret : Int = lambda(LiveObj) //%self.expect('language swift refcount LiveObj', substrs=['(strong = 3, unowned = 1, weak = 1)'])
+  var MyStruct = Tinky() //%self.expect('language swift refcount MyStruct', substrs=['refcount only available for class types'], error=True)
   return Ret
 }
 


### PR DESCRIPTION
This commit has a bunch of improvements:
1) It moves the logic from wrong ad-hoc calculations in lldb to
an API call to the swift stdlib to retrieve the refcount of
objects.
2) It refactors the path to exit early for improved readability,
while also adding some comments.
3) It prints the `unowned` refcount for objects, previously
absent.

<rdar://problem/30538363>
<rdar://problem/30538399>