### PR TITLE
Add a line break before note about help in REPL

### DIFF
--- a/lit/SwiftREPL/Basic.test
+++ b/lit/SwiftREPL/Basic.test
@@ -1,7 +1,7 @@
 // Basic sanity checking of the REPL.
 
 // RUN: %lldb --repl --repl-language swift | FileCheck %s --check-prefix=SWIFT
-// SWIFT: Welcome to Swift version {{.*}} (LLVM {{.*}}, Clang {{.*}}, Swift {{.*}})
+// SWIFT: Welcome to Swift
 
 // RUN: %lldb --repl --repl-language c++ 2>&1 | FileCheck %s --check-prefix=CPP
 // CPP: error: couldn't find a REPL for c++
@@ -11,5 +11,6 @@
 // INVALID: error: Unrecognized language name: "patatino"
 
 // RUN: echo '2 + 3' | %lldb --repl | FileCheck %s --check-prefix=INT
-// INT: Welcome to Swift version {{.*}} (LLVM {{.*}}, Clang {{.*}}, Swift {{.*}})
+// INT: Welcome to Swift
+// INT-NEXT: Type :help
 // INT-NEXT: $R0: Int = 5

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -243,7 +243,7 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
   cleanup.disable();
 
   std::string swift_full_version(swift::version::getSwiftFullVersion());
-  printf("Welcome to %s. Type :help for assistance.\n",
+  printf("Welcome to %s.\nType :help for assistance.\n",
          swift_full_version.c_str());
 
   return repl_sp;


### PR DESCRIPTION
This moves the line about `:help` when you start a REPL to its own line, as it hasn't been visible for everyone (as noted in https://forums.swift.org/t/repl-ergonomics/14347/10).