### PR TITLE
Use "Swift.Optional" to wrap expressions in weak self context.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Makefile
@@ -1,0 +1,15 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules
+
+a.out: main.swift
+	$(SWIFTC) $(SWIFTFLAGS) -sdk "$(SWIFTSDKROOT)" $^ -emit-executable \
+            -o a.out \
+	    -emit-module -Xcc -I$(SRCDIR)
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Optional.h
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Optional.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+@protocol Optional
+@end

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -1,0 +1,40 @@
+"""
+Test that our use of "Optional" to wrap expressions in a weak self
+context doesn't collide with names inherited from ObjC.
+"""
+
+from __future__ import print_function
+
+import os
+import time
+import re
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestOptionalAmbiguity(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_sample_rename_this(self):
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.swift")
+        self.print_in_closure()
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+
+    def print_in_closure(self):
+        (_, _, thread, _) = lldbutil.run_to_source_breakpoint(self,
+                                "Set a breakpoint here", self.main_source_file) 
+
+        # Since the failure mode of a name collision is that the expression fails
+        # to compile, I just check that here.
+        frame = thread.GetFrameAtIndex(0)
+        ret_value = frame.EvaluateExpression("self")
+        self.assertTrue(ret_value.GetError().Success(), "The expression completed successfully")
+

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/main.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Optional
+
+class MyObject : NSObject
+{
+  func callClosure(_ closure : () -> Void) {
+    closure()
+  }
+
+  func doCall() {
+    callClosure() { [weak self] in
+      if let real_self = self {
+        print(real_self) // Set a breakpoint here
+      }
+    }
+  }
+}
+
+var my_object = MyObject()
+my_object.doCall()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/module.modulemap
@@ -1,0 +1,4 @@
+module Optional {
+       export *
+       header "Optional.h"
+}

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -219,7 +219,7 @@ $builtin_logger_initialize()
 
     const char *optional_extension =
         (language_flags & SwiftUserExpression::eLanguageFlagIsWeakSelf)
-            ? "Optional where Wrapped: "
+            ? "Swift.Optional where Wrapped: "
             : "";
 
     if (generic_info.class_bindings.size()) {


### PR DESCRIPTION
We were using Optional, but that could collide with other uses.  So make
it explicit in our wrapper.

<rdar://problem/41525749>