### PR TITLE
[SwiftASTContext] Call collectLinkLibraries for all the modules.

### DIFF
--- a/lit/SwiftREPL/ImportCocoa.test
+++ b/lit/SwiftREPL/ImportCocoa.test
@@ -1,0 +1,7 @@
+// Test that importing Cocoa works.
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s 2>&1 | FileCheck %s
+
+import Cocoa
+// CHECK-NOT: error

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3551,7 +3551,11 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
         all_dlopen_errors.GetData());
   };
 
-  swift_module->collectLinkLibraries(addLinkLibrary);
+  swift_module->forAllVisibleModules(
+      {}, [&](swift::ModuleDecl::ImportedModule import) {
+        import.second->collectLinkLibraries(addLinkLibrary);
+        return true;
+      });
   error = current_error;
 }
 


### PR DESCRIPTION
Unbreaks `import Cocoa`.

<rdar://problem/40458863>