### PR TITLE
Cxx formatters vrs ref

### DIFF
--- a/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/include/lldb/DataFormatters/TypeSynthetic.h
@@ -212,6 +212,19 @@ public:
       return *this;
     }
 
+    bool GetFrontEndWantsDereference() const {
+      return (m_flags & lldb::eTypeOptionFrontEndWantsDereference) ==
+             lldb::eTypeOptionFrontEndWantsDereference;
+    }
+
+    Flags &SetFrontEndWantsDereference(bool value = true) {
+      if (value)
+        m_flags |= lldb::eTypeOptionFrontEndWantsDereference;
+      else
+        m_flags &= ~lldb::eTypeOptionFrontEndWantsDereference;
+      return *this;
+    }
+
     uint32_t GetValue() { return m_flags; }
 
     void SetValue(uint32_t value) { m_flags = value; }
@@ -231,6 +244,8 @@ public:
   bool SkipsReferences() const { return m_flags.GetSkipReferences(); }
 
   bool NonCacheable() const { return m_flags.GetNonCacheable(); }
+  
+  bool WantsDereference() const { return m_flags.GetFrontEndWantsDereference();} 
 
   void SetCascades(bool value) { m_flags.SetCascades(value); }
 

--- a/include/lldb/lldb-enumerations.h
+++ b/include/lldb/lldb-enumerations.h
@@ -797,7 +797,9 @@ FLAGS_ENUM(TypeOptions){eTypeOptionNone = (0u),
                         eTypeOptionShowOneLiner = (1u << 5),
                         eTypeOptionHideNames = (1u << 6),
                         eTypeOptionNonCacheable = (1u << 7),
-                        eTypeOptionHideEmptyAggregates = (1u << 8)};
+                        eTypeOptionHideEmptyAggregates = (1u << 8),
+                        eTypeOptionFrontEndWantsDereference = (1u << 9)
+};
 
 //----------------------------------------------------------------------
 // This is the return value for frame comparisons.  If you are comparing frame A

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/bitset/TestDataFormatterLibcxxBitset.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/bitset/TestDataFormatterLibcxxBitset.py
@@ -45,6 +45,7 @@ class TestDataFormatterLibcxxBitset(TestBase):
         self.check("small", 13)
         self.check("large", 200)
 
+    @add_test_categories(["libc++"])
     def test_ptr_and_ref(self):
         """Test that ref and ptr to std::bitset is displayed correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/bitset/TestDataFormatterLibcxxBitset.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/bitset/TestDataFormatterLibcxxBitset.py
@@ -35,7 +35,7 @@ class TestDataFormatterLibcxxBitset(TestBase):
                     "variable: %s, index: %d"%(name, size))
 
     @add_test_categories(["libc++"])
-    def test(self):
+    def test_value(self):
         """Test that std::bitset is displayed correctly"""
         self.build()
         lldbutil.run_to_source_breakpoint(self, '// break here',
@@ -44,3 +44,18 @@ class TestDataFormatterLibcxxBitset(TestBase):
         self.check("empty", 0)
         self.check("small", 13)
         self.check("large", 200)
+
+    def test_ptr_and_ref(self):
+        """Test that ref and ptr to std::bitset is displayed correctly"""
+        self.build()
+        (_, process, _, bkpt) = lldbutil.run_to_source_breakpoint(self, 
+                'Check ref and ptr',
+                lldb.SBFileSpec("main.cpp", False))
+
+        self.check("ref", 13)
+        self.check("ptr", 13)
+
+        lldbutil.continue_to_breakpoint(process, bkpt)
+        
+        self.check("ref", 200)
+        self.check("ptr", 200)

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/bitset/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/bitset/main.cpp
@@ -1,4 +1,5 @@
 #include <bitset>
+#include <stdio.h>
 
 template<std::size_t N>
 void fill(std::bitset<N> &b) {
@@ -10,11 +11,19 @@ void fill(std::bitset<N> &b) {
   }
 }
 
+template<std::size_t N>
+void by_ref_and_ptr(std::bitset<N> &ref, std::bitset<N> *ptr) {
+    // Check ref and ptr
+    return;
+}
+
 int main() {
   std::bitset<0> empty;
   std::bitset<13> small;
   fill(small);
   std::bitset<200> large;
   fill(large);
-  return 0; // break here
+  by_ref_and_ptr(small, &small); // break here
+  by_ref_and_ptr(large, &large);
+  return 0;
 }

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/multiset/TestDataFormatterLibcxxMultiSet.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/multiset/TestDataFormatterLibcxxMultiSet.py
@@ -27,22 +27,31 @@ class LibcxxMultiSetDataFormatterTestCase(TestBase):
         self.assertTrue(var.IsValid())
         return var.GetType().GetCanonicalType().GetName()
 
+    def check_ii(self, var_name):
+        """ This checks the value of the bitset stored in ii at the call to by_ref_and_ptr.
+            We use this to make sure we get the same values for ii when we look at the object
+            directly, and when we look at a reference to the object. """
+        self.expect(
+            "frame variable " + var_name,
+            substrs=["size=7",
+                     "[2] = 2",
+                     "[3] = 3",
+                     "[6] = 6"])
+        self.expect("frame variable " + var_name + "[2]", substrs=[" = 2"])
+        self.expect(
+            "p " + var_name,
+            substrs=[
+                "size=7",
+                "[2] = 2",
+                "[3] = 3",
+                "[6] = 6"])
+
     @add_test_categories(["libc++"])
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()
-        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
-
-        bkpt = self.target().FindBreakpointByID(
-            lldbutil.run_break_set_by_source_regexp(
-                self, "Set break point at this line."))
-
-        self.runCmd("run", RUN_SUCCEEDED)
-
-        # The stop reason of the thread should be breakpoint.
-        self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
-                    substrs=['stopped',
-                             'stop reason = breakpoint'])
+        (self.target, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Set break point at this line.", lldb.SBFileSpec("main.cpp", False))
 
         # This is the function to remove the custom formats in order to have a
         # clean slate for the next test case.
@@ -63,7 +72,7 @@ class LibcxxMultiSetDataFormatterTestCase(TestBase):
                         "Type: " + ii_type)
 
         self.expect("frame variable ii", substrs=["size=0", "{}"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ii",
             substrs=[
@@ -74,38 +83,26 @@ class LibcxxMultiSetDataFormatterTestCase(TestBase):
                 "[3] = 3",
                 "[4] = 4",
                 "[5] = 5"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
-        self.expect(
-            "frame variable ii",
-            substrs=[
-                "size=7",
-                "[2] = 2",
-                "[3] = 3",
-                "[6] = 6"])
-        self.expect(
-            "p ii",
-            substrs=[
-                "size=7",
-                "[2] = 2",
-                "[3] = 3",
-                "[6] = 6"])
-        self.expect("frame variable ii[2]", substrs=[" = 2"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
+
+        self.check_ii("ii")
+
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("frame variable ii", substrs=["size=0", "{}"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("frame variable ii", substrs=["size=0", "{}"])
         ss_type = self.getVariableType("ss")
         self.assertTrue(ss_type.startswith(self.namespace + "::multiset"),
                         "Type: " + ss_type)
         self.expect("frame variable ss", substrs=["size=0", "{}"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ss",
             substrs=[
                 "size=2",
                 '[0] = "a"',
                 '[1] = "a very long string is right here"'])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ss",
             substrs=[
@@ -123,7 +120,7 @@ class LibcxxMultiSetDataFormatterTestCase(TestBase):
                 '[0] = "a"',
                 '[1] = "a very long string is right here"'])
         self.expect("frame variable ss[2]", substrs=[' = "b"'])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ss",
             substrs=[
@@ -131,3 +128,18 @@ class LibcxxMultiSetDataFormatterTestCase(TestBase):
                 '[0] = "a"',
                 '[1] = "a very long string is right here"',
                 '[2] = "c"'])
+
+    @add_test_categories(["libc++"])
+    def test_ref_and_ptr(self):
+        """Test that the data formatters work on ref and ptr."""
+        self.build()
+        (self.target, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Stop here to check by ref and ptr.", 
+            lldb.SBFileSpec("main.cpp", False))
+        # The reference should print just like the value:
+        self.check_ii("ref")
+
+        self.expect("frame variable ptr",
+                    substrs=["ptr =", "size=7"])
+        self.expect("expr ptr",
+                    substrs=["size=7"])

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/multiset/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/multiset/main.cpp
@@ -20,6 +20,12 @@ int thefoo_rw(int arg = 1)
 	return g_the_foo;
 }
 
+void by_ref_and_ptr(intset &ref, intset *ptr)
+{
+    // Stop here to check by ref and ptr
+    return;
+} 
+
 int main()
 {
     intset ii;
@@ -35,7 +41,9 @@ int main()
 
 	ii.insert(6);
 	thefoo_rw(1);  // Set break point at this line.
-    
+
+        by_ref_and_ptr(ii, &ii);
+
 	ii.clear();
 	thefoo_rw(1);  // Set break point at this line.
 

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/set/TestDataFormatterLibcxxSet.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/set/TestDataFormatterLibcxxSet.py
@@ -27,21 +27,31 @@ class LibcxxSetDataFormatterTestCase(TestBase):
         self.assertTrue(var.IsValid())
         return var.GetType().GetCanonicalType().GetName()
 
+    def check_ii(self, var_name):
+        """ This checks the value of the bitset stored in ii at the call to by_ref_and_ptr.
+            We use this to make sure we get the same values for ii when we look at the object
+            directly, and when we look at a reference to the object. """
+        self.expect(
+            "frame variable " + var_name,
+            substrs=["size=7",
+                     "[2] = 2",
+                     "[3] = 3",
+                     "[6] = 6"])
+        self.expect("frame variable " + var_name + "[2]", substrs=[" = 2"])
+        self.expect(
+            "p " + var_name,
+            substrs=[
+                "size=7",
+                "[2] = 2",
+                "[3] = 3",
+                "[6] = 6"])
+
     @add_test_categories(["libc++"])
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()
-        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
-
-        bkpt = self.target().FindBreakpointByID(
-            lldbutil.run_break_set_by_source_regexp(self, "Set break point at this line."))
-
-        self.runCmd("run", RUN_SUCCEEDED)
-
-        # The stop reason of the thread should be breakpoint.
-        self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
-                    substrs=['stopped',
-                             'stop reason = breakpoint'])
+        (self.target, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Set break point at this line.", lldb.SBFileSpec("main.cpp", False))
 
         # This is the function to remove the custom formats in order to have a
         # clean slate for the next test case.
@@ -62,7 +72,7 @@ class LibcxxSetDataFormatterTestCase(TestBase):
                         "Type: " + ii_type)
 
         self.expect("frame variable ii", substrs=["size=0", "{}"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ii",
             substrs=["size=6",
@@ -72,24 +82,12 @@ class LibcxxSetDataFormatterTestCase(TestBase):
                      "[3] = 3",
                      "[4] = 4",
                      "[5] = 5"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
-        self.expect(
-            "frame variable ii",
-            substrs=["size=7",
-                     "[2] = 2",
-                     "[3] = 3",
-                     "[6] = 6"])
-        self.expect("frame variable ii[2]", substrs=[" = 2"])
-        self.expect(
-            "p ii",
-            substrs=[
-                "size=7",
-                "[2] = 2",
-                "[3] = 3",
-                "[6] = 6"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
+        self.check_ii("ii")
+
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("frame variable ii", substrs=["size=0", "{}"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect("frame variable ii", substrs=["size=0", "{}"])
 
         ss_type = self.getVariableType("ss")
@@ -97,13 +95,13 @@ class LibcxxSetDataFormatterTestCase(TestBase):
                         "Type: " + ss_type)
 
         self.expect("frame variable ss", substrs=["size=0", "{}"])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ss",
             substrs=["size=2",
                      '[0] = "a"',
                      '[1] = "a very long string is right here"'])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ss",
             substrs=["size=4",
@@ -119,10 +117,26 @@ class LibcxxSetDataFormatterTestCase(TestBase):
                      '[0] = "a"',
                      '[1] = "a very long string is right here"'])
         self.expect("frame variable ss[2]", substrs=[' = "b"'])
-        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+        lldbutil.continue_to_breakpoint(process, bkpt)
         self.expect(
             "frame variable ss",
             substrs=["size=3",
                      '[0] = "a"',
                      '[1] = "a very long string is right here"',
                      '[2] = "c"'])
+
+    @add_test_categories(["libc++"])
+    def test_ref_and_ptr(self):
+        """Test that the data formatters work on ref and ptr."""
+        self.build()
+        (self.target, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Stop here to check by ref and ptr.", 
+            lldb.SBFileSpec("main.cpp", False))
+        # The reference should print just like the value:
+        self.check_ii("ref")
+
+        self.expect("frame variable ptr",
+                    substrs=["ptr =", "size=7"])
+        self.expect("expr ptr",
+                    substrs=["size=7"])
+                    

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/set/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/set/main.cpp
@@ -20,6 +20,12 @@ int thefoo_rw(int arg = 1)
 	return g_the_foo;
 }
 
+void by_ref_and_ptr(intset &ref, intset *ptr)
+{
+    // Stop here to check by ref and ptr
+    return;
+} 
+
 int main()
 {
     intset ii;
@@ -35,7 +41,9 @@ int main()
 
 	ii.insert(6);
 	thefoo_rw(1);  // Set break point at this line.
-    
+
+        by_ref_and_ptr(ii, &ii);
+
 	ii.clear();
 	thefoo_rw(1);  // Set break point at this line.
 

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -17,10 +17,6 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @add_test_categories(["libc++"])
-    @skipIf(debug_info="gmodules",
-            bugnumber="https://bugs.llvm.org/show_bug.cgi?id=36048")
-
     def check_numbers(self, var_name):
         self.expect("frame variable " + var_name,
                     substrs=[var_name + ' = size=7',
@@ -54,6 +50,9 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
         self.expect("frame variable " + var_name + "[3]",
                     substrs=['1234'])
 
+    @add_test_categories(["libc++"])
+    @skipIf(debug_info="gmodules",
+            bugnumber="https://bugs.llvm.org/show_bug.cgi?id=36048")
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()
@@ -180,6 +179,9 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
         self.expect("frame variable strings",
                     substrs=['vector has 0 items'])
 
+    @add_test_categories(["libc++"])
+    @skipIf(debug_info="gmodules",
+            bugnumber="https://bugs.llvm.org/show_bug.cgi?id=36048")
     def test_ref_and_ptr(self):
         """Test that that file and class static variables display correctly."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/vector/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/vector/main.cpp
@@ -7,6 +7,12 @@
 typedef std::vector<int> int_vect;
 typedef std::vector<std::string> string_vect;
 
+template <class T>
+void by_ref_and_ptr(std::vector<T> &ref, std::vector<T> *ptr) {
+  // Stop here to check by ref
+  return;  
+}
+
 int main()
 {
     int_vect numbers;
@@ -17,6 +23,7 @@ int main()
     (numbers.push_back(12345)); // break here
     (numbers.push_back(123456));
     (numbers.push_back(1234567));
+    by_ref_and_ptr(numbers, &numbers);
     
     numbers.clear(); // break here
     

--- a/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -419,18 +419,20 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   SyntheticChildren::Flags stl_synth_flags;
   stl_synth_flags.SetCascades(true).SetSkipPointers(false).SetSkipReferences(
       false);
+  SyntheticChildren::Flags stl_deref_flags = stl_synth_flags;
+  stl_deref_flags.SetFrontEndWantsDereference();
 
   AddCXXSynthetic(
       cpp_category_sp,
       lldb_private::formatters::LibcxxBitsetSyntheticFrontEndCreator,
       "libc++ std::bitset synthetic children",
-      ConstString("^std::__(ndk)?1::bitset<.+>(( )?&)?$"), stl_synth_flags,
+      ConstString("^std::__(ndk)?1::bitset<.+>(( )?&)?$"), stl_deref_flags,
       true);
   AddCXXSynthetic(
       cpp_category_sp,
       lldb_private::formatters::LibcxxStdVectorSyntheticFrontEndCreator,
       "libc++ std::vector synthetic children",
-      ConstString("^std::__(ndk)?1::vector<.+>(( )?&)?$"), stl_synth_flags,
+      ConstString("^std::__(ndk)?1::vector<.+>(( )?&)?$"), stl_deref_flags,
       true);
   AddCXXSynthetic(
       cpp_category_sp,
@@ -453,13 +455,13 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       cpp_category_sp,
       lldb_private::formatters::LibcxxStdMapSyntheticFrontEndCreator,
       "libc++ std::set synthetic children",
-      ConstString("^std::__(ndk)?1::set<.+> >(( )?&)?$"), stl_synth_flags,
+      ConstString("^std::__(ndk)?1::set<.+> >(( )?&)?$"), stl_deref_flags,
       true);
   AddCXXSynthetic(
       cpp_category_sp,
       lldb_private::formatters::LibcxxStdMapSyntheticFrontEndCreator,
       "libc++ std::multiset synthetic children",
-      ConstString("^std::__(ndk)?1::multiset<.+> >(( )?&)?$"), stl_synth_flags,
+      ConstString("^std::__(ndk)?1::multiset<.+> >(( )?&)?$"), stl_deref_flags,
       true);
   AddCXXSynthetic(
       cpp_category_sp,


### PR DESCRIPTION
Cherry-pick the changes to make the libcxx data for vector, set, multiset and bitset work for references and pointers to objects to the stable branch.