### PR TITLE
[SwiftExpressionParser] Always inject the DWARF name.

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -842,8 +842,8 @@ static void CountLocals(
     for (size_t vi = 0, ve = variables.GetSize(); vi != ve; ++vi) {
       lldb::VariableSP variable_sp(variables.GetVariableAtIndex(vi));
 
-      const ConstString &name(variable_sp->GetName());
-      const char *name_cstring = variable_sp->GetName().GetCString();
+      const ConstString &name(variable_sp->GetUnqualifiedName());
+      const char *name_cstring = variable_sp->GetUnqualifiedName().GetCString();
 
       if (name.IsEmpty())
         continue;


### PR DESCRIPTION
Here we accidentally ended up injecting the demangled one, so
AST type checking was failing. Fixes several failures on
master-next/upstream-with-swift.

<rdar://problem/42047420>