### PR TITLE
Fix multiple debugserver rules

### DIFF
--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -129,21 +129,6 @@ if (APPLE AND NOT SKIP_DEBUGSERVER)
   else()
     find_library(COCOA_LIBRARY Cocoa)
   endif()
-  
-  target_link_libraries(lldbDebugserverCommon
-                        INTERFACE ${COCOA_LIBRARY}
-                        ${CORE_FOUNDATION_LIBRARY}
-                        ${FOUNDATION_LIBRARY}
-                        lldbDebugserverArchSupport
-                        lldbDebugserverDarwin_DarwinLog)
-  
-  set(LLVM_OPTIONAL_SOURCES ${lldbDebugserverCommonSources})
-  add_lldb_tool(debugserver INCLUDE_IN_FRAMEWORK
-    debugserver.cpp
-  
-    LINK_LIBS
-      lldbDebugserverCommon
-    )
 endif()
 
 if(HAVE_LIBCOMPRESSION)


### PR DESCRIPTION
Previously if ran on macOS with the default setting of
SKIP_DEBUGSERVER=OFF, cmake would fail because a rule for building
debugserver was added twice.

<details>
<summary>full error (click to expand)</summary>

```
CMake Error at /Users/ksmiley/dev/oss-swift/build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/cmake/llvm/AddLLVM.cmake:724 (add_executable):
  add_executable cannot create target "debugserver" because another target
  with the same name already exists.  The existing target is an executable
  created in source directory
  "/Users/ksmiley/dev/oss-swift/lldb/tools/debugserver/source".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  cmake/modules/AddLLDB.cmake:100 (add_llvm_executable)
  cmake/modules/AddLLDB.cmake:154 (add_lldb_executable)
  tools/debugserver/source/CMakeLists.txt:171 (add_lldb_tool)


CMake Error at cmake/modules/AddLLDB.cmake:124 (add_custom_target):
  add_custom_target cannot create target "install-debugserver" because
  another target with the same name already exists.  The existing target is a
  custom target created in source directory
  "/Users/ksmiley/dev/oss-swift/lldb/tools/debugserver/source".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  cmake/modules/AddLLDB.cmake:154 (add_lldb_executable)
  tools/debugserver/source/CMakeLists.txt:171 (add_lldb_tool)


CMake Error at cmake/modules/AddLLDB.cmake:126 (add_custom_target):
  add_custom_target cannot create target "install-debugserver-stripped"
  because another target with the same name already exists.  The existing
  target is a custom target created in source directory
  "/Users/ksmiley/dev/oss-swift/lldb/tools/debugserver/source".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  cmake/modules/AddLLDB.cmake:154 (add_lldb_executable)
  tools/debugserver/source/CMakeLists.txt:171 (add_lldb_tool)
```
</details>

First location it's added from: https://github.com/apple/swift-lldb/blob/197e7093dde90e44fa25ec05914c9e06595565fd/tools/debugserver/source/CMakeLists.txt#L141

Second location: https://github.com/apple/swift-lldb/blob/197e7093dde90e44fa25ec05914c9e06595565fd/tools/debugserver/source/CMakeLists.txt#L171

This might not be the right solution, I'm not sure if it was intentional before that this would hit as well as the `APPLE AND NOT SKIP_DEBUGSERVER` conditional, happy to change this however makes sense from those who have more context.