### PR TITLE
 Fix a crash when resolving overloads of C++ virtual methods.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/cpp/virtual-overload/Makefile
+++ b/packages/Python/lldbsuite/test/lang/cpp/virtual-overload/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../make
+
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/cpp/virtual-overload/TestVirtualOverload.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/virtual-overload/TestVirtualOverload.py
@@ -1,0 +1,3 @@
+from lldbsuite.test import lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/cpp/virtual-overload/main.cpp
+++ b/packages/Python/lldbsuite/test/lang/cpp/virtual-overload/main.cpp
@@ -1,0 +1,17 @@
+// Test that lldb doesn't get confused by an overload of a virtual
+// function of the same name.
+struct Base {
+  virtual void f(int i) {}
+  virtual ~Base() {}
+};
+
+struct Derived : Base {
+  virtual void f(int i, int j) {}
+};
+
+int main(int argc, char **argv) {
+  Derived obj;
+  obj.f(1, 2); //% self.expect("fr var", "not crashing", substrs = ["obj"])
+  return 0;
+}
+

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2179,7 +2179,10 @@ static bool isOverload(clang::CXXMethodDecl *m1, clang::CXXMethodDecl *m2) {
                                  m2p.getUnqualifiedType());
     };
 
-  return !std::equal(m1Type->param_type_begin(), m1Type->param_type_end(),
+  // FIXME: In C++14 and later, we can just pass m2Type->param_type_end()
+  //        as a fourth parameter to std::equal().
+  return (m1->getNumParams() != m2->getNumParams()) ||
+         !std::equal(m1Type->param_type_begin(), m1Type->param_type_end(),
                      m2Type->param_type_begin(), compareArgTypes);
 }
 


### PR DESCRIPTION
The isOverload() method needs to account for situations where the two
methods being compared don't have the same number of arguments.

rdar://problem/39542960

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@330450 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 53113aaa3194cd8dbfa106ad9460e124db6f2570)