### PR TITLE
Disable the EnableTargetOSChecking language option for all Swift AST …

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/deployment_target/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/deployment_target/Makefile
@@ -1,0 +1,15 @@
+LEVEL = ../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+include $(LEVEL)/Makefile.rules
+
+# This test only works on macOS 10.11+.
+
+a.out: main.swift libNewerTarget.dylib
+	$(SWIFTC) -target x86_64-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking
+
+lib%.dylib: %.swift
+	$(SWIFTC) -target x86_64-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/deployment_target/NewerTarget.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/deployment_target/NewerTarget.swift
@@ -1,0 +1,9 @@
+func use<T>(_ t: T) {}
+
+public struct Foo {
+  let i = 23
+  public init() {}
+  public func f() {
+    use(i)
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/packages/Python/lldbsuite/test/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -1,0 +1,54 @@
+# TestSwiftDeploymentTarget.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldbsuite.test.lldbinline as lldbinline
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftDeploymentTarget(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.skipUnlessDarwin
+    @decorators.skipIf(macos_version=["<", "10.11"])
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test_swift_deployment_target(self):
+        self.build()
+        # Create the target
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+
+        # Set the breakpoints
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('main.swift'))
+        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+
+        # Launch the process, and do not stop at the entry point.
+        process = target.LaunchSimple(None, None, os.getcwd())
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # Frame #0 should be at our breakpoint.
+        threads = lldbutil.get_threads_stopped_at_breakpoint(
+            process, breakpoint)
+
+        self.assertTrue(len(threads) == 1)
+        self.thread = threads[0]
+
+        self.expect("p f", substrs=['i = 23'])
+

--- a/packages/Python/lldbsuite/test/lang/swift/deployment_target/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/deployment_target/main.swift
@@ -1,0 +1,5 @@
+import NewerTarget
+
+let f = Foo()
+f.f() // break here
+f.f()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1114,6 +1114,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
 
   swift_ast_sp->GetLanguageOptions().DebuggerSupport = true;
   swift_ast_sp->GetLanguageOptions().EnableAccessControl = false;
+  swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
 
   if (!arch.IsValid())
     return TypeSystemSP();


### PR DESCRIPTION
…contexts.

LLDB started to understand the minimum deployment target embedded in
the Mach-O load commands in r332067. This makes it more likely to hit
the module-too-new warning in a multi-dylib project where any of the
dylibs have a newer minimum deployment target than the main
executable. Since this is only a warning emitted by the serialized
module loader, there isn't much to be gained to enable this warning as
error in LLDB. This patch disables it.

rdar://problem/41652444
(cherry picked from commit a72289ceb4f23d6c7e7b667b70cb84eac4dffa61)