### PR TITLE
 Add support for dwarf expressions on global variables.

### DIFF
--- a/include/lldb/Core/Value.h
+++ b/include/lldb/Core/Value.h
@@ -229,6 +229,9 @@ public:
 
   static const char *GetContextTypeAsCString(ContextType context_type);
 
+  /// Convert this value's file address to a load address, if possible.
+  void ConvertToLoadAddress(SymbolContext sc, Target *target);
+
   bool GetData(DataExtractor &data);
 
   void Clear();

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -17,4 +17,7 @@ func main() {
    //% self.expect("expression -d run -- notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
 }
 
-main()
+var g_notification = Notification(name: Notification.Name(rawValue: "MyNotification"), object: nil, userInfo: [:])
+
+main() //% self.expect("target variable g_notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])
+       //% self.expect("expression -d run -- g_notification", substrs=['name = "MyNotification"', 'object = nil', 'userInfo = 0 key/value pairs'])

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/TestResilience.py
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/TestResilience.py
@@ -81,7 +81,7 @@ class TestResilience(TestBase):
         self.assertTrue(target, VALID_TARGET)
 
         breakpoint = target.BreakpointCreateBySourceRegex('break', source_spec)
-        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+        self.assertTrue(breakpoint.GetNumLocations() > 1, VALID_BREAKPOINT)
 
         process = target.LaunchSimple(None, None, os.getcwd())
         self.assertTrue(process, PROCESS_IS_VALID)
@@ -94,6 +94,17 @@ class TestResilience(TestBase):
         self.frame = self.thread.frames[0]
         self.assertTrue(self.frame, "Frame 0 is valid.")
 
+        # FIXME: this should work with all flavors!
+        if exe_flavor == "a":
+            self.expect("target var global", DATA_TYPES_DISPLAYED_CORRECTLY,
+                        substrs=["a = 1"])
+        process.Continue()
+
+        self.assertTrue(len(threads) == 1)
+        self.thread = threads[0]
+        self.frame = self.thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+        
         # Try 'frame variable'
         var = self.frame.FindVariable("s")
         child = var.GetChildMemberWithName("a")

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/main.swift
@@ -18,4 +18,6 @@ func main() {
   print(a)
 }
 
+let global = S()
+print(global.a) // break here
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/mod.a.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/mod.a.swift
@@ -12,7 +12,11 @@
 
 public struct S {
   public var a = 1
-  
+  public var s1 = "i"
+  public var s2 = "am"
+  public var s3 = "large"
+  public var s4 = "!"
+
   public init() {}
 }
 

--- a/source/Core/Value.cpp
+++ b/source/Core/Value.cpp
@@ -676,6 +676,30 @@ const char *Value::GetContextTypeAsCString(ContextType context_type) {
   return "???";
 }
 
+void Value::ConvertToLoadAddress(SymbolContext sc, Target *target) {
+  if (GetValueType() != eValueTypeFileAddress)
+    return;
+
+  if (!sc.module_sp)
+    return;
+
+  lldb::addr_t file_addr = GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
+  if (file_addr == LLDB_INVALID_ADDRESS)
+    return;
+
+  ObjectFile *objfile = sc.module_sp->GetObjectFile();
+  if (!objfile)
+    return;
+
+  Address so_addr(file_addr, objfile->GetSectionList());
+  lldb::addr_t load_addr = so_addr.GetLoadAddress(target);
+  if (load_addr == LLDB_INVALID_ADDRESS)
+    return;
+
+  SetValueType(Value::eValueTypeLoadAddress);
+  GetScalar() = load_addr;
+}
+
 ValueList::ValueList(const ValueList &rhs) { m_values = rhs.m_values; }
 
 const ValueList &ValueList::operator=(const ValueList &rhs) {

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -251,27 +251,10 @@ bool ValueObjectVariable::UpdateValue() {
         // their own values as needed. If this variable is a simple
         // type, we read all data for it into m_data.
         // Make sure this type has a value before we try and read it
-
+        SymbolContext var_sc;
+        variable->CalculateSymbolContext(&var_sc);
         // If we have a file address, convert it to a load address if we can.
-        if (value_type == Value::eValueTypeFileAddress && process_is_alive) {
-          lldb::addr_t file_addr =
-              m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
-          if (file_addr != LLDB_INVALID_ADDRESS) {
-            SymbolContext var_sc;
-            variable->CalculateSymbolContext(&var_sc);
-            if (var_sc.module_sp) {
-              ObjectFile *objfile = var_sc.module_sp->GetObjectFile();
-              if (objfile) {
-                Address so_addr(file_addr, objfile->GetSectionList());
-                lldb::addr_t load_addr = so_addr.GetLoadAddress(target);
-                if (load_addr != LLDB_INVALID_ADDRESS) {
-                  m_value.SetValueType(Value::eValueTypeLoadAddress);
-                  m_value.GetScalar() = load_addr;
-                }
-              }
-            }
-          }
-        }
+        m_value.ConvertToLoadAddress(var_sc, target);
 
         if (!CanProvideValue()) {
           // this value object represents an aggregate type whose

--- a/source/Expression/DWARFExpression.cpp
+++ b/source/Expression/DWARFExpression.cpp
@@ -1391,6 +1391,9 @@ bool DWARFExpression::Evaluate(
     case DW_OP_addr:
       stack.push_back(Scalar(opcodes.GetAddress(&offset)));
       stack.back().SetValueType(Value::eValueTypeFileAddress);
+      stack.back().ConvertToLoadAddress(
+          frame->GetSymbolContext(eSymbolContextFunction),
+          frame->CalculateTarget().get());
       break;
 
     //----------------------------------------------------------------------


### PR DESCRIPTION
The Swift compiler emits a DW_OP_deref for global variables in a fixed
size buffer, which is correct unless the variable uses inline
storage. This makes the majority of resilient types in Foundation work
as global variables.  The correct solution would be for LLDB to poke
at the runtime to figure out whether the storage is inline or not, but
until then this is the next best thing.

<rdar://problem/39767528>