### PR TITLE
Weaken test for generic typealias demangling.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_extensions_typealias/main.swift
@@ -1,6 +1,6 @@
 extension Array where Element: Comparable {
   public func union(_ rhs: [Element]) -> [Element] {
-    return [] //%self.expect('frame variable -d run -- rhs', substrs=['Element'])
+    return [] //%self.expect('frame variable -d run -- rhs', substrs=['n'])
   }
 }
 


### PR DESCRIPTION
As part of rdar://problem/41444286, we no longer produce generic
typealias mangling in the compiler. Weaken this test so it works
either with or without generic typealias mangling.