### PR TITLE
 Move the persistent variable counter into Target

### DIFF
--- a/include/lldb/Expression/ExpressionVariable.h
+++ b/include/lldb/Expression/ExpressionVariable.h
@@ -242,7 +242,7 @@ public:
                            lldb::ByteOrder byte_order,
                            uint32_t addr_byte_size) = 0;
 
-  virtual ConstString GetNextPersistentVariableName(bool is_error = false) = 0;
+  virtual ConstString GetNextPersistentVariableName(Target &target) = 0;
 
   virtual void
   RemovePersistentVariable(lldb::ExpressionVariableSP variable) = 0;

--- a/include/lldb/Expression/ExpressionVariable.h
+++ b/include/lldb/Expression/ExpressionVariable.h
@@ -242,7 +242,12 @@ public:
                            lldb::ByteOrder byte_order,
                            uint32_t addr_byte_size) = 0;
 
-  virtual ConstString GetNextPersistentVariableName(Target &target) = 0;
+  /// Return a new persistent variable name with the specified prefix.
+  ConstString GetNextPersistentVariableName(Target &target,
+                                            llvm::StringRef prefix);
+
+  virtual llvm::StringRef
+  GetPersistentVariablePrefix(bool is_error = false) const = 0;
 
   virtual void
   RemovePersistentVariable(lldb::ExpressionVariableSP variable) = 0;

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -1218,6 +1218,11 @@ public:
 
   lldb::ExpressionVariableSP GetPersistentVariable(const ConstString &name);
 
+  /// Return the next available number for numbered persistent variables.
+  unsigned GetNextPersistentVariableIndex() {
+    return m_next_persistent_variable_index++;
+  }
+
   lldb::addr_t GetPersistentSymbol(const ConstString &name);
 
   //------------------------------------------------------------------
@@ -1422,6 +1427,7 @@ protected:
   bool m_valid;
   bool m_suppress_stop_hooks;
   bool m_is_dummy_target;
+  unsigned m_next_persistent_variable_index = 0;
 
   bool m_use_scratch_typesystem_per_module = false;
   typedef std::pair<lldb_private::Module *, char> ModuleLanguage;

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -60,9 +60,9 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
         # This initially fails with the shared scratch context and is
         # then retried with the per-dylib scratch context.
-        self.expect("p bar", "expected result", substrs=["42"])
-        self.expect("p $R0", "expected result", substrs=["42"])
-        self.expect("p $R1", "expected result", substrs=["42"])
+        self.expect("p bar", "expected result", substrs=["$R0", "42"])
+        self.expect("p $R0", "expected result", substrs=["$R2", "42"])
+        self.expect("p $R2", "expected result", substrs=["$R4", "42"])
         
         # This works by accident because the search paths are in the right order.
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
@@ -70,8 +70,8 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         process.Continue()
         self.expect("fr var foo", "expected result", substrs=["23"])
         self.expect("p foo", "expected result", substrs=["23"])
-        self.expect("p $R0", "expected result", substrs=["23"])
-        self.expect("p $R1", "expected result", substrs=["23"])
+        self.expect("p $R6", "expected result", substrs=["23"])
+        self.expect("p $R8", "expected result", substrs=["23"])
 
 if __name__ == '__main__':
     import atexit

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -3425,7 +3425,7 @@ ValueObjectSP ValueObject::Persist() {
   if (!persistent_state)
     return nullptr;
 
-  ConstString name(persistent_state->GetNextPersistentVariableName());
+  ConstString name(persistent_state->GetNextPersistentVariableName(*target_sp));
 
   ValueObjectSP const_result_sp =
       ValueObjectConstResult::Create(target_sp.get(), GetValue(), name);

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -3425,7 +3425,9 @@ ValueObjectSP ValueObject::Persist() {
   if (!persistent_state)
     return nullptr;
 
-  ConstString name(persistent_state->GetNextPersistentVariableName(*target_sp));
+  auto prefix = persistent_state->GetPersistentVariablePrefix();
+  ConstString name =
+      persistent_state->GetNextPersistentVariableName(*target_sp, prefix);
 
   ValueObjectSP const_result_sp =
       ValueObjectConstResult::Create(target_sp.get(), GetValue(), name);

--- a/source/Expression/ExpressionVariable.cpp
+++ b/source/Expression/ExpressionVariable.cpp
@@ -9,6 +9,7 @@
 
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Expression/IRExecutionUnit.h"
+#include "lldb/Target/Target.h"
 #include "lldb/Utility/Log.h"
 
 using namespace lldb_private;
@@ -84,4 +85,14 @@ void PersistentExpressionState::RegisterExecutionUnit(
                     global_var.m_name.GetCString(), global_var.m_remote_addr);
     }
   }
+}
+
+ConstString PersistentExpressionState::GetNextPersistentVariableName(
+    Target &target, llvm::StringRef Prefix) {
+  llvm::SmallString<64> name;
+  {
+    llvm::raw_svector_ostream os(name);
+    os << Prefix << target.GetNextPersistentVariableIndex();
+  }
+  return ConstString(name);
 }

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -948,9 +948,10 @@ public:
       return;
     }
 
-    ConstString name = m_delegate
-                           ? m_delegate->GetName()
-                           : persistent_state->GetNextPersistentVariableName();
+    ConstString name =
+        m_delegate
+            ? m_delegate->GetName()
+            : persistent_state->GetNextPersistentVariableName(*target_sp);
 
     lldb::ProcessSP process_sp =
         map.GetBestExecutionContextScope()->CalculateProcess();

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -951,7 +951,8 @@ public:
     ConstString name =
         m_delegate
             ? m_delegate->GetName()
-            : persistent_state->GetNextPersistentVariableName(*target_sp);
+            : persistent_state->GetNextPersistentVariableName(
+                  *target_sp, persistent_state->GetPersistentVariablePrefix());
 
     lldb::ProcessSP process_sp =
         map.GetBestExecutionContextScope()->CalculateProcess();

--- a/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Expression/IRExecutionUnit.h"
 
 #include "lldb/Core/Value.h"
+#include "lldb/Target/Target.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
@@ -83,30 +84,10 @@ void ClangPersistentVariables::RemovePersistentVariable(
 }
 
 ConstString
-ClangPersistentVariables::GetNextPersistentVariableName(bool is_error) {
+ClangPersistentVariables::GetNextPersistentVariableName(Target &target) {
   char name_cstr[256];
-
-  const char *prefix = "$";
-
-  /* THIS NEEDS TO BE HANDLED BY SWIFT-SPECIFIC CODE
-      switch (language_type)
-      {
-      default:
-          break;
-      case lldb::eLanguageTypePLI:
-      case lldb::eLanguageTypeSwift:
-          if (is_error)
-              prefix = "$E";
-          else
-              prefix = "$R";
-          break;
-      }
-   */
-
-  ::snprintf(name_cstr, sizeof(name_cstr), "%s%u", prefix,
-             is_error ? m_next_persistent_error_id++
-                      : m_next_persistent_variable_id++);
-
+  ::snprintf(name_cstr, sizeof(name_cstr), "$%u",
+             target.GetNextPersistentVariableIndex());
   ConstString name(name_cstr);
   return name;
 }

--- a/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.cpp
@@ -83,15 +83,6 @@ void ClangPersistentVariables::RemovePersistentVariable(
   }
 }
 
-ConstString
-ClangPersistentVariables::GetNextPersistentVariableName(Target &target) {
-  char name_cstr[256];
-  ::snprintf(name_cstr, sizeof(name_cstr), "$%u",
-             target.GetNextPersistentVariableIndex());
-  ConstString name(name_cstr);
-  return name;
-}
-
 void ClangPersistentVariables::RegisterPersistentDecl(const ConstString &name,
                                                       clang::NamedDecl *decl) {
   m_persistent_decls.insert(

--- a/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -77,7 +77,7 @@ public:
   /// @return
   ///     A string that contains the next persistent variable name.
   //----------------------------------------------------------------------
-  ConstString GetNextPersistentVariableName(bool is_error = false) override;
+  ConstString GetNextPersistentVariableName(Target &target) override;
 
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 

--- a/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -64,22 +64,11 @@ public:
       const CompilerType &compiler_type, lldb::ByteOrder byte_order,
       uint32_t addr_byte_size) override;
 
-  //----------------------------------------------------------------------
-  /// Return the next entry in the sequence of strings "$0", "$1", ... for
-  /// use naming persistent expression convenience variables.
-  ///
-  /// @param[in] language_type
-  ///     The language for the expression, which can affect the prefix
-  ///
-  /// @param[in] is_error
-  ///     If true, an error variable name is produced.
-  ///
-  /// @return
-  ///     A string that contains the next persistent variable name.
-  //----------------------------------------------------------------------
-  ConstString GetNextPersistentVariableName(Target &target) override;
-
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
+  llvm::StringRef
+  GetPersistentVariablePrefix(bool is_error) const override {
+    return "$";
+  }
 
   // This just adds this module to the list of hand-loaded modules, it doesn't
   // actually load it.

--- a/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -65,7 +65,8 @@ ClangUserExpression::ClangUserExpression(
                          options),
       m_type_system_helper(*m_target_wp.lock().get(),
                            options.GetExecutionPolicy() ==
-                               eExecutionPolicyTopLevel) {
+                               eExecutionPolicyTopLevel),
+      m_result_delegate(exe_scope.CalculateTarget()) {
   m_language_flags |= eLanguageFlagEnforceValidObject;
 
   switch (m_language) {
@@ -685,10 +686,8 @@ void ClangUserExpression::ClangUserExpressionHelper::CommitPersistentDecls() {
   }
 }
 
-ClangUserExpression::ResultDelegate::ResultDelegate() {}
-
 ConstString ClangUserExpression::ResultDelegate::GetName() {
-  return m_persistent_state->GetNextPersistentVariableName();
+  return m_persistent_state->GetNextPersistentVariableName(*m_target_sp);
 }
 
 void ClangUserExpression::ResultDelegate::DidDematerialize(

--- a/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -687,7 +687,9 @@ void ClangUserExpression::ClangUserExpressionHelper::CommitPersistentDecls() {
 }
 
 ConstString ClangUserExpression::ResultDelegate::GetName() {
-  return m_persistent_state->GetNextPersistentVariableName(*m_target_sp);
+  auto prefix = m_persistent_state->GetPersistentVariablePrefix();
+  return m_persistent_state->GetNextPersistentVariableName(*m_target_sp,
+                                                           prefix);
 }
 
 void ClangUserExpression::ResultDelegate::DidDematerialize(

--- a/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -192,7 +192,7 @@ private:
 
   class ResultDelegate : public Materializer::PersistentVariableDelegate {
   public:
-    ResultDelegate();
+    ResultDelegate(lldb::TargetSP target) : m_target_sp(target) {}
     ConstString GetName() override;
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
 
@@ -202,6 +202,7 @@ private:
   private:
     PersistentExpressionState *m_persistent_state;
     lldb::ExpressionVariableSP m_variable;
+    lldb::TargetSP m_target_sp;
   };
 
   ResultDelegate m_result_delegate;

--- a/source/Plugins/ExpressionParser/Go/GoUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Go/GoUserExpression.cpp
@@ -272,7 +272,8 @@ GoUserExpression::DoExecute(DiagnosticManager &diagnostic_manager,
   PersistentExpressionState *pv =
       target->GetPersistentExpressionStateForLanguage(eLanguageTypeGo);
   if (pv != nullptr) {
-    result->SetName(pv->GetNextPersistentVariableName(*target));
+    result->SetName(pv->GetNextPersistentVariableName(
+        *target, pv->GetPersistentVariablePrefix()));
     pv->AddVariable(result);
   }
   return lldb::eExpressionCompleted;
@@ -650,16 +651,6 @@ ValueObjectSP GoUserExpression::GoInterpreter::VisitCallExpr(
 
 GoPersistentExpressionState::GoPersistentExpressionState()
     : PersistentExpressionState(eKindGo) {}
-
-ConstString
-GoPersistentExpressionState::GetNextPersistentVariableName(Target &target) {
-  char name_cstr[256];
-  // We can't use the same variable format as clang.
-  ::snprintf(name_cstr, sizeof(name_cstr), "$go%u",
-             target.GetNextPersistentVariableIndex());
-  ConstString name(name_cstr);
-  return name;
-}
 
 void GoPersistentExpressionState::RemovePersistentVariable(
     lldb::ExpressionVariableSP variable) {

--- a/source/Plugins/ExpressionParser/Go/GoUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Go/GoUserExpression.cpp
@@ -272,7 +272,7 @@ GoUserExpression::DoExecute(DiagnosticManager &diagnostic_manager,
   PersistentExpressionState *pv =
       target->GetPersistentExpressionStateForLanguage(eLanguageTypeGo);
   if (pv != nullptr) {
-    result->SetName(pv->GetNextPersistentVariableName());
+    result->SetName(pv->GetNextPersistentVariableName(*target));
     pv->AddVariable(result);
   }
   return lldb::eExpressionCompleted;
@@ -652,11 +652,11 @@ GoPersistentExpressionState::GoPersistentExpressionState()
     : PersistentExpressionState(eKindGo) {}
 
 ConstString
-GoPersistentExpressionState::GetNextPersistentVariableName(bool is_error) {
+GoPersistentExpressionState::GetNextPersistentVariableName(Target &target) {
   char name_cstr[256];
   // We can't use the same variable format as clang.
   ::snprintf(name_cstr, sizeof(name_cstr), "$go%u",
-             m_next_persistent_variable_id++);
+             target.GetNextPersistentVariableIndex());
   ConstString name(name_cstr);
   return name;
 }

--- a/source/Plugins/ExpressionParser/Go/GoUserExpression.h
+++ b/source/Plugins/ExpressionParser/Go/GoUserExpression.h
@@ -29,8 +29,10 @@ class GoPersistentExpressionState : public PersistentExpressionState {
 public:
   GoPersistentExpressionState();
 
-  ConstString GetNextPersistentVariableName(Target &target) override;
-
+  llvm::StringRef
+  GetPersistentVariablePrefix(bool is_error) const override {
+    return "$go";
+  }
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 
   lldb::addr_t LookupSymbol(const ConstString &name) override {

--- a/source/Plugins/ExpressionParser/Go/GoUserExpression.h
+++ b/source/Plugins/ExpressionParser/Go/GoUserExpression.h
@@ -29,7 +29,7 @@ class GoPersistentExpressionState : public PersistentExpressionState {
 public:
   GoPersistentExpressionState();
 
-  ConstString GetNextPersistentVariableName(bool is_error = false) override;
+  ConstString GetNextPersistentVariableName(Target &target) override;
 
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -85,25 +85,6 @@ void SwiftPersistentExpressionState::RemovePersistentVariable(
   }
 }
 
-ConstString
-SwiftPersistentExpressionState::GetNextPersistentVariableName(bool is_error) {
-  char name_cstr[256];
-
-  const char *prefix = nullptr;
-
-  if (is_error)
-    prefix = "$E";
-  else
-    prefix = "$R";
-
-  ::snprintf(name_cstr, sizeof(name_cstr), "%s%u", prefix,
-             is_error ? m_next_persistent_error_id++
-                      : m_next_persistent_variable_id++);
-
-  ConstString name(name_cstr);
-  return name;
-}
-
 bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(
     swift::Decl *lhs_decl, swift::Decl *rhs_decl) {
   swift::DeclKind lhs_kind = lhs_decl->getKind();

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -76,20 +76,10 @@ public:
       const CompilerType &compiler_type, lldb::ByteOrder byte_order,
       uint32_t addr_byte_size) override;
 
-  //----------------------------------------------------------------------
-  /// Return the next entry in the sequence of strings "$0", "$1", ... for
-  /// use naming persistent expression convenience variables.
-  ///
-  /// @param[in] language_type
-  ///     The language for the expression, which can affect the prefix
-  ///
-  /// @param[in] is_error
-  ///     If true, an error variable name is produced.
-  ///
-  /// @return
-  ///     A string that contains the next persistent variable name.
-  //----------------------------------------------------------------------
-  ConstString GetNextPersistentVariableName(bool is_error = false) override;
+  llvm::StringRef
+  GetPersistentVariablePrefix(bool is_error) const override {
+    return is_error ? "$E" : "$R";
+  }
 
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -100,9 +100,11 @@ public:
                          "doesn't have persistent state");
     }
 
+    auto prefix = persistent_state->GetPersistentVariablePrefix();
     ConstString name =
         m_delegate ? m_delegate->GetName()
-                   : persistent_state->GetNextPersistentVariableName(false);
+                   : persistent_state->GetNextPersistentVariableName(*target_sp,
+                                                                     prefix);
 
     lldb::ExpressionVariableSP ret;
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -157,7 +157,7 @@ private:
 
   class ResultDelegate : public Materializer::PersistentVariableDelegate {
   public:
-    ResultDelegate(SwiftUserExpression &, bool is_error);
+    ResultDelegate(lldb::TargetSP target, SwiftUserExpression &, bool is_error);
     ConstString GetName() override;
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
 
@@ -165,10 +165,11 @@ private:
     lldb::ExpressionVariableSP &GetVariable();
 
   private:
+    lldb::TargetSP m_target_sp;
     SwiftUserExpression &m_user_expression;
-    bool m_is_error;
     PersistentExpressionState *m_persistent_state;
     lldb::ExpressionVariableSP m_variable;
+    bool m_is_error;
   };
 
   ResultDelegate m_result_delegate;

--- a/source/Target/ABI.cpp
+++ b/source/Target/ABI.cpp
@@ -115,8 +115,10 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
     if (!persistent_expression_state)
       return ValueObjectSP();
 
-    ConstString persistent_variable_name(
-        persistent_expression_state->GetNextPersistentVariableName(target));
+    auto prefix = persistent_expression_state->GetPersistentVariablePrefix();
+    ConstString persistent_variable_name =
+        persistent_expression_state->GetNextPersistentVariableName(target,
+                                                                   prefix);
 
     lldb::ValueObjectSP const_valobj_sp;
 

--- a/source/Target/ABI.cpp
+++ b/source/Target/ABI.cpp
@@ -104,19 +104,19 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
   if (persistent) {
     lldb::LanguageType lang = ast_type.GetMinimumLanguage();
     PersistentExpressionState *persistent_expression_state;
-    auto target = thread.CalculateTarget();
+    Target &target = *thread.CalculateTarget();
     if (lang == lldb::eLanguageTypeSwift)
       persistent_expression_state = 
-        target->GetSwiftPersistentExpressionState(thread);
+        target.GetSwiftPersistentExpressionState(thread);
     else
       persistent_expression_state =
-         target->GetPersistentExpressionStateForLanguage(lang);
+         target.GetPersistentExpressionStateForLanguage(lang);
     
     if (!persistent_expression_state)
       return ValueObjectSP();
 
     ConstString persistent_variable_name(
-        persistent_expression_state->GetNextPersistentVariableName());
+        persistent_expression_state->GetNextPersistentVariableName(target));
 
     lldb::ValueObjectSP const_valobj_sp;
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -3130,11 +3130,14 @@ SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
     auto *exe_scope = ctx.GetBestExecutionContextScope();
     if (!exe_scope)
       return error_valobj_sp;
+    Target &target = m_process->GetTarget();
     auto *persistent_state =
-        m_process->GetTarget().GetSwiftPersistentExpressionState(*exe_scope);
+        target.GetSwiftPersistentExpressionState(*exe_scope);
 
+    const bool is_error = true;
+    auto prefix = persistent_state->GetPersistentVariablePrefix(is_error);
     ConstString persistent_variable_name(
-        persistent_state->GetNextPersistentVariableName(true));
+        persistent_state->GetNextPersistentVariableName(target, prefix));
 
     lldb::ValueObjectSP const_valobj_sp;
 

--- a/source/Target/ThreadPlanCallFunction.cpp
+++ b/source/Target/ThreadPlanCallFunction.cpp
@@ -540,8 +540,10 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
             GetTarget().GetPersistentExpressionStateForLanguage(
                 eLanguageTypeSwift);
         const bool is_error = true;
+        auto prefix = persistent_state->GetPersistentVariablePrefix(is_error);
         ConstString persistent_variable_name(
-            persistent_state->GetNextPersistentVariableName(is_error));
+            persistent_state->GetNextPersistentVariableName(GetTarget(),
+                                                            prefix));
         m_return_valobj_sp =
             SwiftLanguageRuntime::CalculateErrorValueFromFirstArgument(
                 frame_sp, persistent_variable_name);


### PR DESCRIPTION
Adopt swift plugin for upstream persistent variable handling changes.  …
Moving persistent variable counters into the target has the
side-effect that the numbering is now shared between all the scratch
SwiftASTContext objects.

rdar://problem/39299889