### PR TITLE
Avoid initializing the Swift IRGenModule for a given AST context concurrently

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -27,6 +27,7 @@
 #include "lldb/Utility/Status.h"
 
 #include "llvm/ADT/Optional.h"
+#include "llvm/Support/Threading.h"
 
 #include <map>
 #include <set>
@@ -822,6 +823,7 @@ protected:
   std::unique_ptr<llvm::TargetOptions> m_target_options_ap;
   std::unique_ptr<swift::irgen::IRGenerator> m_ir_generator_ap;
   std::unique_ptr<swift::irgen::IRGenModule> m_ir_gen_module_ap;
+  llvm::once_flag m_ir_gen_module_once;
   std::unique_ptr<swift::DiagnosticConsumer> m_diagnostic_consumer_ap;
   std::unique_ptr<swift::CompilerInvocation> m_compiler_invocation_ap;
   std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_ap;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4367,7 +4367,7 @@ SwiftASTContext::GetIRGenerator(swift::IRGenOptions &opts,
 swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
   VALID_OR_RETURN(*m_ir_gen_module_ap);
 
-  if (m_ir_gen_module_ap.get() == NULL) {
+  llvm::call_once(m_ir_gen_module_once, [this]() {
     // Make sure we have a good ClangImporter.
     GetClangImporter();
 
@@ -4410,7 +4410,7 @@ swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
         llvm_module->setTargetTriple(triple);
       }
     }
-  }
+  });
   return *m_ir_gen_module_ap;
 }
 


### PR DESCRIPTION

rdar://problem/40290306