### PR TITLE
Use in-tree dsymutil

### DIFF
--- a/packages/Python/lldbsuite/test/dotest.py
+++ b/packages/Python/lldbsuite/test/dotest.py
@@ -303,7 +303,7 @@ def parseOptionsAndInitTestdirs():
 
     if args.dsymutil:
       os.environ['DSYMUTIL'] = args.dsymutil
-    else if platform_system == 'Darwin':
+    elif platform_system == 'Darwin':
       os.environ['DSYMUTIL'] = seven.get_command_output(
           'xcrun -find -toolchain default dsymutil')
 

--- a/packages/Python/lldbsuite/test/dotest.py
+++ b/packages/Python/lldbsuite/test/dotest.py
@@ -301,6 +301,12 @@ def parseOptionsAndInitTestdirs():
                     configuration.compiler = candidate
                     break
 
+    if args.dsymutil:
+      os.environ['DSYMUTIL'] = args.dsymutil
+    else if platform_system == 'Darwin':
+      os.environ['DSYMUTIL'] = seven.get_command_output(
+          'xcrun -find -toolchain default dsymutil')
+
     if args.channels:
         lldbtest_config.channels = args.channels
 

--- a/packages/Python/lldbsuite/test/dotest_args.py
+++ b/packages/Python/lldbsuite/test/dotest_args.py
@@ -91,7 +91,7 @@ def create_parser():
         help=textwrap.dedent('''Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged
                                                            suggestions: do not lump the "-A arch1 -A arch2" together such that the -E option applies to only one of the architectures'''))
 
-    group.add_argument('--dsymutil', metavar='dsymutil', dest='dsymutil', help=textwrap.dedent('Specify Which dsymutil to use.'))
+    group.add_argument('--dsymutil', metavar='dsymutil', dest='dsymutil', help=textwrap.dedent('Specify which dsymutil to use.'))
 
     # Test filtering options
     group = parser.add_argument_group('Test filtering options')

--- a/packages/Python/lldbsuite/test/dotest_args.py
+++ b/packages/Python/lldbsuite/test/dotest_args.py
@@ -91,6 +91,8 @@ def create_parser():
         help=textwrap.dedent('''Specify the extra flags to be passed to the toolchain when building the inferior programs to be debugged
                                                            suggestions: do not lump the "-A arch1 -A arch2" together such that the -E option applies to only one of the architectures'''))
 
+    group.add_argument('--dsymutil', metavar='dsymutil', dest='dsymutil', help=textwrap.dedent('Specify Which dsymutil to use.'))
+
     # Test filtering options
     group = parser.add_argument_group('Test filtering options')
     group.add_argument(

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -183,7 +183,7 @@ ARCHFLAG ?= -arch
 # Change any build/tool options needed
 #----------------------------------------------------------------------
 ifeq "$(OS)" "Darwin"
-	DS := $(shell xcrun -find -toolchain default dsymutil)
+	DS := $(DSYMUTIL)
 	DSFLAGS =
 	DSYM = $(EXE).dSYM
 	AR := $(CROSS_COMPILE)libtool
@@ -758,7 +758,7 @@ endif
 
 #----------------------------------------------------------------------
 # From http://blog.melski.net/tag/debugging-makefiles/
-# 
+#
 # Usage: make print-CC print-CXX print-LD
 #----------------------------------------------------------------------
 print-%:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ function(add_python_test_target name test_script args comment)
     )
 endfunction()
 
-set(LLDB_TEST_DEPS lldb)
+set(LLDB_TEST_DEPS lldb dsymutil)
 
 # darwin-debug is an hard dependency for the testsuite.
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
@@ -81,6 +81,7 @@ set(LLDB_TEST_USER_ARGS
 set(LLDB_TEST_COMMON_ARGS
   --arch=${LLDB_TEST_ARCH}
   --executable $<TARGET_FILE:lldb>
+  --dsymutil $<TARGET_FILE:dsymutil>
   -s
   ${CMAKE_BINARY_DIR}/lldb-test-traces
   --build-dir

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ function(add_python_test_target name test_script args comment)
     )
 endfunction()
 
-set(LLDB_TEST_DEPS lldb dsymutil)
+set(LLDB_TEST_DEPS lldb llvm-dsymutil)
 
 # darwin-debug is an hard dependency for the testsuite.
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")


### PR DESCRIPTION
With the upstream implementation of dsymutil containing almost all
functionality from the one shipped with Xcode, we want to use the
in-tree version for running the test suite.