### PR TITLE
Create one SwiftASTContext per Moudle if the scratch context fails

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -124,9 +124,11 @@ public:
 
   /// Create a SwiftASTContext from a Module.  This context is used
   /// for frame variable ans uses ClangImporter options specific to
-  /// this lldb::Module.
+  /// this lldb::Module.  The optional target is to create a
+  /// module-specific scract context.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
-                                           Module &module);
+                                           Module &module,
+                                           Target *target = nullptr);
   /// Create a SwiftASTContext from a Target.  This context is global
   /// and used for the expression evaluator.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -1093,6 +1093,9 @@ public:
   GetPersistentExpressionStateForLanguage(lldb::LanguageType language);
 #endif
 
+  SwiftPersistentExpressionState *
+  GetSwiftPersistentExpressionState(ExecutionContextScope &exe_scope);
+
   const TypeSystemMap &GetTypeSystemMap();
 
   // Creates a UserExpression for the given language, the rest of the parameters
@@ -1149,22 +1152,23 @@ public:
 #ifdef __clang_analyzer__
   // See GetScratchTypeSystemForLanguage()
   SwiftASTContext *
-  GetScratchSwiftASTContext(Status &error, bool create_on_demand = true,
+  GetScratchSwiftASTContext(Status &error, ExecutionContextScope &exe_scope,
+                            bool create_on_demand = true,
                             const char *extra_options = nullptr)
       __attribute__((always_inline)) {
-    SwiftASTContext *ret =
-        GetScratchSwiftASTContextImpl(error, create_on_demand, extra_options);
+    SwiftASTContext *ret = GetScratchSwiftASTContextImpl(
+        error, exe_scope, create_on_demand, extra_options);
 
     return ret ? ret : nullptr;
   }
 
   SwiftASTContext *
-  GetScratchSwiftASTContextImpl(Status &error, bool create_on_demand = true,
-                                const char *extra_options = nullptr);
+  GetScratchSwiftASTContextImpl(Status &error, ExecutionContextScope &exe_scope,
+                                bool create_on_demand = true);
 #else
-  SwiftASTContext *
-  GetScratchSwiftASTContext(Status &error, bool create_on_demand = true,
-                            const char *extra_options = nullptr);
+  SwiftASTContext *GetScratchSwiftASTContext(Status &error,
+                                             ExecutionContextScope &exe_scope,
+                                             bool create_on_demand = true);
 #endif
 
   //----------------------------------------------------------------------
@@ -1339,6 +1343,15 @@ public:
 
   void SetREPL(lldb::LanguageType language, lldb::REPLSP repl_sp);
 
+  /// Enable the use of a separate sscratch type system per lldb::Module.
+  void SetUseScratchTypesystemPerModule(bool value) {
+    m_use_scratch_typesystem_per_module = value;
+  }
+  bool UseScratchTypesystemPerModule() const {
+    return m_use_scratch_typesystem_per_module;
+  }
+
+
 protected:
   //------------------------------------------------------------------
   /// Implementing of ModuleList::Notifier.
@@ -1409,6 +1422,11 @@ protected:
   bool m_valid;
   bool m_suppress_stop_hooks;
   bool m_is_dummy_target;
+
+  bool m_use_scratch_typesystem_per_module = false;
+  typedef std::pair<lldb_private::Module *, char> ModuleLanguage;
+  llvm::DenseMap<ModuleLanguage, lldb::TypeSystemSP>
+      m_scratch_typesystem_for_module;
 
   static void ImageSearchPathsChanged(const PathMappingList &path_list,
                                       void *baton);

--- a/lldb.xcodeproj/xcshareddata/xcschemes/desktop.xcscheme
+++ b/lldb.xcodeproj/xcshareddata/xcschemes/desktop.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "DebugClang"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/packages/Python/lldbsuite/test/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -25,6 +25,7 @@ class TestSwiftExpressionScopes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
@@ -1,3 +1,4 @@
 LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP = 1
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
@@ -12,5 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-# Swift-4.1-branch doesn't have the necessary build-script changes.
-lldbinline.MakeInlineTest(__file__, globals(), decorators=decorators.skipUnlessDarwin)
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
@@ -16,7 +16,7 @@ import Foundation
 func main() {
   var point = NSPoint(x: 23, y: 42)
   print(point) //% self.expect("frame variable -- point", substrs=['x', '23', 'y', '42'])
-  //% self.expect("expression -- point", substrs=['x', '23', 'y', '42'])
+               //% self.expect("expression -- point", substrs=['x', '23', 'y', '42'])
 }
 
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -12,9 +12,7 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-# https://bugs.swift.org/browse/SR-3320
-# This test fails with an assertion error with stdlib resilience enabled:
-#  https://github.com/apple/swift/pull/13573
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.skipIf])
+        decorators.skipUnlessDarwin,
+        decorators.expectedFailureAll(bugnumber="https://bugs.swift.org/browse/SR-3320")])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -14,5 +14,4 @@ import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=[
-        decorators.skipUnlessDarwin,
-        decorators.expectedFailureAll(bugnumber="https://bugs.swift.org/browse/SR-3320")])
+        decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/data/main.swift
@@ -18,7 +18,7 @@ func main() {
   data.append(data)
   print("break here") //% self.expect('frame variable data', substrs=['10 bytes'])
   //% self.expect('expression data', substrs=['10 bytes'])
-  //% self.expect('expression data.subdata(in: Range(uncheckedBounds: (lower: data.startIndex, upper: data.index(after: data.startIndex))))', substrs=['1 byte'])
+  //FIXME: self.expect('expression data.subdata(in: Range(uncheckedBounds: (lower: data.startIndex, upper: data.index(after: data.startIndex))))', substrs=['1 byte'])
 }
 
 main()

--- a/source/Commands/CommandObjectExpression.cpp
+++ b/source/Commands/CommandObjectExpression.cpp
@@ -405,7 +405,7 @@ bool CommandObjectExpression::EvaluateExpression(const char *expr,
     // We only tell you about the FixIt if we applied it.  The compiler errors
     // will suggest the FixIt if it parsed.
     if (error_stream && !m_fixed_expression.empty() &&
-        target->GetEnableNotifyAboutFixIts()) {
+        (m_fixed_expression != expr) && target->GetEnableNotifyAboutFixIts()) {
       if (success == eExpressionCompleted)
         error_stream->Printf(
             "  Fix-it applied, fixed expression was: \n    %s\n",

--- a/source/Expression/UserExpression.cpp
+++ b/source/Expression/UserExpression.cpp
@@ -391,8 +391,13 @@ UserExpression::Execute(DiagnosticManager &diagnostic_manager,
       diagnostic_manager, exe_ctx, options, shared_ptr_to_me, result_var);
   Target *target = exe_ctx.GetTargetPtr();
   if (options.GetResultIsInternal() && result_var && target) {
-    target->GetPersistentExpressionStateForLanguage(m_language)
-        ->RemovePersistentVariable(result_var);
+    if (m_language == lldb::eLanguageTypeSwift) {
+      if (auto *exe_scope = exe_ctx.GetBestExecutionContextScope())
+        target->GetSwiftPersistentExpressionState(*exe_scope)
+          ->RemovePersistentVariable(result_var);
+    } else
+      target->GetPersistentExpressionStateForLanguage(m_language)
+          ->RemovePersistentVariable(result_var);
   }
   return expr_result;
 }

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1336,10 +1336,7 @@ bool SwiftASTManipulator::AddExternalVariables(
       SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
           variable.m_type.GetTypeSystem());
 
-      CompilerType referent_type;
-
-      if (swift_ast_ctx)
-        referent_type = swift_ast_ctx->GetReferentType(variable.m_type);
+      CompilerType referent_type = variable.m_type;
 
       // One tricky bit here is that this var may be an argument to the function
       // whose context we are

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1336,7 +1336,10 @@ bool SwiftASTManipulator::AddExternalVariables(
       SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
           variable.m_type.GetTypeSystem());
 
-      CompilerType referent_type = variable.m_type;
+      CompilerType referent_type;
+
+      if (swift_ast_ctx)
+        referent_type = swift_ast_ctx->GetReferentType(variable.m_type);
 
       // One tricky bit here is that this var may be an argument to the function
       // whose context we are

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -674,6 +674,12 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     if (!imported_self_type.IsValid())
       break;
 
+    // This might be a referenced type, in which case we really want to extend
+    // the referent:
+    imported_self_type =
+        llvm::cast<SwiftASTContext>(imported_self_type.GetTypeSystem())
+            ->GetReferentType(imported_self_type);
+
     // If we are extending a generic class it's going to be a metatype, and we
     // have to grab the instance type:
     imported_self_type =

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -674,12 +674,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     if (!imported_self_type.IsValid())
       break;
 
-    // This might be a referenced type, in which case we really want to extend
-    // the referent:
-    imported_self_type =
-        llvm::cast<SwiftASTContext>(imported_self_type.GetTypeSystem())
-            ->GetReferentType(imported_self_type);
-
     // If we are extending a generic class it's going to be a metatype, and we
     // have to grab the instance type:
     imported_self_type =

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -28,6 +28,7 @@
 #include "lldb/Expression/ExpressionSourceCode.h"
 #include "lldb/Expression/IRExecutionUnit.h"
 #include "lldb/Symbol/CompileUnit.h"
+#include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/VariableList.h"
@@ -84,7 +85,7 @@ SwiftExpressionParser::SwiftExpressionParser(
     : ExpressionParser(exe_scope, expr, options.GetGenerateDebugInfo()),
       m_expr(expr), m_triple(), m_llvm_context(), m_module(),
       m_execution_unit_sp(), m_swift_ast_context(NULL), m_sc(),
-      m_stack_frame_wp(), m_options(options) {
+      m_exe_scope(exe_scope), m_stack_frame_wp(), m_options(options) {
   assert(expr.Language() == lldb::eLanguageTypeSwift);
 
   // TODO This code is copied from ClangExpressionParser.cpp.
@@ -123,9 +124,9 @@ SwiftExpressionParser::SwiftExpressionParser(
   }
 
   if (target_sp) {
+    Status error;
     m_swift_ast_context = llvm::cast_or_null<SwiftASTContext>(
-        target_sp->GetScratchTypeSystemForLanguage(nullptr,
-                                                   lldb::eLanguageTypeSwift));
+        target_sp->GetScratchSwiftASTContext(error, *exe_scope, true));
   }
 }
 
@@ -193,7 +194,7 @@ static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
 /// Largely lifted from swift::performAutoImport, but serves our own nefarious
 /// purposes.
 static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
-                              SymbolContext &sc,
+                              SymbolContext &sc, ExecutionContextScope &exe_scope,
                               lldb::StackFrameWP &stack_frame_wp,
                               swift::SourceFile &source_file, bool user_imports,
                               Status &error) {
@@ -248,7 +249,7 @@ static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
     if (!swift_module || !error.Success() ||
         swift_ast_context.HasFatalErrors()) {
       if (log)
-        log->Printf("[PerformAutoImport] Couldnt import module %s: %s",
+        log->Printf("[PerformAutoImport] Couldn't import module %s: %s",
                     module_name.AsCString(), error.AsCString());
 
       if (!swift_module || swift_ast_context.HasFatalErrors()) {
@@ -291,10 +292,8 @@ static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
     source_file.getImportedModules(parsed_imports,
                                    swift::ModuleDecl::ImportFilter::All);
 
-    SwiftPersistentExpressionState *persistent_expression_state =
-        llvm::cast<SwiftPersistentExpressionState>(
-            sc.target_sp->GetPersistentExpressionStateForLanguage(
-                lldb::eLanguageTypeSwift));
+    auto *persistent_expression_state =
+        sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
 
     for (auto module_pair : parsed_imports) {
       swift::ModuleDecl *module = module_pair.second;
@@ -309,9 +308,9 @@ static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
                         module_name.c_str());
           if (!load_one_module(module_const_str))
             return false;
-          if (1 /* How do we tell we are in REPL or playground mode? */) {
-            persistent_expression_state->AddHandLoadedModule(module_const_str);
-          }
+
+          // How do we tell we are in REPL or playground mode?
+          persistent_expression_state->AddHandLoadedModule(module_const_str);
         }
       }
     }
@@ -384,17 +383,16 @@ class LLDBNameLookup : public swift::SILDebuggerClient {
 public:
   LLDBNameLookup(SwiftExpressionParser &parser, swift::SourceFile &source_file,
                  SwiftExpressionParser::SILVariableMap &variable_map,
-                 SymbolContext &sc)
+                 SymbolContext &sc, ExecutionContextScope &exe_scope)
       : SILDebuggerClient(source_file.getASTContext()), m_parser(parser),
         m_log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS)),
         m_source_file(source_file), m_variable_map(variable_map), m_sc(sc) {
     source_file.getParentModule()->setDebugClient(this);
 
-    if (m_sc.target_sp) {
-      m_persistent_vars = llvm::cast<SwiftPersistentExpressionState>(
-          m_sc.target_sp->GetPersistentExpressionStateForLanguage(
-              lldb::eLanguageTypeSwift));
-    }
+    if (!m_sc.target_sp)
+      return;
+    m_persistent_vars =
+        m_sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
   }
 
   virtual ~LLDBNameLookup() {}
@@ -498,57 +496,59 @@ public:
     // Note also, we only do this for the persistent decls.  Anything in the
     // "staged" list has been defined in this
     // expr setting and so is more local than local.
+    if (m_persistent_vars) {
+      bool skip_results_with_matching_kind =
+          !(m_parser.GetOptions().GetREPLEnabled() ||
+            m_parser.GetOptions().GetPlaygroundTransformEnabled() ||
+            (!NameStr.empty() && NameStr.front() == '$'));
 
-    bool skip_results_with_matching_kind =
-        !(m_parser.GetOptions().GetREPLEnabled() ||
-          m_parser.GetOptions().GetPlaygroundTransformEnabled() ||
-          (!NameStr.empty() && NameStr.front() == '$'));
+      size_t num_external_results = RV.size();
+      if (skip_results_with_matching_kind && num_external_results > 0) {
+        std::vector<swift::ValueDecl *> persistent_results;
+        m_persistent_vars->GetSwiftPersistentDecls(name_const_str,
+                                                   persistent_results);
 
-    size_t num_external_results = RV.size();
-    if (skip_results_with_matching_kind && num_external_results > 0) {
-      std::vector<swift::ValueDecl *> persistent_results;
-      m_persistent_vars->GetSwiftPersistentDecls(name_const_str,
-                                                 persistent_results);
+        size_t num_persistent_results = persistent_results.size();
+        for (size_t idx = 0; idx < num_persistent_results; idx++) {
+          swift::ValueDecl *value_decl = persistent_results[idx];
+          if (!value_decl)
+            continue;
+          swift::DeclName value_decl_name = value_decl->getFullName();
+          swift::DeclKind value_decl_kind = value_decl->getKind();
+          swift::CanType value_interface_type =
+              value_decl->getInterfaceType()->getCanonicalType();
 
-      size_t num_persistent_results = persistent_results.size();
-      for (size_t idx = 0; idx < num_persistent_results; idx++) {
-        swift::ValueDecl *value_decl = persistent_results[idx];
-        if (!value_decl)
-          continue;
-        swift::DeclName value_decl_name = value_decl->getFullName();
-        swift::DeclKind value_decl_kind = value_decl->getKind();
-        swift::CanType value_interface_type =
-            value_decl->getInterfaceType()->getCanonicalType();
+          bool is_function =
+              swift::isa<swift::AbstractFunctionDecl>(value_decl);
 
-        bool is_function = swift::isa<swift::AbstractFunctionDecl>(value_decl);
-
-        bool skip_it = false;
-        for (size_t rv_idx = 0; rv_idx < num_external_results; rv_idx++) {
-          if (swift::ValueDecl *rv_decl = RV[rv_idx].getValueDecl()) {
-            if (value_decl_kind == rv_decl->getKind()) {
-              if (is_function) {
-                swift::DeclName rv_full_name = rv_decl->getFullName();
-                if (rv_full_name.matchesRef(value_decl_name)) {
-                  // If the full names match, make sure the interface types
-                  // match:
-                  if (rv_decl->getInterfaceType()->getCanonicalType() ==
-                      value_interface_type)
-                    skip_it = true;
+          bool skip_it = false;
+          for (size_t rv_idx = 0; rv_idx < num_external_results; rv_idx++) {
+            if (swift::ValueDecl *rv_decl = RV[rv_idx].getValueDecl()) {
+              if (value_decl_kind == rv_decl->getKind()) {
+                if (is_function) {
+                  swift::DeclName rv_full_name = rv_decl->getFullName();
+                  if (rv_full_name.matchesRef(value_decl_name)) {
+                    // If the full names match, make sure the interface types
+                    // match:
+                    if (rv_decl->getInterfaceType()->getCanonicalType() ==
+                        value_interface_type)
+                      skip_it = true;
+                  }
+                } else {
+                  skip_it = true;
                 }
-              } else {
-                skip_it = true;
-              }
 
-              if (skip_it)
-                break;
+                if (skip_it)
+                  break;
+              }
             }
           }
+          if (!skip_it)
+            results.push_back(value_decl);
         }
-        if (!skip_it)
-          results.push_back(value_decl);
+      } else {
+        m_persistent_vars->GetSwiftPersistentDecls(name_const_str, results);
       }
-    } else {
-      m_persistent_vars->GetSwiftPersistentDecls(name_const_str, results);
     }
 
     for (size_t idx = 0; idx < results.size(); idx++) {
@@ -990,7 +990,8 @@ static void CountLocals(
 }
 
 static void ResolveSpecialNames(
-    SymbolContext &sc, SwiftASTContext &ast_context,
+    SymbolContext &sc, ExecutionContextScope &exe_scope,
+    SwiftASTContext &ast_context,
     llvm::SmallVectorImpl<swift::Identifier> &special_names,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
@@ -998,10 +999,8 @@ static void ResolveSpecialNames(
   if (!sc.target_sp)
     return;
 
-  SwiftPersistentExpressionState *persistent_state =
-      llvm::cast<SwiftPersistentExpressionState>(
-          sc.target_sp->GetPersistentExpressionStateForLanguage(
-              lldb::eLanguageTypeSwift));
+  auto *persistent_state =
+      sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
 
   std::set<ConstString> resolved_names;
 
@@ -1360,8 +1359,21 @@ struct SwiftASTContextError : public llvm::ErrorInfo<SwiftASTContextError> {
   }
 };
 
+/// This indicates an error in the SwiftASTContext.
+struct ModuleImportError : public llvm::ErrorInfo<ModuleImportError> {
+  static char ID;
+  std::string Message;
+
+  ModuleImportError(llvm::Twine Message) : Message(Message.str()) {}
+  void log(llvm::raw_ostream &OS) const override { OS << "ModuleImport"; }
+  std::error_code convertToErrorCode() const override {
+    return inconvertibleErrorCode();
+  }
+};
+  
 char PropagatedError::ID = 0;
 char SwiftASTContextError::ID = 0;
+char ModuleImportError::ID = 0;
 
 /// This holds the result of ParseAndImport.
 struct ParsedExpression {
@@ -1384,6 +1396,7 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
                unsigned &buffer_id, DiagnosticManager &diagnostic_manager,
                SwiftExpressionParser &swift_expr_parser,
                lldb::StackFrameWP &stack_frame_wp, SymbolContext &sc,
+               ExecutionContextScope &exe_scope,
                const EvaluateExpressionOptions &options, bool repl,
                bool playground) {
 
@@ -1407,10 +1420,8 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
   // FIXME: We won't have to do this once the playground adds import statements
   // for the things it needs itself.
   if (playground) {
-    SwiftPersistentExpressionState *persistent_state =
-        llvm::cast<SwiftPersistentExpressionState>(
-            sc.target_sp->GetPersistentExpressionStateForLanguage(
-                lldb::eLanguageTypeSwift));
+    auto *persistent_state =
+        sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
     persistent_state->AddHandLoadedModule(ConstString("Swift"));
   }
 
@@ -1445,8 +1456,8 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
 
   bool done = false;
 
-  auto *external_lookup =
-      new LLDBNameLookup(swift_expr_parser, *source_file, variable_map, sc);
+  auto *external_lookup = new LLDBNameLookup(swift_expr_parser, *source_file,
+                                             variable_map, sc, exe_scope);
 
   // FIXME: This call is here just so that the we keep the
   // DebuggerClients alive as long as the Module we are not inserting
@@ -1490,11 +1501,10 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
   }
 
   Status auto_import_error;
-  if (!PerformAutoImport(*swift_ast_context, sc, stack_frame_wp, *source_file,
-                         false, auto_import_error))
-    return make_error<llvm::StringError>(llvm::Twine("in auto-import:\n") +
-                                             auto_import_error.AsCString(),
-                                         inconvertibleErrorCode());
+  if (!PerformAutoImport(*swift_ast_context, sc, exe_scope, stack_frame_wp,
+                         *source_file, false, auto_import_error))
+    return make_error<ModuleImportError>(llvm::Twine("in auto-import:\n") +
+                                         auto_import_error.AsCString());
 
   // Swift Modules that rely on shared libraries (not frameworks)
   // don't record the link information in the swiftmodule file, so we
@@ -1543,7 +1553,8 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
 
     code_manipulator->FindSpecialNames(special_names, persistent_var_prefix);
 
-    ResolveSpecialNames(sc, *swift_ast_context, special_names, local_variables);
+    ResolveSpecialNames(sc, exe_scope, *swift_ast_context, special_names,
+                        local_variables);
 
     code_manipulator->AddExternalVariables(local_variables);
 
@@ -1576,11 +1587,10 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
         IRExecutionUnit::GetLLVMGlobalContextMutex());
 
     Status auto_import_error;
-    if (!PerformAutoImport(*swift_ast_context, sc, stack_frame_wp, *source_file,
-                           true, auto_import_error)) {
-      return make_error<llvm::StringError>(llvm::Twine("in auto-import:\n") +
-                                               auto_import_error.AsCString(),
-                                           inconvertibleErrorCode());
+    if (!PerformAutoImport(*swift_ast_context, sc, exe_scope, stack_frame_wp,
+                           *source_file, true, auto_import_error)) {
+      return make_error<ModuleImportError>(llvm::Twine("in auto-import:\n") +
+                                           auto_import_error.AsCString());
     }
   }
   ParsedExpression result = {std::move(code_manipulator),
@@ -1595,35 +1605,61 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
 unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
                                       uint32_t first_line, uint32_t last_line,
                                       uint32_t line_offset) {
-  SwiftExpressionParser::SILVariableMap variable_map;
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
+
+  SwiftExpressionParser::SILVariableMap variable_map;
+
+  // Helper function to diagnose errors in m_swift_ast_context.
+  unsigned buffer_id = UINT32_MAX;
+  auto DiagnoseSwiftASTContextError = [&]() {
+    assert(m_swift_ast_context->HasErrors() && "error expected");
+    m_swift_ast_context->PrintDiagnostics(diagnostic_manager, buffer_id,
+                                          first_line, last_line, line_offset);
+  };
 
   // In the case of playgrounds, we turn all rewriting functionality off.
   const bool repl = m_options.GetREPLEnabled();
   const bool playground = m_options.GetPlaygroundTransformEnabled();
 
+  if (!m_exe_scope)
+    return false;
+
   // Parse the expression an import all nececssary swift modules.
-  auto *swift_ast_context = m_swift_ast_context;
-  unsigned buffer_id = UINT32_MAX;
   auto parsed_expr = ParseAndImport(
-      swift_ast_context, m_expr, variable_map, buffer_id, diagnostic_manager,
-      *this, m_stack_frame_wp, m_sc, m_options, repl, playground);
-  auto DiagnoseSwiftASTContextError = [&]() {
-    assert(swift_ast_context->HasErrors());
-    m_swift_ast_context->PrintDiagnostics(diagnostic_manager, buffer_id,
-                                          first_line, last_line, line_offset);
-  };
+      m_swift_ast_context, m_expr, variable_map, buffer_id, diagnostic_manager,
+      *this, m_stack_frame_wp, m_sc, *m_exe_scope, m_options, repl, playground);
 
   if (!parsed_expr) {
-    handleAllErrors(parsed_expr.takeError(), [](const PropagatedError &P) {},
+    bool retry = false;
+    handleAllErrors(parsed_expr.takeError(),
+                    [&](const ModuleImportError &MIE) {
+                      if (m_sc.target_sp->UseScratchTypesystemPerModule())
+                        // Already on backup power.
+                        diagnostic_manager.PutString(eDiagnosticSeverityError,
+                                                     MIE.Message);
+                      else
+                        // Discard the shared scratch context and retry.
+                        retry = true;
+                    },
+                    [&](const SwiftASTContextError &SACE) {
+                      DiagnoseSwiftASTContextError();
+                    },
                     [&](const StringError &SE) {
                       diagnostic_manager.PutString(eDiagnosticSeverityError,
                                                    SE.getMessage());
                     },
-                    [&](const SwiftASTContextError &SACE) {
-                      DiagnoseSwiftASTContextError();
-                    });
-    return 1;
+                    [](const PropagatedError &P) {});
+
+    // Unrecoverable error?
+    if (!retry)
+      return 1;
+
+    // Signal that we want to retry the expression exactly once with
+    // a fresh SwiftASTContext initialized with the flags from the
+    // current lldb::Module / Swift dylib to avoid header search
+    // mismatches.
+    m_sc.target_sp->SetUseScratchTypesystemPerModule(true);
+    return 2;
   }
 
   // Not persistent because we're building source files one at a time.
@@ -1688,13 +1724,11 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     }
 
     Status error;
-    SwiftASTContext *scratch_ast_context =
-        m_sc.target_sp->GetScratchSwiftASTContext(error);
+    SwiftASTContext *scratch_ast_context = m_swift_ast_context;
 
     if (scratch_ast_context) {
-      SwiftPersistentExpressionState *persistent_state =
-          llvm::dyn_cast<SwiftPersistentExpressionState>(
-              scratch_ast_context->GetPersistentExpressionState());
+      auto *persistent_state =
+          m_sc.target_sp->GetSwiftPersistentExpressionState(*m_exe_scope);
 
       llvm::SmallVector<size_t, 1> declaration_indexes;
       parsed_expr->code_manipulator->FindVariableDeclarations(
@@ -1763,8 +1797,8 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   if (!playground && !repl) {
     parsed_expr->code_manipulator->FixCaptures();
 
-    // This currently crashes with Assertion failed: (BufferID != -1), function
-    // findBufferContainingLoc, file
+    // This currently crashes with Assertion failed: (BufferID != -1),
+    // function findBufferContainingLoc, file
     // llvm/tools/swift/include/swift/Basic/SourceManager.h, line 92.
     //        if (log)
     //        {
@@ -1894,26 +1928,24 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
                      nullptr);
   }
 
-  bool fail = m_swift_ast_context->HasErrors();
-  if (!fail) {
-    // The Parse succeeded!  Now put this module into the context's
-    // list of loaded modules, and copy the Decls that were globalized
-    // as part of the parse from the staging area in the external
-    // lookup object into the SwiftPersistentExpressionState.
-    swift::ModuleDecl *module = &parsed_expr->module;
-    parsed_expr->ast_context.LoadedModules.insert({module->getName(), module});
-    if (m_swift_ast_context)
-      m_swift_ast_context->CacheModule(module);
-    if (m_sc.target_sp) {
-      SwiftPersistentExpressionState *persistent_state =
-          llvm::cast<SwiftPersistentExpressionState>(
-              m_sc.target_sp->GetPersistentExpressionStateForLanguage(
-                  lldb::eLanguageTypeSwift));
-      persistent_state->CopyInSwiftPersistentDecls(
-          parsed_expr->external_lookup.GetStagedDecls());
-    }
+  if (m_swift_ast_context->HasErrors())
+    return 1;
+
+  // The Parse succeeded!  Now put this module into the context's
+  // list of loaded modules, and copy the Decls that were globalized
+  // as part of the parse from the staging area in the external
+  // lookup object into the SwiftPersistentExpressionState.
+  swift::ModuleDecl *module = &parsed_expr->module;
+  parsed_expr->ast_context.LoadedModules.insert({module->getName(), module});
+  if (m_swift_ast_context)
+    m_swift_ast_context->CacheModule(module);
+  if (m_sc.target_sp) {
+    auto *persistent_state =
+        m_sc.target_sp->GetSwiftPersistentExpressionState(*m_exe_scope);
+    persistent_state->CopyInSwiftPersistentDecls(
+        parsed_expr->external_lookup.GetStagedDecls());
   }
-  return fail ? 1 : 0;
+  return 0;
 }
 
 static bool FindFunctionInModule(ConstString &mangled_name,

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -149,20 +149,30 @@ private:
   bool PerformAutoImport(swift::SourceFile &source_file, bool user_imports,
                          Status &error);
 
-  Expression &m_expr;   ///< The expression to be parsed
-  std::string m_triple; ///< The triple to use when compiling
-  std::unique_ptr<llvm::LLVMContext>
-      m_llvm_context; ///< The context to use for IR generation
-  std::unique_ptr<llvm::Module> m_module;      ///< The module to build IR into
-  lldb::IRExecutionUnitSP m_execution_unit_sp; ///< The container for the IR, to
-                                               ///be JIT-compiled or interpreted
-  SwiftASTContext
-      *m_swift_ast_context; ///< The AST context to build the expression into
-  SymbolContext m_sc;       ///< The symbol context to use when parsing
-  lldb::StackFrameWP m_stack_frame_wp; ///< The stack frame to use (if possible)
-                                       ///when determining dynamic types.
-  EvaluateExpressionOptions m_options; ///< If true, we are running in REPL mode
+  /// The expression to be parsed.
+  Expression &m_expr;
+  /// The triple to use when compiling.
+  std::string m_triple;
+  /// The context to use for IR generation.
+  std::unique_ptr<llvm::LLVMContext> m_llvm_context;
+  /// The module to build IR into.
+  std::unique_ptr<llvm::Module> m_module;
+  /// The container for the IR, to be JIT-compiled or interpreted.
+  lldb::IRExecutionUnitSP m_execution_unit_sp;
+  /// The AST context to build the expression into.
+  SwiftASTContext *m_swift_ast_context;
+  /// Used to manage the memory of a potential on-off context.
+  //lldb::TypeSystemSP m_typesystem_sp;
+  /// The symbol context to use when parsing.
+  SymbolContext m_sc;
+  // The execution context scope of the expression.
+  ExecutionContextScope *m_exe_scope;
+  /// The stack frame to use (if possible) when determining dynamic
+  /// types.
+  lldb::StackFrameWP m_stack_frame_wp;
+  /// If true, we are running in REPL mode
+  EvaluateExpressionOptions m_options;
 };
-}
+} // namespace lldb_private
 
 #endif // liblldb_SwiftExpressionParser_h_

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -272,8 +272,8 @@ Status SwiftREPL::DoInitialization() {
   Status error;
 
   if (!m_compiler_options.empty()) {
-    (void)m_target.GetScratchSwiftASTContext(error, true,
-                                             m_compiler_options.c_str());
+    (void)m_target.GetScratchTypeSystemForLanguage(
+        &error, eLanguageTypeSwift, true, m_compiler_options.c_str());
   }
 
   return error;
@@ -527,8 +527,8 @@ int SwiftREPL::CompleteCode(const std::string &current_code,
 #define USE_SEPARATE_AST_FOR_COMPLETION
 #if defined(USE_SEPARATE_AST_FOR_COMPLETION)
   if (!m_swift_ast_sp) {
-    SwiftASTContext *target_swift_ast =
-        m_target.GetScratchSwiftASTContext(error);
+    SwiftASTContext *target_swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
+        m_target.GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift));
     if (target_swift_ast)
       m_swift_ast_sp.reset(new SwiftASTContext(*target_swift_ast));
   }

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -26,7 +26,8 @@
 // Project includes
 
 namespace lldb_private {
-
+class SwiftExpressionParser;
+  
 //----------------------------------------------------------------------
 /// @class SwiftUserExpression SwiftUserExpression.h
 /// "lldb/Expression/SwiftUserExpression.h"
@@ -185,6 +186,7 @@ private:
   };
 
   PersistentVariableDelegate m_persistent_variable_delegate;
+  std::unique_ptr<SwiftExpressionParser> m_parser;
 };
 
 } // namespace lldb_private

--- a/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -252,65 +252,27 @@ bool lldb_private::formatters::swift::UUID_SummaryProvider(
 
 bool lldb_private::formatters::swift::Data_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  static ConstString g__wrapped("_wrapped");
-  static ConstString g___wrapped("__wrapped");
-  static ConstString g_Immutable("Immutable");
-  static ConstString g_Mutable("Mutable");
+  static ConstString g__backing("_backing");
+  static ConstString g__length("_length");
   static ConstString g__value("_value");
 
-  ValueObjectSP selected_case_sp =
-      valobj.GetChildAtNamePath({g__wrapped, g___wrapped});
-  if (!selected_case_sp)
+  ValueObjectSP backing_sp = valobj.GetChildAtNamePath(g__backing);
+  if (!backing_sp)
     return false;
 
-  ConstString selected_case(selected_case_sp->GetValueAsCString());
-  if (selected_case == g_Immutable) {
-    if (ValueObjectSP immutable_sp =
-            selected_case_sp->GetChildAtNamePath({g_Immutable, g__value})) {
-      std::string summary;
-      if (immutable_sp->GetSummaryAsCString(summary, options)) {
-        stream.Printf("%s", summary.c_str());
-        return true;
-      }
-    }
-  } else if (selected_case == g_Mutable) {
-    if (ValueObjectSP mutable_sp =
-            selected_case_sp->GetChildAtNamePath({g_Mutable, g__value})) {
-      ProcessSP process_sp(valobj.GetProcessSP());
-      if (!process_sp)
-        return false;
-      TargetSP target_sp(valobj.GetTargetSP());
-      if (!target_sp)
-        return false;
-      if (SwiftLanguageRuntime *swift_runtime =
-              valobj.GetProcessSP()->GetSwiftLanguageRuntime()) {
-        lldb::addr_t value =
-            mutable_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-        if (value != LLDB_INVALID_ADDRESS) {
-          value = swift_runtime->MaskMaybeBridgedPointer(value);
-          DataExtractor buffer(&value, process_sp->GetAddressByteSize(),
-                               process_sp->GetByteOrder(),
-                               process_sp->GetAddressByteSize());
-          if (ClangASTContext *clang_ast_ctx =
-                  target_sp->GetScratchClangASTContext()) {
-            if (CompilerType id_type =
-                    clang_ast_ctx->GetBasicType(lldb::eBasicTypeObjCID)) {
-              if (ValueObjectSP nsdata_sp =
-                      ValueObject::CreateValueObjectFromData(
-                          "nsdata", buffer, process_sp, id_type)) {
-                nsdata_sp = nsdata_sp->GetQualifiedRepresentationIfAvailable(
-                    lldb::eDynamicDontRunTarget, false);
-                std::string summary;
-                if (nsdata_sp->GetSummaryAsCString(summary, options)) {
-                  stream.Printf("%s", summary.c_str());
-                  return true;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+  ValueObjectSP length_sp = backing_sp->GetChildAtNamePath(g__length);
+  if (!length_sp)
+    return false;
+
+  ValueObjectSP value_sp = length_sp->GetChildAtNamePath(g__value);
+  if (!value_sp)
+    return false;
+
+  bool success = false;
+  uint64_t len = value_sp->GetValueAsUnsigned(0, &success);
+  if (success) {
+    stream.Printf("%llu bytes", len);
+    return true;
   }
 
   return false;

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -457,8 +457,9 @@ bool lldb_private::formatters::swift::NSContiguousString_SummaryProvider(
 
   DataExtractor data(buffer_sp, process_sp->GetByteOrder(), ptr_size);
 
-  SwiftASTContext *lldb_swift_ast =
-      process_sp->GetTarget().GetScratchSwiftASTContext(error);
+  SwiftASTContext *lldb_swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
+      process_sp->GetTarget().GetScratchTypeSystemForLanguage(
+          &error, eLanguageTypeSwift));
   if (!lldb_swift_ast)
     return false;
   CompilerType string_guts_type = lldb_swift_ast->GetTypeFromMangledTypename(

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -341,8 +341,9 @@ SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
       native_storage_ptr =
           process_sp->ReadPointerFromMemory(native_storage_ptr, error);
       // (AnyObject,AnyObject)?
-      SwiftASTContext *swift_ast_ctx =
-          process_sp->GetTarget().GetScratchSwiftASTContext(error);
+      SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
+          process_sp->GetTarget().GetScratchTypeSystemForLanguage(
+              &error, eLanguageTypeSwift));
       if (swift_ast_ctx) {
         CompilerType element_type(swift_ast_ctx->GetTypeFromMangledTypename(
             SwiftLanguageRuntime::GetCurrentMangledName(

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1324,8 +1324,8 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             if (target) {
               const bool create_on_demand = false;
               Status error;
-              SwiftASTContext *ast_ctx(
-                  target->GetScratchSwiftASTContext(error, create_on_demand));
+              SwiftASTContext *ast_ctx(target->GetScratchSwiftASTContext(
+                  error, *exe_scope, create_on_demand));
               if (ast_ctx) {
                 const bool is_mangled = true;
                 Mangled mangled(ConstString(input), is_mangled);
@@ -1383,8 +1383,8 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             Target *target = exe_scope->CalculateTarget().get();
             const bool create_on_demand = false;
             Status error;
-            SwiftASTContext *ast_ctx(
-                target->GetScratchSwiftASTContext(error, create_on_demand));
+            SwiftASTContext *ast_ctx(target->GetScratchSwiftASTContext(
+                error, *exe_scope, create_on_demand));
             if (ast_ctx) {
               auto iter = ast_ctx->GetModuleCache().begin(),
                    end = ast_ctx->GetModuleCache().end();

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1284,7 +1284,8 @@ void SwiftASTContext::RemapClangImporterOptions(
 }
 
 lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
-                                                   Module &module) {
+                                                   Module &module,
+                                                   Target *target) {
   if (!SwiftASTContextSupportsLanguage(language))
     return lldb::TypeSystemSP();
 
@@ -1311,7 +1312,9 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     }
   }
 
-  std::shared_ptr<SwiftASTContext> swift_ast_sp(new SwiftASTContext());
+  std::shared_ptr<SwiftASTContext> swift_ast_sp(
+      target ? (new SwiftASTContextForExpressions(*target))
+             : new SwiftASTContext());
 
   swift_ast_sp->GetLanguageOptions().DebuggerSupport = true;
   swift_ast_sp->GetLanguageOptions().EnableAccessControl = false;
@@ -1760,7 +1763,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                 llvm::dyn_cast_or_null<SwiftASTContext>(
                     sym_file->GetTypeSystemForLanguage(
                         lldb::eLanguageTypeSwift));
-            if (ast_context) {
+            if (ast_context && !ast_context->HasErrors()) {
               if (use_all_compiler_flags ||
                   target.GetExecutableModulePointer() == module_sp.get()) {
                 for (size_t msi = 0,

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1653,6 +1653,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     PlatformSP platform_sp(target.GetPlatform());
     uint32_t major, minor, update;
     if (platform_sp &&
+        !target.GetArchitecture().GetTriple().hasEnvironment() &&
         platform_sp->GetOSVersion(major, minor, update,
                                   target.GetProcessSP().get())) {
       StreamString full_triple_name;

--- a/source/Target/ABI.cpp
+++ b/source/Target/ABI.cpp
@@ -102,10 +102,15 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
   // work.
 
   if (persistent) {
-    PersistentExpressionState *persistent_expression_state =
-        thread.CalculateTarget()->GetPersistentExpressionStateForLanguage(
-            ast_type.GetMinimumLanguage());
-
+    lldb::LanguageType lang = ast_type.GetMinimumLanguage();
+    PersistentExpressionState *persistent_expression_state;
+    auto target = thread.CalculateTarget();
+    if (lang == lldb::eLanguageTypeSwift)
+        target->GetSwiftPersistentExpressionState(thread);
+    else
+       persistent_expression_state =
+         target->GetPersistentExpressionStateForLanguage(lang);
+    
     if (!persistent_expression_state)
       return ValueObjectSP();
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1182,7 +1182,9 @@ SwiftLanguageRuntime::GetMemoryReader() {
 
 SwiftASTContext *SwiftLanguageRuntime::GetScratchSwiftASTContext() {
   Status error;
-  return m_process->GetTarget().GetScratchSwiftASTContext(error);
+  return llvm::dyn_cast_or_null<SwiftASTContext>(
+      m_process->GetTarget().GetScratchTypeSystemForLanguage(
+          &error, eLanguageTypeSwift));
 }
 
 SwiftLanguageRuntime::MemberVariableOffsetResolver::
@@ -3000,7 +3002,9 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
     if (mangled_name.GuessLanguage() == lldb::eLanguageTypeSwift) {
       Status error;
       Target &target = frame.GetThread()->GetProcess()->GetTarget();
-      SwiftASTContext *swift_ast = target.GetScratchSwiftASTContext(error);
+      ExecutionContext exe_ctx(frame);
+      SwiftASTContext *swift_ast =
+          target.GetScratchSwiftASTContext(error, frame);
       if (swift_ast) {
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName().AsCString(), error);
@@ -3118,8 +3122,9 @@ SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
 {
   ValueObjectSP error_valobj_sp;
   Status error;
-  SwiftASTContext *ast_context =
-      m_process->GetTarget().GetScratchSwiftASTContext(error);
+  SwiftASTContext *ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(
+      m_process->GetTarget().GetScratchTypeSystemForLanguage(
+          &error, eLanguageTypeSwift));
   if (!ast_context || error.Fail())
     return error_valobj_sp;
 
@@ -3138,9 +3143,13 @@ SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
   }
 
   if (persistent && error_valobj_sp) {
-    PersistentExpressionState *persistent_state =
-        m_process->GetTarget().GetPersistentExpressionStateForLanguage(
-            eLanguageTypeSwift);
+    ExecutionContext ctx =
+      error_valobj_sp->GetExecutionContextRef().Lock(false);
+    auto *exe_scope = ctx.GetBestExecutionContextScope();
+    if (!exe_scope)
+      return error_valobj_sp;
+    auto *persistent_state =
+        m_process->GetTarget().GetSwiftPersistentExpressionState(*exe_scope);
 
     ConstString persistent_variable_name(
         persistent_state->GetNextPersistentVariableName(true));
@@ -3195,7 +3204,8 @@ ValueObjectSP SwiftLanguageRuntime::CalculateErrorValueFromFirstArgument(
     frame_sp->CalculateExecutionContext(exe_ctx);
     DataExtractor data;
 
-    SwiftASTContext *ast_context = target->GetScratchSwiftASTContext(error);
+    SwiftASTContext *ast_context = target->GetScratchSwiftASTContext(
+        error, *frame_sp);
     if (!ast_context || error.Fail())
       return error_valobj_sp;
 
@@ -3225,8 +3235,9 @@ ValueObjectSP SwiftLanguageRuntime::CalculateErrorValueFromFirstArgument(
 void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
                                                lldb::addr_t addr) {
   Status ast_context_error;
-  SwiftASTContext *ast_context =
-      target.GetScratchSwiftASTContext(ast_context_error);
+  SwiftASTContext *ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(
+      target.GetScratchTypeSystemForLanguage(&ast_context_error,
+                                             eLanguageTypeSwift));
 
   if (ast_context_error.Success() && ast_context &&
       !ast_context->HasFatalErrors()) {

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -1581,7 +1581,11 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
     // if there's no SwiftASTContext, clearing it doesn't really matter
     const bool create_on_demand = false;
     Status error;
-    auto swift_ast_ctx = GetScratchSwiftASTContext(error, create_on_demand);
+    // There is no point in notifying the per-module SwiftASTContexts,
+    // but do notify the global scratch context.
+    auto swift_ast_ctx =
+        llvm::dyn_cast_or_null<SwiftASTContext>(GetScratchTypeSystemForLanguage(
+            &error, eLanguageTypeSwift, create_on_demand));
     if (swift_ast_ctx)
       swift_ast_ctx->ModulesDidLoad(module_list);
     module_list.ClearModuleDependentCaches();
@@ -2147,19 +2151,28 @@ TypeSystem *Target::GetScratchTypeSystemForLanguage(
             llvm::dyn_cast_or_null<SwiftASTContext>(type_system)) {
       if (swift_ast_ctx->CheckProcessChanged() ||
           swift_ast_ctx->HasFatalErrors()) {
-        if (swift_ast_ctx->HasFatalErrors()) {
-          if (StreamSP error_stream_sp = GetDebugger().GetAsyncErrorStream()) {
-            error_stream_sp->Printf("Shared Swift state for %s has developed "
-                                    "fatal errors and is being discarded.\n",
-                                    GetExecutableModule()
-                                        ->GetPlatformFileSpec()
-                                        .GetFilename()
-                                        .AsCString());
-            error_stream_sp->PutCString(
-                "REPL definitions and persistent names/types will be lost.\n");
-            error_stream_sp->Flush();
+        if (StreamSP errs = GetDebugger().GetAsyncErrorStream()) {
+          if (swift_ast_ctx->HasFatalErrors()) {
+            auto *module_name = GetExecutableModule()
+                                    ->GetPlatformFileSpec()
+                                    .GetFilename()
+                                    .AsCString();
+            if (m_use_scratch_typesystem_per_module)
+              errs->Printf(
+                  "\nnote: Swift header search options for %s conflict with "
+                  "options found in other modules. Symbols from other modules "
+                  "may not be available.",
+                  module_name);
+            else
+              errs->Printf("Shared Swift state for %s has developed fatal "
+                           "errors and is being discarded.\n",
+                           module_name);
+            errs->PutCString("REPL definitions and persistent names/types will "
+                             "be lost.\n\n");
+            errs->Flush();
           }
         }
+
         m_scratch_type_system_map.RemoveTypeSystemsForLanguage(language);
         type_system = m_scratch_type_system_map.GetTypeSystemForLanguage(
             language, this, create_on_demand, compiler_options);
@@ -2223,6 +2236,18 @@ Target::GetPersistentExpressionStateForLanguage(lldb::LanguageType language)
   } else {
     return nullptr;
   }
+}
+
+SwiftPersistentExpressionState *
+Target::GetSwiftPersistentExpressionState(ExecutionContextScope &exe_scope) {
+  Status error;
+  auto *swift_ast_context =
+      llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
+          GetScratchSwiftASTContext(error, exe_scope, true));
+  if (!swift_ast_context)
+    return nullptr;
+  return (SwiftPersistentExpressionState *)
+      swift_ast_context->GetPersistentExpressionState();
 }
 
 UserExpression *Target::GetUserExpressionForLanguage(
@@ -2334,17 +2359,48 @@ ClangASTImporterSP Target::GetClangASTImporter() {
 #ifdef __clang_analyzer__
 // See GetScratchTypeSystemForLanguage() in Target.h
 SwiftASTContext *
-Target::GetScratchSwiftASTContextImpl(Status &error, bool create_on_demand,
-                                      const char *extra_options)
+Target::GetScratchSwiftASTContextImpl(Status &error,
+                                      ExecutionContextScope &exe_scope,
+                                      bool create_on_demand)
 #else
-SwiftASTContext *Target::GetScratchSwiftASTContext(Status &error,
-                                                   bool create_on_demand,
-                                                   const char *extra_options)
+SwiftASTContext *
+Target::GetScratchSwiftASTContext(Status &error,
+                                  ExecutionContextScope &exe_scope,
+                                  bool create_on_demand)
 #endif
 {
+  Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TARGET));
+  while (m_use_scratch_typesystem_per_module && create_on_demand) {
+    lldb::StackFrameSP stack_frame = exe_scope.CalculateStackFrame();
+    if (!stack_frame)
+      break;
+
+    auto sc = stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
+    auto *lldb_module = sc.module_sp.get();
+    if (!lldb_module)
+      break;
+    ModuleLanguage idx = {lldb_module, lldb::eLanguageTypeSwift};
+    auto cached = m_scratch_typesystem_for_module.find(idx);
+    if (cached != m_scratch_typesystem_for_module.end()) {
+      if (log)
+        log->Printf("returned cached module-wide scratch context\n");
+      return cast<SwiftASTContext>(cached->second.get());
+    }
+
+    auto typesystem_sp = SwiftASTContext::CreateInstance(
+        lldb::eLanguageTypeSwift, *lldb_module, this);
+    auto *swift_ast_context = cast<SwiftASTContext>(typesystem_sp.get());
+    m_scratch_typesystem_for_module.insert({idx, typesystem_sp});
+    if (log)
+      log->Printf("created module-wide scratch context\n");
+    return swift_ast_context;
+  }
+
+  if (log)
+    log->Printf("returned project-wide scratch context\n");
   return llvm::dyn_cast_or_null<SwiftASTContext>(
       GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift,
-                                      create_on_demand, extra_options));
+                                      create_on_demand));
 }
 
 void Target::SettingsInitialize() { Process::SettingsInitialize(); }


### PR DESCRIPTION
because of irreconcilable module import errors.

When a Swift program contains several dylibs with conflicting
ClangImporter options building the common scratch SwiftASTContext
fails and the expression evaluator is unusable. This patch detects the
situation where an expression fails because of a module import error
and then switches into a mode where one scratch context per
lldb::Module is created, using only the ClangImporter flags for the
module which ideally should have been tested by the Swift compiler
that built that module. This also bifurcates the persistent expression
state, such that each lldb::Module has its own set of return
variables, but it is still a strict improvement over not having access
to the expression evaluator at all.

rdar://problem/38686915
(cherry picked from commit 114eb9915431a2fdada35cfa2a3a755634d4efd0)