### PR TITLE
Calculate the dynamic type of Optional's payload whenever possible

### DIFF
--- a/lit/SwiftREPL/OptionalWithDynamicType.test
+++ b/lit/SwiftREPL/OptionalWithDynamicType.test
@@ -1,0 +1,32 @@
+// Test that we print the dynamic type of the object contained within an
+// optional.
+
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s 2>&1 | FileCheck %s
+
+import Foundation
+
+@objc class MyClass : NSObject {
+  let x: String = "MyClass"
+}
+
+let a = MyClass()
+// CHECK: a: MyClass = {
+// CHECK:   ObjectiveC.NSObject
+// CHECK:   x = "MyClass"
+
+let b = a as NSObject
+// CHECK: b: MyClass = {
+// CHECK:   ObjectiveC.NSObject
+// CHECK:   x = "MyClass"
+
+let c = a as MyClass?
+// CHECK: c: MyClass? = {{.*}} {
+// CHECK:   ObjectiveC.NSObject
+// CHECK:   x = "MyClass"
+
+let d = a as NSObject?
+// CHECK: d: NSObject? = {{.*}} {
+// CHECK:   ObjectiveC.NSObject
+// CHECK:   x = "MyClass"

--- a/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -70,10 +70,10 @@ class TestSwiftObjCOptionalType(TestBase):
         """Check formatting for T? and T! when T is an ObjC type"""
         self.expect(
             "frame variable optColor_Some",
-            substrs=['Some = 0x0', 'NSObject ='])
+            substrs=['(Color?) optColor_Some = 0x'])
         self.expect(
             "frame variable uoptColor_Some",
-            substrs=['Some = 0x0', 'NSObject ='])
+            substrs=['(Color?) uoptColor_Some = 0x'])
 
         self.expect("frame variable optColor_None", substrs=['nil'])
         self.expect("frame variable uoptColor_None", substrs=['nil'])


### PR DESCRIPTION
When dumping the value of an Optional, we may not calculate the dynamic
type of the payload. This patch makes it so that we always calculate
this dynamic type. The user-visible change occurs for code like this:

  let d: NSObject? = MyClass() as NSObject

Before this patch, lldb would dump the value of 'd' as:

  d: NSObject? = 0x0000000100200060

After this patch, it would instead print:

  d: NSObject? = 0x0000000100200060 {
    ObjectiveC.NSObject = {}
  }

rdar://39736324
(cherry picked from commit 21e6432acc12674ba9d2eed03b2a51313c5440a5)