### PR TITLE
Fix the .experimental. settings feature so that we don't return an error

### DIFF
--- a/source/Interpreter/OptionValueProperties.cpp
+++ b/source/Interpreter/OptionValueProperties.cpp
@@ -207,12 +207,23 @@ Status OptionValueProperties::SetSubValue(const ExecutionContext *exe_ctx,
                                           llvm::StringRef value) {
   Status error;
   const bool will_modify = true;
+  llvm::SmallVector<llvm::StringRef, 8> components;
+  name.split(components, '.');
+  bool name_contains_experimental = false;
+  for (const auto &part : components)
+    if (Properties::IsSettingExperimental(part))
+      name_contains_experimental = true;
+
+  
   lldb::OptionValueSP value_sp(GetSubValue(exe_ctx, name, will_modify, error));
   if (value_sp)
     error = value_sp->SetValueFromString(value, op);
   else {
-    if (error.AsCString() == nullptr)
+    // Don't set an error if the path contained .experimental. - those are
+    // allowed to be missing and should silently fail.
+    if (name_contains_experimental == false && error.AsCString() == nullptr) {
       error.SetErrorStringWithFormat("invalid value path '%s'", name.str().c_str());
+    }
   }
   return error;
 }


### PR DESCRIPTION
Fix the .experimental. settings feature so that we don't return an error
if an experimental setting has been removed/is missing.

Add tests for the .experimental. settings behaviors -- that they correctly
forward through to the real setting if it has become a real setting,
that they don't generate errors when a settig has been removed.

As Pavel notes in https://reviews.llvm.org/D45348, the way I'm suppressing
errors in the setting is not completely correct - if any of the setting
path components include "experimental", a missing setting would be declared
a non-error.  So

settings set target.experimental.setting-that-does-not-exist true

would not generate an error, which is correct.  But as Pavel notes, 

settings set setting-does-not-exist.experimental.run-stopped true

should generate an error because the unknown name occurs before the
"experimental".  The amount of change to do this correctly hasn't
thrilled me, so I'm leaving this as-is for now.

<rdar://problem/39223054> 
Differential Revision: https://reviews.llvm.org/D45348


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@331315 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 73723d5b2da4f3eff4153953ba5da06d860ca5f1)