### PR TITLE
[Swift] Exclude some tests from PR testing.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/packages/Python/lldbsuite/test/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -24,7 +24,6 @@ class TestSwiftConditionalBreakpoint(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.add_test_categories(["swiftpr"])
     def test_swift_conditional_breakpoint(self):
         """Tests that we can set a conditional breakpoint in Swift code"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
@@ -25,7 +25,6 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.add_test_categories(["swiftpr"])
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/struct_init_display/TestSwiftStructInit.py
+++ b/packages/Python/lldbsuite/test/lang/swift/struct_init_display/TestSwiftStructInit.py
@@ -25,7 +25,6 @@ class TestSwiftStructInit(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.add_test_categories(["swiftpr"])
     def test_swift_struct_init(self):
         """Test that we display self correctly for an inline-initialized struct"""
         self.build()


### PR DESCRIPTION
These doesn't seem to be really stable, so we're temporarily
moving them out of the standard PR cycle to avoid delays in
merges (also, for the swift compiler).

SR-8245
<rdar://problem/42145676>