### PR TITLE
Enable the per-module scratch AST context fallback in dynamic type re…

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Conflict.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Conflict.swift
@@ -1,0 +1,11 @@
+import Bar
+public class C {
+  public var i = 123
+  public let f = FooFoo(i: 42)
+}
+
+public var foofoo = C()
+
+@_silgen_name("init_conflict") public func init_conflict() {
+  foofoo = C()
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Library.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Library.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public protocol LibraryProtocol : class {}
+
+public class Foo : NSObject {
+  public init(_ input : LibraryProtocol) {
+    // When evaluating "input" here, RemoteAST will try to get its
+    // dynamic type.
+    print("break here")
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
@@ -1,0 +1,24 @@
+LEVEL = ../../../../make
+SRCDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+SWIFT_OBJC_INTEROP := 1
+
+all: a.out
+
+include $(LEVEL)/Makefile.rules
+
+# This testcase causes the scratch context to get destroyed by a
+# conflict that is triggered via dynamic type resolution. The two
+# swift modules talk Objective-C to the conflicting swift module to
+# make the conflict possible.
+
+a.out: main.swift libDylib.dylib libConflict.dylib
+	$(SWIFTC) -g -Onone $^ -lDylib -lConflict -L$(shell pwd) -o $@ $(SWIFTFLAGS) -Xcc -I$(SRCDIR)/hidden/Bar -I. -import-objc-header $(SRCDIR)/bridging.h
+
+libDylib.dylib: Library.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name Dylib -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -I. $(SWIFTFLAGS)
+
+libConflict.dylib: Conflict.swift
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name Conflict -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -I. -Xcc -I$(SRCDIR)/hidden/Foo $(SWIFTFLAGS)
+
+clean::
+	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -1,0 +1,72 @@
+# TestSwiftDynamicTypeResolutionImportConflict.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+import shutil
+
+class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @decorators.skipUnlessDarwin
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test(self):
+        """
+        This testcase causes the scratch context to get destroyed by a
+        conflict that is triggered via dynamic type resolution. The
+        conflict is triggered by "frame variable" alone. The final
+        "expr" command is just there to test that after "fr var" has
+        destroyed the scratch context we can recover.
+
+        """
+        # To ensure we hit the rebuild problem remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        # Destroy the scratch context with a dynamic type lookup.
+        self.expect("target var -d run-target -- foofoo",
+                    substrs=['(Conflict.C) foofoo'])
+        self.expect("target var -- foofoo",
+                    substrs=['(Conflict.C) foofoo'])
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('Library.swift'))
+        self.expect("fr v -d no-dynamic-values -- input",
+                    substrs=['(LibraryProtocol) input'])
+        self.expect("fr v -d run-target -- input",
+                    substrs=['(LibraryProtocol) input'])
+                    # FIXME: substrs=['(main.FromMainModule) input'])
+        self.expect("expr -d run-target -- input",
+                    "test that the expression evaluator can recover",
+                    substrs=['(LibraryProtocol) $R0'])
+                    # FIXME: substrs=['(main.FromMainModule) input'])
+        
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/bridging.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/bridging.h
@@ -1,0 +1,1 @@
+void init_conflict();

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Bar.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Bar.h
@@ -1,0 +1,1 @@
+#include <Foo.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Foo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/Foo.h
@@ -1,0 +1,1 @@
+struct FooBar { int j; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Bar/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Bar.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Foo.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Foo.h
@@ -1,0 +1,1 @@
+struct FooFoo { int i; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Outer.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/Outer.h
@@ -1,0 +1,1 @@
+#include <Foo.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/hidden/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Bar {
+  header "Outer.h"
+}

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/main.swift
@@ -1,0 +1,10 @@
+import Bar
+import Dylib
+
+public class FromMainModule : LibraryProtocol {
+  let i = 1
+}
+
+init_conflict()
+let foobar = FooBar(j: 42)
+Foo(FromMainModule()) // break here


### PR DESCRIPTION
…solution.

After switching dynamic type resolution over to the scratch context,
we also need to make sure to support the fallback mechanism there.

This is a smaller, more targeted version of the same patch that went
into the stable branch.

rdar://problem/42554384