### PR TITLE
Fix Module::FindTypes to return the correct number of matches.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/Makefile
+++ b/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../make
+OBJCXX_SOURCES := main.mm myobject.mm
+include $(LEVEL)/Makefile.rules
+
+# myobject.o needs to be built without debug info
+myobject.o: myobject.mm
+	$(CXX) -c -o $@ $<

--- a/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/TestNameClash.py
+++ b/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/TestNameClash.py
@@ -1,0 +1,6 @@
+from lldbsuite.test import decorators
+from lldbsuite.test import lldbinline
+
+lldbinline.MakeInlineTest(
+    __file__, globals(), [
+        decorators.skipIfFreeBSD, decorators.skipIfLinux, decorators.skipIfWindows])

--- a/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/main.mm
+++ b/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/main.mm
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+namespace NS {
+  class MyObject { int i = 42; };
+  NS::MyObject globalObject;
+}
+
+@interface MyObject: NSObject
+@end
+
+int main ()
+{
+  @autoreleasepool
+  {
+    MyObject *o = [MyObject alloc];
+    return 0; //% self.expect("fr var o", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["(MyObject"]);
+              //% self.expect("fr var globalObject", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["42"]);
+  }
+}
+
+

--- a/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/myobject.mm
+++ b/packages/Python/lldbsuite/test/lang/objcxx/class-name-clash/myobject.mm
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface MyObject : NSObject
+@end
+
+@implementation MyObject
+@end

--- a/source/Core/Module.cpp
+++ b/source/Core/Module.cpp
@@ -1064,6 +1064,7 @@ size_t Module::FindTypes(
         std::string name_str(name.AsCString(""));
         typesmap.RemoveMismatchedTypes(type_scope, name_str, type_class,
                                        exact_match);
+        num_matches = typesmap.GetSize();
       }
     }
   }

--- a/source/Symbol/TypeList.cpp
+++ b/source/Symbol/TypeList.cpp
@@ -76,6 +76,7 @@ uint32_t TypeList::GetSize() const { return m_types.size(); }
 TypeSP TypeList::GetTypeAtIndex(uint32_t idx) {
   iterator pos, end;
   uint32_t i = idx;
+  assert(i < GetSize() && "Accessing past the end of a TypeList");
   for (pos = m_types.begin(), end = m_types.end(); pos != end; ++pos) {
     if (i == 0)
       return *pos;


### PR DESCRIPTION
In r331719, I changed Module::FindTypes not to limit the amount
of types returned by the Symbol provider, because we want all
possible matches to be able to filter them. In one code path,
the filtering was applied to the TypeList without changing the
number of types that gets returned. This is turn could cause
consumers to access beyond the end of the TypeList.

This patch fixes this case and also adds an assertion to
TypeList::GetTypeAtIndex to catch those obvious programming
mistakes.

Triggering the condition in which we performed the incorrect
access was not easy. It happened a lot in mixed Swift/ObjectiveC
code, but I was able to trigger it in pure Objective C++ although
in a contrieved way.

rdar://problem/40254997

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@333786 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 6dc827b19e54e64786ed1a304516e5fe16f96db0)