### PR TITLE
 Make Objective-C types work in frame variable when debugging without...

### DIFF
--- a/lit/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lit/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -1,7 +1,16 @@
+import Darwin
 import Foundation
 
 func f() {
-  let object = NSNumber(value: 42) // FIXME: CHECK: objexct = <could not resolve type>
+  // This works only through a weird side-effect with the NSURL below.
+  // CHECK-DAG: (size_t) ctype = 1024
+  let ctype = size_t(1024)
+  // This works as a Clang type via the Objective-C runtime.
+  // CHECK-DAG: (URL) object = "file:///dev/null"
+  let object = URL(fileURLWithPath: "/dev/null")
+  // The Objective-C runtime recognizes this as a tagged pointer.
+  // CHECK-DAG: (__NSCFNumber) inlined = 0x0000000000002a37 42
+  let inlined = NSNumber(value: 42)
   print(object) // break here
 }
 


### PR DESCRIPTION
…a .swiftmodule.

When we failed to look up the type because no .swiftmodule is
present or it couldn't be read, fall back to presenting objects
that look like they might be come from Objective-C as Clang
types. LLDB's Objective-C part is very robust against malformed
object pointers, so this isn't very risky.

rdar://problem/41370330