### PR TITLE
 Pass in the current LLDB module whenever a Swift scratch context is r...

### DIFF
--- a/include/lldb/Core/ValueObject.h
+++ b/include/lldb/Core/ValueObject.h
@@ -615,6 +615,7 @@ public:
   virtual bool HasSyntheticValue();
 
   SwiftASTContext *GetSwiftASTContext();
+  SwiftASTContext *GetScratchSwiftASTContext();
 
   virtual bool IsSynthetic() { return false; }
 

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -420,8 +420,6 @@ protected:
 
   std::shared_ptr<swift::remote::MemoryReader> GetMemoryReader();
 
-  SwiftASTContext *GetScratchSwiftASTContext();
-
   std::unordered_set<std::string> m_library_negative_cache; // We have to load
                                                             // swift dependent
                                                             // libraries by

--- a/lit/Swift/DynamicTyperesolutionConflict.test
+++ b/lit/Swift/DynamicTyperesolutionConflict.test
@@ -1,0 +1,29 @@
+# REQUIRES: darwin
+
+# This testcase causes the scratch context to get destroyed by a
+# conflict that is triggered via dynamic type resolution. The conflict
+# is triggered by "frame variable" alone. The final "expr" command is
+# just there to test that after "fr var" has destroyed the scratch
+# context we can recover.
+
+# Unfortunately this test is extremely sensitive to the side effects
+# of the command interpreter and the debug info format, which is why
+# it is written as a LIT test.
+
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: %target-swiftc -g -Onone -Xfrontend -serialize-debugging-options %p/../../packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Library.swift -emit-library -module-name Dylib -emit-module -Xlinker -install_name -Xlinker @executable_path/libDylib.dylib
+# RUN: %target-swiftc -g -Onone -Xfrontend -serialize-debugging-options %p/../../packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Conflict.swift -Xcc -I%p/../../packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo -emit-library -module-name Conflict -emit-module -Xlinker -install_name -Xlinker @executable_path/libConflict.dylib
+# RUN: %target-swiftc -g -Onone -Xfrontend -serialize-debugging-options %p/../../packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/main.swift -lDylib -lConflict -L%t -o a.out -Xcc -I%p/../../packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar -I. -import-objc-header %p/../../packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/bridging.h
+# RUN: %lldb a.out -s %s 2>&1 | FileCheck %s
+
+b Library.swift:9
+run
+target v foofoo
+p input
+p input
+
+# The {{ }} avoids accidentally matching the input script!
+# CHECK: {{Swift}} error in fallback scratch context
+# CHECK: {{This}} error message is displayed only once.
+# CHECK: (LibraryProtocol) ${{R0}} =
+# CHECK: (LibraryProtocol) ${{R2}} =

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Conflict.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Conflict.swift
@@ -1,0 +1,11 @@
+import Bar
+public class C {
+  public var i = 123
+  public let f = FooFoo(i: 42)
+}
+
+public var foofoo = C()
+
+@_silgen_name("init_conflict") public func init_conflict() {
+  foofoo = C()
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Library.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Library.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public protocol LibraryProtocol : class {}
+
+public class Foo : NSObject {
+  public init(_ input : LibraryProtocol) {
+    // When evaluating "input" here, RemoteAST will try to get its
+    // dynamic type.
+    print("break here")
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
@@ -1,0 +1,24 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+all: a.out
+
+include $(LEVEL)/Makefile.rules
+
+# This testcase causes the scratch context to get destroyed by a
+# conflict that is triggered via dynamic type resolution. The two
+# swift modules talk Objective-C to the conflicting swift module to
+# make the conflict possible.
+
+a.out: main.swift libDylib.dylib libConflict.dylib
+	$(SWIFTC) -g -Onone $^ -lDylib -lConflict -L$(shell pwd) -o $@ $(SWIFTFLAGS) -Xcc -I$(SRCDIR)/hidden/Bar -I. -import-objc-header $(SRCDIR)/bridging.h
+
+libDylib.dylib: Library.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name Dylib -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -I. $(SWIFTFLAGS)
+
+libConflict.dylib: Conflict.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name Conflict -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -I. -Xcc -I$(SRCDIR)/hidden/Foo $(SWIFTFLAGS)
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -1,0 +1,73 @@
+# TestSwiftDynamicTypeResolutionImportConflict.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        """
+        This testcase causes the scratch context to get destroyed by a
+        conflict that is triggered via dynamic type resolution. The
+        conflict is triggered by "frame variable" alone. The final
+        "expr" command is just there to test that after "fr var" has
+        destroyed the scratch context we can recover.
+
+        """
+        # To ensure we hit the rebuild problem remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        # Destroy the scratch context with a dynamic type lookup.
+        self.expect("target var -d run-target -- foofoo",
+                    substrs=['(Conflict.C) foofoo'])
+        self.expect("target var -- foofoo",
+                    substrs=['(Conflict.C) foofoo'])
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('Library.swift'))
+        self.expect("bt", substrs=['Library.swift'])
+        self.expect("fr v -d no-dynamic-values -- input",
+                    substrs=['(LibraryProtocol) input'])
+        self.expect("fr v -d run-target -- input",
+                    substrs=['(LibraryProtocol) input'])
+                    # FIXME: substrs=['(main.FromMainModule) input'])
+        self.expect("expr -d run-target -- input",
+                    "test that the expression evaluator can recover",
+                    substrs=['(LibraryProtocol) $R0'])
+                    # FIXME: substrs=['(main.FromMainModule) input'])
+                    
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/bridging.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/bridging.h
@@ -1,0 +1,1 @@
+void init_conflict();

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Bar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Bar.h
@@ -1,0 +1,1 @@
+#include <Foo.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Foo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Foo.h
@@ -1,0 +1,1 @@
+struct FooBar { int j; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Bar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Foo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Foo.h
@@ -1,0 +1,1 @@
+struct FooFoo { int i; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Outer.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Outer.h
@@ -1,0 +1,1 @@
+#include <Foo.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Outer.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/main.swift
@@ -1,0 +1,10 @@
+import Bar
+import Dylib
+
+public class FromMainModule : LibraryProtocol {
+  let i = 1
+}
+
+init_conflict()
+let foobar = FooBar(j: 42)
+Foo(FromMainModule()) // break here

--- a/source/Breakpoint/BreakpointLocation.cpp
+++ b/source/Breakpoint/BreakpointLocation.cpp
@@ -259,6 +259,7 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
       language = comp_unit->GetLanguage();
 
     m_user_expression_sp.reset(GetTarget().GetUserExpressionForLanguage(
+        exe_ctx,
         condition_text, llvm::StringRef(), language, Expression::eResultTypeAny,
         EvaluateExpressionOptions(), error));
     if (error.Fail()) {

--- a/source/Breakpoint/Watchpoint.cpp
+++ b/source/Breakpoint/Watchpoint.cpp
@@ -287,7 +287,9 @@ void Watchpoint::SetCondition(const char *condition) {
   } else {
     // Pass nullptr for expr_prefix (no translation-unit level definitions).
     Status error;
+    ExecutionContext exe_scope(m_target);
     m_condition_ap.reset(m_target.GetUserExpressionForLanguage(
+        exe_scope,
         condition, llvm::StringRef(), lldb::eLanguageTypeUnknown,
         UserExpression::eResultTypeAny, EvaluateExpressionOptions(), error));
     if (error.Fail()) {

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -1741,18 +1741,22 @@ SwiftASTContext *ValueObject::GetSwiftASTContext() {
   if (GetObjectRuntimeLanguage() != lldb::eLanguageTypeSwift)
     return nullptr;
   lldb::ModuleSP module_sp(GetModule());
-  if (module_sp)
-    return llvm::dyn_cast_or_null<SwiftASTContext>(
-        module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift));
-
-  lldb::TargetSP target_sp(GetTargetSP());
-  if (target_sp) {
-    Status error;
-    ExecutionContext ctx = GetExecutionContextRef().Lock(false);
-    auto *exe_scope = ctx.GetBestExecutionContextScope();
-    return target_sp->GetScratchSwiftASTContext(error, *exe_scope);
+  if (module_sp) {
+    auto ts = module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+    return llvm::dyn_cast_or_null<SwiftASTContext>(ts);
   }
-  return nullptr;
+  return GetScratchSwiftASTContext();
+}
+
+SwiftASTContext *ValueObject::GetScratchSwiftASTContext() {
+  lldb::TargetSP target_sp(GetTargetSP());
+  if (!target_sp)
+    return nullptr;
+
+  Status error;
+  ExecutionContext ctx = GetExecutionContextRef().Lock(false);
+  auto *exe_scope = ctx.GetBestExecutionContextScope();
+  return target_sp->GetScratchSwiftASTContext(error, *exe_scope);
 }
 
 void ValueObject::AddSyntheticChild(const ConstString &key,

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -924,10 +924,10 @@ public:
     Status type_system_error;
     TypeSystem *type_system;
     
-    if (lang == lldb::eLanguageTypeSwift) {
-      Status error;
-      type_system = target_sp->GetScratchSwiftASTContext(error, *frame_sp);
-    } else
+    if (lang == lldb::eLanguageTypeSwift)
+      type_system =
+          target_sp->GetScratchSwiftASTContext(type_system_error, *frame_sp);
+    else
       type_system = target_sp->GetScratchTypeSystemForLanguage(
         &type_system_error, m_type.GetMinimumLanguage());
 

--- a/source/Expression/UserExpression.cpp
+++ b/source/Expression/UserExpression.cpp
@@ -219,7 +219,7 @@ lldb::ExpressionResults UserExpression::Evaluate(
   }
 
   lldb::UserExpressionSP user_expression_sp(
-      target->GetUserExpressionForLanguage(expr, full_prefix, language,
+      target->GetUserExpressionForLanguage(exe_ctx, expr, full_prefix, language,
                                            desired_type, options, error));
   if (error.Fail()) {
     if (log)
@@ -263,7 +263,8 @@ lldb::ExpressionResults UserExpression::Evaluate(
     if (fixed_expression && !fixed_expression->empty() &&
         options.GetAutoApplyFixIts()) {
       lldb::UserExpressionSP fixed_expression_sp(
-          target->GetUserExpressionForLanguage(fixed_expression->c_str(),
+          target->GetUserExpressionForLanguage(exe_ctx,
+                                               fixed_expression->c_str(),
                                                full_prefix, language,
                                                desired_type, options, error));
       DiagnosticManager fixed_diagnostic_manager;

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1066,10 +1066,14 @@ static swift::ASTContext *SetupASTContext(
   }
 
   // Lazily get the clang importer if we can to make sure it exists in case we
-  // need it
+  // need it.
   if (!swift_ast_context->GetClangImporter()) {
+    std::string swift_error = "Fatal Swift ";
+    swift_error +=
+        swift_ast_context->GetFatalErrors().AsCString("error: unknown error.");
+    diagnostic_manager.PutString(eDiagnosticSeverityError, swift_error);
     diagnostic_manager.PutString(
-        eDiagnosticSeverityError,
+        eDiagnosticSeverityRemark,
         "Swift expressions require OS X 10.10 / iOS 8 SDKs or later.\n");
     return nullptr;
   }

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -511,9 +511,10 @@ bool lldb_private::formatters::swift::NSContiguousString_SummaryProvider(
 
   DataExtractor data(buffer_sp, process_sp->GetByteOrder(), ptr_size);
 
+  ExecutionContext exe_ctx(process_sp);
+  ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
   SwiftASTContext *lldb_swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
-      process_sp->GetTarget().GetScratchTypeSystemForLanguage(
-          &error, eLanguageTypeSwift));
+      process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope));
   if (!lldb_swift_ast)
     return false;
   CompilerType string_guts_type = lldb_swift_ast->GetTypeFromMangledTypename(

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -324,9 +324,10 @@ SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
       native_storage_ptr =
           process_sp->ReadPointerFromMemory(native_storage_ptr, error);
       // (AnyObject,AnyObject)?
+      ExecutionContext exe_ctx(process_sp);
+      ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
       SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
-          process_sp->GetTarget().GetScratchTypeSystemForLanguage(
-              &error, eLanguageTypeSwift));
+          process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope));
       if (swift_ast_ctx) {
         CompilerType element_type(swift_ast_ctx->GetTypeFromMangledTypename(
             SwiftLanguageRuntime::GetCurrentMangledName(


### PR DESCRIPTION
…equested.

Using the scratch context for dynamic type resolution has uncovered a
couple of omissions in the original fallback mechanism
implementation. This patch adds a few convenience accesors that make
it easy to always get access to the most appropriate Swift scratch
context in all situations.

The testcase causes the scratch context to get destroyed by a
conflict that is triggered via dynamic type resolution via "frame variable".

rdar://problem/42554384