### PR TITLE
 Add a test for importing a c module into the Swift REPL

### DIFF
--- a/packages/Python/lldbsuite/test/repl/import-dispatch/Makefile
+++ b/packages/Python/lldbsuite/test/repl/import-dispatch/Makefile
@@ -1,0 +1,13 @@
+LEVEL = ../../make
+SWIFT_SOURCES := input.swift
+OBJC_INTEROP = 1
+
+.PHONY a.out: input.swift
+	cat $< | lldb --repl "$(CFLAGS_EXTRAS)"
+	echo "libdispatch could be imported successfully!">$@
+
+input.swift:
+	echo "import Dispatch" >$@
+
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/repl/import-dispatch/TestREPLImportDispatch.py
+++ b/packages/Python/lldbsuite/test/repl/import-dispatch/TestREPLImportDispatch.py
@@ -1,0 +1,34 @@
+# TestREPLImportDispatch.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import unittest2
+import os
+
+class TestREPLImportDispatch(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        self.build()
+        self.assertTrue(os.path.isfile(self.getBuildArtifact("a.out")))
+        # We're good! The test is part of the build.
+
+if __name__ == '__main__':
+    import atexit
+    unittest2.main()


### PR DESCRIPTION
Because of limitations in our test driver an its inability to pass
extra flags around this test is wedged into a Makefile at the moment.

<rdar://problem/37836639>