### PR TITLE
[Swift] Fix dynamic type discovery for classes adhering to `Error`.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/class_error/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/class_error/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/class_error/TestClassError.py
+++ b/packages/Python/lldbsuite/test/lang/swift/class_error/TestClassError.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/class_error/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/class_error/main.swift
@@ -1,0 +1,31 @@
+// Let's try to make sure that frame var prints the dynamic type of a class
+// (and a subclass) conforming to Error correctly (and that we don't crash).
+// This involves resolving the dynamic type correctly in the language runtime.
+
+class MyErr : Error {
+  var x : Int
+
+  init(_ x : Int) {
+    self.x = x
+  }
+}
+
+class MyOtherErr : MyErr {}
+
+func f<T>(_ Pat : T) -> T {
+  return Pat //%self.expect('frame variable -d run -- Pat', substrs=['MyErr', 'x = 23'])
+}
+
+func g<T>(_ Pat : T) -> T {
+  return Pat //%self.expect('frame variable -d run -- Pat', substrs=['MyOtherErr', 'x = 42'])
+}
+
+func main() -> Int {
+  let foo : MyErr = MyErr(23)
+  let goo : MyErr = MyOtherErr(42)
+  let patatino = f(foo)
+  let tinky = g(goo)
+  return 0
+}
+
+let _ = main()

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1953,41 +1953,23 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
         llvm::dyn_cast_or_null<SwiftASTContext>(var_type.GetTypeSystem());
 
     CompilerType protocol_type(promise_sp->FulfillTypePromise());
+    // Error has a special, NSError-compatible layout.
     if (swift_ast_ctx->IsErrorType(protocol_type)) {
       if (swift_ast_ctx) {
         Status error;
-        // the offset
-        size_t ptr_size = m_process->GetAddressByteSize();
-        size_t metadata_offset = ptr_size + 4 + (ptr_size == 8 ? 4 : 0);
-        metadata_offset += ptr_size + ptr_size + ptr_size;
         lldb::addr_t archetype_ptr_value = in_value.GetValueAsUnsigned(0);
-        lldb::addr_t base_errortype_ptr =
+        lldb::addr_t metadata_ptr =
             m_process->ReadPointerFromMemory(archetype_ptr_value, error);
-        lldb::addr_t static_metadata_ptrptr =
-            base_errortype_ptr + metadata_offset;
-        lldb::addr_t static_metadata_ptr =
-            m_process->ReadPointerFromMemory(static_metadata_ptrptr, error);
         MetadataPromiseSP promise_sp(
-            GetMetadataPromise(static_metadata_ptr, swift_ast_ctx));
-        if (promise_sp) {
-          lldb::addr_t load_addr = static_metadata_ptrptr + 2 * ptr_size;
-          if (promise_sp->FulfillKindPromise() &&
-              promise_sp->FulfillKindPromise().getValue() ==
-                  swift::MetadataKind::Class) {
-            load_addr = m_process->ReadPointerFromMemory(load_addr, error);
-            lldb::addr_t dynamic_metadata_location =
-                m_process->ReadPointerFromMemory(load_addr, error);
-            promise_sp =
-                GetMetadataPromise(dynamic_metadata_location, swift_ast_ctx);
+            GetMetadataPromise(metadata_ptr, swift_ast_ctx));
+        if (!promise_sp)
+          return false;
+        CompilerType dynamic_type(promise_sp->FulfillTypePromise());
+        if (dynamic_type.IsValid()) {
+          class_type_or_name.SetCompilerType(dynamic_type);
+          address.SetLoadAddress(archetype_ptr_value, &m_process->GetTarget());
+          return true;
           }
-          CompilerType clang_type(promise_sp->FulfillTypePromise());
-          if (clang_type.IsValid() && load_addr != 0 &&
-              load_addr != LLDB_INVALID_ADDRESS) {
-            class_type_or_name.SetCompilerType(clang_type);
-            address.SetLoadAddress(load_addr, &m_process->GetTarget());
-            return true;
-          }
-        }
       }
     } else {
       Status error;


### PR DESCRIPTION
This replaces the handmade computation of metadata and dynamic
type with a call to fullFillTypePromise(), which uses RemoteAST
for the resolution (apparently, correctly).

I added a test as this fixes a crash.

Fixes <rdar://problem/41025993>