### PR TITLE
[debugserver] Fix the G packet handling.

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteGPacket.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteGPacket.py
@@ -24,6 +24,15 @@ class TestGdbRemoteGPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
         register_bank = context.get("register_bank")
         self.assertTrue(register_bank[0] != 'E')
 
+        self.test_sequence.add_log_lines(
+            ["read packet: $G" + register_bank + "#00",
+             {"direction": "send", "regex": r"^\$(.+)#[0-9a-fA-F]{2}$",
+              "capture": {1: "G_reply"}}],
+            True)
+        context = self.expect_gdbremote_sequence()
+        self.assertTrue(context.get("G_reply")[0] != 'E')
+
+
     @skipIfOutOfTreeDebugserver
     @debugserver_test
     def test_g_packet_debugserver(self):

--- a/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
+++ b/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
@@ -2717,7 +2717,9 @@ nub_size_t DNBArchImplX86_64::SetRegisterContext(const void *buf,
 
     // Copy fcw through mxcsrmask as there is no padding
     memcpy(&m_state.context.fpu.no_avx.__fpu_fcw, p, 5);
-    p += 5;
+    // We wrote 5 bytes, but we skip 6 to account for __fpu_rsrv1
+    // to match the g_fpu_registers_* tables.
+    p += 6;
     memcpy(&m_state.context.fpu.no_avx.__fpu_fop, p, 8);
     p += 8;
     memcpy(&m_state.context.fpu.no_avx.__fpu_dp, p, 6);


### PR DESCRIPTION
Of course r331004 needed a counterpart on the write side.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@331073 91177308-0d34-0410-b5e6-96231b3b80d8