### PR TITLE
Fix the 'tb' alias command

### DIFF
--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -549,7 +549,7 @@ void CommandInterpreter::LoadCommandDictionary() {
       // sure to increase the size of this buffer.
       char buffer[1024];
       int num_printed =
-          snprintf(buffer, 1024, "%s %s", break_regexes[i][1], "-o");
+          snprintf(buffer, 1024, "%s %s", break_regexes[i][1], "-o 1");
       lldbassert(num_printed < 1024);
       UNUSED_IF_ASSERT_DISABLED(num_printed);
       success =


### PR DESCRIPTION
No idea when this broke or if it ever worked. Added a small test
for one-shot breakpoints while I was there.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@334921 91177308-0d34-0410-b5e6-96231b3b80d8