### PR TITLE
Make the command-line REPL not trap C++ exceptions.

### DIFF
--- a/packages/Python/lldbsuite/test/repl/cpp_exceptions/Makefile
+++ b/packages/Python/lldbsuite/test/repl/cpp_exceptions/Makefile
@@ -1,14 +1,19 @@
 LEVEL = ../../make
 SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+CURDIR = $(shell pwd)
 
 include $(LEVEL)/Makefile.rules
 
-a.out: main.swift libCppLib.dylib
-	$(SWIFTC) $(SWIFTFLAGS) -Xlinker -rpath -Xlinker $(shell pwd) -I$(SRCDIR)/CppLib -lCppLib -L$(shell pwd) -o $@ $<
+a.out: main.swift libCppLib.dylib libWrapper.dylib
+	$(SWIFTC) $(SWIFTFLAGS) -Xlinker -rpath -Xlinker $(CURDIR) -I$(CURDIR) -lWrapper -L$(CURDIR) -o $@ $<
 
 libCppLib.dylib: CppLib/CppLib.cpp
 	mkdir -p CppLib
 	$(MAKE) VPATH=$(VPATH) -f $(SRCDIR)/CppLib/Makefile
+	install_name_tool -id $@ $@
+
+libWrapper.dylib: wrapper.swift libCppLib.dylib
+	$(SWIFTC) $(SWIFTFLAGS) -emit-module -emit-library -module-link-name Wrapper -module-name Wrapper -o $@ -L$(CURDIR) -lCppLib -I$(SRCDIR)/CppLib -o $@ -Xlinker -install_name -Xlinker @executable_path/$@ $<
 
 clean::
 	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/repl/cpp_exceptions/TestCPPExceptionsInREPL.py
+++ b/packages/Python/lldbsuite/test/repl/cpp_exceptions/TestCPPExceptionsInREPL.py
@@ -1,5 +1,5 @@
 """
-Make sure we don't trap exceptions with SetREPLEnabled(true)
+Make sure we don't trap exceptions with SetREPLEnabled(true) or "lldb --repl"
 """
 
 from __future__ import print_function
@@ -8,7 +8,9 @@ from __future__ import print_function
 import os
 import time
 import re
+import subprocess
 import lldb
+import swift
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 
@@ -22,23 +24,37 @@ class TestREPLExceptions(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
-    def test_repl_exceptions(self):
+    def test_set_repl_mode_exceptions(self):
+        """ Test that SetREPLMode turns off trapping exceptions."""
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")
-        self.do_test()
+        self.do_repl_mode_test()
+
+    def test_repl_exceptions(self):
+        """ Test the lldb --repl turns off trapping exceptions."""
+        self.build()
+        self.do_repl_test()
 
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)
 
-    def do_test(self):
+    def do_repl_test(self):
+        sdk_root = swift.getSwiftSDKRoot()
+        build_dir = self.getBuildDir()
+        repl_args = [lldbtest_config.lldbExec, "-x", "--repl=-enable-objc-interop -sdk %s -L%s -I%s"%(sdk_root, build_dir, build_dir)]
+        repl_proc = subprocess.Popen(repl_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=build_dir)
+        (stdoutdata, stderrdata) = repl_proc.communicate(input="import Wrapper\ncall_cpp()\n:quit")
+        self.assertTrue("I called it successfully" in stdoutdata, "Didn't call call_cpp successfully: out: \n%s\nerr: %s"%(stdoutdata, stderrdata))
+        
+    def do_repl_mode_test(self):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
                                    "Set a breakpoint here", self.main_source_file) 
 
         frame = thread.GetFrameAtIndex(0)
         options = lldb.SBExpressionOptions()
         options.SetREPLMode(True)
-        val = frame.EvaluateExpression("f_with_exceptions(); 5", options)
+        val = frame.EvaluateExpression("call_cpp(); 5", options)
         self.assertTrue(val.GetError().Success(), 
                         "Got an error evaluating expression: %s."%(val.GetError().GetCString()))
         self.assertEqual(val.GetValueAsUnsigned(), 5,"The expression didn't return the correct result")

--- a/packages/Python/lldbsuite/test/repl/cpp_exceptions/main.swift
+++ b/packages/Python/lldbsuite/test/repl/cpp_exceptions/main.swift
@@ -1,3 +1,7 @@
-import CppLib
+import Wrapper
 
-f_with_exceptions() // Set a breakpoint here
+func main() {
+    call_cpp() // Set a breakpoint here
+}
+
+main()

--- a/packages/Python/lldbsuite/test/repl/cpp_exceptions/wrapper.swift
+++ b/packages/Python/lldbsuite/test/repl/cpp_exceptions/wrapper.swift
@@ -1,0 +1,6 @@
+import CppLib
+
+public func call_cpp() {
+  f_with_exceptions()
+  print("I called it successfully")
+}

--- a/source/Expression/REPL.cpp
+++ b/source/Expression/REPL.cpp
@@ -292,6 +292,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
       expr_options.SetTryAllThreads(m_command_options.try_all_threads);
       expr_options.SetGenerateDebugInfo(true);
       expr_options.SetREPLEnabled(true);
+      expr_options.SetTrapExceptions(false);
       expr_options.SetColorizeErrors(colorize_err);
       expr_options.SetPoundLine(m_repl_source_path.c_str(),
                                 m_code.GetSize() + 1);


### PR DESCRIPTION
Assume that in the REPL, any C++ code that gets called from
swift will catch all the exceptions it throws.  This is a
reasonable expectation, since there's no way to sensibly throw
past a swift frame.

<rdar://problem/39700160>