### PR TITLE
Use the scratch Swift AST context to resolve dynamic types.

### DIFF
--- a/lit/Swift/Inputs/BridgingHeader.h
+++ b/lit/Swift/Inputs/BridgingHeader.h
@@ -1,0 +1,1 @@
+int i = SYNTAX_ERROR;

--- a/lit/Swift/Inputs/Library.swift
+++ b/lit/Swift/Inputs/Library.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public protocol LibraryProtocol : class {}
+
+public final class Foo : NSObject {
+  public init(_ input : LibraryProtocol) {
+    // When evaluating "input" here, RemoteAST will try to get its
+    // dynamic type.  This must *not* trigger an import of the "main"
+    // module in the Library module context.
+    print("break here")
+  }
+}

--- a/lit/Swift/Inputs/main.swift
+++ b/lit/Swift/Inputs/main.swift
@@ -1,0 +1,7 @@
+import Library
+
+class FromMainModule : LibraryProtocol {
+  let i = 1
+}
+
+Foo(FromMainModule())

--- a/lit/Swift/RemoteASTImport.test
+++ b/lit/Swift/RemoteASTImport.test
@@ -48,5 +48,5 @@ p input
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK-NOT: undeclared identifier {{'SYNTAX_ERROR'}}
-# This is the static type of 'input'.
-# CHECK: (LibraryProtocol) ${{R0}}
+# This is the dynamic type of 'input'.
+# CHECK: (main.FromMainModule) ${{R0}}{{.*}}(i = 1)

--- a/lit/Swift/RemoteASTImport.test
+++ b/lit/Swift/RemoteASTImport.test
@@ -1,0 +1,52 @@
+# REQUIRES: darwin
+
+# This tests that RemoteAST querying the dynamic type of a variable
+# doesn't import any modules into a module SwiftASTContext that
+# weren't imported by that module in the source code.  Unfortunately
+# this test is extremely sensitive to the side effects of the command
+# interpreter and the debug info format, which is why it is written as
+# a LIT test.
+
+# RUN: rm -rf %T && mkdir -p %T && cd %T
+# RUN: %target-swift-frontend -c -g -serialize-debugging-options \
+# RUN:          -module-cache-path %T/cache \
+# RUN:          -primary-file %S/Inputs/Library.swift \
+# RUN:          -emit-module-path Library.part.swiftmodule \
+# RUN:          -parse-as-library -module-name Library -o Library.o -I.
+# RUN: %target-swift-frontend -serialize-debugging-options \
+# RUN:          -module-cache-path %T/cache \
+# RUN:          -merge-modules -emit-module \
+# RUN:          -parse-as-library -sil-merge-partial-modules \
+# RUN:          -disable-diagnostic-passes -disable-sil-perf-optzns \
+# RUN:          -module-name Library Library.part.swiftmodule \
+# RUN:          -o Library.swiftmodule -I%T
+# RUN: %target-swiftc -Xlinker -dylib -o libLibrary.dylib Library.o \
+# RUN:          -Xlinker -add_ast_path -Xlinker Library.swiftmodule \
+# RUN:          -Xlinker -install_name -Xlinker @executable_path/libLibrary.dylib
+# RUN: %target-swift-frontend -c -g -serialize-debugging-options \
+# RUN:          -module-cache-path %T/cache \
+# RUN:          -primary-file %S/Inputs/main.swift \
+# RUN:          -module-name main -o main.o \
+# RUN:          -emit-module-path main.part.swiftmodule \
+# RUN:          -import-objc-header %S/Inputs/BridgingHeader.h \
+# RUN:          -I. -Xcc -DSYNTAX_ERROR=1
+# RUN: %target-swift-frontend -serialize-debugging-options  -merge-modules \
+# RUN:          -module-cache-path %T/cache \
+# RUN:          -emit-module main.part.swiftmodule \
+# RUN:          -parse-as-library -sil-merge-partial-modules \
+# RUN:          -disable-diagnostic-passes -disable-sil-perf-optzns \
+# RUN:          -import-objc-header %S/Inputs/BridgingHeader.h \
+# RUN:          -I%T -Xcc -DSYNTAX_ERROR=1 \
+# RUN:          -module-name main -o main.swiftmodule
+# RUN: %target-swiftc -o a.out main.o -Xlinker -add_ast_path \
+# RUN:          -Xlinker main.swiftmodule  -L. -lLibrary
+# RUN: %lldb a.out -s %s | FileCheck %s
+
+b Library.swift:10
+run
+p input
+
+# The {{ }} avoids accidentally matching the input script!
+# CHECK-NOT: undeclared identifier {{'SYNTAX_ERROR'}}
+# This is the static type of 'input'.
+# CHECK: (LibraryProtocol) ${{R0}}

--- a/lit/Swift/lit.local.cfg
+++ b/lit/Swift/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.test']

--- a/lit/lit.cfg
+++ b/lit/lit.cfg
@@ -81,6 +81,12 @@ config.substitutions.append(('%cxx', config.cxx))
 
 config.substitutions.append(('%lldb', lldb))
 
+# Swift support
+swift_sdk = (' -sdk ' + sdk_path) if platform.system() in ['Darwin'] else ''
+config.substitutions.append(('%target-swiftc', config.swiftc + swift_sdk))
+config.substitutions.append(('%target-swift-frontend', config.swiftc[:-1] +
+                             ' -frontend' + swift_sdk))
+
 if debugserver is not None:
     config.substitutions.append(('%debugserver', debugserver))
 

--- a/lit/lit.site.cfg.in
+++ b/lit/lit.site.cfg.in
@@ -12,6 +12,7 @@ config.target_triple = "@TARGET_TRIPLE@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.cc = "@LLDB_TEST_C_COMPILER@"
 config.cxx = "@LLDB_TEST_CXX_COMPILER@"
+config.swiftc = "@LLDB_SWIFTC@"
 config.have_zlib = @LLVM_ENABLE_ZLIB@
 
 # Support substitution of the tools and libs dirs with user parameters. This is

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1758,8 +1758,12 @@ Status SwiftASTContext::GetFatalErrors() {
   Status error;
   if (HasFatalErrors()) {
     error = m_fatal_errors;
-    if (error.Success())
-      error.SetErrorString("unknown fatal error in swift AST context");
+    if (error.Success()) {
+      // Retrieve the error message from the DiagnosticConsumer.
+      DiagnosticManager diagnostic_manager;
+      PrintDiagnostics(diagnostic_manager);
+      error.SetErrorString(diagnostic_manager.GetString());
+    }
   }
   return error;
 }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1463,8 +1463,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     return false;
   address.SetRawAddress(class_metadata_ptr);
 
-  SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
-      in_value.GetCompilerType().GetTypeSystem());
+  // Dynamic type resolution in RemoteAST might pull in other Swift modules, so
+  // use the scratch context where such operations are legal and safe.
+  SwiftASTContext *swift_ast_ctx = GetScratchSwiftASTContext();
 
   Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
 


### PR DESCRIPTION
Use the scratch Swift AST context to resolve dynamic types.  …
Dynamic type resolution in RemoteAST might pull in other Swift
modules, so use the scratch context where such operations are legal
and safe.

<rdar://problem/40950542>

(cherry picked from commit f68ba6b)