### PR TITLE
[debugserver] Fix handling of the 'g' packet

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteGPacket.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteGPacket.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+
+
+import gdbremote_testcase
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestGdbRemoteGPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def run_test_g_packet(self):
+        self.build()
+        self.prep_debug_monitor_and_inferior()
+        self.test_sequence.add_log_lines(
+            ["read packet: $g#67",
+             {"direction": "send", "regex": r"^\$(.+)#[0-9a-fA-F]{2}$",
+              "capture": {1: "register_bank"}}],
+            True)
+        self.connect_to_debug_monitor()
+        context = self.expect_gdbremote_sequence()
+        register_bank = context.get("register_bank")
+        self.assertTrue(register_bank[0] != 'E')
+
+    @debugserver_test
+    def test_g_packet_debugserver(self):
+        self.init_debugserver_test()
+        self.run_test_g_packet()

--- a/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
+++ b/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
@@ -2633,7 +2633,9 @@ nub_size_t DNBArchImplX86_64::GetRegisterContext(void *buf,
 
       // Walk around the gaps in the FPU regs
       memcpy(p, &m_state.context.fpu.no_avx.__fpu_fcw, 5);
-      p += 5;
+      // We read 5 bytes, but we skip 6 to account for __fpu_rsrv1
+      // to match the g_fpu_registers_* tables.
+      p += 6;
       memcpy(p, &m_state.context.fpu.no_avx.__fpu_fop, 8);
       p += 8;
       memcpy(p, &m_state.context.fpu.no_avx.__fpu_dp, 6);


### PR DESCRIPTION
LLDB doesn't use this packet so we never hit this, but it looks like
some other projects talk to debugserver and are hitting an assert
(https://github.com/derekparker/delve/issues/1015).

We had an off by 1 in the accounting of the FPU structure sizes.
I added a test that basically just check that 'g' doesn't return
an error (currently it assert in debug builds). I didn't make
it an lldb-server test because it looks like lldb-server doesn't
implement the g packet.

rdar://39060083

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@331004 91177308-0d34-0410-b5e6-96231b3b80d8