### PR TITLE
[swift] Rename IRGenDebugInfoLevel enum to stay compatible with swift

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -32,7 +32,7 @@
 #include <set>
 
 namespace swift {
-enum class IRGenDebugInfoKind : unsigned;
+enum class IRGenDebugInfoLevel : unsigned;
 class CanType;
 class IRGenOptions;
 class NominalTypeDecl;
@@ -164,12 +164,12 @@ public:
 
   swift::ASTContext *GetASTContext();
 
-  swift::IRGenDebugInfoKind GetGenerateDebugInfo();
+  swift::IRGenDebugInfoLevel GetGenerateDebugInfo();
 
   static swift::PrintOptions
   GetUserVisibleTypePrintingOptions(bool print_help_if_available);
 
-  void SetGenerateDebugInfo(swift::IRGenDebugInfoKind b);
+  void SetGenerateDebugInfo(swift::IRGenDebugInfoLevel b);
 
   bool AddModuleSearchPath(const char *path);
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1143,8 +1143,8 @@ CreateMainFile(SwiftASTContext &swift_ast_context, StringRef filename,
                StringRef text, const EvaluateExpressionOptions &options) {
   const bool generate_debug_info = options.GetGenerateDebugInfo();
   swift_ast_context.SetGenerateDebugInfo(generate_debug_info
-                                             ? swift::IRGenDebugInfoKind::Normal
-                                             : swift::IRGenDebugInfoKind::None);
+                                           ? swift::IRGenDebugInfoLevel::Normal
+                                           : swift::IRGenDebugInfoLevel::None);
   swift::IRGenOptions &ir_gen_options = swift_ast_context.GetIRGenOptions();
 
   if (generate_debug_info) {

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4302,8 +4302,8 @@ CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   return CompilerType();
 }
 
-swift::IRGenDebugInfoKind SwiftASTContext::GetGenerateDebugInfo() {
-  return GetIRGenOptions().DebugInfoKind;
+swift::IRGenDebugInfoLevel SwiftASTContext::GetGenerateDebugInfo() {
+  return GetIRGenOptions().DebugInfoLevel;
 }
 
 swift::PrintOptions SwiftASTContext::GetUserVisibleTypePrintingOptions(
@@ -4324,8 +4324,8 @@ swift::PrintOptions SwiftASTContext::GetUserVisibleTypePrintingOptions(
   return print_options;
 }
 
-void SwiftASTContext::SetGenerateDebugInfo(swift::IRGenDebugInfoKind b) {
-  GetIRGenOptions().DebugInfoKind = b;
+void SwiftASTContext::SetGenerateDebugInfo(swift::IRGenDebugInfoLevel b) {
+  GetIRGenOptions().DebugInfoLevel = b;
 }
 
 llvm::TargetOptions *SwiftASTContext::getTargetOptions() {


### PR DESCRIPTION
The enum IRGenDebugInfoKind in swift has been renamed in the branch gcodeview. This commit should allow lldb to stay compatible with that branch of swift.