### PR TITLE
[SwiftExpressionParser] Correctly dematerialize zero-sized types.

### DIFF
--- a/lit/SwiftREPL/ZeroSizeStruct.test
+++ b/lit/SwiftREPL/ZeroSizeStruct.test
@@ -1,0 +1,10 @@
+// Test that we can define and use zero-sized struct in the repl.
+
+// RUN: %lldb --repl < %s | FileCheck %s
+
+struct Patatino {}
+let tinky = Patatino()
+CHECK: tinky: Patatino = {}
+
+tinky
+CHECK: $R0: Patatino = {}


### PR DESCRIPTION
Fixes <rdar://problem/39211051>
4.2 edition