### PR TITLE
Adjust for change to AbstractStorageDecl storage representation.

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1405,8 +1405,10 @@ bool SwiftASTManipulator::FixCaptures() {
     if (!variable.m_decl)
       continue;
 
-    if (variable.m_decl->getStorageKind() !=
-        swift::AbstractStorageDecl::Computed)
+    auto impl = variable.m_decl->getImplInfo();
+    if (impl.getReadImpl() != swift::ReadImplKind::Get ||
+        (impl.getWriteImpl() != swift::WriteImplKind::Set &&
+         impl.getWriteImpl() != swift::WriteImplKind::Immutable))
       continue;
 
     swift::FuncDecl *getter_decl = variable.m_decl->getGetter();

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1754,8 +1754,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
               llvm::cast<SwiftExpressionVariable>(persistent_variable.get())
                   ->SetIsModifiable(false);
             }
-            if (decl->getStorageKind() ==
-                swift::VarDecl::StorageKindTy::Computed) {
+            if (!decl->hasStorage()) {
               llvm::cast<SwiftExpressionVariable>(persistent_variable.get())
                   ->SetIsComputed(true);
             }


### PR DESCRIPTION
I'm not really sure what this code was trying to do, but this maintains
exactly the current behavior.