### PR TITLE
Mark test as @skipIfOutOfTreeDebugserver

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteGPacket.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteGPacket.py
@@ -24,6 +24,7 @@ class TestGdbRemoteGPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
         register_bank = context.get("register_bank")
         self.assertTrue(register_bank[0] != 'E')
 
+    @skipIfOutOfTreeDebugserver
     @debugserver_test
     def test_g_packet_debugserver(self):
         self.init_debugserver_test()


### PR DESCRIPTION
This test will currently fail for people using the system debugserver.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@331043 91177308-0d34-0410-b5e6-96231b3b80d8