### PR TITLE
Derive LangOpts.EnableObjCInterop every time the triple is changed.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/objc-interop/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/objc-interop/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/objc-interop/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/objc-interop/main.swift
@@ -1,0 +1,13 @@
+import Dispatch
+
+// The dispatch clang module is either imported as Objective-C or as C
+// with blocks, and both varints should work in LLDB's expression evaluator.
+
+func main() {
+  let label = "lldbtest"
+  let queue = DispatchQueue(label: label)
+  print(queue) //% self.expect("fr var -- label", substrs=['lldbtest'])
+               //% self.expect("expr -- label",   substrs=['lldbtest'])
+}
+
+main()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1740,6 +1740,12 @@ bool SwiftASTContext::SetTriple(const char *triple_cstr, Module *module) {
                     this, triple_cstr, triple.c_str(),
                     m_target_wp.lock() ? " (target)" : "");
       m_compiler_invocation_ap->setTargetTriple(triple);
+
+      // Every time the triple is changed the LangOpts must be
+      // updated too, because Swift default-initializes the
+      // EnableObjCInterop flag based on the triple.
+      GetLanguageOptions().EnableObjCInterop = llvm_triple.isOSDarwin();
+
       return true;
     } else {
       if (log)


### PR DESCRIPTION
Every time the triple is changed the LangOpts must be updated too,
because Swift default-initializes the EnableObjCInterop flag based on
the triple.

SR-7388
rdar://problem/39277133