### PR TITLE
patch to get latest tensorflow lldb to compile in google's piper

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -456,11 +456,11 @@ protected:
 // [BEGIN GOOGLE] Change const char * -> std::string
   std::unordered_map<std::string, lldb::SyntheticChildrenSP>
       m_bridged_synthetics_map;
-// [END GOOGLE]
 
   /// Cached member variable offsets.
-  typename KeyHasher<const swift::TypeBase *, const char *, uint64_t>::MapType
+  typename KeyHasher<const swift::TypeBase *, std::string, uint64_t>::MapType
     m_member_offsets;
+// [END GOOGLE]
 
   CompilerType m_box_metadata_type;
 


### PR DESCRIPTION
@allevato previously patched some `const char *`s to be `std::string`s to get lldb to compile in google's internal builds (https://github.com/apple/swift-lldb/commit/5db6779b98764451e31bafa5ee9b475a7f95e5e4). A new `const char *` has appeared, so here's a patch to make it into a `std::string`.