### PR TITLE
[REPL] Add a regression test for single character strings.

### DIFF
--- a/lit/SwiftREPL/rdar30147367.test
+++ b/lit/SwiftREPL/rdar30147367.test
@@ -1,0 +1,7 @@
+// rdar://30147367
+// Make sure that single character strings are displayed correctly.
+
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=STRING
+
+let one_char_string = "-"
+// STRING: one_char_string: String = "-"


### PR DESCRIPTION
This was fixed when rewriting the formatter.

Closes <rdar://problem/30147367>