### PR TITLE
 Honor the search paths of all swiftmodules in one lldb::Module.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Bar.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Bar.swift
@@ -1,0 +1,11 @@
+import CBar
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Bar : NSObject {
+  @objc public func f() {
+    let bar = CBar(j: 42)
+    use(bar) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Foo.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Foo.swift
@@ -1,0 +1,11 @@
+import CFoo
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Foo : NSObject {
+  @objc public func f() {
+    let foo = CFoo(i: 23)
+    use(foo) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Makefile
@@ -1,0 +1,33 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES = Foo.swift Bar.swift
+
+# This test builds an Objective-C main program that imports two Swift
+# .dylibs with conflicting ClangImporter search paths.
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.o libFoo.a libBar.a
+	$(SWIFTC) $(SWIFTFLAGS) $< -lFoo -lBar -L$(shell pwd) -o $@ \
+	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Foo.swiftmodule \
+	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Bar.swiftmodule
+
+main.o: main.m Foo.o Bar.o
+	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -c -o $@ $< \
+		-I$(shell pwd)
+
+%.o: %.swift
+	$(SWIFTC) $(SWIFTFLAGS) $^ -c -parse-as-library -o $@ \
+		-Xcc -I$(SRCDIR) \
+		-Xcc -I$(SRCDIR)/objcmodules/$(shell basename $< .swift)
+	$(SWIFTC) $(SWIFTFLAGS) $^ -emit-module -parse-as-library \
+		-emit-objc-header-path $(shell basename $< .swift).h \
+		-Xcc -I$(SRCDIR) \
+		-Xcc -I$(SRCDIR)/objcmodules/$(shell basename $< .swift)
+
+lib%.a: %.o
+	$(AR) $(ARFLAGS) $@ -L$(shell pwd) $<
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.a a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -1,0 +1,63 @@
+# TestSwiftStaticArchiveTwoSwiftmodules.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        self.build()
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target.
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints.
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Foo.swift'))
+        bar_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Bar.swift'))
+        self.assertTrue(bar_breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+        self.assertTrue(foo_breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        # Launch.
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        # This test tests that the search paths from all swiftmodules
+        # that are part of the main binary are honored.
+        self.expect("fr var foo", "expected result", substrs=["23"])
+        self.expect("p foo", "expected result", substrs=["$R0", "i", "23"])
+        process.Continue()
+        self.expect("fr var bar", "expected result", substrs=["42"])
+        self.expect("p bar", "expected result", substrs=["j", "42"])
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/main.m
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/main.m
@@ -1,0 +1,9 @@
+@import Foundation;
+#include "Foo.h"
+#include "Bar.h"
+
+int main(int argc, char **argv) {
+  [[[Foo alloc] init] f];
+  [[[Bar alloc] init] f];
+  return 0;
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Bar/CBar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Bar/CBar.h
@@ -1,0 +1,3 @@
+struct CBar {
+  int j;
+};

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module CBar {
+  header "CBar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Foo/CFoo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Foo/CFoo.h
@@ -1,0 +1,3 @@
+struct CFoo {
+  int i;
+};

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/objcmodules/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module CFoo {
+  header "CFoo.h"
+}


### PR DESCRIPTION
Prior to this commit LLDB would only load the search paths from the
first serialized AST in the current dylib, after this commit it
concatenates the options from all serialized ASTs in the current
dylib. This improved the debuggability of projects using static
archives at the expense of potential clang module import failures when
the options from within one module are conflicting.

<rdar://problem/39833129>