### PR TITLE
 Decorate the lldb expression functions with availability markup.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/availability/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/availability/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/availability/TestAvailability.py
+++ b/packages/Python/lldbsuite/test/lang/swift/availability/TestAvailability.py
@@ -1,0 +1,126 @@
+"""
+Test that the debugger can call a *really* new function.
+"""
+
+import os
+import lldb
+import lldbsuite.test.lldbplatformutil as lldbplatformutil
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+def getOSName(os):
+    if os == 'macosx': return 'macOS'
+    if os == 'ios': return 'iOS'
+    if os == 'tvos': return 'tvOS'
+    if os == 'watchos': return 'watchOS'
+    return os
+
+class TestAvailability(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+
+    @skipIf(oslist=['linux', 'windows'])
+    def testAvailability(self):
+        os_name = getOSName(lldbplatformutil.getPlatform())
+        platform = lldb.DBG.GetSelectedPlatform()
+        version = '%d.%d.%d'%(platform.GetOSMajorVersion(),
+                              platform.GetOSMinorVersion(),
+                              platform.GetOSUpdateVersion())
+        program = """
+@available(%s %s, *) func f() {}
+
+// ---------------------------------------------------------------------
+// Method context.
+// ---------------------------------------------------------------------
+class C1 {
+  func method() {
+    print("in method") // break_1
+  }
+}
+
+C1().method() // break_0
+
+// ---------------------------------------------------------------------
+// Generic method context.
+// ---------------------------------------------------------------------
+class C2 {
+  func method<T>(_ t: T) {
+    print("in method") // break_2
+  }
+}
+
+C2().method(0)
+
+// ---------------------------------------------------------------------
+// Method in generic class context.
+// ---------------------------------------------------------------------
+class C3<T> {
+  func method() {
+    print("in method") // break_3
+  }
+}
+
+C3<Int>().method()
+
+// ---------------------------------------------------------------------
+// Generic method in generic class context.
+// ---------------------------------------------------------------------
+class C4<U> {
+  func method<V>(_ v: V) {
+    print("in method") // break_4
+  }
+}
+
+C4<Int>().method(0)
+
+// ---------------------------------------------------------------------
+// Function context.
+// ---------------------------------------------------------------------
+func f1() {
+  print("in function") // break_5
+}
+
+f1()
+
+// ---------------------------------------------------------------------
+// Generic function context.
+// ---------------------------------------------------------------------
+func f2<T>(_ t: T) {
+  print("in function") // break_6
+}
+
+f2(0)
+
+// ---------------------------------------------------------------------
+// Top-level context.
+// ---------------------------------------------------------------------
+print("in top_level") // break_7
+"""
+        with open(self.getBuildArtifact("main.swift"), 'w') as main:
+            main.write(program %(os_name, version))
+
+        self.build()
+        source_spec = lldb.SBFileSpec("main.swift")
+        (target, process, thread, brk0) = \
+            lldbutil.run_to_source_breakpoint(self, "break_0", source_spec)
+
+        # Create breakpoints.
+        breakpoints = []
+        for i in range(1, 8):
+            breakpoints.append(target.BreakpointCreateBySourceRegex(
+                'break_%d'%i, lldb.SBFileSpec("main.swift")))
+            self.assertTrue(breakpoints[-1] and
+                            breakpoints[-1].GetNumLocations() >= 1,
+                            VALID_BREAKPOINT)
+
+        for breakpoint in breakpoints:
+            threads = lldbutil.continue_to_breakpoint(process, breakpoint)
+            self.expect("p f()", "can call")
+

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -219,7 +219,7 @@ $builtin_logger_initialize()
       if (generic_info.function_bindings.size()) {
         wrapped_stream.Printf(
             "extension %s$__lldb_context {\n"
-            "  @LLDBDebuggerFunction                                 \n"
+            "  @LLDBDebuggerFunction\n"
             "  %s func $__lldb_wrapped_expr_%u",
             optional_extension, func_decorator, current_counter);
         DumpGenericNames(wrapped_stream, generic_info.function_bindings);
@@ -228,42 +228,38 @@ $builtin_logger_initialize()
                                  generic_info.function_bindings);
         wrapped_stream.Printf(
             ") {\n"
-            "%s" // This is the expression text.  It has all the newlines it
-                 // needs.
-            "  }                                                    \n"
-            "}                                                      \n"
-            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {    "
-            "  \n"
-            "  do {                                          \n"
-            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(     \n"
-            "      $__lldb_arg                                        ",
+            "%s" // This is the expression text (with newlines).
+            "  }\n"
+            "}\n"
+            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {\n"
+            "  do {\n"
+            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(\n"
+            "      $__lldb_arg ",
             wrapped_expr_text.GetData(), current_counter);
         DumpPlaceholdersIntoCall(wrapped_stream,
                                  generic_info.function_bindings);
         wrapped_stream.Printf(
             "\n"
-            "    )                                                  \n"
-            "  }                                                    \n"
-            "}                                                      \n");
+            "    )\n"
+            "  }\n"
+            "}\n");
         first_body_line = 5;
       } else {
         wrapped_stream.Printf(
-            "extension %s$__lldb_context {                            \n"
-            "  @LLDBDebuggerFunction                                \n"
+            "extension %s$__lldb_context {\n"
+            "  @LLDBDebuggerFunction\n"
             "  %s func $__lldb_wrapped_expr_%u(_ $__lldb_arg : "
             "UnsafeMutablePointer<Any>) {\n"
-            "%s" // This is the expression text.  It has all the newlines it
-                 // needs.
-            "  }                                                    \n"
-            "}                                                      \n"
-            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {    "
-            "  \n"
-            "  do {                                          \n"
-            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(     \n"
-            "      $__lldb_arg                                      \n"
-            "    )                                                  \n"
-            "  }                                                    \n"
-            "}                                                      \n",
+            "%s" // This is the expression text (with newlines).
+            "  }\n"
+            "}\n"
+            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {\n"
+            "  do {\n"
+            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(\n"
+            "      $__lldb_arg\n"
+            "    )\n"
+            "  }\n"
+            "}\n",
             optional_extension, func_decorator, current_counter,
             wrapped_expr_text.GetData(), current_counter);
 
@@ -272,9 +268,9 @@ $builtin_logger_initialize()
     } else {
       if (generic_info.function_bindings.size()) {
         wrapped_stream.Printf(
-            "extension %s$__lldb_context {                            \n"
-            "  @LLDBDebuggerFunction                                \n"
-            "  %s func $__lldb_wrapped_expr_%u                        ",
+            "extension %s$__lldb_context {\n"
+            "  @LLDBDebuggerFunction\n"
+            "  %s func $__lldb_wrapped_expr_%u ",
             optional_extension, func_decorator, current_counter);
         DumpGenericNames(wrapped_stream, generic_info.function_bindings);
         wrapped_stream.Printf("(_ $__lldb_arg : UnsafeMutablePointer<Any>");
@@ -282,43 +278,39 @@ $builtin_logger_initialize()
                                  generic_info.function_bindings);
         wrapped_stream.Printf(
             ") {\n"
-            "%s" // This is the expression text.  It has all the newlines it
-                 // needs.
-            "  }                                                    \n"
-            "}                                                      \n"
-            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {    "
-            "  \n"
-            "  do {                                          \n"
-            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(     \n"
-            "      $__lldb_arg                                        ",
+            "%s" // This is the expression text (with newlines).
+            "  }\n"
+            "}\n"
+            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {\n"
+            "  do {\n"
+            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(\n"
+            "      $__lldb_arg ",
             wrapped_expr_text.GetData(), current_counter);
         DumpPlaceholdersIntoCall(wrapped_stream,
                                  generic_info.function_bindings);
         wrapped_stream.Printf(
             "\n"
-            "    )                                                  \n"
-            "  }                                                    \n"
-            "}                                                      \n");
+            "    )\n"
+            "  }\n"
+            "}\n");
         first_body_line = 5;
 
       } else {
         wrapped_stream.Printf(
-            "extension %s$__lldb_context {                            \n"
-            "@LLDBDebuggerFunction                                  \n"
+            "extension %s$__lldb_context {\n"
+            "@LLDBDebuggerFunction\n"
             "  %s func $__lldb_wrapped_expr_%u(_ $__lldb_arg : "
             "UnsafeMutablePointer<Any>) {\n"
-            "%s" // This is the expression text.  It has all the newlines it
-                 // needs.
-            "  }                                                    \n"
-            "}                                                      \n"
-            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {    "
-            "  \n"
-            "  do {                                          \n"
-            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(     \n"
-            "      $__lldb_arg                                      \n"
-            "    )                                                  \n"
-            "  }                                                    \n"
-            "}                                                      \n",
+            "%s" // This is the expression text (with newlines).
+            "  }\n"
+            "}\n"
+            "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {\n"
+            "  do {\n"
+            "    $__lldb_injected_self.$__lldb_wrapped_expr_%u(\n"
+            "      $__lldb_arg\n"
+            "    )\n"
+            "  }\n"
+            "}\n",
             optional_extension, func_decorator, current_counter,
             wrapped_expr_text.GetData(), current_counter);
 
@@ -328,38 +320,34 @@ $builtin_logger_initialize()
   } else {
     if (generic_info.function_bindings.size()) {
       wrapped_stream.Printf(
-          "@LLDBDebuggerFunction                                  \n"
+          "@LLDBDebuggerFunction\n"
           "func $__lldb_wrapped_expr_%u",
           current_counter);
       DumpGenericNames(wrapped_stream, generic_info.function_bindings);
       wrapped_stream.Printf("(_ $__lldb_arg : UnsafeMutablePointer<Any>");
       DumpPlaceholderArguments(wrapped_stream, generic_info.function_bindings);
       wrapped_stream.Printf(
-          ") { \n"
-          "%s" // This is the expression text.  It has all the newlines it
-               // needs.
-          "}                                                      \n"
-          "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {      "
-          "\n"
-          "  do {                                          \n"
-          "    $__lldb_wrapped_expr_%u(                           \n"
+          ") {\n"
+          "%s" // This is the expression text (with newlines).
+          "}\n"
+          "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {\n"
+          "  do {\n"
+          "    $__lldb_wrapped_expr_%u(\n"
           "      $__lldb_arg",
           wrapped_expr_text.GetData(), current_counter);
       DumpPlaceholdersIntoCall(wrapped_stream, generic_info.function_bindings);
       wrapped_stream.Printf(
           "\n"
-          "    )                                                  \n"
-          "  }                                                    \n"
-          "}                                                      \n");
+          "    )\n"
+          "  }\n"
+          "}\n");
       first_body_line = 4;
     } else {
       wrapped_stream.Printf(
-          "@LLDBDebuggerFunction                                  \n"
-          "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {      "
-          "\n"
-          "%s" // This is the expression text.  It has all the newlines it
-               // needs.
-          "}                                                      \n",
+          "@LLDBDebuggerFunction\n"
+          "func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {\n"
+          "%s" // This is the expression text (with newlines).
+          "}\n",
           wrapped_expr_text.GetData());
       first_body_line = 4;
     }

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -133,6 +133,7 @@ public:
                              uint32_t language_flags,
                              const EvaluateExpressionOptions &options,
                              const Expression::SwiftGenericInfo &generic_info,
+                             llvm::StringRef os_version,
                              uint32_t &first_body_line);
 
   void FindSpecialNames(llvm::SmallVectorImpl<swift::Identifier> &names,


### PR DESCRIPTION
This allows users to call API that is available on the target, but
newer than the minimum deployment target of the debugged application
without having to guard their expressions in `#if available`.
    
rdar://problem/40316424