### PR TITLE
[FileSpec] Re-implmenet removeLastPathComponent

### DIFF
--- a/include/lldb/Utility/FileSpec.h
+++ b/include/lldb/Utility/FileSpec.h
@@ -549,7 +549,14 @@ public:
   void AppendPathComponent(llvm::StringRef component);
   void AppendPathComponent(const FileSpec &new_path);
 
-  void RemoveLastPathComponent();
+  //------------------------------------------------------------------
+  /// Removes the last path component by replacing the current path with its
+  /// parent. When the current path has no parent, this is a no-op.
+  ///
+  /// @return
+  ///     A boolean value indicating whether the path was updated.
+  //------------------------------------------------------------------
+  bool RemoveLastPathComponent();
 
   ConstString GetLastPathComponent() const;
 

--- a/source/Utility/FileSpec.cpp
+++ b/source/Utility/FileSpec.cpp
@@ -841,10 +841,11 @@ void FileSpec::AppendPathComponent(const FileSpec &new_path) {
 
 bool FileSpec::RemoveLastPathComponent() {
   llvm::SmallString<64> current_path;
+  auto style = m_syntax == ePathSyntaxWindows ? llvm::sys::path::Style::windows
+                                              : llvm::sys::path::Style::posix;
   GetPath(current_path, false);
-  if (llvm::sys::path::has_parent_path(current_path, m_style)) {
-    SetFile(llvm::sys::path::parent_path(current_path, m_style), false,
-            m_style);
+  if (llvm::sys::path::has_parent_path(current_path, style)) {
+    SetFile(llvm::sys::path::parent_path(current_path, style), false, m_syntax);
     return true;
   }
   return false;

--- a/source/Utility/FileSpec.cpp
+++ b/source/Utility/FileSpec.cpp
@@ -839,36 +839,15 @@ void FileSpec::AppendPathComponent(const FileSpec &new_path) {
   return AppendPathComponent(new_path.GetPath(false));
 }
 
-void FileSpec::RemoveLastPathComponent() {
-  // CLEANUP: Use StringRef for string handling.
-
-  const bool resolve = false;
-  if (m_filename.IsEmpty() && m_directory.IsEmpty()) {
-    SetFile("", resolve);
-    return;
+bool FileSpec::RemoveLastPathComponent() {
+  llvm::SmallString<64> current_path;
+  GetPath(current_path, false);
+  if (llvm::sys::path::has_parent_path(current_path, m_style)) {
+    SetFile(llvm::sys::path::parent_path(current_path, m_style), false,
+            m_style);
+    return true;
   }
-  if (m_directory.IsEmpty()) {
-    SetFile("", resolve);
-    return;
-  }
-  if (m_filename.IsEmpty()) {
-    const char *dir_cstr = m_directory.GetCString();
-    const char *last_slash_ptr = ::strrchr(dir_cstr, '/');
-
-    // check for obvious cases before doing the full thing
-    if (!last_slash_ptr) {
-      SetFile("", resolve);
-      return;
-    }
-    if (last_slash_ptr == dir_cstr) {
-      SetFile("/", resolve);
-      return;
-    }
-    size_t last_slash_pos = last_slash_ptr - dir_cstr + 1;
-    ConstString new_path(dir_cstr, last_slash_pos);
-    SetFile(new_path.GetCString(), resolve);
-  } else
-    SetFile(m_directory.GetCString(), resolve);
+  return false;
 }
 //------------------------------------------------------------------
 /// Returns true if the filespec represents an implementation source

--- a/unittests/Host/FileSpecTest.cpp
+++ b/unittests/Host/FileSpecTest.cpp
@@ -310,7 +310,7 @@ TEST(FileSpecTest, FormatFileSpec) {
 }
 
 TEST(FileSpecTest, RemoveLastPathComponent) {
-  FileSpec fs_posix("/foo/bar/baz", false, FileSpec::Style::posix);
+  FileSpec fs_posix("/foo/bar/baz", false, FileSpec::ePathSyntaxPosix);
   EXPECT_STREQ("/foo/bar/baz", fs_posix.GetCString());
   EXPECT_TRUE(fs_posix.RemoveLastPathComponent());
   EXPECT_STREQ("/foo/bar", fs_posix.GetCString());
@@ -321,23 +321,23 @@ TEST(FileSpecTest, RemoveLastPathComponent) {
   EXPECT_FALSE(fs_posix.RemoveLastPathComponent());
   EXPECT_STREQ("/", fs_posix.GetCString());
 
-  FileSpec fs_posix_relative("./foo/bar/baz", false, FileSpec::Style::posix);
-  EXPECT_STREQ("foo/bar/baz", fs_posix_relative.GetCString());
+  FileSpec fs_posix_relative("./foo/bar/baz", false, FileSpec::ePathSyntaxPosix);
+  EXPECT_STREQ("./foo/bar/baz", fs_posix_relative.GetCString());
   EXPECT_TRUE(fs_posix_relative.RemoveLastPathComponent());
-  EXPECT_STREQ("foo/bar", fs_posix_relative.GetCString());
+  EXPECT_STREQ("./foo/bar", fs_posix_relative.GetCString());
   EXPECT_TRUE(fs_posix_relative.RemoveLastPathComponent());
-  EXPECT_STREQ("foo", fs_posix_relative.GetCString());
-  EXPECT_FALSE(fs_posix_relative.RemoveLastPathComponent());
-  EXPECT_STREQ("foo", fs_posix_relative.GetCString());
+  EXPECT_STREQ("./foo", fs_posix_relative.GetCString());
+  EXPECT_TRUE(fs_posix_relative.RemoveLastPathComponent());
+  EXPECT_STREQ(".", fs_posix_relative.GetCString());
 
-  FileSpec fs_posix_relative2("./", false, FileSpec::Style::posix);
-  EXPECT_STREQ(".", fs_posix_relative2.GetCString());
-  EXPECT_FALSE(fs_posix_relative2.RemoveLastPathComponent());
+  FileSpec fs_posix_relative2("./", false, FileSpec::ePathSyntaxPosix);
+  EXPECT_STREQ("./.", fs_posix_relative2.GetCString());
+  EXPECT_TRUE(fs_posix_relative2.RemoveLastPathComponent());
   EXPECT_STREQ(".", fs_posix_relative2.GetCString());
   EXPECT_FALSE(fs_posix_relative.RemoveLastPathComponent());
   EXPECT_STREQ(".", fs_posix_relative2.GetCString());
 
-  FileSpec fs_windows("C:\\foo\\bar\\baz", false, FileSpec::Style::windows);
+  FileSpec fs_windows("C:\\foo\\bar\\baz", false, FileSpec::ePathSyntaxWindows);
   EXPECT_STREQ("C:\\foo\\bar\\baz", fs_windows.GetCString());
   EXPECT_TRUE(fs_windows.RemoveLastPathComponent());
   EXPECT_STREQ("C:\\foo\\bar", fs_windows.GetCString());

--- a/unittests/Host/FileSpecTest.cpp
+++ b/unittests/Host/FileSpecTest.cpp
@@ -308,3 +308,45 @@ TEST(FileSpecTest, FormatFileSpec) {
   EXPECT_EQ("foo", llvm::formatv("{0:F}", F).str());
   EXPECT_EQ("(empty)", llvm::formatv("{0:D}", F).str());
 }
+
+TEST(FileSpecTest, RemoveLastPathComponent) {
+  FileSpec fs_posix("/foo/bar/baz", false, FileSpec::Style::posix);
+  EXPECT_STREQ("/foo/bar/baz", fs_posix.GetCString());
+  EXPECT_TRUE(fs_posix.RemoveLastPathComponent());
+  EXPECT_STREQ("/foo/bar", fs_posix.GetCString());
+  EXPECT_TRUE(fs_posix.RemoveLastPathComponent());
+  EXPECT_STREQ("/foo", fs_posix.GetCString());
+  EXPECT_TRUE(fs_posix.RemoveLastPathComponent());
+  EXPECT_STREQ("/", fs_posix.GetCString());
+  EXPECT_FALSE(fs_posix.RemoveLastPathComponent());
+  EXPECT_STREQ("/", fs_posix.GetCString());
+
+  FileSpec fs_posix_relative("./foo/bar/baz", false, FileSpec::Style::posix);
+  EXPECT_STREQ("foo/bar/baz", fs_posix_relative.GetCString());
+  EXPECT_TRUE(fs_posix_relative.RemoveLastPathComponent());
+  EXPECT_STREQ("foo/bar", fs_posix_relative.GetCString());
+  EXPECT_TRUE(fs_posix_relative.RemoveLastPathComponent());
+  EXPECT_STREQ("foo", fs_posix_relative.GetCString());
+  EXPECT_FALSE(fs_posix_relative.RemoveLastPathComponent());
+  EXPECT_STREQ("foo", fs_posix_relative.GetCString());
+
+  FileSpec fs_posix_relative2("./", false, FileSpec::Style::posix);
+  EXPECT_STREQ(".", fs_posix_relative2.GetCString());
+  EXPECT_FALSE(fs_posix_relative2.RemoveLastPathComponent());
+  EXPECT_STREQ(".", fs_posix_relative2.GetCString());
+  EXPECT_FALSE(fs_posix_relative.RemoveLastPathComponent());
+  EXPECT_STREQ(".", fs_posix_relative2.GetCString());
+
+  FileSpec fs_windows("C:\\foo\\bar\\baz", false, FileSpec::Style::windows);
+  EXPECT_STREQ("C:\\foo\\bar\\baz", fs_windows.GetCString());
+  EXPECT_TRUE(fs_windows.RemoveLastPathComponent());
+  EXPECT_STREQ("C:\\foo\\bar", fs_windows.GetCString());
+  EXPECT_TRUE(fs_windows.RemoveLastPathComponent());
+  EXPECT_STREQ("C:\\foo", fs_windows.GetCString());
+  EXPECT_TRUE(fs_windows.RemoveLastPathComponent());
+  EXPECT_STREQ("C:\\", fs_windows.GetCString());
+  EXPECT_TRUE(fs_windows.RemoveLastPathComponent());
+  EXPECT_STREQ("C:", fs_windows.GetCString());
+  EXPECT_FALSE(fs_windows.RemoveLastPathComponent());
+  EXPECT_STREQ("C:", fs_windows.GetCString());
+}


### PR DESCRIPTION
When reading DBGSourcePathRemapping from a dSYM, we remove the last two
path components to make the source lookup more general. However, when
dealing with a relative path that has less than 2 components, we ended
up with an invalid (empty) FileSpec.

This patch changes the behavior of removeLastPathComponent to remove the
last path component, if possible. It does this by checking whether a
parent path exists, and if so using that as the new path. We rely
entirely on LLVM's path implementation to do the heavy lifting.

We now also return a boolean which indicates whether the operator was
successful or not.

Differential revision: https://reviews.llvm.org/D47495

rdar://37791687

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@333540 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 23454e85f0ef4916fc9282deddcbaa378d06c62d)