### PR TITLE
[test-suite] Add a decorator for the lack of libstdcxx on the system.

### DIFF
--- a/packages/Python/lldbsuite/test/decorators.py
+++ b/packages/Python/lldbsuite/test/decorators.py
@@ -743,6 +743,18 @@ def skipUnlessSupportedTypeAttribute(attr):
         return None
     return skipTestIfFn(compiler_doesnt_support_struct_attribute)
 
+def skipUnlessLibstdcxxAvailable(func):
+    """Decorate the item to skip test unless libstdc++ is available on the system."""
+    def compiler_doesnt_support_libstdcxx(self):
+        compiler_path = self.getCompiler()
+        f = tempfile.NamedTemporaryFile()
+        f = tempfile.NamedTemporaryFile()
+        cmd = "echo '#include <string> | %s -x c++ -stdlib=libstdc++ -o %s -" % (compiler_path, f.name)
+        if os.popen(cmd).close() is not None:
+            return "libstdcxx not available on the sytem"
+        return None
+    return skipTestIfFn(compiler_doesnt_support_libstdcxx)(func)
+
 def skipUnlessThreadSanitizer(func):
     """Decorate the item to skip test unless Clang -fsanitize=thread is supported."""
 

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/iterator/TestDataFormatterStdIterator.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/iterator/TestDataFormatterStdIterator.py
@@ -23,8 +23,7 @@ class StdIteratorDataFormatterTestCase(TestBase):
         # Find the line number to break at.
         self.line = line_number('main.cpp', '// Set break point at this line.')
 
-    @skipIfWindows  # libstdcpp not ported to Windows
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         """Test that libstdcpp iterators format properly."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/list/TestDataFormatterStdList.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/list/TestDataFormatterStdList.py
@@ -27,8 +27,7 @@ class StdListDataFormatterTestCase(TestBase):
         self.final_line = line_number(
             'main.cpp', '// Set final break point at this line.')
 
-    @skipIfWindows  # libstdcpp not ported to Windows
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/map/TestDataFormatterStdMap.py
@@ -23,9 +23,7 @@ class StdMapDataFormatterTestCase(TestBase):
         # Find the line number to break at.
         self.line = line_number('main.cpp', '// Set break point at this line.')
 
-    @skipIfWindows  # libstdcpp not ported to Windows
-    @skipIfFreeBSD
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/smart_ptr/TestDataFormatterStdSmartPtr.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/smart_ptr/TestDataFormatterStdSmartPtr.py
@@ -15,10 +15,8 @@ from lldbsuite.test import lldbutil
 class StdSmartPtrDataFormatterTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
-    @skipIfFreeBSD
-    @skipIfWindows  # libstdcpp not ported to Windows
     @skipIfDarwin  # doesn't compile on Darwin
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         self.build()
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/TestDataFormatterStdString.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/TestDataFormatterStdString.py
@@ -24,8 +24,7 @@ class StdStringDataFormatterTestCase(TestBase):
         # Find the line number to break at.
         self.line = line_number('main.cpp', '// Set break point at this line.')
 
-    @skipIfWindows  # libstdcpp not ported to Windows
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/tuple/TestDataFormatterStdTuple.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/tuple/TestDataFormatterStdTuple.py
@@ -15,10 +15,8 @@ from lldbsuite.test import lldbutil
 class StdTupleDataFormatterTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
-    @skipIfFreeBSD
-    @skipIfWindows  # libstdcpp not ported to Windows
     @skipIfDarwin  # doesn't compile on Darwin
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         self.build()
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -15,10 +15,8 @@ from lldbsuite.test import lldbutil
 class StdUniquePtrDataFormatterTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
-    @skipIfFreeBSD
-    @skipIfWindows  # libstdcpp not ported to Windows
     @skipIfDarwin  # doesn't compile on Darwin
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         self.build()
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/vbool/TestDataFormatterStdVBool.py
@@ -23,12 +23,8 @@ class StdVBoolDataFormatterTestCase(TestBase):
         # Find the line number to break at.
         self.line = line_number('main.cpp', '// Set break point at this line.')
 
-    @expectedFailureAll(
-        oslist=['freebsd'],
-        bugnumber='llvm.org/pr20548 fails to build on lab.llvm.org buildbot')
-    @skipIfWindows  # libstdcpp not ported to Windows.
     @skipIfDarwin
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libstdcpp/vector/TestDataFormatterStdVector.py
@@ -23,9 +23,7 @@ class StdVectorDataFormatterTestCase(TestBase):
         # Find the line number to break at.
         self.line = line_number('main.cpp', '// Set break point at this line.')
 
-    @skipIfFreeBSD
-    @skipIfWindows  # libstdcpp not ported to Windows
-    @skipIfwatchOS  # libstdcpp not ported to watchos
+    @skipUnlessLibstdcxxAvailable
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()


### PR DESCRIPTION
This generalizes a bunch of target-specific tests. MacOS has no
libstdcxx anymore, and neither does FreeBSD (or Windows).

<rdar://problem/41896105>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@336463 91177308-0d34-0410-b5e6-96231b3b80d8