### PR TITLE
Revert "This test fails with inject-local-variables set to false."

### DIFF
--- a/packages/Python/lldbsuite/test/lang/cpp/type_lookup/TestCppTypeLookup.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/type_lookup/TestCppTypeLookup.py
@@ -35,7 +35,6 @@ class TestCppTypeLookup(TestBase):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "Set a breakpoint here", self.main_source_file)
 
-        self.dbg.HandleCommand("settings set target.experimental.inject-local-vars 1")
         # Get frame for current thread
         frame = thread.GetSelectedFrame()
 


### PR DESCRIPTION
This reverts commit 8f5f318a799128a4e29faf613e52f43c94cd8870.