### PR TITLE
[Swift] Test that we print an array of Any.Type(s) correctly.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/anytype_array/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/anytype_array/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/anytype_array/TestAnyTypeArray.py
+++ b/packages/Python/lldbsuite/test/lang/swift/anytype_array/TestAnyTypeArray.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/anytype_array/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/anytype_array/main.swift
@@ -1,0 +1,14 @@
+// Make sure [Any.Type] is reconstructed correctly.
+// (and a subclass) conforming to Error correctly (and that we don't crash).
+// This involves resolving the dynamic type correctly in the language runtime.
+
+func main() -> Int {
+  let patatino: [Any.Type] = [
+    String.self,
+    Int.self,
+    Float.self,
+  ]
+  return 0 //%self.expect('frame variable -d run -- patatino', substrs=['Any.Type', '3 values', 'String', 'Int', 'Float'])
+}
+
+let _ = main()


### PR DESCRIPTION
This was a bug in type reconstruction, but I'm adding a test on
the lldb side to make sure this doesn't regress here.