### PR TITLE
[SwiftLanguageRuntime] Switch archetype resolution to use RemoteAST.

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2120,25 +2120,22 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Archetype(
   if (promise_sp->IsStaticallyDetermined())
     return true;
 
-  // when an archetype represents a class, it will represent the static type
-  // of the class
-  // but the dynamic type might be different
+  // Resolve dynamically the archetype asking RemoteAST what it thinks.
   Status error;
   lldb::addr_t addr_of_meta = address.GetLoadAddress(&m_process->GetTarget());
   addr_of_meta = m_process->ReadPointerFromMemory(addr_of_meta, error);
-  if (addr_of_meta == LLDB_INVALID_ADDRESS || addr_of_meta == 0 ||
-      error.Fail())
-    return true; // my gut says we should fail here, but we seemed to be on a
-                 // good track before..
-  MetadataPromiseSP actual_type_promise(GetMetadataPromise(addr_of_meta));
-  if (actual_type_promise && actual_type_promise.get() != promise_sp.get()) {
-    CompilerType static_type(class_type_or_name.GetCompilerType());
-    class_type_or_name.SetCompilerType(
-        actual_type_promise->FulfillTypePromise());
-    if (error.Fail() ||
-        class_type_or_name.GetCompilerType().IsValid() == false)
-      class_type_or_name.SetCompilerType(static_type);
-  }
+  SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
+      in_value.GetCompilerType().GetTypeSystem());
+  auto &remote_ast = GetRemoteASTContext(*swift_ast_ctx);
+  swift::remote::RemoteAddress metadata_address(addr_of_meta);
+  auto instance_type =
+      remote_ast.getTypeForRemoteTypeMetadata(metadata_address,
+                                              /*skipArtificial*/ true);
+  if (!instance_type)
+    return false;
+  CompilerType result_type(swift_ast_ctx,
+                           instance_type.getValue().getPointer());
+  class_type_or_name.SetCompilerType(result_type);
   return true;
 }
 


### PR DESCRIPTION
Another step towards removing our homegrown dynamic lookup logic now
that we have infra in the compiler to fix this.