### PR TITLE
[ObjCRuntime] Add support for obfuscation in tagged pointers.

### DIFF
--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -284,6 +284,10 @@ bool AppleObjCRuntimeV1::ClassDescriptorV1::Describe(
   return false;
 }
 
+lldb::addr_t AppleObjCRuntimeV1::GetTaggedPointerObfuscator() {
+  return 0;
+}
+
 lldb::addr_t AppleObjCRuntimeV1::GetISAHashTablePointer() {
   if (m_isa_hash_table_ptr == LLDB_INVALID_ADDRESS) {
     ModuleSP objc_module_sp(GetObjCModule());

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
@@ -45,6 +45,8 @@ public:
     }
   }
 
+  lldb::addr_t GetTaggedPointerObfuscator();
+
   class ClassDescriptorV1 : public ObjCLanguageRuntime::ClassDescriptor {
   public:
     ClassDescriptorV1(ValueObject &isa_pointer);

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -385,7 +385,9 @@ AppleObjCRuntimeV2::AppleObjCRuntimeV2(Process *process,
       m_get_class_info_args_mutex(), m_get_shared_cache_class_info_code(),
       m_get_shared_cache_class_info_args(LLDB_INVALID_ADDRESS),
       m_get_shared_cache_class_info_args_mutex(), m_decl_vendor_ap(),
-      m_isa_hash_table_ptr(LLDB_INVALID_ADDRESS), m_hash_signature(),
+      m_tagged_pointer_obfuscator(LLDB_INVALID_ADDRESS),
+      m_isa_hash_table_ptr(LLDB_INVALID_ADDRESS),
+      m_hash_signature(),
       m_has_object_getClass(false), m_loaded_objc_opt(false),
       m_non_pointer_isa_cache_ap(
           NonPointerISACache::CreateInstance(*this, objc_module_sp)),
@@ -1207,6 +1209,38 @@ AppleObjCRuntimeV2::GetClassDescriptor(ValueObject &valobj) {
     }
   }
   return objc_class_sp;
+}
+
+lldb::addr_t AppleObjCRuntimeV2::GetTaggedPointerObfuscator() {
+  if (m_tagged_pointer_obfuscator != LLDB_INVALID_ADDRESS)
+    return m_tagged_pointer_obfuscator;
+
+
+  Process *process = GetProcess();
+  ModuleSP objc_module_sp(GetObjCModule());
+
+  if (!objc_module_sp)
+    return LLDB_INVALID_ADDRESS;
+
+  static ConstString g_gdb_objc_obfuscator("objc_debug_taggedpointer_obfuscator");
+
+  const Symbol *symbol = objc_module_sp->FindFirstSymbolWithNameAndType(
+  g_gdb_objc_obfuscator, lldb::eSymbolTypeAny);
+  if (symbol) {
+    lldb::addr_t g_gdb_obj_obfuscator_ptr =
+      symbol->GetLoadAddress(&process->GetTarget());
+
+    if (g_gdb_obj_obfuscator_ptr != LLDB_INVALID_ADDRESS) {
+      Status error;
+      m_tagged_pointer_obfuscator = process->ReadPointerFromMemory(
+        g_gdb_obj_obfuscator_ptr, error);
+    }
+  }
+  // If we don't have a correct value at this point, there must be no obfuscation.
+  if (m_tagged_pointer_obfuscator == LLDB_INVALID_ADDRESS)
+    m_tagged_pointer_obfuscator = 0;
+
+  return m_tagged_pointer_obfuscator;
 }
 
 lldb::addr_t AppleObjCRuntimeV2::GetISAHashTablePointer() {
@@ -2227,7 +2261,9 @@ AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
       return ObjCLanguageRuntime::ClassDescriptorSP();
     }
   }
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(name, ptr));
+
+  lldb::addr_t unobfuscated = ptr ^ m_runtime.GetTaggedPointerObfuscator();
+  return ClassDescriptorSP(new ClassDescriptorV2Tagged(name, unobfuscated));
 }
 
 AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::
@@ -2259,8 +2295,9 @@ AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
     lldb::addr_t ptr) {
   ClassDescriptorSP actual_class_descriptor_sp;
   uint64_t data_payload;
+  uint64_t unobfuscated = (ptr) ^ m_runtime.GetTaggedPointerObfuscator();
 
-  if (!IsPossibleTaggedPointer(ptr))
+  if (!IsPossibleTaggedPointer(unobfuscated))
     return ObjCLanguageRuntime::ClassDescriptorSP();
 
   uintptr_t slot = (ptr >> m_objc_debug_taggedpointer_slot_shift) &
@@ -2286,7 +2323,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
   }
 
   data_payload =
-      (((uint64_t)ptr << m_objc_debug_taggedpointer_payload_lshift) >>
+      (((uint64_t)unobfuscated << m_objc_debug_taggedpointer_payload_lshift) >>
        m_objc_debug_taggedpointer_payload_rshift);
 
   return ClassDescriptorSP(
@@ -2343,11 +2380,12 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
     lldb::addr_t ptr) {
   ClassDescriptorSP actual_class_descriptor_sp;
   uint64_t data_payload;
+  uint64_t unobfuscated = (ptr) ^ m_runtime.GetTaggedPointerObfuscator();
 
-  if (!IsPossibleTaggedPointer(ptr))
+  if (!IsPossibleTaggedPointer(unobfuscated))
     return ObjCLanguageRuntime::ClassDescriptorSP();
 
-  if (!IsPossibleExtendedTaggedPointer(ptr))
+  if (!IsPossibleExtendedTaggedPointer(unobfuscated))
     return this->TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(ptr);
 
   uintptr_t slot = (ptr >> m_objc_debug_taggedpointer_ext_slot_shift) &
@@ -2373,7 +2411,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
   }
 
   data_payload =
-      (((uint64_t)ptr << m_objc_debug_taggedpointer_ext_payload_lshift) >>
+      (((uint64_t)unobfuscated << m_objc_debug_taggedpointer_ext_payload_lshift) >>
        m_objc_debug_taggedpointer_ext_payload_rshift);
 
   return ClassDescriptorSP(

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -100,6 +100,8 @@ public:
     return m_tagged_pointer_vendor_ap.get();
   }
 
+  lldb::addr_t GetTaggedPointerObfuscator();
+
   void GetValuesForGlobalCFBooleans(lldb::addr_t &cf_true,
                                     lldb::addr_t &cf_false) override;
 
@@ -337,6 +339,7 @@ private:
   std::mutex m_get_shared_cache_class_info_args_mutex;
 
   std::unique_ptr<DeclVendor> m_decl_vendor_ap;
+  lldb::addr_t m_tagged_pointer_obfuscator;
   lldb::addr_t m_isa_hash_table_ptr;
   HashTableSignature m_hash_signature;
   bool m_has_object_getClass;


### PR DESCRIPTION
This is the default in MacOS Mojave. No testcases, as basically
we have a lot of coverage (and the testsuite fails quite a bit
without this change in Beta 3).

Thanks to Fred Riss for helping me with this patch (fixing
bugs/nondeterminism).

<rdar://problem/38305553>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@336607 91177308-0d34-0410-b5e6-96231b3b80d8