### PR TITLE
Remove premature caching of the global variables list in CompileUnit.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/c/global_variables/main.c
+++ b/packages/Python/lldbsuite/test/lang/c/global_variables/main.c
@@ -13,6 +13,7 @@ int g_file_global_int = 42;
 static const int g_file_static_int = 2;
 const char *g_file_global_cstr = "g_file_global_cstr";
 static const char *g_file_static_cstr = "g_file_static_cstr";
+int *g_ptr = &g_file_global_int;
 
 extern int g_a;
 int main (int argc, char const *argv[])
@@ -20,5 +21,5 @@ int main (int argc, char const *argv[])
     g_common_1 = g_file_global_int / g_file_static_int;
     static const char *g_func_static_cstr = "g_func_static_cstr";
     printf ("%s %s\n", g_file_global_cstr, g_file_static_cstr);
-    return g_file_global_int + g_a + g_common_1; // Set break point at this line.  //// break $source:$line; continue; var -global g_a -global g_global_int
+    return g_file_global_int + g_a + g_common_1 + *g_ptr; // Set break point at this line.  //// break $source:$line; continue; var -global g_a -global g_global_int
 }

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -4479,7 +4479,6 @@ size_t SymbolFileDWARF::ParseVariables(const SymbolContext &sc,
               variable_list_sp = sc.comp_unit->GetVariableList(false);
               if (variable_list_sp.get() == NULL) {
                 variable_list_sp.reset(new VariableList());
-                sc.comp_unit->SetVariableList(variable_list_sp);
               }
             } else {
               GetObjectFile()->GetModule()->ReportError(


### PR DESCRIPTION
This fixes a bug where

  (lldb) target var g_ptr

would populate the global variables list with exactly one entry
because SymbolFileDWARF::ParseVariables() was invoked with a list of
DIEs pre-filtered by name, such that a subsequent call to

  (lldb) fr var --show-globals

would only list that one variable, because CompileUnit::m_variables
was already initialized, fooling CompileUnit::GetVariableList().

CompileUnit::GetVariableList() grabs the *complete* list of variables
via (SymbolFileDWARF, ...)::ParseVariablesForContext and that still
calls CompileUnit::SetVariableList(variables) which acts as the
caching mechanism.

Differential Revision: https://reviews.llvm.org/D46220

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@331230 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit bc92d947a5445e2656babfacb90509bd03daa0cb)