### PR TITLE
Avoid crashing when printing global variables without a process.

### DIFF
--- a/lit/Swift/Inputs/Global.swift
+++ b/lit/Swift/Inputs/Global.swift
@@ -1,0 +1,5 @@
+class C {
+  var i = 23
+}
+// CHECK: (main.C) c = <uninitialized>
+let c = C()

--- a/lit/Swift/global.test
+++ b/lit/Swift/global.test
@@ -1,0 +1,7 @@
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t/cache %S/Inputs/Global.swift \
+# RUN:          -module-name main -o a.out
+# RUN: %lldb a.out -s %s | FileCheck %S/Inputs/Global.swift
+
+target var c

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5870,6 +5870,8 @@ CompilerType SwiftASTContext::MapIntoContext(lldb::StackFrameSP &frame_sp,
   VALID_OR_RETURN(CompilerType());
   if (!type)
     return CompilerType(GetASTContext(), nullptr);
+  if (!frame_sp)
+    return CompilerType(GetASTContext(), GetSwiftType(type));
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   const SymbolContext &sc(frame_sp->GetSymbolContext(eSymbolContextFunction));
   if (!sc.function || (swift_can_type && !swift_can_type->hasTypeParameter()))


### PR DESCRIPTION
This fixes a regression introduced the big generic type representation overhaul.