### PR TITLE
[lldb-test] Help dotest to find the directory where clang is built.

### DIFF
--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -1596,6 +1596,10 @@ class Base(unittest2.TestCase):
     def findBuiltClang(self):
         """Tries to find and use Clang from the build directory as the compiler (instead of the system compiler)."""
         paths_to_try = [
+            # Begin Swift modifications
+            "llvm-build/Ninja-DebugAssert/llvm-macosx-x86_64/bin/clang",
+            "llvm-build/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/clang",
+            # End Swift modifications
             "llvm-build/Release+Asserts/x86_64/bin/clang",
             "llvm-build/Debug+Asserts/x86_64/bin/clang",
             "llvm-build/Release/x86_64/bin/clang",


### PR DESCRIPTION
This is really not ideal, but needed. Upstream does the same,
I'm going to probably have a discussion there to avoid this
depedency but in the meanwhile, we're trying to get the
bot green again. I think this has still some missing cases,
as swift adds a `-Asan` suffix when building with asan.