### PR TITLE
[SwiftASTContext] Fix the definition of IsFullyRealized.

### DIFF
--- a/lit/SwiftREPL/SwiftTypeLookup.test
+++ b/lit/SwiftREPL/SwiftTypeLookup.test
@@ -1,0 +1,6 @@
+// Test that we don't crash when looking up types.
+
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=TYPE
+
+:type lookup Swift
+// TYPE: Optional

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5212,7 +5212,7 @@ bool SwiftASTContext::IsFullyRealized(const CompilerType &compiler_type) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(compiler_type));
     if (swift::isa<swift::MetatypeType>(swift_can_type))
       return true;
-    return !swift_can_type->hasArchetype();
+    return !swift_can_type->hasArchetype() && !swift_can_type->hasTypeParameter();
   }
 
   return false;


### PR DESCRIPTION
IRGen always expects a substituted type when asking for TypeInfo,
otherwise the behaviour is undefined (assertions hit/crashes).
IsFullyRealized is supposed to guard us against passing
not-fully-realized types down to the compiler, but the check was
incomplete. This fixes SR-7728.

<rdar://problem/40417941>