### PR TITLE
[REPL] Make sure threads don't interrupt each other.

### DIFF
--- a/lit/SwiftREPL/SleepREPL.test
+++ b/lit/SwiftREPL/SleepREPL.test
@@ -1,0 +1,8 @@
+// Test that we can sleep in the repl
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=SLEEP
+
+import Foundation
+sleep(2)
+// SLEEP: $R0: UInt32 = 0

--- a/source/Expression/REPL.cpp
+++ b/source/Expression/REPL.cpp
@@ -295,6 +295,12 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
       expr_options.SetColorizeErrors(colorize_err);
       expr_options.SetPoundLine(m_repl_source_path.c_str(),
                                 m_code.GetSize() + 1);
+
+      // We don't want other threads to interfere and block the thread
+      // it's currently running. This is needed to get, e.g. sleep() to
+      // work reliably in the REPL.
+      expr_options.SetStopOthers(false);
+
       if (m_command_options.timeout > 0)
         expr_options.SetTimeout(std::chrono::microseconds(m_command_options.timeout));
       else


### PR DESCRIPTION
Fixes sleep() in the REPL, which before just returned immediately.

<rdar://problem/39398038>