### PR TITLE
An additional fix to ObjectFileMachO's minimum version

### DIFF
--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6027,20 +6027,29 @@ uint32_t ObjectFileMachO::GetMinimumOSVersion(uint32_t *versions,
             m_min_os_versions.push_back(xxxx);
             m_min_os_versions.push_back(yy);
             m_min_os_versions.push_back(zz);
+            success = true;
+          } else {
+            GetModule()->ReportWarning(
+                "minimum OS version load command with invalid (0) version found.");
           }
-          success = true;
         }
       }
       offset = load_cmd_offset + lc.cmdsize;
     }
 
     if (success == false) {
-      // Push an invalid value so we don't keep trying to
+      // Push an invalid value so we don't try to find
+      // the version # again on the next call to this
+      // method.
       m_min_os_versions.push_back(UINT32_MAX);
     }
   }
 
-  if (m_min_os_versions.size() > 1 || m_min_os_versions[0] != UINT32_MAX) {
+  // Legitimate version numbers will have 3 entries pushed
+  // on to m_min_os_versions.  If we only have one value, it's
+  // the sentinel value indicating that this object file
+  // does not have a valid minimum os version #.
+  if (m_min_os_versions.size() > 1) {
     if (versions != NULL && num_versions > 0) {
       for (size_t i = 0; i < num_versions; ++i) {
         if (i < m_min_os_versions.size())


### PR DESCRIPTION
An additional fix to ObjectFileMachO's minimum version
number reporting; handle the case where we're given a
minimum OS version of 0 correctly. This is the same
as the change I made in r335556 for ObjectFileMachO::GetSDKVersion
but it also needs to be made to the similar code in
ObjectFileMachO::GetMinimumOSVersion.

rdar://problem/41372699