### PR TITLE
[4.2] Fix TSan reports for Swift access races, and add a testcase.

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules
+
+SWIFTFLAGS += -sanitize=thread

--- a/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/TestTsanSwiftAccessRace.py
+++ b/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/TestTsanSwiftAccessRace.py
@@ -1,0 +1,79 @@
+# TestTsanSwift.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test Swift support of TSan.
+"""
+import lldb
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import json
+
+
+class TsanSwiftAccessRaceTestCase(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    @decorators.skipIfLinux
+    @decorators.skipUnlessSwiftThreadSanitizer
+    def test_tsan_swift(self):
+        self.build()
+        self.do_test()
+
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+    def do_test(self):
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, lldbtest.VALID_TARGET)
+
+        self.runCmd("run")
+
+        stop_reason = self.dbg.GetSelectedTarget().process.GetSelectedThread().GetStopReason()
+        if stop_reason == lldb.eStopReasonExec:
+            # On OS X 10.10 and older, we need to re-exec to enable
+            # interceptors.
+            self.runCmd("continue")
+
+        # the stop reason of the thread should be a TSan report.
+        self.expect("thread list", "A Swift access race should be detected",
+                    substrs=['stopped', 'stop reason = Swift access race detected'])
+
+        self.assertEqual(
+            self.dbg.GetSelectedTarget().process.GetSelectedThread().GetStopReason(),
+            lldb.eStopReasonInstrumentation)
+
+        self.expect(
+            "thread info -s",
+            "The extended stop info should contain the TSan provided fields",
+            substrs=[
+                "instrumentation_class",
+                "description",
+                "mops"])
+
+        output_lines = self.res.GetOutput().split('\n')
+        json_line = '\n'.join(output_lines[2:])
+        data = json.loads(json_line)
+        self.assertEqual(data["instrumentation_class"], "ThreadSanitizer")
+        self.assertEqual(data["issue_type"], "external-race")
+        self.assertEqual(len(data["mops"]), 2)
+        self.assertTrue(data["location_filename"].endswith("/main.swift"))
+

--- a/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/TestTsanSwiftAccessRace.py
+++ b/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/TestTsanSwiftAccessRace.py
@@ -10,7 +10,8 @@
 #
 # ------------------------------------------------------------------------------
 """
-Test Swift support of TSan.
+Test that the TSan support correctly reports Swift access races (races on
+mutating methods of a struct).
 """
 import lldb
 import lldbsuite.test.decorators as decorators

--- a/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/main.swift
+++ b/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/main.swift
@@ -1,0 +1,30 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Foundation
+
+let q = DispatchQueue.global()
+let g = DispatchGroup()
+let s = DispatchSemaphore(value: 0)
+var arr = [1, 2, 3]
+g.enter()
+q.async {
+    _ = arr.count
+    s.wait()
+    g.leave()
+}
+g.enter()
+q.async {
+    arr.append(5)
+    s.signal()
+    g.leave()
+}
+g.wait()

--- a/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/main.swift
+++ b/packages/Python/lldbsuite/test/functionalities/tsan/swift-access-race/main.swift
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-import Foundation
+import Dispatch
 
 let q = DispatchQueue.global()
 let g = DispatchGroup()

--- a/source/Plugins/InstrumentationRuntime/TSan/TSanRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/TSan/TSanRuntime.cpp
@@ -89,6 +89,7 @@ extern "C"
     // TODO: dlsym won't work on Windows.
     void *dlsym(void* handle, const char* symbol);
     int (*ptr__tsan_get_report_loc_object_type)(void *report, unsigned long idx, const char **object_type);
+    int (*ptr__tsan_get_report_tag)(void *report, unsigned long *tag);
 }
 
 const int REPORT_TRACE_SIZE = 128;
@@ -98,6 +99,7 @@ struct data {
     void *report;
     const char *description;
     int report_count;
+    unsigned long tag;
     
     void *sleep_trace[REPORT_TRACE_SIZE];
     
@@ -164,9 +166,13 @@ const char *thread_sanitizer_retrieve_report_data_command = R"(
 data t = {0};
 
 ptr__tsan_get_report_loc_object_type = (typeof(ptr__tsan_get_report_loc_object_type))(void *)dlsym((void*)-2 /*RTLD_DEFAULT*/, "__tsan_get_report_loc_object_type");
+ptr__tsan_get_report_tag = (typeof(ptr__tsan_get_report_tag))(void *)dlsym((void*)-2 /*RTLD_DEFAULT*/, "__tsan_get_report_tag");
 
 t.report = __tsan_get_current_report();
 __tsan_get_report_data(t.report, &t.description, &t.report_count, &t.stack_count, &t.mop_count, &t.loc_count, &t.mutex_count, &t.thread_count, &t.unique_tid_count, t.sleep_trace, REPORT_TRACE_SIZE);
+
+if (ptr__tsan_get_report_tag)
+    ptr__tsan_get_report_tag(t.report, &t.tag);
 
 if (t.stack_count > REPORT_ARRAY_SIZE) t.stack_count = REPORT_ARRAY_SIZE;
 for (int i = 0; i < t.stack_count; i++) {
@@ -349,6 +355,9 @@ ThreadSanitizerRuntime::RetrieveReportData(ExecutionContextRef exe_ctx_ref) {
                            ->GetValueAsUnsigned(0));
   dict->AddItem("sleep_trace", StructuredData::ObjectSP(CreateStackTrace(
                                    main_value, ".sleep_trace")));
+  dict->AddIntegerItem(
+      "tag",
+      main_value->GetValueForExpressionPath(".tag")->GetValueAsUnsigned(0));
 
   StructuredData::Array *stacks = ConvertToStructuredArray(
       main_value, ".stacks", ".stack_count",
@@ -487,8 +496,8 @@ ThreadSanitizerRuntime::RetrieveReportData(ExecutionContextRef exe_ctx_ref) {
   return StructuredData::ObjectSP(dict);
 }
 
-std::string
-ThreadSanitizerRuntime::FormatDescription(StructuredData::ObjectSP report) {
+std::string ThreadSanitizerRuntime::FormatDescription(
+    StructuredData::ObjectSP report, bool &is_swift_access_race) {
   std::string description = report->GetAsDictionary()
                                 ->GetValueForKey("issue_type")
                                 ->GetAsString()
@@ -523,8 +532,18 @@ ThreadSanitizerRuntime::FormatDescription(StructuredData::ObjectSP report) {
   } else if (description == "lock-order-inversion") {
     return "Lock order inversion (potential deadlock)";
   } else if (description == "external-race") {
+    auto tag = report->GetAsDictionary()
+                   ->GetValueForKey("tag")
+                   ->GetAsInteger()
+                   ->GetValue();
+    static const unsigned long kSwiftAccessRaceTag = 0x1;
+    if (tag == kSwiftAccessRaceTag) {
+      is_swift_access_race = true;
+      return "Swift access race";
+    }
     return "Race on a library object";
   } else if (description == "swift-access-race") {
+    is_swift_access_race = true;
     return "Swift access race";
   }
 
@@ -618,9 +637,14 @@ ThreadSanitizerRuntime::GenerateSummary(StructuredData::ObjectSP report) {
                             ->GetValueForKey("description")
                             ->GetAsString()
                             ->GetValue();
+  bool is_swift_access_race = report->GetAsDictionary()
+                                  ->GetValueForKey("is_swift_access_race")
+                                  ->GetAsBoolean()
+                                  ->GetValue();
+
   bool skip_one_frame =
-      report->GetObjectForDotSeparatedPath("issue_type")->GetStringValue() ==
-      "external-race";
+      (report->GetObjectForDotSeparatedPath("issue_type")->GetStringValue() ==
+      "external-race") && (!is_swift_access_race);
 
   addr_t pc = 0;
   if (report->GetAsDictionary()
@@ -812,8 +836,12 @@ bool ThreadSanitizerRuntime::NotifyBreakpointHit(
       instance->RetrieveReportData(context->exe_ctx_ref);
   std::string stop_reason_description;
   if (report) {
-    std::string issue_description = instance->FormatDescription(report);
+    bool is_swift_access_race = false;
+    std::string issue_description =
+        instance->FormatDescription(report, is_swift_access_race);
     report->GetAsDictionary()->AddStringItem("description", issue_description);
+    report->GetAsDictionary()->AddBooleanItem("is_swift_access_race",
+                                              is_swift_access_race);
     stop_reason_description = issue_description + " detected";
     report->GetAsDictionary()->AddStringItem("stop_description",
                                              stop_reason_description);

--- a/source/Plugins/InstrumentationRuntime/TSan/TSanRuntime.h
+++ b/source/Plugins/InstrumentationRuntime/TSan/TSanRuntime.h
@@ -66,7 +66,8 @@ private:
 
   StructuredData::ObjectSP RetrieveReportData(ExecutionContextRef exe_ctx_ref);
 
-  std::string FormatDescription(StructuredData::ObjectSP report);
+  std::string FormatDescription(StructuredData::ObjectSP report,
+                                bool &is_swift_access_race);
 
   std::string GenerateSummary(StructuredData::ObjectSP report);
 


### PR DESCRIPTION
We currently fail to report "Swift access races" (race between mutating methods on a struct) as such, and we only show a generic "Race on a library object". Let's fix that and add a test case.
