### PR TITLE
 Update the SummaryProvider for Data.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -12,9 +12,7 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-# https://bugs.swift.org/browse/SR-3320
-# This test fails with an assertion error with stdlib resilience enabled:
-#  https://github.com/apple/swift/pull/13573
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.skipIf])
+        decorators.skipUnlessDarwin,
+        decorators.expectedFailureAll(bugnumber="https://bugs.swift.org/browse/SR-3320")])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -14,5 +14,4 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.skipUnlessDarwin,
-        decorators.expectedFailureAll(bugnumber="https://bugs.swift.org/browse/SR-3320")])
+        decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/main.swift
@@ -18,7 +18,7 @@ func main() {
   data.append(data)
   print("break here") //% self.expect('frame variable data', substrs=['10 bytes'])
   //% self.expect('expression data', substrs=['10 bytes'])
-  //% self.expect('expression data.subdata(in: Range(uncheckedBounds: (lower: data.startIndex, upper: data.index(after: data.startIndex))))', substrs=['1 byte'])
+  //FIXME: self.expect('expression data.subdata(in: Range(uncheckedBounds: (lower: data.startIndex, upper: data.index(after: data.startIndex))))', substrs=['1 byte'])
 }
 
 main()

--- a/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -252,65 +252,27 @@ bool lldb_private::formatters::swift::UUID_SummaryProvider(
 
 bool lldb_private::formatters::swift::Data_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  static ConstString g__wrapped("_wrapped");
-  static ConstString g___wrapped("__wrapped");
-  static ConstString g_Immutable("Immutable");
-  static ConstString g_Mutable("Mutable");
+  static ConstString g__backing("_backing");
+  static ConstString g__length("_length");
   static ConstString g__value("_value");
 
-  ValueObjectSP selected_case_sp =
-      valobj.GetChildAtNamePath({g__wrapped, g___wrapped});
-  if (!selected_case_sp)
+  ValueObjectSP backing_sp = valobj.GetChildAtNamePath(g__backing);
+  if (!backing_sp)
     return false;
 
-  ConstString selected_case(selected_case_sp->GetValueAsCString());
-  if (selected_case == g_Immutable) {
-    if (ValueObjectSP immutable_sp =
-            selected_case_sp->GetChildAtNamePath({g_Immutable, g__value})) {
-      std::string summary;
-      if (immutable_sp->GetSummaryAsCString(summary, options)) {
-        stream.Printf("%s", summary.c_str());
-        return true;
-      }
-    }
-  } else if (selected_case == g_Mutable) {
-    if (ValueObjectSP mutable_sp =
-            selected_case_sp->GetChildAtNamePath({g_Mutable, g__value})) {
-      ProcessSP process_sp(valobj.GetProcessSP());
-      if (!process_sp)
-        return false;
-      TargetSP target_sp(valobj.GetTargetSP());
-      if (!target_sp)
-        return false;
-      if (SwiftLanguageRuntime *swift_runtime =
-              valobj.GetProcessSP()->GetSwiftLanguageRuntime()) {
-        lldb::addr_t value =
-            mutable_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-        if (value != LLDB_INVALID_ADDRESS) {
-          value = swift_runtime->MaskMaybeBridgedPointer(value);
-          DataExtractor buffer(&value, process_sp->GetAddressByteSize(),
-                               process_sp->GetByteOrder(),
-                               process_sp->GetAddressByteSize());
-          if (ClangASTContext *clang_ast_ctx =
-                  target_sp->GetScratchClangASTContext()) {
-            if (CompilerType id_type =
-                    clang_ast_ctx->GetBasicType(lldb::eBasicTypeObjCID)) {
-              if (ValueObjectSP nsdata_sp =
-                      ValueObject::CreateValueObjectFromData(
-                          "nsdata", buffer, process_sp, id_type)) {
-                nsdata_sp = nsdata_sp->GetQualifiedRepresentationIfAvailable(
-                    lldb::eDynamicDontRunTarget, false);
-                std::string summary;
-                if (nsdata_sp->GetSummaryAsCString(summary, options)) {
-                  stream.Printf("%s", summary.c_str());
-                  return true;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+  ValueObjectSP length_sp = backing_sp->GetChildAtNamePath(g__length);
+  if (!length_sp)
+    return false;
+
+  ValueObjectSP value_sp = length_sp->GetChildAtNamePath(g__value);
+  if (!value_sp)
+    return false;
+
+  bool success = false;
+  uint64_t len = value_sp->GetValueAsUnsigned(0, &success);
+  if (success) {
+    stream.Printf("%llu bytes", len);
+    return true;
   }
 
   return false;


### PR DESCRIPTION
Update the SummaryProvider for Data.  …
The current implementation of Data makes it much easier to get at the
length of the underlying storage.

This uncovered an unrelated bug, so I'm only re-enabling part of the
original test.

<rdar://problem/36649559>
