### PR TITLE
Fix TestLoadUsingPaths on linux

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/load_using_paths/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/load_using_paths/Makefile
@@ -1,6 +1,7 @@
 LEVEL := ../../make
 
 CXX_SOURCES := main.cpp
+LD_EXTRAS := -ldl
 
 include $(LEVEL)/Makefile.rules
 


### PR DESCRIPTION
we need to explicitly link the test program with -ldl for the dlopen
function to be available.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@335956 91177308-0d34-0410-b5e6-96231b3b80d8