### PR TITLE
[Swift] Fix dynamic type discovery for classes adhering to `Error`.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/class_error/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/class_error/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/class_error/TestClassError.py
+++ b/packages/Python/lldbsuite/test/lang/swift/class_error/TestClassError.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/class_error/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/class_error/main.swift
@@ -1,0 +1,31 @@
+// Let's try to make sure that frame var prints the dynamic type of a class
+// (and a subclass) conforming to Error correctly (and that we don't crash).
+// This involves resolving the dynamic type correctly in the language runtime.
+
+class MyErr : Error {
+  var x : Int
+
+  init(_ x : Int) {
+    self.x = x
+  }
+}
+
+class MyOtherErr : MyErr {}
+
+func f<T>(_ Pat : T) -> T {
+  return Pat //%self.expect('frame variable -d run -- Pat', substrs=['MyErr', 'x = 23'])
+}
+
+func g<T>(_ Pat : T) -> T {
+  return Pat //%self.expect('frame variable -d run -- Pat', substrs=['MyOtherErr', 'x = 42'])
+}
+
+func main() -> Int {
+  let foo : MyErr = MyErr(23)
+  let goo : MyErr = MyOtherErr(42)
+  let patatino = f(foo)
+  let tinky = g(goo)
+  return 0
+}
+
+let _ = main()


### PR DESCRIPTION
This replaces the handmade computation of metadata and dynamic
type with a call to fullFillTypePromise(), which uses RemoteAST
for the resolution (apparently, correctly).

I added a test as this fixes a crash.

Fixes <rdar://problem/41025993>