### PR TITLE
Revert "Remove infinite recursion due to FileSpec change."

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1843,10 +1843,12 @@ PlatformDarwin::FindBundleBinaryInExecSearchPaths (const ModuleSpec &module_spec
 
     FileSpec platform_pull_apart(platform_file);
     std::vector<std::string> path_parts;
-    path_parts.push_back(
-        platform_pull_apart.GetLastPathComponent().AsCString());
-    while (platform_pull_apart.RemoveLastPathComponent()) {
+    ConstString unix_root_dir("/");
+    while (true) {
       ConstString part = platform_pull_apart.GetLastPathComponent();
+      platform_pull_apart.RemoveLastPathComponent();
+      if (part.IsEmpty() || part == unix_root_dir)
+        break;
       path_parts.push_back(part.AsCString());
     }
     const size_t path_parts_size = path_parts.size();


### PR DESCRIPTION
This reverts commit e8be40ae461bd7948429ebc5bfc4423f2c30bde2.

This was auto merged into stable, and appears to have broken the lldb build there:

```
/Users/vsk/src/github-swift-master/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp:1848:12: error: value of type 'void' is not contextually convertible to 'bool'
    while (platform_pull_apart.RemoveLastPathComponent()) {
```