### PR TITLE
 Use a backwards-compatible way of retreiving the host os version.

### DIFF
--- a/lit/SwiftREPL/DeploymentTarget.test
+++ b/lit/SwiftREPL/DeploymentTarget.test
@@ -2,7 +2,7 @@
 // REQUIRES: darwin
 
 // RUN: echo -n "@available(macOS " >%t.swift
-// RUN: sysctl kern.osproductversion | awk '{printf $2}' >>%t.swift
+// RUN: python -c 'from __future__ import print_function; import platform; print(platform.mac_ver()[0],end="")' >>%t.swift
 // RUN: echo  ", *) func newAPI() -> Int { return 11+12 }" >>%t.swift
 // RUN: echo  "newAPI()" >>%t.swift
 


### PR DESCRIPTION
It looks like the sysctl was introduced in 10.13.

<rdar://problem/40419341>