### PR TITLE
Sync-up the installed Clang resource directory and the code looking f…

### DIFF
--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -163,8 +163,8 @@ endif()
 # Copy the clang resource directory.
 add_custom_command_target(
     unused_var
-    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang/${LLVM_PACKAGE_VERSION}"
-    OUTPUT "${lib_dir}/lldb/clang/${LLVM_PACKAGE_VERSION}"
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang/"
+    OUTPUT "${lib_dir}/lldb/clang/"
     VERBATIM
     ALL
     DEPENDS ${clang_headers_target})

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -34,6 +34,8 @@ static bool ComputeClangDirectory(FileSpec &file_spec) { return false; }
 #else
 static bool DefaultComputeClangDirectory(FileSpec &file_spec) {
   return HostInfoPosix::ComputePathRelativeToLibrary(
+      file_spec, "/lib/lldb/clang/");
+  return HostInfoPosix::ComputePathRelativeToLibrary(
       file_spec, (llvm::Twine("/lib") + CLANG_LIBDIR_SUFFIX + "/clang/" +
                   CLANG_VERSION_STRING)
                      .str());


### PR DESCRIPTION
…or it.

All Swift tests where failing because they couldn't build the ClangImporter. This patch gets
things going again even though I'm really not sure it's the correct solution.