### PR TITLE
[SwiftASTContext] Register the request functions when creating a cont…

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2911,6 +2911,9 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));
     }
 
+    // Set up the required state for the evaluator in the TypeChecker.
+    registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
+
     GetASTMap().Insert(m_ast_context_ap.get(), this);
   }
 


### PR DESCRIPTION
…ext.

Not doing that results in the state not properly set up, and an
assertion hit in the compiler. No test as several are already failing
on the bots, so we have coverage.

<rdar://problem/41738966>