### PR TITLE
 Don't import modules from an Objective-C context into a Swift expression.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -55,7 +55,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             process, bar_breakpoint)
 
-        # This works becaue the Module-SwiftASTContext uses the dylib flags.
+        # This works because the Module-SwiftASTContext uses the dylib flags.
         self.expect("fr var bar", "expected result", substrs=["42"])
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
         # This initially fails with the shared scratch context and is

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Bar/Bar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Bar/Bar.h
@@ -1,0 +1,3 @@
+@import Foundation;
+@interface Bar : NSObject {}
+@end

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Bar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Foo.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Foo.swift
@@ -1,0 +1,2 @@
+import Foundation
+@objc public class Foo : NSObject {}

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/Makefile
@@ -1,0 +1,17 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+# This test builds an Objective-C main program that imports two Swift
+# .dylibs with conflicting ClangImporter search paths.
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.m libFoo.dylib
+	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -L$(shell pwd) -o $@ $<
+
+lib%.dylib: %.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -1,0 +1,58 @@
+# TestSwiftExpressionObjCContext.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftExpressionObjCContext(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        self.build()
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('main.m'))
+        process = target.LaunchSimple(None, None, os.getcwd())
+        # This is expected to fail because we can't yet import ObjC
+        # modules into a Swift context.
+        self.expect("expr -lang Swift -- Bar()", "failure",
+                    substrs=["unresolved identifier 'Bar'"],
+                    error=True)
+        self.expect("expr -lang Swift -- [1, 2, 3]",
+                    "context-less swift expression works",
+                    substrs=["([Int])"])
+        
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/main.m
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/main.m
@@ -1,0 +1,12 @@
+@import Foundation;
+@import Bar;
+#include "Foo.h"
+
+@implementation Bar
+@end
+
+int main(int argc, char **argv) {
+  [[Bar alloc] init];
+  [[Foo alloc] init];
+  return 0; // break here
+}

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -204,7 +204,7 @@ static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
 
   CompileUnit *compile_unit = sc.comp_unit;
 
-  if (compile_unit)
+  if (compile_unit && compile_unit->GetLanguage() == lldb::eLanguageTypeSwift)
     cu_modules = &compile_unit->GetImportedModules();
 
   llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> imported_modules;


### PR DESCRIPTION
This doesn't work in general because PerformAutoImport calls
ast->GetModule() which only succeeds if the module has been loaded
beforehand. In an Objective-C context there is no master .swiftmodule
that would pre-import the clang modules so this fails.
    
By disabling the feature we get a more reasonable error message.
   
<rdar://problem/39696005>