### PR TITLE
[ObjC] Add dataformatter for NSDecimalNumber

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjC.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjC.py
@@ -216,6 +216,14 @@ class ObjCDataFormatterTestCase(TestBase):
                              '(NSNumber *) num_at3 = ', ' (double)12.5',
                              '(NSNumber *) num_at4 = ', ' (double)-12.5'])
 
+    def nsdecimalnumber_data_formatter_commands(self):
+        self.expect('frame variable decimal_number decimal_neg_number decimal_one decimal_zero decimal_nan',
+                    substrs=['(NSDecimalNumber *) decimal_number = ', '123456 x 10^-10',
+                             '(NSDecimalNumber *) decimal_neg_number = ', '-123456 x 10^10',
+                             '(NSDecimalNumber *) decimal_one = ', '1 x 10^0',
+                             '(NSDecimalNumber *) decimal_zero = ', '0',
+                             '(NSDecimalNumber *) decimal_nan = ', 'NaN'])
+
     def nscontainers_data_formatter_commands(self):
         self.expect(
             'frame variable newArray newDictionary newMutableDictionary cfarray_ref mutable_array_ref',

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/main.m
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/main.m
@@ -169,7 +169,11 @@ int main (int argc, const char * argv[])
 	    NSNumber* num_at3 = @12.5;
 	    NSNumber* num_at4 = @-12.5;
 
-		NSDecimalNumber* decimal_one = [NSDecimalNumber one];
+	    NSDecimalNumber* decimal_number = [NSDecimalNumber decimalNumberWithMantissa:123456 exponent:-10 isNegative:NO];
+	    NSDecimalNumber* decimal_number_neg = [NSDecimalNumber decimalNumberWithMantissa:123456 exponent:10 isNegative:YES];
+	    NSDecimalNumber* decimal_one = [NSDecimalNumber one];
+	    NSDecimalNumber* decimal_zero = [NSDecimalNumber zero];
+	    NSDecimalNumber* decimal_nan = [NSDecimalNumber notANumber];
 
 	    NSString *str0 = [num6 stringValue];
 

--- a/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -469,6 +469,9 @@ bool lldb_private::formatters::NSNumberSummaryProvider(
   if (class_name == "__NSCFBoolean")
     return ObjCBooleanSummaryProvider(valobj, stream, options);
 
+  if (class_name == "NSDecimalNumber")
+    return NSDecimalNumberSummaryProvider(valobj, stream, options);
+
   if (class_name == "NSNumber" || class_name == "__NSCFNumber") {
     uint64_t value = 0;
     uint64_t i_bits = 0;
@@ -634,6 +637,55 @@ bool lldb_private::formatters::NSNumberSummaryProvider(
   }
 
   return false;
+}
+
+bool lldb_private::formatters::NSDecimalNumberSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  ProcessSP process_sp = valobj.GetProcessSP();
+  if (!process_sp)
+    return false;
+
+  lldb::addr_t valobj_addr = valobj.GetValueAsUnsigned(0);
+  uint32_t ptr_size = process_sp->GetAddressByteSize();
+
+  Status error;
+  int8_t exponent = process_sp->ReadUnsignedIntegerFromMemory(
+      valobj_addr + ptr_size, 1, 0, error);
+  if (error.Fail())
+    return false;
+
+  uint8_t length_and_negative = process_sp->ReadUnsignedIntegerFromMemory(
+      valobj_addr + ptr_size + 1, 1, 0, error);
+  if (error.Fail())
+    return false;
+
+  // Fifth bit marks negativity.
+  const bool is_negative = (length_and_negative >> 4) & 1;
+
+  // Zero length and negative means NaN.
+  uint8_t length = length_and_negative & 0xf;
+  const bool is_nan = is_negative && (length == 0);
+
+  if (is_nan) {
+    stream.Printf("NaN");
+    return true;
+  }
+
+  if (length == 0) {
+    stream.Printf("0");
+    return true;
+  }
+
+  uint64_t mantissa = process_sp->ReadUnsignedIntegerFromMemory(
+      valobj_addr + ptr_size + 4, 8, 0, error);
+  if (error.Fail())
+    return false;
+
+  if (is_negative)
+    stream.Printf("-");
+
+  stream.Printf("%" PRIu64 " x 10^%" PRIi8, mantissa, exponent);
+  return true;
 }
 
 bool lldb_private::formatters::NSURLSummaryProvider(

--- a/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -78,12 +78,12 @@ bool lldb_private::formatters::NSBundleSummaryProvider(
   if (!valobj_addr)
     return false;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name(descriptor->GetClassName().GetCString());
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
-  if (!strcmp(class_name, "NSBundle")) {
+  if (class_name == "NSBundle") {
     uint64_t offset = 5 * ptr_size;
     ValueObjectSP text(valobj.GetSyntheticChildAtOffset(
         offset,
@@ -128,12 +128,12 @@ bool lldb_private::formatters::NSTimeZoneSummaryProvider(
   if (!valobj_addr)
     return false;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name(descriptor->GetClassName().GetCString());
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
-  if (!strcmp(class_name, "__NSTimeZone")) {
+  if (class_name == "__NSTimeZone") {
     uint64_t offset = ptr_size;
     ValueObjectSP text(valobj.GetSyntheticChildAtOffset(
         offset, valobj.GetCompilerType(), true));
@@ -175,12 +175,12 @@ bool lldb_private::formatters::NSNotificationSummaryProvider(
   if (!valobj_addr)
     return false;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name(descriptor->GetClassName().GetCString());
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
-  if (!strcmp(class_name, "NSConcreteNotification")) {
+  if (class_name == "NSConcreteNotification") {
     uint64_t offset = ptr_size;
     ValueObjectSP text(valobj.GetSyntheticChildAtOffset(
         offset, valobj.GetCompilerType(), true));
@@ -222,14 +222,14 @@ bool lldb_private::formatters::NSMachPortSummaryProvider(
   if (!valobj_addr)
     return false;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name(descriptor->GetClassName().GetCString());
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
   uint64_t port_number = 0;
 
-  if (!strcmp(class_name, "NSMachPort")) {
+  if (class_name == "NSMachPort") {
     uint64_t offset = (ptr_size == 4 ? 12 : 20);
     Status error;
     port_number = process_sp->ReadUnsignedIntegerFromMemory(
@@ -270,16 +270,15 @@ bool lldb_private::formatters::NSIndexSetSummaryProvider(
   if (!valobj_addr)
     return false;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name(descriptor->GetClassName().GetCString());
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
   uint64_t count = 0;
 
   do {
-    if (!strcmp(class_name, "NSIndexSet") ||
-        !strcmp(class_name, "NSMutableIndexSet")) {
+    if (class_name == "NSIndexSet" || class_name == "NSMutableIndexSet") {
       Status error;
       uint32_t mode = process_sp->ReadUnsignedIntegerFromMemory(
           valobj_addr + ptr_size, 4, 0, error);
@@ -462,15 +461,15 @@ bool lldb_private::formatters::NSNumberSummaryProvider(
   if (!valobj_addr)
     return false;
 
-  const char *class_name = descriptor->GetClassName().GetCString();
+  llvm::StringRef class_name(descriptor->GetClassName().GetCString());
 
-  if (!class_name || !*class_name)
+  if (class_name.empty())
     return false;
 
-  if (!strcmp(class_name, "__NSCFBoolean"))
+  if (class_name == "__NSCFBoolean")
     return ObjCBooleanSummaryProvider(valobj, stream, options);
 
-  if (!strcmp(class_name, "NSNumber") || !strcmp(class_name, "__NSCFNumber")) {
+  if (class_name == "NSNumber" || class_name == "__NSCFNumber") {
     uint64_t value = 0;
     uint64_t i_bits = 0;
     if (descriptor->GetTaggedPointerInfo(&i_bits, &value)) {

--- a/source/Plugins/Language/ObjC/Cocoa.h
+++ b/source/Plugins/Language/ObjC/Cocoa.h
@@ -35,6 +35,9 @@ bool NSDataSummaryProvider(ValueObject &valobj, Stream &stream,
 bool NSNumberSummaryProvider(ValueObject &valobj, Stream &stream,
                              const TypeSummaryOptions &options);
 
+bool NSDecimalNumberSummaryProvider(ValueObject &valobj, Stream &stream,
+                                    const TypeSummaryOptions &options);
+
 bool NSNotificationSummaryProvider(ValueObject &valobj, Stream &stream,
                                    const TypeSummaryOptions &options);
 

--- a/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -769,6 +769,10 @@ static void LoadObjCFormatters(TypeCategoryImplSP objc_category_sp) {
   AddCXXSummary(
       objc_category_sp, lldb_private::formatters::NSNumberSummaryProvider,
       "NSNumber summary provider", ConstString("NSCFNumber"), appkit_flags);
+  AddCXXSummary(objc_category_sp,
+                lldb_private::formatters::NSNumberSummaryProvider,
+                "NSDecimalNumber summary provider",
+                ConstString("NSDecimalNumber"), appkit_flags);
 
   AddCXXSummary(objc_category_sp,
                 lldb_private::formatters::NSURLSummaryProvider,


### PR DESCRIPTION
This patch adds a data formatter for NSDecimalNumber. The latter is a
Foundation object used for representing and performing arithmetic on
base-10 numbers that bridges to Decimal.