### PR TITLE
No empty search paths

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/load_using_paths/TestLoadUsingPaths.py
+++ b/packages/Python/lldbsuite/test/functionalities/load_using_paths/TestLoadUsingPaths.py
@@ -103,10 +103,27 @@ class LoadUsingPathsTestCase(TestBase):
         out_spec = lldb.SBFileSpec()
         token = process.LoadImageUsingPaths(relative_spec, paths, out_spec, error)
 
-        self.assertNotEqual(token, lldb.LLDB_INVALID_IMAGE_TOKEN, "Got a valid token")
-        self.assertEqual(out_spec, lldb.SBFileSpec(self.hidden_lib), "Found the expected library")
+        self.assertNotEqual(token, lldb.LLDB_INVALID_IMAGE_TOKEN, "Got a valid token with relative path")
+        self.assertEqual(out_spec, lldb.SBFileSpec(self.hidden_lib), "Found the expected library with relative path")
 
         process.UnloadImage(token)
+        
+        # Make sure the presence of an empty path doesn't mess anything up:
+        paths.Clear()
+        paths.AppendString("")
+        paths.AppendString(os.path.join(self.wd, "no_such_dir"))
+        paths.AppendString(self.wd)
+        relative_spec = lldb.SBFileSpec(os.path.join("hidden", self.lib_name))
+
+        out_spec = lldb.SBFileSpec()
+        token = process.LoadImageUsingPaths(relative_spec, paths, out_spec, error)
+
+        self.assertNotEqual(token, lldb.LLDB_INVALID_IMAGE_TOKEN, "Got a valid token with included empty path")
+        self.assertEqual(out_spec, lldb.SBFileSpec(self.hidden_lib), "Found the expected library with included empty path")
+
+        process.UnloadImage(token)
+        
+
 
         # Finally, passing in an absolute path should work like the basename:
         # This should NOT work because we've taken hidden_dir off the paths:

--- a/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -1164,6 +1164,10 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
     size_t buffer_size = 0;
     std::string path_array;
     for (auto path : *paths) {
+      // Don't insert empty paths, they will make us abort the path
+      // search prematurely.
+      if (path.empty())
+        continue;
       size_t path_size = path.size();
       path_array.append(path);
       path_array.push_back('\0');

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3390,9 +3390,8 @@ static void
 GetLibrarySearchPaths(std::vector<std::string> &paths,
                       const swift::SearchPathOptions &search_path_opts) {
   paths.clear();
-  paths.resize(search_path_opts.LibrarySearchPaths.size() + 1);
-  std::copy(search_path_opts.LibrarySearchPaths.begin(),
-            search_path_opts.LibrarySearchPaths.end(), paths.begin());
+  paths.assign(search_path_opts.LibrarySearchPaths.begin(),
+            search_path_opts.LibrarySearchPaths.end());
   paths.push_back(search_path_opts.RuntimeLibraryPath);
 }
 


### PR DESCRIPTION
The new dlopen along a list of paths code doesn't work if any of the paths are the empty string.  Filter them out in the dlopen code, and also remove a thinko in the GetLibrarySearchPaths from SwiftASTContext.cpp that was adding empty paths to the search path list.