### PR TITLE
Cherry-pick the fixes for SR-7388 to swift-4.1-branch

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/Makefile
@@ -1,3 +1,4 @@
 LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP = 1
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
@@ -1,0 +1,15 @@
+# TestSwiftFoundation.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[])

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/TestSwiftFoundation.py
@@ -12,4 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[])
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
@@ -1,0 +1,22 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Foundation
+
+// Test that importing Foundation and printing a value for which
+// no data formatter exists works consistently on all platforms.
+func main() {
+  var point = NSPoint(x: 23, y: 42)
+  print(point) //% self.expect("frame variable -- point", substrs=['x', '23', 'y', '42'])
+  //% self.expect("expression -- point", substrs=['x', '23', 'y', '42'])
+}
+
+main()

--- a/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation/main.swift
@@ -16,7 +16,7 @@ import Foundation
 func main() {
   var point = NSPoint(x: 23, y: 42)
   print(point) //% self.expect("frame variable -- point", substrs=['x', '23', 'y', '42'])
-  //% self.expect("expression -- point", substrs=['x', '23', 'y', '42'])
+               //% self.expect("expression -- point", substrs=['x', '23', 'y', '42'])
 }
 
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/objc-interop/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/objc-interop/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/objc-interop/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/objc-interop/main.swift
@@ -1,0 +1,13 @@
+import Dispatch
+
+// The dispatch clang module is either imported as Objective-C or as C
+// with blocks, and both varints should work in LLDB's expression evaluator.
+
+func main() {
+  let label = "lldbtest"
+  let queue = DispatchQueue(label: label)
+  print(queue) //% self.expect("fr var -- label", substrs=['lldbtest'])
+               //% self.expect("expr -- label",   substrs=['lldbtest'])
+}
+
+main()

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -482,8 +482,16 @@ endif
 # Check if we need the Swift/ObjC interop features
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_OBJC_INTEROP)" "1"
-	SWIFTFLAGS += -framework Foundation -framework CoreGraphics
-	LDFLAGS +=-lswiftObjectiveC -lswiftFoundation -framework Foundation -framework CoreGraphics
+        ifeq "$(OS)" "Darwin"
+		SWIFTFLAGS += -framework Foundation -framework CoreGraphics
+		LDFLAGS += -lswiftObjectiveC -lswiftFoundation -framework Foundation -framework CoreGraphics
+        else
+                # CFLAGS_EXTRAS is used via "dotest.py -E" to pass the -I and -L paths
+                # for Foundation and libdispatch on Linux.
+                SWIFTFLAGS += $(CFLAGS_EXTRAS)
+                LDFLAGS += $(CFLAGS_EXTRAS)
+        endif
+
 endif
 
 #----------------------------------------------------------------------

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -170,10 +170,11 @@ if(NOT LLDB_BUILT_STANDALONE)
   set(clang_headers_target symlink_clang_headers)
 endif()
 
+# Copy the clang resource directory.
 add_custom_command_target(
     unused_var
-    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang"
-    OUTPUT "${lib_dir}/lldb/clang"
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang/${LLVM_PACKAGE_VERSION}"
+    OUTPUT "${lib_dir}/lldb/clang/${LLVM_PACKAGE_VERSION}"
     VERBATIM
     ALL
     DEPENDS ${clang_headers_target})

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2020,6 +2020,12 @@ bool SwiftASTContext::SetTriple(const char *triple_cstr, Module *module) {
                     this, triple_cstr, triple.c_str(),
                     m_target_wp.lock() ? " (target)" : "");
       m_compiler_invocation_ap->setTargetTriple(triple);
+
+      // Every time the triple is changed the LangOpts must be
+      // updated too, because Swift default-initializes the
+      // EnableObjCInterop flag based on the triple.
+      GetLanguageOptions().EnableObjCInterop = llvm_triple.isOSDarwin();
+
       return true;
     } else {
       if (log)


### PR DESCRIPTION
This fixes two bugs that prevent LLDB and the REPL from working properly on Linux. For Darwin this is NFC.

- Fix the installation path of the clang resource directory (Linux only!)
- Derive LangOpts.EnableObjCInterop every time the triple is changed

https://bugs.swift.org/browse/SR-7388