### PR TITLE
[testsuite] Re-enable TestLLVMStyle.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/cpp/llvm-style/TestLLVMStyle.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/llvm-style/TestLLVMStyle.py
@@ -4,6 +4,5 @@ from lldbsuite.test import decorators
 lldbinline.MakeInlineTest(
     __file__, globals(), [
         decorators.expectedFailureAll(
-            oslist=["windows"], bugnumber="llvm.org/pr24764"),
-        decorators.expectedFailureAll(bugnumber="<rdar://problem/31811802>")])
+            oslist=["windows"], bugnumber="llvm.org/pr24764")])
 


### PR DESCRIPTION
The recent inject-local-variables fixes made sure this was
passing again, but it hasn't been marked as such.

<rdar://problem/31811802>