### PR TITLE
[REPL] Make sure threads don't interrupt each other.

### DIFF
--- a/lit/SwiftREPL/SleepREPL.test
+++ b/lit/SwiftREPL/SleepREPL.test
@@ -1,0 +1,8 @@
+// Test that we can sleep in the repl
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=SLEEP
+
+import Foundation
+sleep(2)
+// SLEEP: $R0: UInt32 = 0

--- a/source/Expression/REPL.cpp
+++ b/source/Expression/REPL.cpp
@@ -295,6 +295,16 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
       expr_options.SetColorizeErrors(colorize_err);
       expr_options.SetPoundLine(m_repl_source_path.c_str(),
                                 m_code.GetSize() + 1);
+
+      // There is no point in trying to run REPL expressions on just the
+      // current thread of the program, since the REPL tracks the states of
+      // individual threads as you would in a regular debugging session.
+      // Interrupting the process to switch from one thread to many has
+      // observable effects (for instance it causes anything waiting in the
+      // kernel to be interrupted). Since we aren't getting any benefit from
+      // doing this in the REPL, let's not.
+      expr_options.SetStopOthers(false);
+
       if (m_command_options.timeout > 0)
         expr_options.SetTimeout(std::chrono::microseconds(m_command_options.timeout));
       else


### PR DESCRIPTION
Fixes sleep() in the REPL, which before just returned immediately.

<rdar://problem/39398038>