### PR TITLE
Revert "Unbreak non darwin unified builds"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,11 +15,7 @@ function(add_python_test_target name test_script args comment)
     )
 endfunction()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  set(LLDB_TEST_DEPS lldb)
-else()
-  set(LLDB_TEST_DEPS lldb llvm-dsymutil)
-endif()
+set(LLDB_TEST_DEPS lldb)
 
 # darwin-debug is an hard dependency for the testsuite.
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
@@ -41,11 +37,7 @@ if(TARGET lldb-mi)
 endif()
 
 if(NOT LLDB_BUILT_STANDALONE)
-  if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    list(APPEND LLDB_TEST_DEPS yaml2obj dsymutil)
-  else()
-    list(APPEND LLDB_TEST_DEPS yaml2obj)
-  endif()
+  list(APPEND LLDB_TEST_DEPS yaml2obj dsymutil)
 endif()
 
 if(TARGET liblldb)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ if(TARGET lldb-mi)
 endif()
 
 if(NOT LLDB_BUILT_STANDALONE)
-  list(APPEND LLDB_TEST_DEPS yaml2obj dsymutil)
+  list(APPEND LLDB_TEST_DEPS yaml2obj llvm-dsymutil)
 endif()
 
 if(TARGET liblldb)


### PR DESCRIPTION
The change in #746 is not correct. The goal is to use the in-tree dsymutil, which on swift-llvm still has the llvm-prefix. This reverts Dave's change and renames the dependency instead. 