### PR TITLE
Fix a thinko in CommandObjectMemoryRegion.

### DIFF
--- a/source/Commands/CommandObjectMemory.cpp
+++ b/source/Commands/CommandObjectMemory.cpp
@@ -1709,8 +1709,8 @@ protected:
                                      m_cmd_name.c_str(), m_cmd_syntax.c_str());
         result.SetStatus(eReturnStatusFailed);
       } else {
-        auto load_addr_str = command[0].ref;
         if (command.GetArgumentCount() == 1) {
+          auto load_addr_str = command[0].ref;
           load_addr = Args::StringToAddress(&m_exe_ctx, load_addr_str,
                                             LLDB_INVALID_ADDRESS, &error);
           if (error.Fail() || load_addr == LLDB_INVALID_ADDRESS) {


### PR DESCRIPTION
Don't try to read the first argument till you've checked
that there is one.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@329844 91177308-0d34-0410-b5e6-96231b3b80d8