### PR TITLE
[SwiftLanguageRuntime] Switch archetype resolution to RemoteAST.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
+++ b/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/archetype_resolution_subclass/main.swift
@@ -1,0 +1,12 @@
+class Patatino {}
+class Tinky : Patatino {}
+
+// Let's try to make sure that frame var prints the dynamic type, i.e.
+// the subclass `Tinky`.
+func f<T>(_ arg : T) -> T {
+  return arg //%self.expect('frame variable -d run -- arg', substrs=['Tinky'])
+}
+
+var x : Patatino = Tinky()
+f(x)
+print(x)


### PR DESCRIPTION
While here, add a test to cover a case that regressed (and wasn't
tested).