### PR TITLE
IWYU: add SILModule inclusion to build on Windows

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -37,6 +37,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/IDE/REPLCodeCompletion.h"
 #include "swift/IDE/Utils.h"
+#include "swift/SIL/SILModule.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -66,6 +66,8 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
 
+#include "swift/SIL/SILModule.h"
+
 using namespace lldb;
 using namespace lldb_private;
 


### PR DESCRIPTION
This fixes the build of lldb on Windows with cl.