### PR TITLE
Correct the pathname that PlatformDarwinKernel::ExamineKextForMatchin…

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -790,10 +790,10 @@ Status PlatformDarwinKernel::GetSharedModule(
 }
 
 std::vector<lldb_private::FileSpec>
-PlatformDarwinKernel::SearchForExecutablesRecursively(const ConstString &dir) {
+PlatformDarwinKernel::SearchForExecutablesRecursively(const std::string &dir) {
   std::vector<FileSpec> executables;
   std::error_code EC;
-  for (llvm::sys::fs::recursive_directory_iterator it(dir.GetStringRef(), EC),
+  for (llvm::sys::fs::recursive_directory_iterator it(dir.c_str(), EC),
        end;
        it != end && !EC; it.increment(EC)) {
     auto status = it->status();
@@ -810,7 +810,7 @@ Status PlatformDarwinKernel::ExamineKextForMatchingUUID(
     const FileSpec &kext_bundle_path, const lldb_private::UUID &uuid,
     const ArchSpec &arch, ModuleSP &exe_module_sp) {
   for (const auto &exe_file :
-       SearchForExecutablesRecursively(kext_bundle_path.GetDirectory())) {
+       SearchForExecutablesRecursively(kext_bundle_path.GetPath())) {
     if (exe_file.Exists()) {
       ModuleSpec exe_spec(exe_file);
       exe_spec.GetUUID() = uuid;

--- a/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.h
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.h
@@ -128,7 +128,7 @@ protected:
                                       bool recurse);
 
   static std::vector<lldb_private::FileSpec>
-  SearchForExecutablesRecursively(const lldb_private::ConstString &dir);
+  SearchForExecutablesRecursively(const std::string &dir);
 
   static void AddKextToMap(PlatformDarwinKernel *thisp,
                            const lldb_private::FileSpec &file_spec);


### PR DESCRIPTION
…gUUID

passes to the recursive search function so we only recursively
search the kext bundle directory, instead of its parent directory.

<rdar://problem/41227170> 

Differential Revision: https://reviews.llvm.org/D48302


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@335079 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit eaad0c9bc3e7933aa351b778a19f3a2a08a5bc4f)