### PR TITLE
Run GetTypeSystemForLanguage(Swift) in parallel for every module.

### DIFF
--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -146,6 +146,8 @@ public:
 
   FileSpecList &GetSwiftModuleSearchPaths();
 
+  bool GetSwiftCreateModuleContextsInParallel() const;
+
   bool GetEnableAutoImportClangModules() const;
 
   bool GetUseAllCompilerFlags() const;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1338,6 +1338,11 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   }
 
   if (target.GetSwiftCreateModuleContextsInParallel()) {
+    // The first call to GetTypeSystemForLanguage() on a module will
+    // trigger the import (and thus most likely the rebuild) of all
+    // the Clang modules that were imported in this module. This can
+    // be a lot of work (potentially ten seconds per module), but it
+    // can be performed in parallel.
     llvm::ThreadPool pool;
     for (size_t mi = 0; mi != num_images; ++mi) {
       auto module_sp = target.GetImages().GetModuleAtIndex(mi);

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3635,6 +3635,8 @@ static PropertyDefinition g_properties[] = {
     {"swift-module-search-paths", OptionValue::eTypeFileSpecList, false, 0,
      nullptr, nullptr,
      "List of directories to be searched when locating modules for Swift."},
+    {"swift-create-module-contexts-in-parallel", OptionValue::eTypeBoolean, false, true,
+     nullptr, nullptr, "Create modules AST context in parallel."},
     {"auto-import-clang-modules", OptionValue::eTypeBoolean, false, true,
      nullptr, nullptr,
      "Automatically load Clang modules referred to by the program."},
@@ -3774,6 +3776,7 @@ enum {
   ePropertyClangModuleSearchPaths,
   ePropertySwiftFrameworkSearchPaths,
   ePropertySwiftModuleSearchPaths,
+  ePropertySwiftCreateModuleContextsInParallel,
   ePropertyAutoImportClangModules,
   ePropertyUseAllCompilerFlags,
   ePropertyAutoApplyFixIts,
@@ -4222,6 +4225,12 @@ FileSpecList &TargetProperties::GetSwiftModuleSearchPaths() {
                                                                    idx);
   assert(option_value);
   return option_value->GetCurrentValue();
+}
+
+bool TargetProperties::GetSwiftCreateModuleContextsInParallel() const {
+  const uint32_t idx = ePropertySwiftCreateModuleContextsInParallel;
+  return m_collection_sp->GetPropertyAtIndexAsBoolean(
+      nullptr, idx, g_properties[idx].default_uint_value != 0);
 }
 
 FileSpecList &TargetProperties::GetClangModuleSearchPaths() {


### PR DESCRIPTION
This can shave quite a bit of time from the first expression
evaluation in a session. GetTypeSystemForLanguage() on a module
runs the import of all the referenced clang modules, which means
it will likely rebuild all of them.