### PR TITLE
Change the default for target.use-all-compiler-flags to true

### DIFF
--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3582,7 +3582,7 @@ static PropertyDefinition g_properties[] = {
     {"auto-import-clang-modules", OptionValue::eTypeBoolean, false, true,
      nullptr, nullptr,
      "Automatically load Clang modules referred to by the program."},
-    {"use-all-compiler-flags", OptionValue::eTypeBoolean, false, false, nullptr,
+    {"use-all-compiler-flags", OptionValue::eTypeBoolean, false, true, nullptr,
      nullptr, "Try to use compiler flags for all modules when setting up the "
               "Swift expression parser, not just the main executable."},
     {"auto-apply-fixits", OptionValue::eTypeBoolean, false, true, nullptr,


### PR DESCRIPTION
This is a safe thing to do now since we have a reliable fallback
mechanism in the module-specific scract AST contexts. The main
difference for the end user that are affected by this change will be
that they don't get a confusing error message befopre the first
expression is evaluated.

<rdar://problem/39243524>