### PR TITLE
Disable EnableTargetOSChecking in the scratch AST context.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1345,6 +1345,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   if (!arch.IsValid())
     return TypeSystemSP();
 
+  swift_ast_sp->GetLanguageOptions().EnableTargetOSChecking = false;
+
   bool handled_sdk_path = false;
   bool handled_resource_dir = false;
   const size_t num_images = target.GetImages().GetSize();


### PR DESCRIPTION
This is not needed in the general case, as this flag is set by the
expression parser. There is one case where it matters though: if the
Swift code is loaded by a main executable that has a deploymnent target
lower than 10.9, then we will fail to import the standard library
module in SwiftASTContext::CreateInstance().

I'm still working on a testcase for this, but I wanted to get the trivial
fix in for users to test.