### PR TITLE
Move the LLDB_TEST_SWIFT to test/CMakeLists.txt where it is used

### DIFF
--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -49,11 +49,6 @@ llvm_canonicalize_cmake_booleans(
   LLDB_DISABLE_PYTHON
   LLVM_ENABLE_ZLIB)
 
-# BEGIN - Swift Mods
-option(LLDB_TEST_CLANG "Use in-tree clang when testing lldb" On)
-option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
-# END - Swift Mods
-
 # This should be inherited from the `check-lldb` target. We currently don't run
 # it for swift, but we might consider removing this code once we're done.
 set(LIT_ARGS "-sv")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,12 +25,15 @@ set(LLDB_TEST_ARCH
   ${LLDB_DEFAULT_TEST_ARCH}
   CACHE STRING "Specify the architecture to run LLDB tests as (x86|x64).  Determines whether tests are compiled with -m32 or -m64")
 
+# BEGIN - Swift Mods
+option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 
 if(LLDB_TEST_SWIFT)
   set(SWIFT_TEST_ARGS
     --swift-compiler ${LLDB_SWIFTC}
     --swift-library ${LLDB_SWIFT_LIBS})
 endif()
+# END - Swift Mods
 
 # Users can override LLDB_TEST_USER_ARGS to specify arbitrary arguments to pass to the script
 set(LLDB_TEST_USER_ARGS


### PR DESCRIPTION
It looks like the LLDB_TEST_SWIFT option never actually worked. We never
noticed as master-next was broken, but daa2eb72666e78be7 removed the
fallback code that seemed to have kept the swift tests running.

This commit also removes LLDB_TEST_CLANG which doesn't seem to be used
anywhere.