### PR TITLE
[Swift] Remove unneccessary call to performSILLinking()

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1857,8 +1857,6 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     log->PutCString(s.c_str());
   }
 
-  swift::performSILLinking(sil_module.get());
-
   if (m_swift_ast_context->HasErrors()) {
     DiagnoseSwiftASTContextError();
     return 1;


### PR DESCRIPTION
(cherry picked from commit 0d7f7029e643b716e5c53cfc434a20eb86f67eb5)