### PR TITLE
Destroy RemoteASTContexts before associated swift::ASTContexts

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -309,6 +309,11 @@ public:
   swift::remoteAST::RemoteASTContext &
   GetRemoteASTContext(SwiftASTContext &swift_ast_ctx);
 
+  /// Release the RemoteASTContext associated with the given swift::ASTContext.
+  /// Note that a RemoteASTContext must be destroyed before its associated
+  /// swift::ASTContext is destroyed.
+  void ReleaseAssociatedRemoteASTContext(swift::ASTContext *ctx);
+
   /// Retrieve the offset of the named member variable within an instance
   /// of the given type.
   ///

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -887,8 +887,15 @@ SwiftASTContext::SwiftASTContext(const SwiftASTContext &rhs)
 }
 
 SwiftASTContext::~SwiftASTContext() {
-  if (m_ast_context_ap.get()) {
-    GetASTMap().Erase(m_ast_context_ap.get());
+  if (swift::ASTContext *ctx = m_ast_context_ap.get()) {
+    // A RemoteASTContext associated with this swift::ASTContext has to be
+    // destroyed before the swift::ASTContext is destroyed.
+    if (TargetSP target_sp = m_target_wp.lock())
+      if (ProcessSP process_sp = target_sp->GetProcessSP())
+        if (auto *runtime = process_sp->GetSwiftLanguageRuntime())
+          runtime->ReleaseAssociatedRemoteASTContext(ctx);
+
+    GetASTMap().Erase(ctx);
   }
 }
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1339,6 +1339,11 @@ SwiftLanguageRuntime::GetRemoteASTContext(SwiftASTContext &swift_ast_ctx) {
     .first->second;
 }
 
+void SwiftLanguageRuntime::ReleaseAssociatedRemoteASTContext(
+    swift::ASTContext *ctx) {
+  m_remote_ast_contexts.erase(ctx);
+}
+
 llvm::Optional<uint64_t>
 SwiftLanguageRuntime::GetMemberVariableOffset(CompilerType instance_type,
                                               ValueObject *instance,


### PR DESCRIPTION
This fixes a use-after-free caught by assertions in swift (and by ASan).

A RemoteASTContext must be destroyed before its swift::ASTContext can be
destroyed: otherwise, its destructor will try to operate on freed
memory.

Thanks to John McCall for pointing this out!

rdar://40491481
(cherry picked from commit 22c70c376dbff8c0cf606bdb082a8b47bc2ebff5)