### PR TITLE
Map generic types into the context before printing them.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -61,7 +61,7 @@ class TestSwiftGenericTypes(TestBase):
         self.assertTrue(len(threads) == 1)
         self.thread = threads[0]
 
-        self.expect("frame variable object",
+        self.expect("frame variable -d no-dynamic-values object",
                     substrs=['(JustSomeType) object = 0x'])
         self.expect(
             "frame variable -d run-target -- object",

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -80,8 +80,14 @@ ConstString ValueObjectVariable::GetTypeName() {
 
 ConstString ValueObjectVariable::GetDisplayTypeName() {
   Type *var_type = m_variable_sp->GetType();
-  if (var_type)
-    return var_type->GetForwardCompilerType().GetDisplayTypeName();
+  if (var_type) {
+    CompilerType fwd_type = var_type->GetForwardCompilerType();
+    // FIXME: This is probably not the best place to do this.
+    auto ts = fwd_type.GetTypeSystem();
+    auto qual_type = fwd_type.GetOpaqueQualType();
+    auto stack_frame_sp = GetFrameSP();
+    return ts->MapIntoContext(stack_frame_sp, qual_type).GetDisplayTypeName();
+  }
   return ConstString();
 }
 


### PR DESCRIPTION
This is more fallout from adapting the Swift type metadata lookup to
the τ_depth_index convention.

rdar://problem/38306926