### PR TITLE
[Platform] Accept arbitrary kext variants

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -694,7 +694,7 @@ Status PlatformDarwinKernel::GetSharedModule(
       }
     }
 
-    // Give the generic methods, including possibly calling into 
+    // Give the generic methods, including possibly calling into
     // DebugSymbols framework on macOS systems, a chance.
     error = PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
                                            module_search_paths_ptr,
@@ -749,7 +749,7 @@ Status PlatformDarwinKernel::GetSharedModule(
       }
     }
 
-    // Give the generic methods, including possibly calling into 
+    // Give the generic methods, including possibly calling into
     // DebugSymbols framework on macOS systems, a chance.
     error = PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
                                             module_search_paths_ptr,
@@ -789,37 +789,53 @@ Status PlatformDarwinKernel::GetSharedModule(
   return error;
 }
 
+std::vector<lldb_private::FileSpec>
+PlatformDarwinKernel::SearchForExecutablesRecursively(const ConstString &dir) {
+  std::vector<FileSpec> executables;
+  std::error_code EC;
+  for (llvm::sys::fs::recursive_directory_iterator it(dir.GetStringRef(), EC),
+       end;
+       it != end && !EC; it.increment(EC)) {
+    auto status = it->status();
+    if (!status)
+      break;
+    if (llvm::sys::fs::is_regular_file(*status) &&
+        llvm::sys::fs::can_execute(it->path()))
+      executables.emplace_back(it->path(), false);
+  }
+  return executables;
+}
+
 Status PlatformDarwinKernel::ExamineKextForMatchingUUID(
     const FileSpec &kext_bundle_path, const lldb_private::UUID &uuid,
     const ArchSpec &arch, ModuleSP &exe_module_sp) {
-  Status error;
-  FileSpec exe_file = kext_bundle_path;
-  Host::ResolveExecutableInBundle(exe_file);
-  if (exe_file.Exists()) {
-    ModuleSpec exe_spec(exe_file);
-    exe_spec.GetUUID() = uuid;
-    if (!uuid.IsValid()) {
-      exe_spec.GetArchitecture() = arch;
-    }
-
-    // First try to create a ModuleSP with the file / arch and see if the UUID
-    // matches.
-    // If that fails (this exec file doesn't have the correct uuid), don't call
-    // GetSharedModule
-    // (which may call in to the DebugSymbols framework and therefore can be
-    // slow.)
-    ModuleSP module_sp(new Module(exe_spec));
-    if (module_sp && module_sp->GetObjectFile() &&
-        module_sp->MatchesModuleSpec(exe_spec)) {
-      error = ModuleList::GetSharedModule(exe_spec, exe_module_sp, NULL, NULL,
-                                          NULL);
-      if (exe_module_sp && exe_module_sp->GetObjectFile()) {
-        return error;
+  for (const auto &exe_file :
+       SearchForExecutablesRecursively(kext_bundle_path.GetDirectory())) {
+    if (exe_file.Exists()) {
+      ModuleSpec exe_spec(exe_file);
+      exe_spec.GetUUID() = uuid;
+      if (!uuid.IsValid()) {
+        exe_spec.GetArchitecture() = arch;
       }
+
+      // First try to create a ModuleSP with the file / arch and see if the UUID
+      // matches. If that fails (this exec file doesn't have the correct uuid),
+      // don't call GetSharedModule (which may call in to the DebugSymbols
+      // framework and therefore can be slow.)
+      ModuleSP module_sp(new Module(exe_spec));
+      if (module_sp && module_sp->GetObjectFile() &&
+          module_sp->MatchesModuleSpec(exe_spec)) {
+        Status error = ModuleList::GetSharedModule(exe_spec, exe_module_sp,
+                                                   NULL, NULL, NULL);
+        if (exe_module_sp && exe_module_sp->GetObjectFile()) {
+          return error;
+        }
+      }
+      exe_module_sp.reset();
     }
-    exe_module_sp.reset();
   }
-  return error;
+
+  return {};
 }
 
 bool PlatformDarwinKernel::GetSupportedArchitectureAtIndex(uint32_t idx,

--- a/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.h
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.h
@@ -127,6 +127,9 @@ protected:
                                       const lldb_private::FileSpec &file_spec,
                                       bool recurse);
 
+  static std::vector<lldb_private::FileSpec>
+  SearchForExecutablesRecursively(const lldb_private::ConstString &dir);
+
   static void AddKextToMap(PlatformDarwinKernel *thisp,
                            const lldb_private::FileSpec &file_spec);
 


### PR DESCRIPTION
When loading kexts in PlatformDarwinKernel, we use the BundleID as the
filename to to create shared modules. In GetSharedModule we call
ExamineKextForMatchingUUID for any BundleID it finds that is a match, to
see if the UUID is also a match. Until now we were using
Host::ResolveExecutableInBundle which calls a CoreFoundation API to
obtain the executable. However, it's possible that the executable has a
variant suffix (e.g. foo_development) and these files were ignored.

This patch replaces that call with logic that looks for all the binaries
in the bundle. Because of the way ExamineKextForMatchingUUID works, it's
fine to try to load executables that are not valid and we can just
iterate over the list until we found a match.

Differential revision: https://reviews.llvm.org/D47539

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@334205 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 209989753af17fcc18d1769d2f68be45d2a16feb)