### PR TITLE
Use the scratch Swift AST context to resolve dynamic types.

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1462,8 +1462,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     return false;
   address.SetRawAddress(class_metadata_ptr);
 
-  SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
-      in_value.GetCompilerType().GetTypeSystem());
+  // Dynamic type resolution in RemoteAST might pull in other Swift modules, so
+  // use the scratch context where such operations are legal and safe.
+  SwiftASTContext *swift_ast_ctx = GetScratchSwiftASTContext();
 
   Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
 
@@ -2133,8 +2134,10 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_GenericTypeParam(
   if (addr_of_meta == LLDB_INVALID_ADDRESS || addr_of_meta == 0 ||
       error.Fail())
     return true;
-  SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
-       in_value.GetCompilerType().GetTypeSystem());
+  
+   // Dynamic type resolution in RemoteAST might pull in other Swift modules, so
+   // use the scratch context where such operations are legal and safe.
+   SwiftASTContext *swift_ast_ctx = GetScratchSwiftASTContext();
    auto &remote_ast = GetRemoteASTContext(*swift_ast_ctx);
    swift::remote::RemoteAddress metadata_address(addr_of_meta);
    auto instance_type =


### PR DESCRIPTION
Dynamic type resolution in RemoteAST might pull in other Swift
modules, so use the scratch context where such operations are legal
and safe.

<rdar://problem/40950542>