### PR TITLE
A little cleanup in ObjectFileMachO::GetSDKVersion.

### DIFF
--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6079,20 +6079,29 @@ uint32_t ObjectFileMachO::GetSDKVersion(uint32_t *versions,
             m_sdk_versions.push_back(xxxx);
             m_sdk_versions.push_back(yy);
             m_sdk_versions.push_back(zz);
+            success = true;
+          } else {
+            GetModule()->ReportWarning(
+                "minimum OS version load command with invalid (0) version found.");
           }
-          success = true;
         }
       }
       offset = load_cmd_offset + lc.cmdsize;
     }
 
     if (success == false) {
-      // Push an invalid value so we don't keep trying to
+      // Push an invalid value so we don't try to find
+      // the version # again on the next call to this
+      // method.
       m_sdk_versions.push_back(UINT32_MAX);
     }
   }
 
-  if (m_sdk_versions.size() > 1 || m_sdk_versions[0] != UINT32_MAX) {
+  // Legitimate version numbers will have 3 entries pushed
+  // on to m_sdk_versions.  If we only have one value, it's
+  // the sentinel value indicating that this object file
+  // does not have a valid minimum os version #.
+  if (m_sdk_versions.size() > 1) {
     if (versions != NULL && num_versions > 0) {
       for (size_t i = 0; i < num_versions; ++i) {
         if (i < m_sdk_versions.size())


### PR DESCRIPTION
A little cleanup in ObjectFileMachO::GetSDKVersion.

This method does one of two things:

1. finds a minimum os deployment version # in a Mach-O load
command and saves the three parts in the m_sdk_version, or

2. finds no valid min os version # load command, pushes a 
sentinel value on the m_sdk_version vector so we don't search
the same load commands multiple times.

There was a little bug when we found a load command with 
a version of 0.0.0 - the method would not add anything to
the m_sdk_version vector but would declare that a success.
It would not push the sentinel value to the vector.
There was code later in the method which assumed that
the vector always had a sentinel value, at least, and that
code could crash when this method was called back when
evaluating a Swift expression.  (these version #'s are 
fetched lazily so it wouldn't happen when the object file
was parsed, only when doing an expression that needed
the version #).

<rdar://problem/41372699> 


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@335556 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 65a6a445a6498c6e01aee6183b2ce88fa5f3d700)
(cherry picked from commit 3567d7360f5ba97406dd733e7f1fac0b321ff96c)