### PR TITLE
HostInfoMacOSX: Share the clang resource directory with Swift.

### DIFF
--- a/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -39,9 +39,15 @@ protected:
   static bool ComputeHeaderDirectory(FileSpec &file_spec);
   static bool ComputePythonDirectory(FileSpec &file_spec);
   static bool ComputeClangDirectory(FileSpec &file_spec);
-  static bool ComputeSwiftDirectory(FileSpec &file_spec);
+  static bool ComputeClangDirectory(FileSpec &lldb_shlib_spec,
+                                    FileSpec &file_spec, bool verify);
   static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);
   static bool ComputeUserPluginsDirectory(FileSpec &file_spec);
+
+  /// Swift additions.
+  /// @{
+  static bool ComputeSwiftDirectory(FileSpec &file_spec);
+  /// @}
 };
 }
 

--- a/source/Host/macosx/HostInfoMacOSX.mm
+++ b/source/Host/macosx/HostInfoMacOSX.mm
@@ -273,10 +273,11 @@ bool HostInfoMacOSX::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
   // same Clang module cache.
   llvm::SmallString<256> clang_path;
   const char *swift_clang_resource_dir = "usr/lib/swift/clang";
-  ++rev_it;
-  if (rev_it != r_end && *rev_it == "SharedFrameworks") {
+  auto parent = std::next(rev_it);
+  if (parent != r_end && *parent == "SharedFrameworks") {
     // This is the top-level LLDB in the Xcode.app bundle.
-    raw_path.resize(rev_it - r_end);
+    // e.g., "Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A"
+    raw_path.resize(parent - r_end);
     llvm::sys::path::append(clang_path, raw_path,
                             "Developer/Toolchains/XcodeDefault.xctoolchain",
                             swift_clang_resource_dir);
@@ -284,10 +285,14 @@ bool HostInfoMacOSX::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
       file_spec.SetFile(clang_path.c_str(), true);
       return true;
     }
-  } else if (rev_it != r_end && *rev_it == "PrivateFrameworks" &&
-             ++rev_it != r_end && ++rev_it != r_end) {
+  } else if (parent != r_end && *parent == "PrivateFrameworks" &&
+             std::distance(parent, r_end) > 2) {
     // This is LLDB inside an Xcode toolchain.
-    raw_path.resize(rev_it - r_end);
+    // e.g., "Xcode.app/Contents/Developer/Toolchains/" \
+    //       "My.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework"
+    ++parent;
+    ++parent;
+    raw_path.resize(parent - r_end);
     llvm::sys::path::append(clang_path, raw_path, swift_clang_resource_dir);
     if (!verify || VerifyClangPath(clang_path)) {
       file_spec.SetFile(clang_path.c_str(), true);
@@ -298,7 +303,7 @@ bool HostInfoMacOSX::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
   }
 
   // Fall back to the Clang resource directory inside the framework.
-  raw_path.append("/Resources/Clang");
+  raw_path.append("LLDB.framework/Resources/Clang");
   file_spec.SetFile(raw_path.c_str(), true);
   return true;
 }

--- a/source/Host/macosx/HostInfoMacOSX.mm
+++ b/source/Host/macosx/HostInfoMacOSX.mm
@@ -258,7 +258,13 @@ bool HostInfoMacOSX::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
   auto r_end = llvm::sys::path::rend(raw_path);
 
   // Check for a Posix-style build of LLDB.
-  if (rev_it == r_end || *rev_it != "LLDB.framework")
+  while (rev_it != r_end) {
+    if (*rev_it == "LLDB.framework")
+      break;
+    ++rev_it;
+  }
+
+  if (rev_it == r_end)
     return HostInfoPosix::ComputeClangDirectory(file_spec);
 
   // Inside Xcode and in Xcode toolchains LLDB is always in lockstep

--- a/unittests/Host/CMakeLists.txt
+++ b/unittests/Host/CMakeLists.txt
@@ -22,4 +22,5 @@ add_lldb_unittest(HostTests
   LINK_LIBS
     lldbCore
     lldbHost
+    lldbUtilityHelpers
   )

--- a/unittests/Host/HostInfoTest.cpp
+++ b/unittests/Host/HostInfoTest.cpp
@@ -58,6 +58,7 @@ struct HostInfoMacOSXTest : public HostInfoMacOSX {
 };
 
 
+#ifdef __APPLE__
 TEST_F(HostInfoTest, MacOSX) {
   // This returns whatever the POSIX fallback returns.
   std::string posix = "/usr/lib/liblldb.dylib";
@@ -89,3 +90,4 @@ TEST_F(HostInfoTest, MacOSX) {
   EXPECT_NE(HostInfoMacOSXTest::ComputeClangDir(GetInputFilePath(xcode), true),
             HostInfoMacOSXTest::ComputeClangDir(GetInputFilePath(xcode)));
 }
+#endif

--- a/unittests/Host/HostInfoTest.cpp
+++ b/unittests/Host/HostInfoTest.cpp
@@ -63,11 +63,11 @@ TEST_F(HostInfoTest, MacOSX) {
   std::string posix = "/usr/lib/liblldb.dylib";
   EXPECT_FALSE(HostInfoMacOSXTest::ComputeClangDir(posix).empty());
 
-  std::string framework =
-    "/SharedFrameworks/LLDB.framework";
-  std::string framework_clang =
-    "/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/clang";
-  EXPECT_EQ(HostInfoMacOSXTest::ComputeClangDir(framework), framework_clang);
+  std::string build =
+    "/lldb-macosx-x86_64/Library/Frameworks/LLDB.framework/Versions/A";
+  std::string build_clang =
+    "/lldb-macosx-x86_64/Library/Frameworks/LLDB.framework/Resources/Clang";
+  EXPECT_EQ(HostInfoMacOSXTest::ComputeClangDir(build), build_clang);
 
   std::string xcode =
     "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A";

--- a/unittests/Host/HostInfoTest.cpp
+++ b/unittests/Host/HostInfoTest.cpp
@@ -63,8 +63,14 @@ TEST_F(HostInfoTest, MacOSX) {
   std::string posix = "/usr/lib/liblldb.dylib";
   EXPECT_FALSE(HostInfoMacOSXTest::ComputeClangDir(posix).empty());
 
+  std::string framework =
+    "/SharedFrameworks/LLDB.framework";
+  std::string framework_clang =
+    "/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/clang";
+  EXPECT_EQ(HostInfoMacOSXTest::ComputeClangDir(framework), framework_clang);
+
   std::string xcode =
-    "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework";
+    "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A";
   std::string xcode_clang =
     "/Applications/Xcode.app/Contents/Developer/Toolchains/"
     "XcodeDefault.xctoolchain/usr/lib/swift/clang";


### PR DESCRIPTION
Inside Xcode and in Xcode toolchains LLDB is always in lockstep
with the Swift compiler, so it can reuse its Clang resource
directory. This allows LLDB and the Swift compiler to share the
same Clang module cache.

rdar://problem/40039633

Differential Revision: https://reviews.llvm.org/D46736

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@332111 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d68e35a5485e4155f15183889f310967beefcef6)