### PR TITLE
[DataFmt] Fix formatting of bridged CFStrings

### DIFF
--- a/lit/SwiftREPL/CFString.test
+++ b/lit/SwiftREPL/CFString.test
@@ -1,0 +1,11 @@
+// Test that CFString works in the REPL.
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s
+// CHECK: Welcome to Swift
+
+import Foundation
+
+let s = CFStringCreateWithCString(nil, "abcdefghijklmnop", kCFStringEncodingASCII)!
+let s2 = s as String
+// CHECK: s2: String = "abcdefghijklmnop"

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -230,8 +230,15 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
     CompilerType id_type =
         process->GetTarget().GetScratchClangASTContext()->GetBasicType(
             lldb::eBasicTypeObjCID);
-    ValueObjectSP nsstring = ValueObject::CreateValueObjectFromAddress(
-        "nsstring", startAddress, valobj.GetExecutionContextRef(), id_type);
+
+    // Warning: Using ValueObject::CreateValueObjectFromAddress can create an
+    // invalid ValueObject here in an unknown set of cases. Until this is fixed,
+    // use CreateValueObjectFromData (rdar://39741576).
+    DataExtractor DE(&startAddress, process->GetAddressByteSize(),
+                     process->GetByteOrder(), process->GetAddressByteSize());
+    ValueObjectSP nsstring = ValueObject::CreateValueObjectFromData(
+        "nsstring", DE, valobj.GetExecutionContextRef(), id_type);
+
     if (nsstring)
       return NSStringSummaryProvider(*nsstring.get(), stream, summary_options);
     return false;


### PR DESCRIPTION
The formatter for Swift strings called CreateValueObjectFromAddress in
order to construct a ValueObject for bridged strings. In an unknown set
of cases, this API call can accidentally dereference the payload, giving
an invalid ValueObject that the NSString summary provider doesn't
understand.

Address the issue by making sure the address is never dereferenced when
constructing the ValueObject for bridged strings. As a follow-up, there
is a radar to investigate why the accidental dereference occurs
(r://39741576)

rdar://39710387