### PR TITLE
[SwiftASTContext] Print fatal error if there is one

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1311,7 +1311,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
         StreamString ss;
         module_sp->GetDescription(&ss, eDescriptionLevelBrief);
         if (module_swift_ast->HasFatalErrors())
-          ss << ": " << module_swift_ast->GetFatalErrors().AsCString();
+          ss << ": "
+             << module_swift_ast->GetFatalErrors().AsCString("unknown error");
 
         target.GetDebugger().GetErrorFile()->Printf(
             "warning: Swift error in module %s.\n"

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1310,9 +1310,12 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
       if (result.second) {
         StreamString ss;
         module_sp->GetDescription(&ss, eDescriptionLevelBrief);
+        if (module_swift_ast->HasFatalErrors())
+          ss << ": " << module_swift_ast->GetFatalErrors().AsCString();
+
         target.GetDebugger().GetErrorFile()->Printf(
-            "warning: Swift error in module %s" /*": \n    %s\n"*/
-            ".\nDebug info from this module will be unavailable in the "
+            "warning: Swift error in module %s.\n"
+            "Debug info from this module will be unavailable in the "
             "debugger.\n\n",
             ss.GetData());
       }


### PR DESCRIPTION
When we error out because of a swift error, we should print the fatal
error if it exists. I was debugging a Swift issue without realizing my
reproducer was outdated. This seems like something we'd want to
communicate to the end user.

In my particular case, this now prints:

  warning: Swift error in module Foo: the swift module file format is
  too old to be used by the version of the swift compiler in LLDB.
  Debug info from this module will be unavailable in the debugger.