### PR TITLE
Fix _NSCFBoolean data formatter.

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjC.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjC.py
@@ -187,16 +187,18 @@ class ObjCDataFormatterTestCase(TestBase):
 
     def nsnumber_data_formatter_commands(self):
         # Now enable AppKit and check we are displaying Cocoa classes correctly
-        self.expect('frame variable num1 num2 num3 num5 num6 num7 num9',
+        self.expect('frame variable num1 num2 num3 num5 num6 num7 num8_Y num8_N num9',
                     substrs=['(NSNumber *) num1 = ', ' (int)5',
                              '(NSNumber *) num2 = ', ' (float)3.1',
                              '(NSNumber *) num3 = ', ' (double)3.14',
                              '(NSNumber *) num5 = ', ' (char)65',
                              '(NSNumber *) num6 = ', ' (long)255',
                              '(NSNumber *) num7 = ', '2000000',
+                             '(NSNumber *) num8_Y = ', 'YES',
+                             '(NSNumber *) num8_N = ', 'NO',
                              '(NSNumber *) num9 = ', ' (short)-31616'])
 
-        
+
         self.runCmd('frame variable num4', check=True)
         output = self.res.GetOutput()
         i128_handled_correctly = False

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2543,14 +2543,14 @@ bool AppleObjCRuntimeV2::GetCFBooleanValuesIfNeeded() {
   if (m_CFBoolean_values)
     return true;
 
-  static ConstString g_kCFBooleanFalse("kCFBooleanFalse");
-  static ConstString g_kCFBooleanTrue("kCFBooleanTrue");
+  static ConstString g_kCFBooleanFalse("__kCFBooleanFalse");
+  static ConstString g_kCFBooleanTrue("__kCFBooleanTrue");
 
   std::function<lldb::addr_t(ConstString)> get_symbol =
       [this](ConstString sym) -> lldb::addr_t {
     SymbolContextList sc_list;
     if (GetProcess()->GetTarget().GetImages().FindSymbolsWithNameAndType(
-            g_kCFBooleanFalse, lldb::eSymbolTypeData, sc_list) == 1) {
+            sym, lldb::eSymbolTypeData, sc_list) == 1) {
       SymbolContext sc;
       sc_list.GetContextAtIndex(0, sc);
       if (sc.symbol)


### PR DESCRIPTION
In r265181 the test for the NSCFBoolean data formatter was removed.
Later, in r279353 and r279446 a new implementation was provided for the
formatter, which I believe never worked (and this wasn't caught because
the test was never re-enabled).

This commit fixes the bug and re-enables the old test case.

Differential revision: https://reviews.llvm.org/D47014

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@332700 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e2b500258d6d5352c48c308449e0fc0981b30923)