### PR TITLE
Remove infinite recursion due to FileSpec change.

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1843,12 +1843,10 @@ PlatformDarwin::FindBundleBinaryInExecSearchPaths (const ModuleSpec &module_spec
 
     FileSpec platform_pull_apart(platform_file);
     std::vector<std::string> path_parts;
-    ConstString unix_root_dir("/");
-    while (true) {
+    path_parts.push_back(
+        platform_pull_apart.GetLastPathComponent().AsCString());
+    while (platform_pull_apart.RemoveLastPathComponent()) {
       ConstString part = platform_pull_apart.GetLastPathComponent();
-      platform_pull_apart.RemoveLastPathComponent();
-      if (part.IsEmpty() || part == unix_root_dir)
-        break;
       path_parts.push_back(part.AsCString());
     }
     const size_t path_parts_size = path_parts.size();


### PR DESCRIPTION
Fixes infinite recursion due to change in how FileSpec deals with
removing the last path component.

Fixes timout for TestMiniDumpNew.py

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@333666 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 9f2521522ea0402e16e06038269679a7c0f6c17e)