### PR TITLE
[lldbsuite, windows] Don't crash LLDB when we try to retrieve a regis…

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/register/intel_avx/TestYMMRegister.py
+++ b/packages/Python/lldbsuite/test/functionalities/register/intel_avx/TestYMMRegister.py
@@ -22,6 +22,7 @@ class TestYMMRegister(TestBase):
     @skipIfTargetAndroid()
     @skipIf(archs=no_match(['i386', 'x86_64']))
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://30523153")
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
     def test(self):
         self.build(dictionary={"CFLAGS_EXTRAS": "-march=haswell"})
         self.setTearDownCleanup()

--- a/packages/Python/lldbsuite/test/functionalities/register/register_command/TestRegisters.py
+++ b/packages/Python/lldbsuite/test/functionalities/register/register_command/TestRegisters.py
@@ -63,7 +63,7 @@ class RegisterCommandsTestCase(TestBase):
     @skipIf(archs=no_match(['amd64', 'arm', 'i386', 'x86_64']))
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054801")
     @skipIfOutOfTreeDebugserver # rdar://38480016
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37683")
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
     def test_fp_register_write(self):
         """Test commands that write to registers, in particular floating-point registers."""
         self.build()
@@ -77,7 +77,7 @@ class RegisterCommandsTestCase(TestBase):
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054801")
     @expectedFailureDarwin(bugnumber="<rdar://problem/34092153>")  # CI bots need to use updated debugserver to match ftag size change in r311579.
     @skipIfOutOfTreeDebugserver
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37683")
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
     def test_fp_special_purpose_register_read(self):
         """Test commands that read fpu special purpose registers."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/cpp/trivial_abi/TestTrivialABI.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/trivial_abi/TestTrivialABI.py
@@ -9,25 +9,26 @@ import os
 import time
 import re
 import lldb
-import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import decorators
+from lldbsuite.test import lldbutil
+
 
 class TestTrivialABI(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
 
-    @decorators.skipUnlessSupportedTypeAttribute("trivial_abi")
+    @skipUnlessSupportedTypeAttribute("trivial_abi")
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
     def test_call_trivial(self):
         """Test that we can print a variable & call a function with a trivial ABI class."""
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.cpp")
         self.expr_test(True)
 
-    @decorators.skipUnlessSupportedTypeAttribute("trivial_abi")
-    @decorators.expectedFailureAll(bugnumber="llvm.org/pr36870")
+    @skipUnlessSupportedTypeAttribute("trivial_abi")
+    @expectedFailureAll(bugnumber="llvm.org/pr36870")
     def test_call_nontrivial(self):
         """Test that we can print a variable & call a function on the same class w/o the trivial ABI marker."""
         self.build()
@@ -43,7 +44,7 @@ class TestTrivialABI(TestBase):
         ivar = test_var.GetChildMemberWithName("ivar")
         self.assertTrue(test_var.GetError().Success(), "Failed to fetch ivar")
         self.assertEqual(ivar_value, ivar.GetValueAsSigned(), "Got the right value for ivar")
-        
+
     def check_frame(self, thread):
         frame = thread.frames[0]
         inVal_var = frame.FindVariable("inVal")
@@ -56,7 +57,7 @@ class TestTrivialABI(TestBase):
         thread.StepOut()
         outVal_ret = thread.GetStopReturnValue()
         self.check_value(outVal_ret, 30)
-        
+
     def expr_test(self, trivial):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
                                    "Set a breakpoint here", self.main_source_file) 
@@ -71,5 +72,3 @@ class TestTrivialABI(TestBase):
         self.assertEqual(len(threads), 1, "Hit my breakpoint the second time.")
 
         self.check_frame(threads[0])
-        
-

--- a/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
+++ b/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
@@ -206,6 +206,9 @@ bool RegisterContextWindows_x64::ReadRegister(const RegisterInfo *reg_info,
   if (!CacheAllRegisterValues())
     return false;
 
+  if (reg_info == nullptr)
+    return false;
+
   switch (reg_info->kinds[eRegisterKindLLDB]) {
   case lldb_rax_x86_64:
     reg_value.SetUInt64(m_context.Rax);

--- a/source/Plugins/Process/Windows/Common/x86/RegisterContextWindows_x86.cpp
+++ b/source/Plugins/Process/Windows/Common/x86/RegisterContextWindows_x86.cpp
@@ -176,6 +176,9 @@ bool RegisterContextWindows_x86::ReadRegister(const RegisterInfo *reg_info,
   if (!CacheAllRegisterValues())
     return false;
 
+  if (reg_info == nullptr)
+    return false;
+
   uint32_t reg = reg_info->kinds[eRegisterKindLLDB];
   switch (reg) {
   case lldb_eax_i386:


### PR DESCRIPTION
…ter on Windows

Summary:
1) When ReadRegister is called with a null register into on Windows, rather than crashing due to an access violation, simply return false. Not all registers and properties will be read or calculated correctly, but that is consistent with other platforms that also return false in that case
2) Update a couple of tests to reference pr37995 as their reason for failure since it is much more accurate. Support for floating point registers doesn't exist on Windows at all, rather than having issues.

Reviewers: asmith, labath, zturner

Subscribers: llvm-commits

Differential Revision: https://reviews.llvm.org/D48844

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@336147 91177308-0d34-0410-b5e6-96231b3b80d8