### PR TITLE
Revert "test/functionalities/signal/raise seems to be passing on macO…

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/signal/raise/TestRaise.py
+++ b/packages/Python/lldbsuite/test/functionalities/signal/raise/TestRaise.py
@@ -190,7 +190,8 @@ class RaiseTestCase(TestBase):
         self.set_handle(signal, default_pass, default_stop, default_notify)
 
     @expectedFailureAll(
-        oslist=["linux"],
+        oslist=["linux"] +
+        getDarwinOSTriples(),
         bugnumber="llvm.org/pr20231")
     def test_restart_bug(self):
         """Test that we catch a signal in the edge case where the process receives it while we are


### PR DESCRIPTION
…S, remove expected failure"

This test is still failing intermittently.

This reverts commit af77acf41e3a59cd447e828cc254bc3f91f8c6df.