### PR TITLE
Add a line break before note about help in REPL

### DIFF
--- a/lit/SwiftREPL/Basic.test
+++ b/lit/SwiftREPL/Basic.test
@@ -12,4 +12,5 @@
 
 // RUN: echo '2 + 3' | %lldb --repl | FileCheck %s --check-prefix=INT
 // INT: Welcome to Swift
+// INT-NEXT: Type :help
 // INT-NEXT: $R0: Int = 5

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -256,7 +256,7 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
   cleanup.disable();
 
   std::string swift_full_version(swift::version::getSwiftFullVersion());
-  printf("Welcome to %s. Type :help for assistance.\n",
+  printf("Welcome to %s.\nType :help for assistance.\n",
          swift_full_version.c_str());
 
   return repl_sp;


### PR DESCRIPTION
This moves the line about `:help` when you start a REPL to its own line, as it hasn't been visible for everyone (as noted in https://forums.swift.org/t/repl-ergonomics/14347/10). 

(Recreated from #794, in which either I or GitHub was doing it wrong.)