### PR TITLE
Delay passing the persistent_state till after making the expression c…

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -363,15 +363,6 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                  "couldn't start parsing (no target)");
     return false;
   }
-  if (auto *persistent_state = GetPersistentState(target, exe_ctx)) {
-    persistent_state->AddHandLoadedModule(ConstString("Swift"));
-    m_result_delegate.RegisterPersistentState(persistent_state);
-    m_error_delegate.RegisterPersistentState(persistent_state);
-  } else {
-    diagnostic_manager.PutString(eDiagnosticSeverityError,
-                                 "couldn't start parsing (no persistent data)");
-    return false;
-  }
 
   ScanContext(exe_ctx, err);
 
@@ -446,6 +437,21 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
 
   m_parser =
       llvm::make_unique<SwiftExpressionParser>(exe_scope, *this, m_options);
+  
+  // Don't set the persistent state in the result & error delegates till after
+  // you have made the expression parser.  Doing that could invalidate the 
+  // Target ScratchASTContext, which would destroy the old persistent state, 
+  // leaving the delegates holding onto a dangling pointer.
+  
+  if (auto *persistent_state = GetPersistentState(target, exe_ctx)) {
+    persistent_state->AddHandLoadedModule(ConstString("Swift"));
+    m_result_delegate.RegisterPersistentState(persistent_state);
+    m_error_delegate.RegisterPersistentState(persistent_state);
+  } else {
+    diagnostic_manager.PutString(eDiagnosticSeverityError,
+                                 "couldn't start parsing (no persistent data)");
+    return false;
+  }
 
   unsigned error_code = m_parser->Parse(
       diagnostic_manager, first_body_line,


### PR DESCRIPTION
…ould invalidate it.

In the SwiftExpressionParser, we set the persistent_state associated with the currently
active scratch AST context into a couple of delegate objects that we will use at the
end of the expression evaluation.  But in the course of making an expression parser in the context
of a new module, some conflicting imports could invalidate the scratch AST context, leaving
the persistent_state pointers as dangling pointers.

So this patch delays getting and passing the persistent_state to the delegates till after
making the new SwiftExpressionParser, at which point we know the ones we calculate are the
ones we really intend to use.

Before this patch, I was getting a crash in:

lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers

<rdar://problem/42410482>