### PR TITLE
radar42585636-demangling

### DIFF
--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -423,15 +423,6 @@ if(LLDB_USING_LIBSTDCXX)
     endif()
 endif()
 
-if(MSVC)
-    set(LLDB_USE_BUILTIN_DEMANGLER ON)
-else()
-    option(LLDB_USE_BUILTIN_DEMANGLER "Use lldb's builtin demangler instead of the system one" ON)
-endif()
-if(LLDB_USE_BUILTIN_DEMANGLER)
-    add_definitions(-DLLDB_USE_BUILTIN_DEMANGLER)
-endif()
-
 if ((CMAKE_SYSTEM_NAME MATCHES "Android") AND LLVM_BUILD_STATIC AND
     ((ANDROID_ABI MATCHES "armeabi") OR (ANDROID_ABI MATCHES "mips")))
   add_definitions(-DANDROID_USE_ACCEPT_WORKAROUND)

--- a/include/lldb/Core/RichManglingContext.h
+++ b/include/lldb/Core/RichManglingContext.h
@@ -1,0 +1,110 @@
+//===-- RichManglingContext.h -----------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_RichManglingContext_h_
+#define liblldb_RichManglingContext_h_
+
+#include "lldb/lldb-forward.h"
+#include "lldb/lldb-private.h"
+
+#include "lldb/Utility/ConstString.h"
+
+#include "llvm/ADT/Any.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Demangle/Demangle.h"
+
+namespace lldb_private {
+
+/// Uniform wrapper for access to rich mangling information from different
+/// providers. See Mangled::DemangleWithRichManglingInfo()
+class RichManglingContext {
+public:
+  RichManglingContext()
+      : m_provider(None), m_ipd_buf_size(2048), m_ipd_str_len(0) {
+    m_ipd_buf = static_cast<char *>(std::malloc(m_ipd_buf_size));
+    m_ipd_buf[m_ipd_str_len] = '\0';
+  }
+
+  ~RichManglingContext() { std::free(m_ipd_buf); }
+
+  /// Use the ItaniumPartialDemangler to obtain rich mangling information from
+  /// the given mangled name.
+  bool FromItaniumName(const ConstString &mangled);
+
+  /// Use the legacy language parser implementation to obtain rich mangling
+  /// information from the given demangled name.
+  bool FromCxxMethodName(const ConstString &demangled);
+
+  /// If this symbol describes a constructor or destructor.
+  bool IsCtorOrDtor() const;
+
+  /// If this symbol describes a function.
+  bool IsFunction() const;
+
+  /// Get the base name of a function. This doesn't include trailing template
+  /// arguments, ie "a::b<int>" gives "b". The result will overwrite the
+  /// internal buffer. It can be obtained via GetBufferRef().
+  void ParseFunctionBaseName();
+
+  /// Get the context name for a function. For "a::b::c", this function returns
+  /// "a::b". The result will overwrite the internal buffer. It can be obtained
+  /// via GetBufferRef().
+  void ParseFunctionDeclContextName();
+
+  /// Get the entire demangled name. The result will overwrite the internal
+  /// buffer. It can be obtained via GetBufferRef().
+  void ParseFullName();
+
+  /// Obtain a StringRef to the internal buffer that holds the result of the
+  /// most recent ParseXy() operation. The next ParseXy() call invalidates it.
+  llvm::StringRef GetBufferRef() const {
+    assert(m_provider != None && "Initialize a provider first");
+    return m_buffer;
+  }
+
+private:
+  enum InfoProvider { None, ItaniumPartialDemangler, PluginCxxLanguage };
+
+  /// Selects the rich mangling info provider.
+  InfoProvider m_provider;
+
+  /// Reference to the buffer used for results of ParseXy() operations.
+  llvm::StringRef m_buffer;
+
+  /// Members for ItaniumPartialDemangler
+  llvm::ItaniumPartialDemangler m_ipd;
+  char *m_ipd_buf;
+  size_t m_ipd_buf_size;
+  size_t m_ipd_str_len;
+
+  /// Members for PluginCxxLanguage
+  /// Cannot forward declare inner class CPlusPlusLanguage::MethodName. The
+  /// respective header is in Plugins and including it from here causes cyclic
+  /// dependency. Instead keep a llvm::Any and cast it on-access in the cpp.
+  llvm::Any m_cxx_method_parser;
+
+  /// Clean up memory and set a new info provider for this instance.
+  void ResetProvider(InfoProvider new_provider);
+
+  /// Uniform handling of string buffers for ItaniumPartialDemangler.
+  void processIPDStrResult(char *ipd_res, size_t res_len);
+
+  /// Cast the given parser to the given type. Ideally we would have a type
+  /// trait to deduce \a ParserT from a given InfoProvider, but unfortunately we
+  /// can't access CPlusPlusLanguage::MethodName from within the header.
+  template <class ParserT> static ParserT *get(llvm::Any parser) {
+    assert(parser.hasValue());
+    assert(llvm::any_isa<ParserT *>(parser));
+    return llvm::any_cast<ParserT *>(parser);
+  }
+};
+
+} // namespace lldb_private
+
+#endif

--- a/include/lldb/Symbol/Symtab.h
+++ b/include/lldb/Symbol/Symtab.h
@@ -201,6 +201,15 @@ private:
   void SymbolIndicesToSymbolContextList(std::vector<uint32_t> &symbol_indexes,
                                         SymbolContextList &sc_list);
 
+  void RegisterMangledNameEntry(
+      NameToIndexMap::Entry &entry, std::set<const char *> &class_contexts,
+      std::vector<std::pair<NameToIndexMap::Entry, const char *>> &backlog,
+      RichManglingContext &rmc);
+
+  void RegisterBacklogEntry(const NameToIndexMap::Entry &entry,
+                            const char *decl_context,
+                            const std::set<const char *> &class_contexts);
+
   DISALLOW_COPY_AND_ASSIGN(Symtab);
 };
 

--- a/include/lldb/Utility/ConstString.h
+++ b/include/lldb/Utility/ConstString.h
@@ -373,15 +373,14 @@ public:
   /// them.
   ///
   /// @param[in] demangled
-  ///     The demangled C string to correlate with the \a mangled
-  ///     name.
+  ///     The demangled string to correlate with the \a mangled name.
   ///
   /// @param[in] mangled
   ///     The already uniqued mangled ConstString to correlate the
   ///     soon to be uniqued version of \a demangled.
   //------------------------------------------------------------------
-  void SetCStringWithMangledCounterpart(const char *demangled,
-                                        const ConstString &mangled);
+  void SetStringWithMangledCounterpart(llvm::StringRef demangled,
+                                       const ConstString &mangled);
 
   //------------------------------------------------------------------
   /// Retrieve the mangled or demangled counterpart for a mangled or demangled

--- a/include/lldb/Utility/ConstString.h
+++ b/include/lldb/Utility/ConstString.h
@@ -346,6 +346,15 @@ public:
   bool IsEmpty() const { return m_string == nullptr || m_string[0] == '\0'; }
 
   //------------------------------------------------------------------
+  /// Test for null string.
+  ///
+  /// @return
+  ///     @li \b true if there is no string associated with this instance.
+  ///     @li \b false if there is a string associated with this instance.
+  //------------------------------------------------------------------
+  bool IsNull() const { return m_string == nullptr; }
+
+  //------------------------------------------------------------------
   /// Set the C string value.
   ///
   /// Set the string value in the object by uniquing the \a cstr string value

--- a/include/lldb/lldb-forward.h
+++ b/include/lldb/lldb-forward.h
@@ -191,6 +191,7 @@ class RegisterLocationList;
 class RegisterValue;
 class RegularExpression;
 class REPL;
+class RichManglingContext;
 class Scalar;
 class ScriptInterpreter;
 class ScriptInterpreterLocker;
@@ -495,6 +496,16 @@ typedef std::shared_ptr<lldb_private::ValueObjectList> ValueObjectListSP;
 typedef std::shared_ptr<lldb_private::Watchpoint> WatchpointSP;
 
 } // namespace lldb
+
+//----------------------------------------------------------------------
+// llvm forward declarations
+//----------------------------------------------------------------------
+namespace llvm {
+
+struct ItaniumPartialDemangler;
+class StringRef;
+
+} // namespace llvm
 
 #endif // #if defined(__cplusplus)
 #endif // LLDB_lldb_forward_h_

--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -539,6 +539,9 @@
 		8C3BD9961EF45DA50016C343 /* MainThreadCheckerRuntime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C3BD9951EF45D9B0016C343 /* MainThreadCheckerRuntime.cpp */; };
 		2689004313353E0400698AC0 /* Mangled.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26BC7E8010F1B85900F91463 /* Mangled.cpp */; };
 		4F29D3CF21010FA3003B549A /* MangledTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F29D3CD21010F84003B549A /* MangledTest.cpp */; };
+		4FBC04EF211A06820015A814 /* RichManglingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FBC04EE211A06820015A814 /* RichManglingContext.h */; };
+		4FBC04ED211A06200015A814 /* RichManglingContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBC04EC211A06200015A814 /* RichManglingContext.cpp */; };
+		4FBC04F5211A13770015A814 /* RichManglingContextTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FBC04F3211A0F0F0015A814 /* RichManglingContextTest.cpp */; };
 		4CD44CFC20B37C440003557C /* ManualDWARFIndex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CD44CF920B37C440003557C /* ManualDWARFIndex.cpp */; };
 		49DCF702170E70120092F75E /* Materializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49DCF700170E70120092F75E /* Materializer.cpp */; };
 		2690B3711381D5C300ECFBAE /* Memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2690B3701381D5C300ECFBAE /* Memory.cpp */; };
@@ -2342,6 +2345,9 @@
 		26BC7E8010F1B85900F91463 /* Mangled.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Mangled.cpp; path = source/Core/Mangled.cpp; sourceTree = "<group>"; };
 		26BC7D6910F1B77400F91463 /* Mangled.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Mangled.h; path = include/lldb/Core/Mangled.h; sourceTree = "<group>"; };
 		4F29D3CD21010F84003B549A /* MangledTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangledTest.cpp; sourceTree = "<group>"; };
+		4FBC04EE211A06820015A814 /* RichManglingContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RichManglingContext.h; path = include/lldb/Core/RichManglingContext.h; sourceTree = "<group>"; };
+		4FBC04EC211A06200015A814 /* RichManglingContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RichManglingContext.cpp; path = source/Core/RichManglingContext.cpp; sourceTree = "<group>"; };
+		4FBC04F3211A0F0F0015A814 /* RichManglingContextTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RichManglingContextTest.cpp; sourceTree = "<group>"; };
 		4CD44CF920B37C440003557C /* ManualDWARFIndex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ManualDWARFIndex.cpp; sourceTree = "<group>"; };
 		4CD44D0020B37C580003557C /* ManualDWARFIndex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManualDWARFIndex.h; sourceTree = "<group>"; };
 		2682100C143A59AE004BCF2D /* MappedHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MappedHash.h; path = include/lldb/Core/MappedHash.h; sourceTree = "<group>"; };
@@ -3810,6 +3816,7 @@
 				23CB14E61D66CC0E00EDDDE1 /* BroadcasterTest.cpp */,
 				23CB14E81D66CC0E00EDDDE1 /* DataExtractorTest.cpp */,
 				23CB14E91D66CC0E00EDDDE1 /* ScalarTest.cpp */,
+				4FBC04F3211A0F0F0015A814 /* RichManglingContextTest.cpp */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -5149,6 +5156,8 @@
 				2626B6AD143E1BEA00EF935C /* RangeMap.h */,
 				26C6886D137880B900407EDF /* RegisterValue.h */,
 				26C6886E137880C400407EDF /* RegisterValue.cpp */,
+				4FBC04EE211A06820015A814 /* RichManglingContext.h */,
+				4FBC04EC211A06200015A814 /* RichManglingContext.cpp */,
 				26BC7D7410F1B77400F91463 /* Scalar.h */,
 				26BC7E8D10F1B85900F91463 /* Scalar.cpp */,
 				26BC7CF910F1B71400F91463 /* SearchFilter.h */,
@@ -7158,6 +7167,7 @@
 				267F68541CC02E920086832B /* RegisterContextLinux_s390x.h in Headers */,
 				AF235EB11FBE77B6009C5541 /* RegisterContextPOSIX_ppc64le.h in Headers */,
 				267F68501CC02E270086832B /* RegisterContextPOSIXCore_s390x.h in Headers */,
+				4FBC04EF211A06820015A814 /* RichManglingContext.h in Headers */,
 				4984BA181B979C08008658D4 /* ExpressionVariable.h in Headers */,
 				26C7C4841BFFEA7E009BD01F /* WindowsMiniDump.h in Headers */,
 				30B38A001CAAA6D7009524E3 /* ClangUtil.h in Headers */,
@@ -7846,6 +7856,7 @@
 				9A2057181F3B861400F6C293 /* TestType.cpp in Sources */,
 				9A2057171F3B861400F6C293 /* TestDWARFCallFrameInfo.cpp in Sources */,
 				4F29D3CF21010FA3003B549A /* MangledTest.cpp in Sources */,
+				4FBC04F5211A13770015A814 /* RichManglingContextTest.cpp in Sources */,
 				9A3D43EC1F3237F900EB767C /* ListenerTest.cpp in Sources */,
 				9A3D43DC1F3151C400EB767C /* TimeoutTest.cpp in Sources */,
 				9A3D43D61F3151C400EB767C /* ConstStringTest.cpp in Sources */,
@@ -7960,6 +7971,7 @@
 				2689FFDA13353D9D00698AC0 /* lldb.cpp in Sources */,
 				4C0083401B9F9BA900D5CF24 /* UtilityFunction.cpp in Sources */,
 				26474CCD18D0CB5B0073DEBA /* RegisterContextPOSIX_x86.cpp in Sources */,
+				4FBC04ED211A06200015A814 /* RichManglingContext.cpp in Sources */,
 				AEB0E4591BD6E9F800B24093 /* LLVMUserExpression.cpp in Sources */,
 				AFF81FB320D1CC910010F95E /* PlatformiOSSimulatorCoreSimulatorSupport.mm in Sources */,
 				2689FFEF13353DB600698AC0 /* Breakpoint.cpp in Sources */,

--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -538,6 +538,7 @@
 		9A20573A1F3B8E7E00F6C293 /* MainLoopTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9A2057301F3B8E7600F6C293 /* MainLoopTest.cpp */; };
 		8C3BD9961EF45DA50016C343 /* MainThreadCheckerRuntime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C3BD9951EF45D9B0016C343 /* MainThreadCheckerRuntime.cpp */; };
 		2689004313353E0400698AC0 /* Mangled.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26BC7E8010F1B85900F91463 /* Mangled.cpp */; };
+		4F29D3CF21010FA3003B549A /* MangledTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4F29D3CD21010F84003B549A /* MangledTest.cpp */; };
 		4CD44CFC20B37C440003557C /* ManualDWARFIndex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CD44CF920B37C440003557C /* ManualDWARFIndex.cpp */; };
 		49DCF702170E70120092F75E /* Materializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49DCF700170E70120092F75E /* Materializer.cpp */; };
 		2690B3711381D5C300ECFBAE /* Memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2690B3701381D5C300ECFBAE /* Memory.cpp */; };
@@ -2340,6 +2341,7 @@
 		2669415F1A6DC2AB0063BE93 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; name = Makefile; path = "tools/lldb-mi/Makefile"; sourceTree = SOURCE_ROOT; };
 		26BC7E8010F1B85900F91463 /* Mangled.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Mangled.cpp; path = source/Core/Mangled.cpp; sourceTree = "<group>"; };
 		26BC7D6910F1B77400F91463 /* Mangled.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Mangled.h; path = include/lldb/Core/Mangled.h; sourceTree = "<group>"; };
+		4F29D3CD21010F84003B549A /* MangledTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangledTest.cpp; sourceTree = "<group>"; };
 		4CD44CF920B37C440003557C /* ManualDWARFIndex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ManualDWARFIndex.cpp; sourceTree = "<group>"; };
 		4CD44D0020B37C580003557C /* ManualDWARFIndex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManualDWARFIndex.h; sourceTree = "<group>"; };
 		2682100C143A59AE004BCF2D /* MappedHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MappedHash.h; path = include/lldb/Core/MappedHash.h; sourceTree = "<group>"; };
@@ -3800,6 +3802,7 @@
 		23CB14E51D66CBEB00EDDDE1 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				4F29D3CD21010F84003B549A /* MangledTest.cpp */,
 				9A3D43E31F3237D500EB767C /* ListenerTest.cpp */,
 				9A3D43E21F3237D500EB767C /* StateTest.cpp */,
 				9A3D43E11F3237D500EB767C /* StreamCallbackTest.cpp */,
@@ -7842,6 +7845,7 @@
 				9A3D43D71F3151C400EB767C /* LogTest.cpp in Sources */,
 				9A2057181F3B861400F6C293 /* TestType.cpp in Sources */,
 				9A2057171F3B861400F6C293 /* TestDWARFCallFrameInfo.cpp in Sources */,
+				4F29D3CF21010FA3003B549A /* MangledTest.cpp in Sources */,
 				9A3D43EC1F3237F900EB767C /* ListenerTest.cpp in Sources */,
 				9A3D43DC1F3151C400EB767C /* TimeoutTest.cpp in Sources */,
 				9A3D43D61F3151C400EB767C /* ConstStringTest.cpp in Sources */,
@@ -9486,7 +9490,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -9494,7 +9497,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 				);
 				OTHER_LDFLAGS = "";
 				PATH = /opt/local/bin;
@@ -10630,7 +10632,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -10638,7 +10639,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 				);
 				OTHER_LDFLAGS = "";
@@ -10684,7 +10684,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -10692,7 +10691,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 				);
 				OTHER_LDFLAGS = "";
@@ -10738,7 +10736,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -10746,7 +10743,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -12085,7 +12081,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -12093,7 +12088,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 				);
 				OTHER_LDFLAGS = "";
@@ -12784,7 +12778,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -12792,7 +12785,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 				);
 				OTHER_LDFLAGS = "";
@@ -13765,7 +13757,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -13773,7 +13764,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 				);
 				OTHER_LDFLAGS = "";
 				PATH = /opt/local/bin;
@@ -14368,7 +14358,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 					"-DLIBXML2_DEFINED",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 				);
@@ -14376,7 +14365,6 @@
 					"-fno-rtti",
 					"-Wglobal-constructors",
 					"$(OTHER_CFLAGS)",
-					"-DLLDB_USE_BUILTIN_DEMANGLER",
 				);
 				OTHER_LDFLAGS = "";
 				PATH = /opt/local/bin;

--- a/source/Core/CMakeLists.txt
+++ b/source/Core/CMakeLists.txt
@@ -34,6 +34,7 @@ add_lldb_library(lldbCore
   Opcode.cpp
   PluginManager.cpp
   RegisterValue.cpp
+  RichManglingContext.cpp
   Scalar.cpp
   SearchFilter.cpp
   Section.cpp

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -235,7 +235,7 @@ void Mangled::Clear() {
 int Mangled::Compare(const Mangled &a, const Mangled &b) {
   return ConstString::Compare(
       a.GetName(lldb::eLanguageTypeUnknown, ePreferMangled),
-      a.GetName(lldb::eLanguageTypeUnknown, ePreferMangled));
+      b.GetName(lldb::eLanguageTypeUnknown, ePreferMangled));
 }
 
 //----------------------------------------------------------------------

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -24,6 +24,7 @@
 #include "swift/Demangling/Demangle.h"
 #include "llvm/ADT/DenseMap.h"
 
+#include "lldb/Core/RichManglingContext.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Logging.h"
@@ -273,6 +274,128 @@ void Mangled::SetValue(const ConstString &name) {
 }
 
 //----------------------------------------------------------------------
+// Local helpers for different demangling implementations.
+//----------------------------------------------------------------------
+static char *GetMSVCDemangledStr(const char *M) {
+#if defined(_MSC_VER)
+  const size_t demangled_length = 2048;
+  char *demangled_cstr = static_cast<char *>(::malloc(demangled_length));
+  ::ZeroMemory(demangled_cstr, demangled_length);
+  DWORD result = safeUndecorateName(M, demangled_cstr, demangled_length);
+
+  if (Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_DEMANGLE)) {
+    if (demangled_cstr && demangled_cstr[0])
+      log->Printf("demangled msvc: %s -> \"%s\"", M, demangled_cstr);
+    else
+      log->Printf("demangled msvc: %s -> error: 0x%lu", M, result);
+  }
+
+  if (result != 0) {
+    return demangled_cstr;
+  } else {
+    ::free(demangled_cstr);
+    return nullptr;
+  }
+#else
+  return nullptr;
+#endif
+}
+
+static char *GetItaniumDemangledStr(const char *M,
+                                    llvm::ItaniumPartialDemangler &ipd) {
+  char *demangled_cstr = nullptr;
+  bool err = ipd.partialDemangle(M);
+  if (!err) {
+    // Default buffer and size (will realloc in case it's too small).
+    size_t demangled_size = 80;
+    demangled_cstr = static_cast<char *>(std::malloc(demangled_size));
+    demangled_cstr = ipd.finishDemangle(demangled_cstr, &demangled_size);
+
+    assert(demangled_cstr &&
+           "finishDemangle must always succeed if partialDemangle did");
+    assert(demangled_cstr[demangled_size - 1] == '\0' &&
+           "Expected demangled_size to return length including trailing null");
+  }
+
+  if (Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_DEMANGLE)) {
+    if (demangled_cstr)
+      log->Printf("demangled itanium: %s -> \"%s\"", M, demangled_cstr);
+    else
+      log->Printf("demangled itanium: %s -> error: failed to demangle", M);
+  }
+
+  return demangled_cstr;
+}
+
+//----------------------------------------------------------------------
+// Explicit demangling for scheduled requests during batch processing. This
+// makes use of ItaniumPartialDemangler's rich demangle info
+//----------------------------------------------------------------------
+bool Mangled::DemangleWithRichManglingInfo(
+    RichManglingContext &context, SkipMangledNameFn *skip_mangled_name) {
+  // We need to generate and cache the demangled name.
+  static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
+  Timer scoped_timer(func_cat,
+                     "Mangled::DemangleWithRichNameIndexInfo (m_mangled = %s)",
+                     m_mangled.GetCString());
+
+  // Others are not meant to arrive here. ObjC names or C's main() for example
+  // have their names stored in m_demangled, while m_mangled is empty.
+  assert(m_mangled);
+
+  // Check whether or not we are interested in this name at all.
+  ManglingScheme scheme = cstring_mangling_scheme(m_mangled.GetCString());
+  if (skip_mangled_name && skip_mangled_name(m_mangled.GetStringRef(), scheme))
+    return false;
+
+  switch (scheme) {
+  case eManglingSchemeNone:
+    // The current mangled_name_filter would allow llvm_unreachable here.
+    return false;
+
+  case eManglingSchemeItanium:
+    // We want the rich mangling info here, so we don't care whether or not
+    // there is a demangled string in the pool already.
+    if (context.FromItaniumName(m_mangled)) {
+      // If we got an info, we have a name. Copy to string pool and connect the
+      // counterparts to accelerate later access in GetDemangledName().
+      context.ParseFullName();
+      m_demangled.SetStringWithMangledCounterpart(context.GetBufferRef(),
+                                                  m_mangled);
+      return true;
+    } else {
+      m_demangled.SetCString("");
+      return false;
+    }
+
+  case eManglingSchemeMSVC: {
+    // We have no rich mangling for MSVC-mangled names yet, so first try to
+    // demangle it if necessary.
+    if (!m_demangled && !m_mangled.GetMangledCounterpart(m_demangled)) {
+      if (char *d = GetMSVCDemangledStr(m_mangled.GetCString())) {
+        // If we got an info, we have a name. Copy to string pool and connect
+        // the counterparts to accelerate later access in GetDemangledName().
+        m_demangled.SetStringWithMangledCounterpart(llvm::StringRef(d),
+                                                    m_mangled);
+        ::free(d);
+      } else {
+        m_demangled.SetCString("");
+      }
+    }
+
+    if (m_demangled.IsEmpty()) {
+      // Cannot demangle it, so don't try parsing.
+      return false;
+    } else {
+      // Demangled successfully, we can try and parse it with
+      // CPlusPlusLanguage::MethodName.
+      return context.FromCxxMethodName(m_demangled);
+    }
+  }
+  }
+}
+
+//----------------------------------------------------------------------
 // Generate the demangled name on demand using this accessor. Code in this
 // class will need to use this accessor if it wishes to decode the demangled
 // name. The result is cached and will be kept until a new string value is
@@ -288,8 +411,6 @@ Mangled::GetDemangledName(lldb::LanguageType language) const {
     Timer scoped_timer(func_cat, "Mangled::GetDemangledName (m_mangled = %s)",
                        m_mangled.GetCString());
 
-    Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_DEMANGLE);
-
     // Don't bother running anything that isn't mangled
     const char *mangled_name = m_mangled.GetCString();
     ManglingScheme mangling_scheme{cstring_mangling_scheme(mangled_name)};
@@ -299,56 +420,20 @@ Mangled::GetDemangledName(lldb::LanguageType language) const {
       // add it to our map.
       char *demangled_name = nullptr;
       switch (mangling_scheme) {
-      case eManglingSchemeMSVC: {
-#if defined(_MSC_VER)
-        if (log)
-          log->Printf("demangle msvc: %s", mangled_name);
-        const size_t demangled_length = 2048;
-        demangled_name = static_cast<char *>(::malloc(demangled_length));
-        ::ZeroMemory(demangled_name, demangled_length);
-        DWORD result =
-            safeUndecorateName(mangled_name, demangled_name, demangled_length);
-        if (log) {
-          if (demangled_name && demangled_name[0])
-            log->Printf("demangled msvc: %s -> \"%s\"", mangled_name,
-                        demangled_name);
-          else
-            log->Printf("demangled msvc: %s -> error: 0x%lu", mangled_name,
-                        result);
-        }
-
-        if (result == 0) {
-          free(demangled_name);
-          demangled_name = nullptr;
-        }
-#endif
+      case eManglingSchemeMSVC:
+        demangled_name = GetMSVCDemangledStr(mangled_name);
         break;
-      }
       case eManglingSchemeItanium: {
-        llvm::ItaniumPartialDemangler IPD;
-        bool demangle_err = IPD.partialDemangle(mangled_name);
-        if (!demangle_err) {
-          // Default buffer and size (realloc is used in case it's too small).
-          size_t demangled_size = 80;
-          demangled_name = static_cast<char *>(::malloc(demangled_size));
-          demangled_name = IPD.finishDemangle(demangled_name, &demangled_size);
-        }
-
-        if (log) {
-          if (demangled_name)
-            log->Printf("demangled itanium: %s -> \"%s\"", mangled_name,
-                        demangled_name);
-          else
-            log->Printf("demangled itanium: %s -> error: failed to demangle",
-                        mangled_name);
-        }
+        llvm::ItaniumPartialDemangler ipd;
+        demangled_name = GetItaniumDemangledStr(mangled_name, ipd);
         break;
       }
       case eManglingSchemeNone:
-        break;
+        llvm_unreachable("eManglingSchemeNone was handled already");
       }
       if (demangled_name) {
-        m_demangled.SetStringWithMangledCounterpart(demangled_name, m_mangled);
+        m_demangled.SetStringWithMangledCounterpart(
+            llvm::StringRef(demangled_name), m_mangled);
         free(demangled_name);
       }
     } else if (mangling_scheme == eManglingSchemeNone &&

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -282,7 +282,7 @@ const ConstString &
 Mangled::GetDemangledName(lldb::LanguageType language) const {
   // Check to make sure we have a valid mangled name and that we haven't
   // already decoded our mangled name.
-  if (m_mangled && !m_demangled) {
+  if (m_mangled && m_demangled.IsNull()) {
     // We need to generate and cache the demangled name.
     static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
     Timer scoped_timer(func_cat, "Mangled::GetDemangledName (m_mangled = %s)",
@@ -370,7 +370,7 @@ Mangled::GetDemangledName(lldb::LanguageType language) const {
                       mangled_name);
       }
     }
-    if (!m_demangled) {
+    if (m_demangled.IsNull()) {
       // Set the demangled string to the empty string to indicate we tried to
       // parse it once and failed.
       m_demangled.SetCString("");

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -348,7 +348,7 @@ Mangled::GetDemangledName(lldb::LanguageType language) const {
         break;
       }
       if (demangled_name) {
-        m_demangled.SetCStringWithMangledCounterpart(demangled_name, m_mangled);
+        m_demangled.SetStringWithMangledCounterpart(demangled_name, m_mangled);
         free(demangled_name);
       }
     } else if (mangling_scheme == eManglingSchemeNone &&

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -439,13 +439,14 @@ Mangled::GetDemangledName(lldb::LanguageType language) const {
     } else if (mangling_scheme == eManglingSchemeNone &&
                !m_mangled.GetMangledCounterpart(m_demangled) &&
                SwiftLanguageRuntime::IsSwiftMangledName(mangled_name)) {
+      Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_DEMANGLE);
       if (log)
         log->Printf("demangle swift: %s", mangled_name);
       std::string demangled(SwiftLanguageRuntime::DemangleSymbolAsString(
           mangled_name));
       if (!demangled.empty()) {
-        m_demangled.SetCStringWithMangledCounterpart(demangled.c_str(),
-                                                     m_mangled);
+        m_demangled.SetStringWithMangledCounterpart(llvm::StringRef(demangled),
+                                                    m_mangled);
         if (log)
           log->Printf("demangle swift: %s -> \"%s\"", mangled_name,
                       demangled.c_str());

--- a/source/Core/RichManglingContext.cpp
+++ b/source/Core/RichManglingContext.cpp
@@ -1,0 +1,178 @@
+//===-- RichManglingContext.cpp ---------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Core/RichManglingContext.h"
+
+#include "lldb/Utility/Log.h"
+#include "lldb/Utility/Logging.h"
+
+#include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
+
+#include "llvm/ADT/StringRef.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+//----------------------------------------------------------------------
+// RichManglingContext
+//----------------------------------------------------------------------
+void RichManglingContext::ResetProvider(InfoProvider new_provider) {
+  // If we want to support parsers for other languages some day, we need a
+  // switch here to delete the correct parser type.
+  if (m_cxx_method_parser.hasValue()) {
+    assert(m_provider == PluginCxxLanguage);
+    delete get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser);
+    m_cxx_method_parser.reset();
+  }
+
+  assert(new_provider != None && "Only reset to a valid provider");
+  m_provider = new_provider;
+}
+
+bool RichManglingContext::FromItaniumName(const ConstString &mangled) {
+  bool err = m_ipd.partialDemangle(mangled.GetCString());
+  if (!err) {
+    ResetProvider(ItaniumPartialDemangler);
+  }
+
+  if (Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_DEMANGLE)) {
+    if (!err) {
+      ParseFullName();
+      LLDB_LOG(log, "demangled itanium: {0} -> \"{1}\"", mangled, m_ipd_buf);
+    } else {
+      LLDB_LOG(log, "demangled itanium: {0} -> error: failed to demangle",
+               mangled);
+    }
+  }
+
+  return !err; // true == success
+}
+
+bool RichManglingContext::FromCxxMethodName(const ConstString &demangled) {
+  ResetProvider(PluginCxxLanguage);
+  m_cxx_method_parser = new CPlusPlusLanguage::MethodName(demangled);
+  return true;
+}
+
+bool RichManglingContext::IsCtorOrDtor() const {
+  assert(m_provider != None && "Initialize a provider first");
+  switch (m_provider) {
+  case ItaniumPartialDemangler:
+    return m_ipd.isCtorOrDtor();
+  case PluginCxxLanguage: {
+    // We can only check for destructors here.
+    auto base_name =
+        get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)->GetBasename();
+    return base_name.startswith("~");
+  }
+  case None:
+    return false;
+  }
+}
+
+bool RichManglingContext::IsFunction() const {
+  assert(m_provider != None && "Initialize a provider first");
+  switch (m_provider) {
+  case ItaniumPartialDemangler:
+    return m_ipd.isFunction();
+  case PluginCxxLanguage:
+    return get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)->IsValid();
+  case None:
+    return false;
+  }
+}
+
+void RichManglingContext::processIPDStrResult(char *ipd_res, size_t res_size) {
+  if (LLVM_UNLIKELY(ipd_res == nullptr)) {
+    assert(res_size == m_ipd_buf_size &&
+           "Failed IPD queries keep the original size in the N parameter");
+
+    // Error case: Clear the buffer.
+    m_ipd_str_len = 0;
+    m_ipd_buf[m_ipd_str_len] = '\0';
+  } else {
+    // IPD's res_size includes null terminator.
+    size_t res_len = res_size - 1;
+    assert(ipd_res[res_len] == '\0' &&
+           "IPD returns null-terminated strings and we rely on that");
+
+    if (LLVM_UNLIKELY(ipd_res != m_ipd_buf)) {
+      // Realloc case: Take over the new buffer.
+      m_ipd_buf = ipd_res; // std::realloc freed or reused the old buffer.
+      m_ipd_buf_size =
+          res_size; // Actual buffer may be bigger, but we can't know.
+      m_ipd_str_len = res_len;
+
+      Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_DEMANGLE);
+      if (log)
+        log->Printf("ItaniumPartialDemangler Realloc: new buffer size %lu",
+                    m_ipd_buf_size);
+    } else {
+      // 99% case: Just remember the string length.
+      m_ipd_str_len = res_len;
+    }
+  }
+
+  m_buffer = llvm::StringRef(m_ipd_buf, m_ipd_str_len);
+}
+
+void RichManglingContext::ParseFunctionBaseName() {
+  assert(m_provider != None && "Initialize a provider first");
+  switch (m_provider) {
+  case ItaniumPartialDemangler: {
+    auto n = m_ipd_buf_size;
+    auto buf = m_ipd.getFunctionBaseName(m_ipd_buf, &n);
+    processIPDStrResult(buf, n);
+    return;
+  }
+  case PluginCxxLanguage:
+    m_buffer =
+        get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)->GetBasename();
+    return;
+  case None:
+    return;
+  }
+}
+
+void RichManglingContext::ParseFunctionDeclContextName() {
+  assert(m_provider != None && "Initialize a provider first");
+  switch (m_provider) {
+  case ItaniumPartialDemangler: {
+    auto n = m_ipd_buf_size;
+    auto buf = m_ipd.getFunctionDeclContextName(m_ipd_buf, &n);
+    processIPDStrResult(buf, n);
+    return;
+  }
+  case PluginCxxLanguage:
+    m_buffer =
+        get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)->GetContext();
+    return;
+  case None:
+    return;
+  }
+}
+
+void RichManglingContext::ParseFullName() {
+  assert(m_provider != None && "Initialize a provider first");
+  switch (m_provider) {
+  case ItaniumPartialDemangler: {
+    auto n = m_ipd_buf_size;
+    auto buf = m_ipd.finishDemangle(m_ipd_buf, &n);
+    processIPDStrResult(buf, n);
+    return;
+  }
+  case PluginCxxLanguage:
+    m_buffer = get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)
+                   ->GetFullName()
+                   .GetStringRef();
+    return;
+  case None:
+    return;
+  }
+}

--- a/source/Symbol/Symtab.cpp
+++ b/source/Symbol/Symtab.cpp
@@ -10,9 +10,10 @@
 #include <map>
 #include <set>
 
-#include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "Plugins/Language/ObjC/ObjCLanguage.h"
+
 #include "lldb/Core/Module.h"
+#include "lldb/Core/RichManglingContext.h"
 #include "lldb/Core/STLUtils.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Symbol/ObjectFile.h"
@@ -23,8 +24,9 @@
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/Timer.h"
 
-
 #include "lldb/Target/SwiftLanguageRuntime.h"
+
+#include "llvm/ADT/StringRef.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -220,6 +222,39 @@ const Symbol *Symtab::SymbolAtIndex(size_t idx) const {
 //----------------------------------------------------------------------
 // InitNameIndexes
 //----------------------------------------------------------------------
+static bool lldb_skip_name(llvm::StringRef mangled,
+                           Mangled::ManglingScheme scheme) {
+  switch (scheme) {
+  case Mangled::eManglingSchemeItanium: {
+    if (mangled.size() < 3 || !mangled.startswith("_Z"))
+      return true;
+
+    // Avoid the following types of symbols in the index.
+    switch (mangled[2]) {
+    case 'G': // guard variables
+    case 'T': // virtual tables, VTT structures, typeinfo structures + names
+    case 'Z': // named local entities (if we eventually handle
+              // eSymbolTypeData, we will want this back)
+      return true;
+
+    default:
+      break;
+    }
+
+    // Include this name in the index.
+    return false;
+  }
+
+  // No filters for this scheme yet. Include all names in indexing.
+  case Mangled::eManglingSchemeMSVC:
+    return false;
+
+  // Don't try and demangle things we can't categorize.
+  case Mangled::eManglingSchemeNone:
+    return true;
+  }
+}
+
 void Symtab::InitNameIndexes() {
   // Protected function, no need to lock mutex...
   if (!m_name_indexes_computed) {
@@ -248,16 +283,19 @@ void Symtab::InitNameIndexes() {
     m_name_to_index.Reserve(actual_count);
 #endif
 
+    // The "const char *" in "class_contexts" and backlog::value_type::second
+    // must come from a ConstString::GetCString()
+    std::set<const char *> class_contexts;
+    std::vector<std::pair<NameToIndexMap::Entry, const char *>> backlog;
+    backlog.reserve(num_symbols / 2);
+
+    // Instantiation of the demangler is expensive, so better use a single one
+    // for all entries during batch processing.
+    RichManglingContext rmc;
     NameToIndexMap::Entry entry;
 
-    // The "const char *" in "class_contexts" must come from a
-    // ConstString::GetCString()
-    std::set<const char *> class_contexts;
-    UniqueCStringMap<uint32_t> mangled_name_to_index;
-    std::vector<const char *> symbol_contexts(num_symbols, nullptr);
-
     for (entry.value = 0; entry.value < num_symbols; ++entry.value) {
-      const Symbol *symbol = &m_symbols[entry.value];
+      Symbol *symbol = &m_symbols[entry.value];
 
       // Don't let trampolines get into the lookup by name map If we ever need
       // the trampoline symbols to be searchable by name we can remove this and
@@ -266,7 +304,9 @@ void Symtab::InitNameIndexes() {
       if (symbol->IsTrampoline())
         continue;
 
-      const Mangled &mangled = symbol->GetMangled();
+      // If the symbol's name string matched a Mangled::ManglingScheme, it is
+      // stored in the mangled field.
+      Mangled &mangled = symbol->GetMangled();
       entry.cstring = mangled.GetMangledName();
       if (entry.cstring) {
         m_name_to_index.Append(entry);
@@ -283,65 +323,16 @@ void Symtab::InitNameIndexes() {
           m_name_to_index.Append(entry);
         }
 
-        const SymbolType symbol_type = symbol->GetType();
-        if (symbol_type == eSymbolTypeCode ||
-            symbol_type == eSymbolTypeResolver) {
-          llvm::StringRef entry_ref(entry.cstring.GetStringRef());
-          if (entry_ref[0] == '_' && entry_ref[1] == 'Z' &&
-              (entry_ref[2] != 'T' && // avoid virtual table, VTT structure,
-                                      // typeinfo structure, and typeinfo
-                                      // name
-               entry_ref[2] != 'G' && // avoid guard variables
-               entry_ref[2] != 'Z'))  // named local entities (if we
-                                          // eventually handle eSymbolTypeData,
-                                          // we will want this back)
-          {
-            CPlusPlusLanguage::MethodName cxx_method(
-                mangled.GetDemangledName(lldb::eLanguageTypeC_plus_plus));
-            entry.cstring = ConstString(cxx_method.GetBasename());
-            if (entry.cstring) {
-              // ConstString objects permanently store the string in the pool
-              // so calling GetCString() on the value gets us a const char *
-              // that will never go away
-              const char *const_context =
-                  ConstString(cxx_method.GetContext()).GetCString();
+        const SymbolType type = symbol->GetType();
+        if (type == eSymbolTypeCode || type == eSymbolTypeResolver) {
+          // Other schemes are not relevant in the Swift use case.
+          bool is_relevant_itanium =
+              !lldb_skip_name(entry.cstring.GetStringRef(),
+                              Mangled::eManglingSchemeItanium);
 
-              if (!const_context || const_context[0] == 0) {
-                // No context for this function so this has to be a basename
-                m_basename_to_index.Append(entry);
-                // If there is no context (no namespaces or class scopes that
-                // come before the function name) then this also could be a
-                // fullname.
-                m_name_to_index.Append(entry);
-              } else {
-                entry_ref = entry.cstring.GetStringRef();
-                if (entry_ref[0] == '~' ||
-                    !cxx_method.GetQualifiers().empty()) {
-                  // The first character of the demangled basename is '~' which
-                  // means we have a class destructor. We can use this
-                  // information to help us know what is a class and what
-                  // isn't.
-                  if (class_contexts.find(const_context) == class_contexts.end())
-                    class_contexts.insert(const_context);
-                  m_method_to_index.Append(entry);
-                } else {
-                  if (class_contexts.find(const_context) !=
-                      class_contexts.end()) {
-                    // The current decl context is in our "class_contexts"
-                    // which means this is a method on a class
-                    m_method_to_index.Append(entry);
-                  } else {
-                    // We don't know if this is a function basename or a
-                    // method, so put it into a temporary collection so once we
-                    // are done we can look in class_contexts to see if each
-                    // entry is a class or just a function and will put any
-                    // remaining items into m_method_to_index or
-                    // m_basename_to_index as needed
-                    mangled_name_to_index.Append(entry);
-                    symbol_contexts[entry.value] = const_context;
-                  }
-                }
-              }
+          if (is_relevant_itanium) {
+            if (mangled.DemangleWithRichManglingInfo(rmc, lldb_skip_name)) {
+              RegisterMangledNameEntry(entry, class_contexts, backlog, rmc);
             }
           } else if (SwiftLanguageRuntime::IsSwiftMangledName(name.str().c_str())) {
             lldb_private::ConstString basename;
@@ -362,6 +353,8 @@ void Symtab::InitNameIndexes() {
         }
       }
 
+      // Symbol name strings that didn't match a Mangled::ManglingScheme, are
+      // stored in the demangled field.
       entry.cstring = mangled.GetDemangledName(symbol->GetLanguage());
       if (entry.cstring) {
         m_name_to_index.Append(entry);
@@ -391,25 +384,10 @@ void Symtab::InitNameIndexes() {
       }
     }
 
-    size_t count;
-    if (!mangled_name_to_index.IsEmpty()) {
-      count = mangled_name_to_index.GetSize();
-      for (size_t i = 0; i < count; ++i) {
-        if (mangled_name_to_index.GetValueAtIndex(i, entry.value)) {
-          entry.cstring = mangled_name_to_index.GetCStringAtIndex(i);
-          if (symbol_contexts[entry.value] &&
-              class_contexts.find(symbol_contexts[entry.value]) !=
-                  class_contexts.end()) {
-            m_method_to_index.Append(entry);
-          } else {
-            // If we got here, we have something that had a context (was inside
-            // a namespace or class) yet we don't know if the entry
-            m_method_to_index.Append(entry);
-            m_basename_to_index.Append(entry);
-          }
-        }
-      }
+    for (const auto &record : backlog) {
+      RegisterBacklogEntry(record.first, record.second, class_contexts);
     }
+
     m_name_to_index.Sort();
     m_name_to_index.SizeToFit();
     m_selector_to_index.Sort();
@@ -418,6 +396,71 @@ void Symtab::InitNameIndexes() {
     m_basename_to_index.SizeToFit();
     m_method_to_index.Sort();
     m_method_to_index.SizeToFit();
+  }
+}
+
+void Symtab::RegisterMangledNameEntry(
+    NameToIndexMap::Entry &entry, std::set<const char *> &class_contexts,
+    std::vector<std::pair<NameToIndexMap::Entry, const char *>> &backlog,
+    RichManglingContext &rmc) {
+  // Only register functions that have a base name.
+  rmc.ParseFunctionBaseName();
+  llvm::StringRef base_name = rmc.GetBufferRef();
+  if (base_name.empty())
+    return;
+
+  // The base name will be our entry's name.
+  entry.cstring = ConstString(base_name);
+
+  rmc.ParseFunctionDeclContextName();
+  llvm::StringRef decl_context = rmc.GetBufferRef();
+
+  // Register functions with no context.
+  if (decl_context.empty()) {
+    // This has to be a basename
+    m_basename_to_index.Append(entry);
+    // If there is no context (no namespaces or class scopes that come before
+    // the function name) then this also could be a fullname.
+    m_name_to_index.Append(entry);
+    return;
+  }
+
+  // Make sure we have a pool-string pointer and see if we already know the
+  // context name.
+  const char *decl_context_ccstr = ConstString(decl_context).GetCString();
+  auto it = class_contexts.find(decl_context_ccstr);
+
+  // Register constructors and destructors. They are methods and create
+  // declaration contexts.
+  if (rmc.IsCtorOrDtor()) {
+    m_method_to_index.Append(entry);
+    if (it == class_contexts.end())
+      class_contexts.insert(it, decl_context_ccstr);
+    return;
+  }
+
+  // Register regular methods with a known declaration context.
+  if (it != class_contexts.end()) {
+    m_method_to_index.Append(entry);
+    return;
+  }
+
+  // Regular methods in unknown declaration contexts are put to the backlog. We
+  // will revisit them once we processed all remaining symbols.
+  backlog.push_back(std::make_pair(entry, decl_context_ccstr));
+}
+
+void Symtab::RegisterBacklogEntry(
+    const NameToIndexMap::Entry &entry, const char *decl_context,
+    const std::set<const char *> &class_contexts) {
+  auto it = class_contexts.find(decl_context);
+  if (it != class_contexts.end()) {
+    m_method_to_index.Append(entry);
+  } else {
+    // If we got here, we have something that had a context (was inside
+    // a namespace or class) yet we don't know the entry
+    m_method_to_index.Append(entry);
+    m_basename_to_index.Append(entry);
   }
 }
 

--- a/source/Symbol/Symtab.cpp
+++ b/source/Symbol/Symtab.cpp
@@ -309,12 +309,11 @@ void Symtab::InitNameIndexes() {
       Mangled &mangled = symbol->GetMangled();
       entry.cstring = mangled.GetMangledName();
       if (entry.cstring) {
-        m_name_to_index.Append(entry);
-
         // Now try and figure out the basename and figure out if the
         // basename is a method, function, etc and put that in the
         // appropriate table.
-        llvm::StringRef name = entry.cstring.GetStringRef();
+        m_name_to_index.Append(entry);
+
         if (symbol->ContainsLinkerAnnotations()) {
           // If the symbol has linker annotations, also add the version without
           // the annotations.
@@ -326,15 +325,15 @@ void Symtab::InitNameIndexes() {
         const SymbolType type = symbol->GetType();
         if (type == eSymbolTypeCode || type == eSymbolTypeResolver) {
           // Other schemes are not relevant in the Swift use case.
-          bool is_relevant_itanium =
-              !lldb_skip_name(entry.cstring.GetStringRef(),
-                              Mangled::eManglingSchemeItanium);
+          bool is_relevant_itanium = !lldb_skip_name(
+              entry.cstring.GetStringRef(), Mangled::eManglingSchemeItanium);
 
           if (is_relevant_itanium) {
             if (mangled.DemangleWithRichManglingInfo(rmc, lldb_skip_name)) {
               RegisterMangledNameEntry(entry, class_contexts, backlog, rmc);
             }
-          } else if (SwiftLanguageRuntime::IsSwiftMangledName(name.str().c_str())) {
+          } else if (SwiftLanguageRuntime::IsSwiftMangledName(
+                         entry.cstring.GetCString())) {
             lldb_private::ConstString basename;
             bool is_method = false;
             ConstString mangled_name = mangled.GetMangledName();

--- a/source/Utility/ConstString.cpp
+++ b/source/Utility/ConstString.cpp
@@ -303,7 +303,7 @@ void ConstString::SetString(const llvm::StringRef &s) {
 }
 
 void ConstString::SetStringWithMangledCounterpart(llvm::StringRef demangled,
-                                                   const ConstString &mangled) {
+                                                  const ConstString &mangled) {
   m_string = StringPool().GetConstCStringAndSetMangledCounterPart(
       demangled, mangled.m_string);
 }

--- a/unittests/Core/CMakeLists.txt
+++ b/unittests/Core/CMakeLists.txt
@@ -11,7 +11,19 @@ add_lldb_unittest(LLDBCoreTests
   LINK_LIBS
     lldbCore
     lldbHost
+    lldbSymbol
+    lldbPluginObjectFileELF
+    lldbPluginSymbolVendorELF
+    lldbUtilityHelpers
     LLVMTestingSupport
   LINK_COMPONENTS
     Support
   )
+
+add_dependencies(LLDBCoreTests yaml2obj)
+add_definitions(-DYAML2OBJ="$<TARGET_FILE:yaml2obj>")
+
+set(test_inputs
+  mangled-function-names.yaml
+  )
+add_unittest_inputs(LLDBCoreTests "${test_inputs}")

--- a/unittests/Core/CMakeLists.txt
+++ b/unittests/Core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_lldb_unittest(LLDBCoreTests
   EventTest.cpp
   ListenerTest.cpp
   MangledTest.cpp
+  RichManglingContextTest.cpp
   ScalarTest.cpp
   StateTest.cpp
   StreamCallbackTest.cpp

--- a/unittests/Core/CMakeLists.txt
+++ b/unittests/Core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_lldb_unittest(LLDBCoreTests
   DataExtractorTest.cpp
   EventTest.cpp
   ListenerTest.cpp
+  MangledTest.cpp
   ScalarTest.cpp
   StateTest.cpp
   StreamCallbackTest.cpp

--- a/unittests/Core/Inputs/mangled-function-names.yaml
+++ b/unittests/Core/Inputs/mangled-function-names.yaml
@@ -1,0 +1,116 @@
+--- !ELF
+FileHeader:      
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:        
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x0000000000000010
+    Content:         554889E58B0425A80000005DC30F1F00
+  - Name:            .anothertext
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x0000000000000010
+    AddressAlign:    0x0000000000000010
+    Content:         554889E54883EC20488D0425A8000000C745FC00000000488945F0488B45F08B08894DECE8C7FFFFFF8B4DEC01C189C84883C4205D746573742073747200C3
+  - Name:            .eh_frame
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x0000000000000050
+    AddressAlign:    0x0000000000000008
+    Content:         1400000000000000017A5200017810011B0C0708900100001C0000001C00000090FFFFFF0D00000000410E108602430D06000000000000001C0000003C00000080FFFFFF3F00000000410E108602430D0600000000000000
+  - Name:            .data
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_WRITE, SHF_ALLOC ]
+    Address:         0x00000000000000A8
+    AddressAlign:    0x0000000000000004
+    Content:         '01000000'
+  - Name:            .comment
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_MERGE, SHF_STRINGS ]
+    AddressAlign:    0x0000000000000001
+    Content:         5562756E747520636C616E672076657273696F6E20332E352D317562756E74753120287472756E6B2920286261736564206F6E204C4C564D20332E352900
+Symbols:         
+  Local:           
+    - Type:            STT_SECTION
+      Section:         .text
+    - Type:            STT_SECTION
+      Section:         .anothertext
+      Value:           0x0000000000000010
+    - Type:            STT_SECTION
+      Section:         .eh_frame
+      Value:           0x0000000000000050
+    - Type:            STT_SECTION
+      Section:         .data
+      Value:           0x00000000000000A8
+    - Type:            STT_SECTION
+      Section:         .comment
+    - Name:            /tmp/a.c
+      Type:            STT_FILE
+    - Type:            STT_FILE
+  Global:          
+    - Name:            somedata
+      Type:            STT_OBJECT
+      Section:         .anothertext
+      Value:           0x0000000000000045
+    - Name:            main
+      Type:            STT_FUNC
+      Section:         .anothertext
+      Value:           0x0000000000000010
+      Size:            0x000000000000003F
+    - Name:            _Z3foov
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            puts@GLIBC_2.5
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            puts@GLIBC_2.6
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _Z5annotv@VERSION3
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _ZN1AC2Ev
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _ZN1AD2Ev
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _ZN1A3barEv
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _ZGVZN4llvm4dbgsEvE7thestrm
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _ZZN4llvm4dbgsEvE7thestrm
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _ZTVN5clang4DeclE
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            -[ObjCfoo]
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            +[B ObjCbar(WithCategory)]
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+    - Name:            _Z12undemangableEvx42
+      Type:            STT_FUNC
+      Section:         .text
+      Size:            0x000000000000000D
+...

--- a/unittests/Core/MangledTest.cpp
+++ b/unittests/Core/MangledTest.cpp
@@ -1,0 +1,38 @@
+//===-- MangledTest.cpp -----------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "lldb/Core/Mangled.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+TEST(MangledTest, ResultForValidName) {
+  ConstString MangledName("_ZN1a1b1cIiiiEEvm");
+  bool IsMangled = true;
+
+  Mangled TheMangled(MangledName, IsMangled);
+  const ConstString &TheDemangled =
+      TheMangled.GetDemangledName(eLanguageTypeC_plus_plus);
+
+  ConstString ExpectedResult("void a::b::c<int, int, int>(unsigned long)");
+  EXPECT_STREQ(ExpectedResult.GetCString(), TheDemangled.GetCString());
+}
+
+TEST(MangledTest, EmptyForInvalidName) {
+  ConstString MangledName("_ZN1a1b1cmxktpEEvm");
+  bool IsMangled = true;
+
+  Mangled TheMangled(MangledName, IsMangled);
+  const ConstString &TheDemangled =
+      TheMangled.GetDemangledName(eLanguageTypeC_plus_plus);
+
+  EXPECT_STREQ("", TheDemangled.GetCString());
+}

--- a/unittests/Core/MangledTest.cpp
+++ b/unittests/Core/MangledTest.cpp
@@ -7,9 +7,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
+#include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
+#include "Plugins/SymbolVendor/ELF/SymbolVendorELF.h"
+#include "TestingSupport/TestUtilities.h"
 
 #include "lldb/Core/Mangled.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Core/ModuleSpec.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Symbol/SymbolContext.h"
+
+#include "llvm/Support/FileUtilities.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+
+#include "gtest/gtest.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -35,4 +47,124 @@ TEST(MangledTest, EmptyForInvalidName) {
       TheMangled.GetDemangledName(eLanguageTypeC_plus_plus);
 
   EXPECT_STREQ("", TheDemangled.GetCString());
+}
+
+#define ASSERT_NO_ERROR(x)                                                     \
+  if (std::error_code ASSERT_NO_ERROR_ec = x) {                                \
+    llvm::SmallString<128> MessageStorage;                                     \
+    llvm::raw_svector_ostream Message(MessageStorage);                         \
+    Message << #x ": did not return errc::success.\n"                          \
+            << "error number: " << ASSERT_NO_ERROR_ec.value() << "\n"          \
+            << "error message: " << ASSERT_NO_ERROR_ec.message() << "\n";      \
+    GTEST_FATAL_FAILURE_(MessageStorage.c_str());                              \
+  } else {                                                                     \
+  }
+
+TEST(MangledTest, NameIndexes_FindFunctionSymbols) {
+  HostInfo::Initialize();
+  ObjectFileELF::Initialize();
+  SymbolVendorELF::Initialize();
+
+  std::string Yaml = GetInputFilePath("mangled-function-names.yaml");
+  llvm::SmallString<128> Obj;
+  ASSERT_NO_ERROR(llvm::sys::fs::createTemporaryFile(
+      "mangled-function-names-%%%%%%", "obj", Obj));
+
+  llvm::FileRemover Deleter(Obj);
+  llvm::StringRef Args[] = {YAML2OBJ, Yaml};
+  llvm::StringRef ObjRef = Obj;
+  const llvm::Optional<llvm::StringRef> redirects[] = {llvm::None, ObjRef,
+                                                       llvm::None};
+  ASSERT_EQ(0,
+            llvm::sys::ExecuteAndWait(YAML2OBJ, Args, llvm::None, redirects));
+  uint64_t Size;
+  ASSERT_NO_ERROR(llvm::sys::fs::file_size(Obj, Size));
+  ASSERT_GT(Size, 0u);
+
+  ModuleSpec Spec{FileSpec(Obj, false)};
+  Spec.GetSymbolFileSpec().SetFile(Obj, false, FileSpec::Style::native);
+  auto M = std::make_shared<Module>(Spec);
+
+  auto Count = [M](const char *Name, FunctionNameType Type) -> int {
+    SymbolContextList SymList;
+    return M->FindFunctionSymbols(ConstString(Name), Type, SymList);
+  };
+
+  // Unmangled
+  EXPECT_EQ(1, Count("main", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("main", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("main", eFunctionNameTypeMethod));
+
+  // Itanium mangled
+  EXPECT_EQ(1, Count("_Z3foov", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_Z3foov", eFunctionNameTypeBase));
+  EXPECT_EQ(1, Count("foo", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("foo", eFunctionNameTypeMethod));
+
+  // Unmangled with linker annotation
+  EXPECT_EQ(1, Count("puts@GLIBC_2.5", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("puts@GLIBC_2.6", eFunctionNameTypeFull));
+  EXPECT_EQ(2, Count("puts", eFunctionNameTypeFull));
+  EXPECT_EQ(2, Count("puts", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("puts", eFunctionNameTypeMethod));
+
+  // Itanium mangled with linker annotation
+  EXPECT_EQ(1, Count("_Z5annotv@VERSION3", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_Z5annotv", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_Z5annotv", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("annot", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("annot", eFunctionNameTypeMethod));
+
+  // Itanium mangled ctor A::A()
+  EXPECT_EQ(1, Count("_ZN1AC2Ev", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_ZN1AC2Ev", eFunctionNameTypeBase));
+  EXPECT_EQ(1, Count("A", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("A", eFunctionNameTypeBase));
+
+  // Itanium mangled dtor A::~A()
+  EXPECT_EQ(1, Count("_ZN1AD2Ev", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_ZN1AD2Ev", eFunctionNameTypeBase));
+  EXPECT_EQ(1, Count("~A", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("~A", eFunctionNameTypeBase));
+
+  // Itanium mangled method A::bar()
+  EXPECT_EQ(1, Count("_ZN1A3barEv", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_ZN1A3barEv", eFunctionNameTypeBase));
+  EXPECT_EQ(1, Count("bar", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("bar", eFunctionNameTypeBase));
+
+  // Itanium mangled names that are explicitly excluded from parsing
+  EXPECT_EQ(1, Count("_ZGVZN4llvm4dbgsEvE7thestrm", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_ZGVZN4llvm4dbgsEvE7thestrm", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("dbgs", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("dbgs", eFunctionNameTypeBase));
+  EXPECT_EQ(1, Count("_ZZN4llvm4dbgsEvE7thestrm", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_ZZN4llvm4dbgsEvE7thestrm", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("dbgs", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("dbgs", eFunctionNameTypeBase));
+  EXPECT_EQ(1, Count("_ZTVN5clang4DeclE", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_ZTVN5clang4DeclE", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("Decl", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("Decl", eFunctionNameTypeBase));
+
+  // ObjC mangled static
+  EXPECT_EQ(1, Count("-[ObjCfoo]", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("-[ObjCfoo]", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("ObjCfoo", eFunctionNameTypeMethod));
+
+  // ObjC mangled method with category
+  EXPECT_EQ(1, Count("+[B ObjCbar(WithCategory)]", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("+[B ObjCbar(WithCategory)]", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("ObjCbar", eFunctionNameTypeMethod));
+
+  // Invalid things: unable to decode but still possible to find by full name
+  EXPECT_EQ(1, Count("_Z12undemangableEvx42", eFunctionNameTypeFull));
+  EXPECT_EQ(1, Count("_Z12undemangableEvx42", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("_Z12undemangableEvx42", eFunctionNameTypeMethod));
+  EXPECT_EQ(0, Count("undemangable", eFunctionNameTypeBase));
+  EXPECT_EQ(0, Count("undemangable", eFunctionNameTypeMethod));
+
+  SymbolVendorELF::Terminate();
+  ObjectFileELF::Terminate();
+  HostInfo::Terminate();
 }

--- a/unittests/Core/RichManglingContextTest.cpp
+++ b/unittests/Core/RichManglingContextTest.cpp
@@ -1,0 +1,114 @@
+//===-- RichManglingContextTest.cpp -----------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Core/RichManglingContext.h"
+
+#include "lldb/Utility/ConstString.h"
+
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+TEST(RichManglingContextTest, Basic) {
+  RichManglingContext RMC;
+  ConstString mangled("_ZN3foo3barEv");
+  EXPECT_TRUE(RMC.FromItaniumName(mangled));
+
+  EXPECT_TRUE(RMC.IsFunction());
+  EXPECT_FALSE(RMC.IsCtorOrDtor());
+
+  RMC.ParseFunctionDeclContextName();
+  EXPECT_EQ("foo", RMC.GetBufferRef());
+
+  RMC.ParseFunctionBaseName();
+  EXPECT_EQ("bar", RMC.GetBufferRef());
+
+  RMC.ParseFullName();
+  EXPECT_EQ("foo::bar()", RMC.GetBufferRef());
+}
+
+TEST(RichManglingContextTest, FromCxxMethodName) {
+  RichManglingContext ItaniumRMC;
+  ConstString mangled("_ZN3foo3barEv");
+  EXPECT_TRUE(ItaniumRMC.FromItaniumName(mangled));
+
+  RichManglingContext CxxMethodRMC;
+  ConstString demangled("foo::bar()");
+  EXPECT_TRUE(CxxMethodRMC.FromCxxMethodName(demangled));
+
+  EXPECT_TRUE(ItaniumRMC.IsFunction() == CxxMethodRMC.IsFunction());
+  EXPECT_TRUE(ItaniumRMC.IsCtorOrDtor() == CxxMethodRMC.IsCtorOrDtor());
+
+  ItaniumRMC.ParseFunctionDeclContextName();
+  CxxMethodRMC.ParseFunctionDeclContextName();
+  EXPECT_TRUE(ItaniumRMC.GetBufferRef() == CxxMethodRMC.GetBufferRef());
+
+  ItaniumRMC.ParseFunctionBaseName();
+  CxxMethodRMC.ParseFunctionBaseName();
+  EXPECT_TRUE(ItaniumRMC.GetBufferRef() == CxxMethodRMC.GetBufferRef());
+
+  ItaniumRMC.ParseFullName();
+  CxxMethodRMC.ParseFullName();
+  EXPECT_TRUE(ItaniumRMC.GetBufferRef() == CxxMethodRMC.GetBufferRef());
+}
+
+TEST(RichManglingContextTest, SwitchProvider) {
+  RichManglingContext RMC;
+  llvm::StringRef mangled = "_ZN3foo3barEv";
+  llvm::StringRef demangled = "foo::bar()";
+
+  EXPECT_TRUE(RMC.FromItaniumName(ConstString(mangled)));
+  RMC.ParseFullName();
+  EXPECT_EQ("foo::bar()", RMC.GetBufferRef());
+
+  EXPECT_TRUE(RMC.FromCxxMethodName(ConstString(demangled)));
+  RMC.ParseFullName();
+  EXPECT_EQ("foo::bar()", RMC.GetBufferRef());
+
+  EXPECT_TRUE(RMC.FromItaniumName(ConstString(mangled)));
+  RMC.ParseFullName();
+  EXPECT_EQ("foo::bar()", RMC.GetBufferRef());
+}
+
+TEST(RichManglingContextTest, IPDRealloc) {
+  // The demangled name should fit into the Itanium default buffer.
+  const char *short_mangled = "_ZN3foo3barEv";
+
+  // The demangled name for this will certainly not fit into the default buffer.
+  const char *long_mangled =
+      "_ZNK3shk6detail17CallbackPublisherIZNS_5ThrowERKNSt15__exception_"
+      "ptr13exception_ptrEEUlOT_E_E9SubscribeINS0_9ConcatMapINS0_"
+      "18CallbackSubscriberIZNS_6GetAllIiNS1_IZZNS_9ConcatMapIZNS_6ConcatIJNS1_"
+      "IZZNS_3MapIZZNS_7IfEmptyIS9_EEDaS7_ENKUlS6_E_clINS1_IZZNS_4TakeIiEESI_"
+      "S7_ENKUlS6_E_clINS1_IZZNS_6FilterIZNS_9ElementAtEmEUlS7_E_EESI_S7_"
+      "ENKUlS6_E_clINS1_IZZNSL_ImEESI_S7_ENKUlS6_E_clINS1_IZNS_4FromINS0_"
+      "22InfiniteRangeContainerIiEEEESI_S7_EUlS7_E_EEEESI_S6_EUlS7_E_EEEESI_S6_"
+      "EUlS7_E_EEEESI_S6_EUlS7_E_EEEESI_S6_EUlS7_E_EESI_S7_ENKUlS6_E_clIS14_"
+      "EESI_S6_EUlS7_E_EERNS1_IZZNSH_IS9_EESI_S7_ENKSK_IS14_EESI_S6_EUlS7_E0_"
+      "EEEEESI_DpOT_EUlS7_E_EESI_S7_ENKUlS6_E_clINS1_IZNS_5StartIJZNS_"
+      "4JustIJS19_S1C_EEESI_S1F_EUlvE_ZNS1K_IJS19_S1C_EEESI_S1F_EUlvE0_EEESI_"
+      "S1F_EUlS7_E_EEEESI_S6_EUlS7_E_EEEESt6vectorIS6_SaIS6_EERKT0_NS_"
+      "12ElementCountEbEUlS7_E_ZNSD_IiS1Q_EES1T_S1W_S1X_bEUlOS3_E_ZNSD_IiS1Q_"
+      "EES1T_S1W_S1X_bEUlvE_EES1G_S1O_E25ConcatMapValuesSubscriberEEEDaS7_";
+
+  RichManglingContext RMC;
+
+  // Demangle the short one and remember the buffer address.
+  EXPECT_TRUE(RMC.FromItaniumName(ConstString(short_mangled)));
+  RMC.ParseFullName();
+  const char *short_demangled_ptr = RMC.GetBufferRef().data();
+
+  // Demangle the long one and make sure the buffer address changed.
+  EXPECT_TRUE(RMC.FromItaniumName(ConstString(long_mangled)));
+  RMC.ParseFullName();
+  const char *long_demangled_ptr = RMC.GetBufferRef().data();
+
+  EXPECT_TRUE(short_demangled_ptr != long_demangled_ptr);
+}

--- a/unittests/Utility/ConstStringTest.cpp
+++ b/unittests/Utility/ConstStringTest.cpp
@@ -34,6 +34,26 @@ TEST(ConstStringTest, MangledCounterpart) {
   EXPECT_EQ("bar", counterpart.GetStringRef());
 }
 
+TEST(ConstStringTest, FromMidOfBufferStringRef) {
+  // StringRef's into bigger buffer: no null termination
+  const char *buffer = "foobarbaz";
+  llvm::StringRef foo_ref(buffer, 3);
+  llvm::StringRef bar_ref(buffer + 3, 3);
+
+  ConstString foo(foo_ref);
+
+  ConstString bar;
+  bar.SetStringWithMangledCounterpart(bar_ref, foo);
+  EXPECT_EQ("bar", bar.GetStringRef());
+
+  ConstString counterpart;
+  EXPECT_TRUE(bar.GetMangledCounterpart(counterpart));
+  EXPECT_EQ("foo", counterpart.GetStringRef());
+
+  EXPECT_TRUE(foo.GetMangledCounterpart(counterpart));
+  EXPECT_EQ("bar", counterpart.GetStringRef());
+}
+
 TEST(ConstStringTest, NullAndEmptyStates) {
   ConstString foo("foo");
   EXPECT_FALSE(!foo);

--- a/unittests/Utility/ConstStringTest.cpp
+++ b/unittests/Utility/ConstStringTest.cpp
@@ -16,3 +16,20 @@ using namespace lldb_private;
 TEST(ConstStringTest, format_provider) {
   EXPECT_EQ("foo", llvm::formatv("{0}", ConstString("foo")).str());
 }
+
+TEST(ConstStringTest, MangledCounterpart) {
+  ConstString foo("foo");
+  ConstString counterpart;
+  EXPECT_FALSE(foo.GetMangledCounterpart(counterpart));
+  EXPECT_EQ("", counterpart.GetStringRef());
+
+  ConstString bar;
+  bar.SetStringWithMangledCounterpart("bar", foo);
+  EXPECT_EQ("bar", bar.GetStringRef());
+
+  EXPECT_TRUE(bar.GetMangledCounterpart(counterpart));
+  EXPECT_EQ("foo", counterpart.GetStringRef());
+
+  EXPECT_TRUE(foo.GetMangledCounterpart(counterpart));
+  EXPECT_EQ("bar", counterpart.GetStringRef());
+}

--- a/unittests/Utility/ConstStringTest.cpp
+++ b/unittests/Utility/ConstStringTest.cpp
@@ -33,3 +33,20 @@ TEST(ConstStringTest, MangledCounterpart) {
   EXPECT_TRUE(foo.GetMangledCounterpart(counterpart));
   EXPECT_EQ("bar", counterpart.GetStringRef());
 }
+
+TEST(ConstStringTest, NullAndEmptyStates) {
+  ConstString foo("foo");
+  EXPECT_FALSE(!foo);
+  EXPECT_FALSE(foo.IsEmpty());
+  EXPECT_FALSE(foo.IsNull());
+
+  ConstString empty("");
+  EXPECT_TRUE(!empty);
+  EXPECT_TRUE(empty.IsEmpty());
+  EXPECT_FALSE(empty.IsNull());
+
+  ConstString null;
+  EXPECT_TRUE(!null);
+  EXPECT_TRUE(null.IsEmpty());
+  EXPECT_TRUE(null.IsNull());
+}


### PR DESCRIPTION
This PR brings https://reviews.llvm.org/D50071 to the current swift-lldb stable.
It depends on https://github.com/apple/swift-llvm/pull/106

Notes:
* Requires a fix in LLVM (see 5b2b8b5 in swift-llvm)
* Depends on llvm::Any, which was introduced after the cut and needs 4 cherry-picks from the upstream LLVM
* Pavel submitted a big reorg in between my commits (see https://reviews.llvm.org/D497404), which caused some merge headache, mostly in (less critical?) Xcode project files

I think this would be nice to have and it's all sorted out now, but if you have any concerns please speak up.