### PR TITLE
Get the running OS version from the process rather than the platform.

### DIFF
--- a/source/Expression/ExpressionSourceCode.cpp
+++ b/source/Expression/ExpressionSourceCode.cpp
@@ -480,15 +480,16 @@ bool ExpressionSourceCode::GetText(
     case lldb::eLanguageTypeSwift: {
       llvm::SmallString<16> buffer;
       llvm::raw_svector_ostream os_vers(buffer);
-      auto platform = target->GetPlatform();
-      auto arch_spec = platform->GetSystemArchitecture();
+
+      auto arch_spec = target->GetArchitecture();
       auto triple = arch_spec.GetTriple();
       if (triple.isOSDarwin()) {
-        uint32_t major, minor, patch;
-        platform->GetOSVersion(major, minor, patch,
-                               target->GetProcessSP().get());
-        os_vers << getAvailabilityName(triple.getOS()) << " ";
-        os_vers << major << "." << minor << "." << patch;
+        if (auto process_sp = exe_ctx.GetProcessSP()) {
+          uint32_t major, minor, patch;
+          process_sp->GetHostOSVersion(major, minor, patch);
+          os_vers << getAvailabilityName(triple.getOS()) << " ";
+          os_vers << major << "." << minor << "." << patch;
+        }
       }
       SwiftASTManipulator::WrapExpression(wrap_stream, m_body.c_str(),
                                           language_flags, options, generic_info,


### PR DESCRIPTION
It turns out the OS information returned by the platform can't be trusted
because the platform code is bogus (rdar://problem/42595503). Get the OS
version information from the process instead where it is accurate. This
commit also fixes the test to pass an older deployment target to the
compilation command so that it actually tests the feature we are trying
to exercise.

rdar://problem/42351790

(cherry picked from commit dbf58532c3a277690d28a88a52c4a564fd4fc2d8)