### PR TITLE
[swift/ClangImporter] build() doesn't take a `clean` argument anymore.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -45,7 +45,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         return lst[0]
         
     def dotest(self, remap):
-        self.build(clean=True)
+        self.build()
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)
 


### PR DESCRIPTION
Fixes a test error.