### PR TITLE
Fix TestAttachDenied on macOS Mojave

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/Makefile
@@ -4,4 +4,11 @@ CXX_SOURCES := main.cpp
 
 EXE := AttachDenied
 
+all: AttachDenied sign
+
 include $(LEVEL)/Makefile.rules
+
+sign: entitlements.plist AttachDenied
+ifeq ($(OS),Darwin)
+	codesign -s - -f --entitlements $^
+endif

--- a/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/entitlements.plist
+++ b/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
TestAttachDenied tries to attach to a process that is ptracing itself and
verifies that we error out. Starting with macOS Mojave, processes need
an entitlement to be able to ptrace. This commit adds the entitlement for
the test binary when building on Darwin.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@337029 91177308-0d34-0410-b5e6-96231b3b80d8