### PR TITLE
 HostInfoMacOSX: Support finding the clang resource directory within CLTools.

### DIFF
--- a/source/Host/macosx/HostInfoMacOSX.mm
+++ b/source/Host/macosx/HostInfoMacOSX.mm
@@ -276,7 +276,7 @@ bool HostInfoMacOSX::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
   auto parent = std::next(rev_it);
   if (parent != r_end && *parent == "SharedFrameworks") {
     // This is the top-level LLDB in the Xcode.app bundle.
-    // e.g., "Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A"
+    // E.g., "Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A"
     raw_path.resize(parent - r_end);
     llvm::sys::path::append(clang_path, raw_path,
                             "Developer/Toolchains/XcodeDefault.xctoolchain",
@@ -287,17 +287,21 @@ bool HostInfoMacOSX::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
     }
   } else if (parent != r_end && *parent == "PrivateFrameworks" &&
              std::distance(parent, r_end) > 2) {
-    // This is LLDB inside an Xcode toolchain.
-    // e.g., "Xcode.app/Contents/Developer/Toolchains/" \
-    //       "My.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework"
     ++parent;
     ++parent;
-    raw_path.resize(parent - r_end);
-    llvm::sys::path::append(clang_path, raw_path, swift_clang_resource_dir);
-    if (!verify || VerifyClangPath(clang_path)) {
-      file_spec.SetFile(clang_path.c_str(), true);
-      return true;
+    if (*parent == "System") {
+      // This is LLDB inside an Xcode toolchain.
+      // E.g., "Xcode.app/Contents/Developer/Toolchains/"               \
+      //       "My.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework"
+      raw_path.resize(parent - r_end);
+      llvm::sys::path::append(clang_path, raw_path, swift_clang_resource_dir);
+      if (!verify || VerifyClangPath(clang_path)) {
+        file_spec.SetFile(clang_path.c_str(), true);
+        return true;
+      }
+      raw_path = lldb_shlib_spec.GetPath();
     }
+    raw_path.resize(rev_it - r_end);
   } else {
     raw_path.resize(rev_it - r_end);
   }

--- a/unittests/Host/HostInfoTest.cpp
+++ b/unittests/Host/HostInfoTest.cpp
@@ -86,6 +86,14 @@ TEST_F(HostInfoTest, MacOSX) {
       "Swift-4.1-development-snapshot.xctoolchain/usr/lib/swift/clang";
   EXPECT_EQ(HostInfoMacOSXTest::ComputeClangDir(toolchain), toolchain_clang);
 
+  std::string cltools = "/Library/Developer/CommandLineTools/Library/"
+                        "PrivateFrameworks/LLDB.framework";
+  std::string cltools_clang =
+      "/Library/Developer/CommandLineTools/Library/PrivateFrameworks/"
+      "LLDB.framework/Resources/Clang";
+  EXPECT_EQ(HostInfoMacOSXTest::ComputeClangDir(cltools), cltools_clang);
+
+
   // Test that a bogus path is detected.
   EXPECT_NE(HostInfoMacOSXTest::ComputeClangDir(GetInputFilePath(xcode), true),
             HostInfoMacOSXTest::ComputeClangDir(GetInputFilePath(xcode)));


### PR DESCRIPTION
…LTools.

rdar://problem/40537961

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@333248 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit dd1044b4d5de6f9608da86fdb158b916ebfffda9)