### PR TITLE
DWARFExpression: Convert file addresses to load addresses early on.

### DIFF
--- a/include/lldb/Core/Value.h
+++ b/include/lldb/Core/Value.h
@@ -230,7 +230,7 @@ public:
   static const char *GetContextTypeAsCString(ContextType context_type);
 
   /// Convert this value's file address to a load address, if possible.
-  void ConvertToLoadAddress(SymbolContext sc, Target *target);
+  void ConvertToLoadAddress(SymbolContext sc);
 
   bool GetData(DataExtractor &data);
 

--- a/source/Core/Value.cpp
+++ b/source/Core/Value.cpp
@@ -676,7 +676,7 @@ const char *Value::GetContextTypeAsCString(ContextType context_type) {
   return "???";
 }
 
-void Value::ConvertToLoadAddress(SymbolContext sc, Target *target) {
+void Value::ConvertToLoadAddress(SymbolContext sc) {
   if (GetValueType() != eValueTypeFileAddress)
     return;
 
@@ -687,12 +687,10 @@ void Value::ConvertToLoadAddress(SymbolContext sc, Target *target) {
   if (file_addr == LLDB_INVALID_ADDRESS)
     return;
 
-  ObjectFile *objfile = sc.module_sp->GetObjectFile();
-  if (!objfile)
+  Address so_addr;
+  if (!sc.module_sp->ResolveFileAddress(file_addr, so_addr))
     return;
-
-  Address so_addr(file_addr, objfile->GetSectionList());
-  lldb::addr_t load_addr = so_addr.GetLoadAddress(target);
+  lldb::addr_t load_addr = so_addr.GetLoadAddress(sc.target_sp.get());
   if (load_addr == LLDB_INVALID_ADDRESS)
     return;
 

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -244,17 +244,17 @@ bool ValueObjectVariable::UpdateValue() {
       case Value::eValueTypeFileAddress:
       case Value::eValueTypeLoadAddress:
       case Value::eValueTypeHostAddress:
-        // The DWARF expression result was an address in the inferior
-        // process. If this variable is an aggregate type, we just need
-        // the address as the main value as all child variable objects
-        // will rely upon this location and add an offset and then read
-        // their own values as needed. If this variable is a simple
-        // type, we read all data for it into m_data.
-        // Make sure this type has a value before we try and read it
+        // The DWARF expression result was an address in the inferior process.
+        // If this variable is an aggregate type, we just need the address as
+        // the main value as all child variable objects will rely upon this
+        // location and add an offset and then read their own values as needed.
+        // If this variable is a simple type, we read all data for it into
+        // m_data. Make sure this type has a value before we try and read it
+
         SymbolContext var_sc;
         variable->CalculateSymbolContext(&var_sc);
         // If we have a file address, convert it to a load address if we can.
-        m_value.ConvertToLoadAddress(var_sc, target);
+        m_value.ConvertToLoadAddress(var_sc);
 
         if (!CanProvideValue()) {
           // this value object represents an aggregate type whose

--- a/source/Expression/DWARFExpression.cpp
+++ b/source/Expression/DWARFExpression.cpp
@@ -1388,13 +1388,13 @@ bool DWARFExpression::Evaluate(
     // The DW_OP_addr operation has a single operand that encodes a machine
     // address and whose size is the size of an address on the target machine.
     //----------------------------------------------------------------------
-    case DW_OP_addr:
+    case DW_OP_addr: {
       stack.push_back(Scalar(opcodes.GetAddress(&offset)));
       stack.back().SetValueType(Value::eValueTypeFileAddress);
-      stack.back().ConvertToLoadAddress(
-          frame->GetSymbolContext(eSymbolContextFunction),
-          frame->CalculateTarget().get());
+      auto sc = frame->GetSymbolContext(eSymbolContextFunction);
+      stack.back().ConvertToLoadAddress(sc);
       break;
+    }
 
     //----------------------------------------------------------------------
     // The DW_OP_addr_sect_offset4 is used for any location expressions in


### PR DESCRIPTION
This is a change that only affects Swift and is NFC for the language
plugins on llvm.org. In Swift, we can have global variables with a
location such as DW_OP_addr <addr> DW_OP_deref. The DWARF expression
evaluator doesn't know how to apply a DW_OP_deref to a file address,
but at the very end we convert the file address into a load address.

This patch moves the file->load address conversion to right after the
result of the DW_OP_addr is pushed onto the stack so that a subsequent
DW_OP_deref (and potentially other operations) can be interpreted.

rdar://problem/39767528

Differential revision: https://reviews.llvm.org/D46362

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@331462 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit ef04d19bbb3bd3475db2d76b066611725bc632a4)