### PR TITLE
[CMake] Set the default test compiler deterministically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,16 +71,10 @@ add_subdirectory(tools)
 option(LLDB_INCLUDE_TESTS "Generate build targets for the LLDB unit tests."
   ${LLVM_INCLUDE_TESTS})
 if(LLDB_INCLUDE_TESTS)
-  # TARGET clang works for a non-standalone build.
-  #
-  # FIXME: This can be avoided by importing the cmake configuration from swift.
-  if (TARGET clang OR LLDB_BUILD_STANDALONE)
-    set(LLDB_DEFAULT_TEST_C_COMPILER "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
-    set(LLDB_DEFAULT_TEST_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}")
-  else()
-    set(LLDB_DEFAULT_TEST_C_COMPILER "")
-    set(LLDB_DEFAULT_TEST_CXX_COMPILER "")
-  endif()
+  # BEGIN - Swift Mods
+  set(LLDB_DEFAULT_TEST_C_COMPILER "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX}")
+  set(LLDB_DEFAULT_TEST_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX}")
+  # END - Swift Mods
 
   set(LLDB_TEST_C_COMPILER "${LLDB_DEFAULT_TEST_C_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
   set(LLDB_TEST_CXX_COMPILER "${LLDB_DEFAULT_TEST_CXX_COMPILER}" CACHE PATH "C++ Compiler to use for building LLDB test inferiors")

--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -15,10 +15,10 @@ endif(BUILD_SHARED_LIBS)
 llvm_canonicalize_cmake_booleans(
   LLVM_ENABLE_ZLIB)
 
-option(LLDB_TEST_CLANG "Use in-tree clang when testing lldb" Off)
-option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" Off)
-set(LLDB_TEST_C_COMPILER "" CACHE STRING "C compiler to use when testing LLDB")
-set(LLDB_TEST_CXX_COMPILER "" CACHE STRING "C++ compiler to use when testing LLDB")
+# BEGIN - Swift Mods
+option(LLDB_TEST_CLANG "Use in-tree clang when testing lldb" On)
+option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
+# END - Swift Mods
 
 # This should be inherited from the `check-lldb` target. We currently don't run
 # it for swift, but we might consider removing this code once we're done.


### PR DESCRIPTION
For swift-lldb, switch the default testing behavior so we use the
in-tree compilers by default.

Also, stop setting the cached LLDB_TEST_C_COMPILER variable multiple
times. Just set it one time to the compiler we want to test with.

This address a non-deterministic issue which sometimes caused
LLDB_TEST_C_COMPILER to be set to the empty string. My theory for how
this happened is:

We set the cached variable LLDB_TEST_C_COMPILER for the first time
in the top-level cmake file, and then

We set the variable again in lit/CMakeLists.txt.

The second set did not use the FORCE modifier, so the empty string
should never have been assigned to LLDB_TEST_C_COMPILER, but perhaps
there was a bug in the version of cmake installed on the Linux bots
where we sporadically saw this issue.

At any rate, this PR should address the non-determinism by removing the
multiple assignments to the cached variable.

rdar://39537655, rdar://38935299

(cherry picked from commit ac3f72dc7a6fa3de46530b45cc74631d26c448bd)

 Conflicts:
	CMakeLists.txt