### PR TITLE
[SwiftASTContext] Stopgap solution to avoid crashing when printing ge…

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/main.swift
@@ -1,0 +1,8 @@
+extension Array where Element: Comparable {
+  public func union(_ rhs: [Element]) -> [Element] {
+    return [] //%self.expect('frame variable -d run -- rhs', substrs=['Element'])
+  }
+}
+
+var patatino = [1]
+patatino.union([2])

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5947,6 +5947,8 @@ const swift::irgen::TypeInfo *SwiftASTContext::GetSwiftTypeInfo(void *type) {
   if (type) {
     auto &irgen_module = GetIRGenModule();
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
+    if (swift_can_type->hasTypeParameter())
+      return nullptr;
     swift::SILType swift_sil_type = irgen_module.getLoweredType(
         swift_can_type);
     return &irgen_module.getTypeInfo(swift_sil_type);


### PR DESCRIPTION
…neric extensions.

The proper fix requires backporting a bunch of stuffs that's not really
worth it. `stable` contains a working version.

<rdar://problem/41343572>