### PR TITLE
Don't assume backing thread shares protocol ID.

### DIFF
--- a/include/lldb/Target/ThreadList.h
+++ b/include/lldb/Target/ThreadList.h
@@ -102,6 +102,8 @@ public:
 
   lldb::ThreadSP GetThreadSPForThreadPtr(Thread *thread_ptr);
 
+  lldb::ThreadSP GetBackingThread(const lldb::ThreadSP &real_thread);
+
   bool ShouldStop(Event *event_ptr);
 
   Vote ShouldReportStop(Event *event_ptr);

--- a/packages/Python/lldbsuite/test/functionalities/gdb_remote_client/TestThreadSelectionBug.py
+++ b/packages/Python/lldbsuite/test/functionalities/gdb_remote_client/TestThreadSelectionBug.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from gdbclientutils import *
+
+
+class TestThreadSelectionBug(GDBRemoteTestBase):
+    def test(self):
+        class MyResponder(MockGDBServerResponder):
+            def cont(self):
+                # Simulate process stopping due to a raise(SIGINT)
+                return "T01reason:signal"
+
+        self.server.responder = MyResponder()
+        target = self.createTarget("a.yaml")
+        process = self.connect(target)
+        python_os_plugin_path = os.path.join(self.getSourceDir(),
+                                             'operating_system.py')
+        command = "settings set target.process.python-os-plugin-path '{}'".format(
+            python_os_plugin_path)
+        self.dbg.HandleCommand(command)
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+        self.assertEqual(process.GetNumThreads(), 3)
+
+        # Verify our OS plug-in threads showed up
+        thread = process.GetThreadByID(0x1)
+        self.assertTrue(
+            thread.IsValid(),
+            "Make sure there is a thread 0x1 after we load the python OS plug-in")
+        thread = process.GetThreadByID(0x2)
+        self.assertTrue(
+            thread.IsValid(),
+            "Make sure there is a thread 0x2 after we load the python OS plug-in")
+        thread = process.GetThreadByID(0x3)
+        self.assertTrue(
+            thread.IsValid(),
+            "Make sure there is a thread 0x3 after we load the python OS plug-in")
+
+        # Verify that a thread other than 3 is selected.
+        thread = process.GetSelectedThread()
+        self.assertNotEqual(thread.GetThreadID(), 0x3)
+
+        # Verify that we select the thread backed by physical thread 1, rather
+        # than virtual thread 1. The mapping comes from the OS plugin, where we
+        # specified that thread 3 is backed by real thread 1.
+        process.Continue()
+        thread = process.GetSelectedThread()
+        self.assertEqual(thread.GetThreadID(), 0x3)

--- a/packages/Python/lldbsuite/test/functionalities/gdb_remote_client/operating_system.py
+++ b/packages/Python/lldbsuite/test/functionalities/gdb_remote_client/operating_system.py
@@ -1,0 +1,45 @@
+import lldb
+import struct
+
+
+class OperatingSystemPlugIn(object):
+    """Class that provides data for an instance of a LLDB 'OperatingSystemPython' plug-in class"""
+
+    def __init__(self, process):
+        '''Initialization needs a valid.SBProcess object.
+
+        This plug-in will get created after a live process is valid and has stopped for the first time.
+        '''
+        self.process = None
+        self.registers = None
+        self.threads = None
+        if isinstance(process, lldb.SBProcess) and process.IsValid():
+            self.process = process
+            self.threads = None  # Will be an dictionary containing info for each thread
+
+    def get_target(self):
+        return self.process.target
+
+    def get_thread_info(self):
+        if not self.threads:
+            self.threads = [{
+                'tid': 0x1,
+                'name': 'one',
+                'queue': 'queue1',
+                'state': 'stopped',
+                'stop_reason': 'none'
+            }, {
+                'tid': 0x2,
+                'name': 'two',
+                'queue': 'queue2',
+                'state': 'stopped',
+                'stop_reason': 'none'
+            }, {
+                'tid': 0x3,
+                'name': 'three',
+                'queue': 'queue3',
+                'state': 'stopped',
+                'stop_reason': 'sigstop',
+                'core': 0
+            }]
+        return self.threads

--- a/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -156,9 +156,10 @@ bool OperatingSystemPython::UpdateThreadList(ThreadList &old_thread_list,
 
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_OS));
 
-  // First thing we have to do is to try to get the API lock, and the run lock.
-  // We're going to change the thread content of the process, and we're going
-  // to use python, which requires the API lock to do it.
+  // First thing we have to do is to try to get the API lock, and the
+  // interpreter lock. We're going to change the thread content of the process,
+  // and we're going to use python, which requires the API lock to do it. We
+  // need the interpreter lock to make sure thread_info_dict stays alive.
   //
   // If someone already has the API lock, that is ok, we just want to avoid
   // external code from making new API calls while this call is happening.
@@ -166,9 +167,10 @@ bool OperatingSystemPython::UpdateThreadList(ThreadList &old_thread_list,
   // This is a recursive lock so we can grant it to any Python code called on
   // the stack below us.
   Target &target = m_process->GetTarget();
-  std::unique_lock<std::recursive_mutex> lock(target.GetAPIMutex(),
-                                              std::defer_lock);
-  lock.try_lock();
+  std::unique_lock<std::recursive_mutex> api_lock(target.GetAPIMutex(),
+                                                  std::defer_lock);
+  api_lock.try_lock();
+  auto interpreter_lock = m_interpreter->AcquireInterpreterLock();
 
   if (log)
     log->Printf("OperatingSystemPython::UpdateThreadList() fetching thread "
@@ -176,12 +178,8 @@ bool OperatingSystemPython::UpdateThreadList(ThreadList &old_thread_list,
                 m_process->GetID());
 
   // The threads that are in "new_thread_list" upon entry are the threads from
-  // the
-  // lldb_private::Process subclass, no memory threads will be in this list.
-
-  auto interpreter_lock =
-      m_interpreter
-          ->AcquireInterpreterLock(); // to make sure threads_list stays alive
+  // the lldb_private::Process subclass, no memory threads will be in this
+  // list.
   StructuredData::ArraySP threads_list =
       m_interpreter->OSPlugin_ThreadsInfo(m_python_object_sp);
 
@@ -301,20 +299,24 @@ OperatingSystemPython::CreateRegisterContextForThread(Thread *thread,
   if (!IsOperatingSystemPluginThread(thread->shared_from_this()))
     return reg_ctx_sp;
 
-  // First thing we have to do is get the API lock, and the run lock.  We're
-  // going to change the thread
-  // content of the process, and we're going to use python, which requires the
-  // API lock to do it.
-  // So get & hold that.  This is a recursive lock so we can grant it to any
-  // Python code called on the stack below us.
+  // First thing we have to do is to try to get the API lock, and the
+  // interpreter lock. We're going to change the thread content of the process,
+  // and we're going to use python, which requires the API lock to do it. We
+  // need the interpreter lock to make sure thread_info_dict stays alive.
+  //
+  // If someone already has the API lock, that is ok, we just want to avoid
+  // external code from making new API calls while this call is happening.
+  //
+  // This is a recursive lock so we can grant it to any Python code called on
+  // the stack below us.
   Target &target = m_process->GetTarget();
-  std::lock_guard<std::recursive_mutex> guard(target.GetAPIMutex());
+  std::unique_lock<std::recursive_mutex> api_lock(target.GetAPIMutex(),
+                                                  std::defer_lock);
+  api_lock.try_lock();
+  auto interpreter_lock = m_interpreter->AcquireInterpreterLock();
 
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_THREAD));
 
-  auto lock =
-      m_interpreter
-          ->AcquireInterpreterLock(); // to make sure python objects stays alive
   if (reg_data_addr != LLDB_INVALID_ADDRESS) {
     // The registers data is in contiguous memory, just create the register
     // context using the address provided
@@ -383,18 +385,23 @@ lldb::ThreadSP OperatingSystemPython::CreateThread(lldb::tid_t tid,
                 tid, context);
 
   if (m_interpreter && m_python_object_sp) {
-    // First thing we have to do is get the API lock, and the run lock.  We're
-    // going to change the thread
-    // content of the process, and we're going to use python, which requires the
-    // API lock to do it.
-    // So get & hold that.  This is a recursive lock so we can grant it to any
-    // Python code called on the stack below us.
+    // First thing we have to do is to try to get the API lock, and the
+    // interpreter lock. We're going to change the thread content of the
+    // process, and we're going to use python, which requires the API lock to
+    // do it. We need the interpreter lock to make sure thread_info_dict stays
+    // alive.
+    //
+    // If someone already has the API lock, that is ok, we just want to avoid
+    // external code from making new API calls while this call is happening.
+    //
+    // This is a recursive lock so we can grant it to any Python code called on
+    // the stack below us.
     Target &target = m_process->GetTarget();
-    std::lock_guard<std::recursive_mutex> guard(target.GetAPIMutex());
+    std::unique_lock<std::recursive_mutex> api_lock(target.GetAPIMutex(),
+                                                    std::defer_lock);
+    api_lock.try_lock();
+    auto interpreter_lock = m_interpreter->AcquireInterpreterLock();
 
-    auto lock = m_interpreter->AcquireInterpreterLock(); // to make sure
-                                                         // thread_info_dict
-                                                         // stays alive
     StructuredData::DictionarySP thread_info_dict =
         m_interpreter->OSPlugin_CreateThread(m_python_object_sp, tid, context);
     std::vector<bool> core_used_map;

--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1827,10 +1827,9 @@ ThreadSP ProcessGDBRemote::SetThreadStopInfo(
       if (!thread_sp->StopInfoIsUpToDate()) {
         thread_sp->SetStopInfo(StopInfoSP());
         // If there's a memory thread backed by this thread, we need to use it
-        // to calcualte StopInfo.
-        ThreadSP memory_thread_sp =
-            m_thread_list.FindThreadByProtocolID(thread_sp->GetProtocolID());
-        if (memory_thread_sp)
+        // to calculate StopInfo.
+        if (ThreadSP memory_thread_sp =
+                m_thread_list.GetBackingThread(thread_sp))
           thread_sp = memory_thread_sp;
 
         if (exc_type != 0) {

--- a/source/Target/ThreadList.cpp
+++ b/source/Target/ThreadList.cpp
@@ -195,6 +195,20 @@ ThreadSP ThreadList::GetThreadSPForThreadPtr(Thread *thread_ptr) {
   return thread_sp;
 }
 
+ThreadSP ThreadList::GetBackingThread(const ThreadSP &real_thread) {
+  std::lock_guard<std::recursive_mutex> guard(GetMutex());
+
+  ThreadSP thread_sp;
+  const uint32_t num_threads = m_threads.size();
+  for (uint32_t idx = 0; idx < num_threads; ++idx) {
+    if (m_threads[idx]->GetBackingThread() == real_thread) {
+      thread_sp = m_threads[idx];
+      break;
+    }
+  }
+  return thread_sp;
+}
+
 ThreadSP ThreadList::FindThreadByIndexID(uint32_t index_id, bool can_update) {
   std::lock_guard<std::recursive_mutex> guard(GetMutex());
 


### PR DESCRIPTION
When we're dealing with virtual (memory) threads created by the OS
plugins, there's no guarantee that the real thread and the backing
thread share a protocol ID. Instead, we should iterate over the memory
threads to find the virtual thread that is backed by the current real
thread.

Differential revision: https://reviews.llvm.org/D45497

rdar://36485830