### PR TITLE
[Swift] Mark global variables defined in the REPL as such

### DIFF
--- a/lit/SwiftREPL/FoundationTypes.test
+++ b/lit/SwiftREPL/FoundationTypes.test
@@ -1,0 +1,29 @@
+// Test that we can correctly print (resilient) Foundation
+// types when they're stored in REPL-defined globals.
+
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s
+
+import Foundation
+
+let u = URL(string: "http://www.apple.com")!
+// CHECK:      u: URL = "http://www.apple.com"
+
+
+let n = Notification(name: Notification.Name("abc"), object: Double(42.0), userInfo: ["hello":"world"])
+
+// CHECK:      n: Notification = {
+// CHECK-NEXT:   name = "abc"
+// CHECK-NEXT:   object = 42
+// CHECK-NEXT:   userInfo = 1 key/value pair {
+// CHECK-NEXT:     [0] = {
+// CHECK-NEXT:       key = {
+// CHECK-NEXT:         _box = {
+// CHECK-NEXT:           _baseHashable = "hello"
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       value = "world"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/lit/SwiftREPL/FoundationTypes.test
+++ b/lit/SwiftREPL/FoundationTypes.test
@@ -8,12 +8,12 @@
 import Foundation
 
 let u = URL(string: "http://www.apple.com")!
-// CHECK:      u: URL = "http://www.apple.com"
+// CHECK:      {{u}}: URL = "http://www.apple.com"
 
 
 let n = Notification(name: Notification.Name("abc"), object: Double(42.0), userInfo: ["hello":"world"])
 
-// CHECK:      n: Notification = {
+// CHECK:      {{n}}: Notification = {
 // CHECK-NEXT:   name = "abc"
 // CHECK-NEXT:   object = 42
 // CHECK-NEXT:   userInfo = 1 key/value pair {

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/url/main.swift
@@ -17,4 +17,7 @@ func main() {
    //% self.expect("expression -d run -- url", substrs=['www.apple.com'])
 }
 
-main()
+var g_url = URL(string: "http://www.apple.com")!
+
+main() //% self.expect("target variable g_url", substrs=['www.apple.com'])
+       //% self.expect("expression -d run -- g_url", substrs=['www.apple.com'])

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -767,6 +767,11 @@ void SwiftASTManipulator::MakeDeclarationsPublic() {
           var_decl->overwriteSetterAccess(access);
       }
 
+      // FIXME: Remove this once LLDB has proper support for resilience.
+      if (swift::VarDecl *var_decl =
+              llvm::dyn_cast<swift::VarDecl>(decl)) {
+        var_decl->setREPLVar(true);
+      }
       return true;
     }
   };


### PR DESCRIPTION
Fixes <rdar://problem/39722386>.