### PR TITLE
[lit] Relax NSString test by not checking the REPL welcome message, NFC

### DIFF
--- a/lit/SwiftREPL/NSString.test
+++ b/lit/SwiftREPL/NSString.test
@@ -5,8 +5,7 @@
 
 import Foundation
 var aString = "patatino" as NSString
-// NSSTRING: Welcome to Swift
-// NSSTRING-NEXT: aString: NSTaggedPointerString = "patatino"
+// NSSTRING: aString: NSTaggedPointerString = "patatino"
 
 aString.substring(to: 3)
 // NSSTRING: $R0: String = "pat"


### PR DESCRIPTION
This NSString-in-REPL test was checking the text of the REPL welcome
message, which is a little brittle, and was broken by a change which
added a newline.

It seems simpler to not check the welcome text at all.

https://ci.swift.org/job/oss-lldb-incremental-osx-cmake/1112