### PR TITLE
[DataFmt] Add formatters for Accelerate/simd (4.2)

### DIFF
--- a/lit/SwiftREPL/SIMD.test
+++ b/lit/SwiftREPL/SIMD.test
@@ -1,0 +1,170 @@
+// Test formatters for Accelerate/simd.
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s
+
+import simd
+
+simd_int2(-1, 2)
+// CHECK: $R{{.*}}: simd_int2 = (-1, 2)
+
+simd_int3(-1, 2, 3)
+// CHECK: $R{{.*}}: simd_int3 = (-1, 2, 3)
+
+simd_int4(-1, 2, 3, 4)
+// CHECK: $R{{.*}}: simd_int4 = (-1, 2, 3, 4)
+
+simd_uint2(1, 2)
+// CHECK: $R{{.*}}: simd_uint2 = (1, 2)
+
+simd_uint3(1, 2, 3)
+// CHECK: $R{{.*}}: simd_uint3 = (1, 2, 3)
+
+simd_uint4(1, 2, 3, 4)
+// CHECK: $R{{.*}}: simd_uint4 = (1, 2, 3, 4)
+
+let colf2 = simd_float2(1.5, 2)
+// CHECK: colf2: simd_float2 = (1.500000e+00, 2.000000e+00)
+
+let colf3 = simd_float3(1.5, 2, 3)
+// CHECK: colf3: simd_float3 = (1.500000e+00, 2.000000e+00, 3.000000e+00)
+
+let colf4 = simd_float4(1.5, 2, 3, 4)
+// CHECK: colf4: simd_float4 = (1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)
+
+let cold2 = simd_double2(1.5, 2)
+// CHECK: cold2: simd_double2 = (1.500000e+00, 2.000000e+00)
+
+let cold3 = simd_double3(1.5, 2, 3)
+// CHECK: cold3: simd_double3 = (1.500000e+00, 2.000000e+00, 3.000000e+00)
+
+let cold4 = simd_double4(1.5, 2, 3, 4)
+// CHECK: cold4: simd_double4 = (1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)
+
+simd_float2x2([colf2, colf2])
+// CHECK: $R{{.*}}: simd_float2x2 =
+// CHECK: [ [1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00] ]
+
+simd_float3x2([colf2, colf2, colf2])
+// CHECK: $R{{.*}}: simd_float3x2 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00] ]
+
+simd_float4x2([colf2, colf2, colf2, colf2])
+// CHECK: $R{{.*}}: simd_float4x2 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00] ]
+
+simd_float2x3([colf3, colf3])
+// CHECK: $R{{.*}}: simd_float2x3 =
+// CHECK: [ [1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00] ]
+
+simd_float3x3([colf3, colf3, colf3])
+// CHECK: $R{{.*}}: simd_float3x3 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00] ]
+
+simd_float4x3([colf3, colf3, colf3, colf3])
+// CHECK: $R{{.*}}: simd_float4x3 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00, 3.000000e+00] ]
+
+simd_float2x4([colf4, colf4])
+// CHECK: $R{{.*}}: simd_float2x4 =
+// CHECK: [ [1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00],
+// CHECK:   [4.000000e+00, 4.000000e+00] ]
+
+simd_float3x4([colf4, colf4, colf4])
+// CHECK: $R{{.*}}: simd_float3x4 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00],
+// CHECK:   [4.000000e+00, 4.000000e+00, 4.000000e+00] ]
+
+simd_float4x4([colf4, colf4, colf4, colf4])
+// CHECK: $R{{.*}}: simd_float4x4 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00, 3.000000e+00],
+// CHECK:   [4.000000e+00, 4.000000e+00, 4.000000e+00, 4.000000e+00] ]
+
+simd_float4x4(rows: [colf4, colf4, colf4, colf4])
+// CHECK: $R{{.*}}: simd_float4x4 =
+// CHECK: [ [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00],
+// CHECK:   [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00],
+// CHECK:   [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00],
+// CHECK:   [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00] ]
+
+simd_double2x2([cold2, cold2])
+// CHECK: $R{{.*}}: simd_double2x2 =
+// CHECK: [ [1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00] ]
+
+simd_double3x2([cold2, cold2, cold2])
+// CHECK: $R{{.*}}: simd_double3x2 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00] ]
+
+simd_double4x2([cold2, cold2, cold2, cold2])
+// CHECK: $R{{.*}}: simd_double4x2 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00] ]
+
+simd_double2x3([cold3, cold3])
+// CHECK: $R{{.*}}: simd_double2x3 =
+// CHECK: [ [1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00] ]
+
+simd_double3x3([cold3, cold3, cold3])
+// CHECK: $R{{.*}}: simd_double3x3 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00] ]
+
+simd_double4x3([cold3, cold3, cold3, cold3])
+// CHECK: $R{{.*}}: simd_double4x3 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00, 3.000000e+00] ]
+
+simd_double2x4([cold4, cold4])
+// CHECK: $R{{.*}}: simd_double2x4 =
+// CHECK: [ [1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00],
+// CHECK:   [4.000000e+00, 4.000000e+00] ]
+
+simd_double3x4([cold4, cold4, cold4])
+// CHECK: $R{{.*}}: simd_double3x4 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00],
+// CHECK:   [4.000000e+00, 4.000000e+00, 4.000000e+00] ]
+
+simd_double4x4([cold4, cold4, cold4, cold4])
+// CHECK: $R{{.*}}: simd_double4x4 =
+// CHECK: [ [1.500000e+00, 1.500000e+00, 1.500000e+00, 1.500000e+00],
+// CHECK:   [2.000000e+00, 2.000000e+00, 2.000000e+00, 2.000000e+00],
+// CHECK:   [3.000000e+00, 3.000000e+00, 3.000000e+00, 3.000000e+00],
+// CHECK:   [4.000000e+00, 4.000000e+00, 4.000000e+00, 4.000000e+00] ]
+
+simd_double4x4(rows: [cold4, cold4, cold4, cold4])
+// CHECK: $R{{.*}}: simd_double4x4 =
+// CHECK: [ [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00],
+// CHECK:   [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00],
+// CHECK:   [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00],
+// CHECK:   [1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00] ]
+
+simd_quatf(vector: colf4)
+// CHECK: $R{{.*}}: simd_quatf = (1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)
+
+simd_quatd(vector: cold4)
+// CHECK: $R{{.*}}: simd_quatd = (1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)

--- a/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/TestAccelerateSIMD.py
+++ b/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/TestAccelerateSIMD.py
@@ -1,0 +1,19 @@
+# TestAccelerateSIMD.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
+
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[decorators.skipUnlessDarwin,
+                ])

--- a/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/main.swift
@@ -1,0 +1,21 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+import simd
+
+func main() -> Int {
+  let d4 = simd_double4(1.5, 2, 3, 4) //%self.expect('frame variable d4', substrs=['1.5', '2', '3', '4'])
+  print(d4)
+  return 0
+}
+
+main()

--- a/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -84,6 +84,9 @@ bool CountableClosedRange_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool StridedRangeGenerator_SummaryProvider(ValueObject &valobj, Stream &stream,
                                            const TypeSummaryOptions &options);
 
+bool AccelerateSIMD_SummaryProvider(ValueObject &valobj, Stream &stream,
+                                    const TypeSummaryOptions &options);
+
 // TODO: this is a transient workaround for the fact that
 // ObjC types are totally opaque in Swift for LLDB
 bool BuiltinObjC_SummaryProvider(ValueObject &valobj, Stream &stream,

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -723,6 +723,21 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Swift.StridedRangeGenerator summary provider",
       ConstString("Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
 
+  TypeSummaryImpl::Flags simd_summary_flags;
+  simd_summary_flags.SetCascades(false)
+      .SetDontShowChildren(true)
+      .SetHideItemNames(true)
+      .SetShowMembersOneLiner(false);
+  const char *accelSIMDTypes = "^(simd\.)?(simd_)?("
+                               "(int|uint|float|double)[234]|"
+                               "(float|double)[234]x[234]|"
+                               "quat(f|d)"
+                               ")$";
+  AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::AccelerateSIMD_SummaryProvider,
+                "Accelerate/SIMD summary provider", ConstString(accelSIMDTypes),
+                simd_summary_flags, true);
+
   TypeSummaryImpl::Flags nil_summary_flags;
   nil_summary_flags.SetCascades(true)
       .SetDontShowChildren(true)


### PR DESCRIPTION
Add Swift data formatters for vectors, matrices, and quaternions from
the Accelerate/simd framework.

rdar://40294100
(cherry picked from commit fd5112d8c64db6ad6e5584b9ba071dae2d15da30)