### PR TITLE
[lldb-mi] Disable flakey pexpect tests

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiCliSupport.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiCliSupport.py
@@ -37,6 +37,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfRemote   # We do not currently support remote debugging via the MI.
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows.
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races.
+    @skipIfDarwin
     def test_lldbmi_target_list(self):
         """Test that 'lldb-mi --interpreter' can list targets by 'target list' command."""
 

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
@@ -39,6 +39,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfRemote   # We do not currently support remote debugging via the MI.
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows.
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races.
+    @skipIfDarwin
     def test_lldbmi_target_list(self):
         """Test that 'lldb-mi --interpreter' can list targets by 'target list' command."""
 


### PR DESCRIPTION
Disable two pexpect-based test that are timing out. The real fix for
this is to rewrite the tests using LIT but until then we removed these
two from Darwin testing.