### PR TITLE
Add an entitlement to debugserver

### DIFF
--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -7618,7 +7618,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${CONFIGURATION}\" != BuildAndIntegration ]\nthen\n    if [ \"${DEBUGSERVER_USE_FROM_SYSTEM}\" == \"\" ]\n    then\n        if [ \"${DEBUGSERVER_DISABLE_CODESIGN}\" == \"\" ]\n        then\n            codesign -f -s lldb_codesign \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n        fi\n    fi\nfi\n";
+			shellScript = "if [ \"${CONFIGURATION}\" != BuildAndIntegration ]\nthen\n    if [ \"${DEBUGSERVER_USE_FROM_SYSTEM}\" == \"\" ]\n    then\n        if [ \"${DEBUGSERVER_DISABLE_CODESIGN}\" == \"\" ]\n        then\n            codesign -f -s lldb_codesign --entitlements ${SRCROOT}/resources/debugserver-macosx-entitlements.plist \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n        fi\n    fi\nfi\n";
 		};
 		4C848E0918D289FD00EC6DD0 /* Install Clang compiler headers */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/resources/debugserver-macosx-entitlements.plist
+++ b/resources/debugserver-macosx-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>

--- a/tools/debugserver/debugserver.xcodeproj/project.pbxproj
+++ b/tools/debugserver/debugserver.xcodeproj/project.pbxproj
@@ -568,7 +568,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -x";
-			shellScript = "if [ \"${CONFIGURATION}\" != BuildAndIntegration ]\nthen\n    if [ -n \"${DEBUGSERVER_USE_FROM_SYSTEM}\" ]\n    then\n\t\tditto \"${DEVELOPER_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver\" \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    elif [ \"${DEBUGSERVER_DISABLE_CODESIGN}\" == \"\" ]\n    then\n        codesign -f -s lldb_codesign \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    fi\nfi\n";
+			shellScript = "if [ \"${CONFIGURATION}\" != BuildAndIntegration ]\nthen\n    if [ -n \"${DEBUGSERVER_USE_FROM_SYSTEM}\" ]\n    then\n\t\tditto \"${DEVELOPER_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver\" \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    elif [ \"${DEBUGSERVER_DISABLE_CODESIGN}\" == \"\" ]\n    then\n        codesign -f -s lldb_codesign --entitlements ${SRCROOT}/../../resources/debugserver-macosx-entitlements.plist \"${TARGET_BUILD_DIR}/${TARGET_NAME}\"\n    fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -216,14 +216,13 @@ endif()
 set(entitlements_xml ${CMAKE_CURRENT_SOURCE_DIR}/debugserver-macosx-entitlements.plist)
 if(IOS)
   set(entitlements_xml ${CMAKE_CURRENT_SOURCE_DIR}/debugserver-entitlements.plist)
+else()
+  set(entitlements_xml ${CMAKE_CURRENT_SOURCE_DIR}/../../../resources/debugserver-macosx-entitlements.plist)
 endif()
 
 set(LLDB_CODESIGN_IDENTITY "lldb_codesign"
   CACHE STRING "Identity used for code signing. Set to empty string to skip the signing step.")
 set(LLDB_USE_ENTITLEMENTS_Default On)
-if("${LLDB_CODESIGN_IDENTITY}" STREQUAL "lldb_codesign")
-  set(LLDB_USE_ENTITLEMENTS_Default Off)
-endif()
 option(LLDB_USE_ENTITLEMENTS "Use entitlements when codesigning (Defaults Off when using lldb_codesign identity, otherwise On)" ${LLDB_USE_ENTITLEMENTS_Default})
 
 if (SKIP_DEBUGSERVER)


### PR DESCRIPTION
On macOS 10.14, debugserver needs to have an entitlement do be
allowed to debug processes. Adding this to both the Xcode and
cmake build system. This shouldn't have any impact on previous
OSs.

rdar://39024915

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@334772 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 889aaeeef0e6b3d42f3405ea0ee883c1712cd0ee)