### PR TITLE
 Avoid adding duplicate configuration macros to clang importer options.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -175,7 +175,7 @@ public:
 
   bool AddFrameworkSearchPath(const char *path);
 
-  bool AddClangArgument(const char *arg, bool force = false);
+  bool AddClangArgument(std::string arg, bool force = false);
 
   bool AddClangArgumentPair(const char *arg1, const char *arg2);
 

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
@@ -1,0 +1,20 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+all: a.out
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.swift libDylib.dylib
+	$(SWIFTC) -g -Onone $^ -lDylib -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I. \
+	  -Xcc -DDEBUG=1 -Xcc -DSPACE -Xcc -UNDEBUG
+
+libDylib.dylib: dylib.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name Dylib -emit-module \
+	  -Xlinker -install_name -Xlinker @executable_path/$@ \
+	  -Xcc -DDEBUG=1 -Xcc -D -Xcc SPACE -Xcc -U -Xcc NDEBUG
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -1,0 +1,82 @@
+# TestSwiftDedupMacros.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+class TestSwiftDedupMacros(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def testSwiftDebugMacros(self):
+        """This tests that configuration macros get uniqued when building the
+        scratch ast context. Note that "-D MACRO" options with a space
+        are currently only combined to "-DMACRO" when they appear
+        outside of the main binary.
+
+        """
+        self.build()
+            
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        # Create the target.
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints.
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('dylib.swift'))
+
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        # Turn on logging.
+        command_result = lldb.SBCommandReturnObject()
+        interpreter = self.dbg.GetCommandInterpreter()
+        log = self.getBuildArtifact("types.log")
+        interpreter.HandleCommand("log enable lldb types -f "+log, command_result)
+        
+        self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        debug = 0
+        space = 0
+        ndebug = 0
+        space_with_space = 0
+        logfile = open(log, "r")
+        for line in logfile:
+            if "-DDEBUG=1" in line:
+                debug += 1
+            if "-DSPACE" in line:
+                space += 1
+            if " SPACE" in line:
+                space_with_space += 1
+            if "-UNDEBUG" in line:
+                ndebug += 1
+        self.assertTrue(debug == 1)
+        self.assertTrue(space == 1)
+        self.assertTrue(space_with_space == 0)
+        self.assertTrue(ndebug == 1)
+        
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/dylib.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/dylib.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+func use<T>(_ t: T) {}
+
+@objc public class Foo : NSObject {
+  @objc public func f() {
+    let foo = 42
+    use(foo) // break here
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/main.swift
@@ -1,0 +1,4 @@
+import Dylib
+
+let foo = Foo()
+foo.f()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1320,6 +1320,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   std::shared_ptr<SwiftASTContextForExpressions> swift_ast_sp(
       new SwiftASTContextForExpressions(target));
 
+  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+  if (log)
+    log->Printf("SwiftASTContext::CreateInstance(Target)");
+  
   if (!arch.IsValid())
     return TypeSystemSP();
 
@@ -1430,8 +1434,6 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
       exe_module_sp = unit_test_module;
     }
   }
-
-  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
 
   // Attempt to deserialize the compiler flags from the AST.
   if (exe_module_sp) {
@@ -1587,11 +1589,22 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                   swift_ast_sp->AddFrameworkSearchPath(search_path);
                 }
 
+                std::string clang_argument;
                 for (size_t osi = 0, ose = ast_context->GetNumClangArguments();
                      osi < ose; ++osi) {
-                  const char *clang_argument =
-                      ast_context->GetClangArgumentAtIndex(osi);
-                  swift_ast_sp->AddClangArgument(clang_argument, true);
+                  // Join multi-arg -D and -U options for uniquing.
+                  clang_argument += ast_context->GetClangArgumentAtIndex(osi);
+                  if (clang_argument == "-D" || clang_argument == "-U")
+                    continue;
+
+                  // Enable uniquing for -D and -U options.
+                  bool force = true;
+                  if (clang_argument.size() >= 2 && clang_argument[0] == '-' &&
+                      (clang_argument[1] == 'D' || clang_argument[1] == 'U'))
+                    force = false;
+
+                  swift_ast_sp->AddClangArgument(clang_argument, force);
+                  clang_argument.clear();
                 }
               }
 
@@ -2975,8 +2988,8 @@ bool SwiftASTContext::AddFrameworkSearchPath(const char *path) {
   return false;
 }
 
-bool SwiftASTContext::AddClangArgument(const char *clang_arg, bool force) {
-  if (clang_arg && clang_arg[0]) {
+bool SwiftASTContext::AddClangArgument(std::string clang_arg, bool force) {
+  if (!clang_arg.empty()) {
     swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
 
     bool add_hmap = true;


### PR DESCRIPTION
When concatenating the clang options from all dylibs we don't unique
configuration macros which can lead to more unnecessary module
configurations to be built.

<rdar://problem/40220286>