### PR TITLE
[CMake] Have check-lldb-unit use CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -41,12 +41,12 @@ set(LLDB_TEST_DEPS
 if(NOT LLDB_BUILT_STANDALONE)
   list(APPEND LLDB_TEST_DEPS FileCheck not yaml2obj)
 endif()
-  
+
 # lldb-server is not built on every platform.
 if (TARGET lldb-server)
   list(APPEND LLDB_TEST_DEPS lldb-server)
 endif()
-  
+
 if(APPLE)
   list(APPEND LLDB_TEST_DEPS debugserver)
 endif()
@@ -63,7 +63,7 @@ add_lit_testsuite(check-lldb-lit "Running lldb lit test suite"
   ${CMAKE_CURRENT_BINARY_DIR}
   ${LIT_ARGS}
   PARAMS lldb_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
-       lldb_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
+         lldb_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
   DEPENDS ${LLDB_TEST_DEPS}
   )
 
@@ -75,7 +75,8 @@ if (TARGET clang)
   add_dependencies(check-lldb-lit clang)
 endif()
 
-add_lit_testsuites(LLDB ${CMAKE_CURRENT_SOURCE_DIR}
+add_lit_testsuites(LLDB
+  ${CMAKE_CURRENT_BINARY_DIR}
   ${LIT_ARGS}
   PARAMS lldb_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
          lldb_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg


### PR DESCRIPTION
llvm-lit uses `map_config` directives (generated at configuration-time) to
make it possible to pass a test path relative to the source instead of
the build folder (CMAKE_CURRENT_BINARY_DIR).

However, this doesn't work in the case of swift where the build
directory layout prevents llvm-lit from knowing about lldb and its test
paths. This caused check-lldb-unit to fail in this configuration, while
everything was working as expected upstream. This patch fixes the issue
by passing a path relative to the build directory. This was already the
case for check-lldb-lit.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@337291 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e71634d556cf23871b427126d15adf9fc9c05283)