### PR TITLE
Fixes for Swift-side changes to support inlinable autolinking [4.2]

### DIFF
--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1410,7 +1410,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                 swift::ModuleDecl::AccessPathTy access_path;
 
                 module->forAllVisibleModules(
-                    access_path, true,
+                    access_path,
                     [ast_ctx, input, name_parts, &results](
                         swift::ModuleDecl::ImportedModule imported_module) -> bool {
                       auto module = imported_module.second;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3457,12 +3457,7 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
         all_dlopen_errors.GetData());
   };
 
-  swift_module->forAllVisibleModules({},
-                                     true, // includePrivateTopLevel
-                                     [&](swift::ModuleDecl::ImportedModule import) {
-                                       import.second->collectLinkLibraries(
-                                           addLinkLibrary);
-                                     });
+  swift_module->collectLinkLibraries(addLinkLibrary);
   error = current_error;
 }
 


### PR DESCRIPTION
These two patches are already on the stable branch, and go with https://github.com/apple/swift/pull/16301 on the swift-4.2-branch.