### PR TITLE
[Swift/Optional] Fix this test on Linux and make it simpler.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Makefile
@@ -1,15 +1,5 @@
 LEVEL = ../../../../make
-SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-SWIFT_OBJC_INTEROP := 1
 
 SWIFT_SOURCES := main.swift
 
 include $(LEVEL)/Makefile.rules
-
-a.out: main.swift
-	$(SWIFTC) $(SWIFTFLAGS) -sdk "$(SWIFTSDKROOT)" $^ -emit-executable \
-            -o a.out \
-	    -emit-module -Xcc -I$(SRCDIR)
-
-clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Optional.h
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/Optional.h
@@ -1,4 +1,0 @@
-#import <Foundation/Foundation.h>
-
-@protocol Optional
-@end

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -19,6 +19,8 @@ class TestOptionalAmbiguity(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
     def test_sample_rename_this(self):
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/main.swift
@@ -1,7 +1,11 @@
-import Foundation
-import Optional
+class Optional {
+  var patatino : Int
+  init(_ patatino : Int) {
+    self.patatino = patatino
+  }
+}
 
-class MyObject : NSObject
+class MyObject
 {
   func callClosure(_ closure : () -> Void) {
     closure()
@@ -10,6 +14,7 @@ class MyObject : NSObject
   func doCall() {
     callClosure() { [weak self] in
       if let real_self = self {
+        let x : Optional = Optional(25)
         print(real_self) // Set a breakpoint here
       }
     }

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/module.modulemap
@@ -1,4 +1,0 @@
-module Optional {
-       export *
-       header "Optional.h"
-}


### PR DESCRIPTION
-> We don't really need a module or the Obj-C bridging, just
another object called `Optional` to trigger the bug.

-> We now add this test to @swiftpr so that it gets run as
part of the standard PR pipeline.

Thanks to Jordan/Jim for discussing this with me.

<rdar://problem/41525749>