### PR TITLE
This test fails with inject-local-variables set to false.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/cpp/type_lookup/TestCppTypeLookup.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/type_lookup/TestCppTypeLookup.py
@@ -35,6 +35,7 @@ class TestCppTypeLookup(TestBase):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "Set a breakpoint here", self.main_source_file)
 
+        self.dbg.HandleCommand("settings set target.experimental.inject-local-vars 1")
         # Get frame for current thread
         frame = thread.GetSelectedFrame()
 


### PR DESCRIPTION
We will address that issue but the test still tests useful things,
so instead of xfailing it till we figure out why, I'm setting
inject-local-variables to true by hand in the test.

<rdar://problem/39908723>