### PR TITLE
Fix data formatters for Swift Set and Dictionary types

### DIFF
--- a/lit/SwiftREPL/DictBridging.test
+++ b/lit/SwiftREPL/DictBridging.test
@@ -1,0 +1,109 @@
+// -*- mode: swift; -*-
+// Test formatters on bridged dictionaries in the REPL.
+// REQUIRES: darwin
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
+
+import Foundation
+
+// Baseline case: empty Dictionary
+let d0: Dictionary<Int, Int> = [:]
+// DICT-LABEL: d0: [Int : Int] = 0 key/value pairs
+
+// All empty dictionaries use the same type-punned storage class.
+let d0b = d0 as NSDictionary
+// DICT-LABEL: d0b: _RawNativeDictionaryStorage = 0 key/value pairs
+
+// Baseline case: native Dictionary of non-verbatim bridged elements
+let d1: Dictionary<Int,Int> = [1:2]
+// DICT-LABEL: d1: [Int : Int] = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = 1
+// DICT-NEXT:      value = 2
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Non-verbatim bridging from Swift to Objective-C
+let d1b = d1 as NSDictionary
+// DICT-LABEL: d1b: _SwiftDeferredNSDictionary<Int, Int> = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = 1
+// DICT-NEXT:      value = 2
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Baseline case: native Dictionary of verbatim bridged elements
+let d2: Dictionary<NSObject,AnyObject> = [
+  NSNumber(value: 1): NSNumber(value: 2),
+]
+// DICT-LABEL: d2: [NSObject : AnyObject] = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = Int64(1)
+// DICT-NEXT:      value = Int64(2)
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Verbatim bridging from Swift to Objective-C
+let d2b = d2 as NSDictionary
+// DICT-LABEL: d2b: _HashableTypedNativeDictionaryStorage<NSObject, AnyObject> = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = Int64(1)
+// DICT-NEXT:      value = Int64(2)
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Baseline case: NSDictionary
+let d3 = NSDictionary(
+  object: NSNumber(value: 2),
+  forKey: NSNumber(value: 1)
+)
+// DICT-LABEL: d3: NSDictionary = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = Int64(1)
+// DICT-NEXT:      value = Int64(2)
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Verbatim bridging from Objective-C to Swift
+let d3b = d3 as! [NSObject: NSObject]
+// DICT-LABEL: d3b: [NSObject : NSObject] = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = Int64(1)
+// DICT-NEXT:      value = Int64(2)
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Non-verbatim bridging from Objective-C to Swift
+let d3b2 = d3 as! [Int: Int]
+// DICT-LABEL: d3b2: [Int : Int] = 1 key/value pair {
+// DICT-NEXT:    [0] = {
+// DICT-NEXT:      key = 1
+// DICT-NEXT:      value = 2
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Test formatters in Objective-C context.
+
+// Empty singleton
+let d4 = NSArray(object: [:] as [NSNumber: NSNumber] as NSDictionary)
+// DICT-LABEL: d4: NSArray = 1 element {
+// DICT-NEXT:    [0] = 0 key/value pairs
+// DICT-NEXT:  }
+
+// Verbatim bridging
+let d5 = NSArray(object: [1: 2] as [NSNumber: NSNumber] as NSDictionary)
+// DICT-LABEL: d5: NSArray = 1 element {
+// DICT-NEXT:    [0] = 1 key/value pair {
+// DICT-NEXT:      [0] = {
+// DICT-NEXT:        key = Int64(1)
+// DICT-NEXT:        value = Int64(2)
+// DICT-NEXT:      }
+// DICT-NEXT:    }
+// DICT-NEXT:  }
+
+// Non-verbatim bridging
+let d6 = NSArray(object: [1: 2] as [Int: Int] as NSDictionary)
+// DICT-LABEL: d6: NSArray = 1 element {
+// DICT-NEXT:    [0] = 1 key/value pair {
+// DICT-NEXT:      [0] = (key = 1, value = 2)
+// DICT-NEXT:    }
+// DICT-NEXT:  }

--- a/lit/SwiftREPL/SetBridging.test
+++ b/lit/SwiftREPL/SetBridging.test
@@ -1,0 +1,84 @@
+// -*- mode: swift; -*-
+// Test formatters on bridged sets in the REPL.
+// REQUIRES: darwin
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=SET
+
+import Foundation
+
+// Baseline case: empty Set
+let s0: Set<Int> = []
+// DICT-LABEL: s0: Set<Int> = 0 values
+
+// All empty sets use the same type-punned storage class.
+let s0b = s0 as NSSet
+// DICT-LABEL: s0b: _RawNativeSetStorage = 0 values
+
+// Baseline case: native Set of non-verbatim bridged elements
+let s1: Set<Int> = [1]
+// SET-LABEL: s1: Set<Int> = 1 value {
+// SET-NEXT:    [0] = 1
+// SET-NEXT:  }
+
+// Non-verbatim bridging from Swift to Objective-C
+let s1b = s1 as NSSet
+// SET-LABEL: s1b: _SwiftDeferredNSSet<Int> = 1 value {
+// SET-NEXT:    [0] = 1
+// SET-NEXT:  }
+
+// Baseline case: native Set of verbatim bridged elements
+let s2: Set<NSObject> = [NSNumber(value: 1)]
+// SET-LABEL: s2: Set<NSObject> = 1 value {
+// SET-NEXT:    [0] = Int64(1)
+// SET-NEXT:  }
+
+// Verbatim bridging from Swift to Objective-C
+let s2b = s2 as NSSet
+// SET-LABEL: s2b: _HashableTypedNativeSetStorage<NSObject> = 1 value {
+// SET-NEXT:    [0] = Int64(1)
+// SET-NEXT:  }
+
+// Baseline case: NSSet
+let s3 = NSSet(array: [NSNumber(value: 1), NSNumber(value: 2)])
+// FIXME: NSSet's synthetic children formatters are currently broken.
+// DISABLED-SET-LABEL: s3: NSSet = 2 elements {
+// DISABLED-SET-NEXT:    [0] = Int64({{[12]}})
+// DISABLED-SET-NEXT:    [1] = Int64({{[12]}})
+// DISABLED-SET-NEXT:  }
+
+// Verbatim bridging from Objective-C to Swift
+let s3b = s3 as! Set<NSObject>
+// SET-LABEL: s3b: Set<NSObject> = 2 values {
+// SET-NEXT:    [0] = Int64({{[12]}})
+// SET-NEXT:    [1] = Int64({{[12]}})
+// SET-NEXT:  }
+
+// Non-verbatim bridging from Objective-C to Swift
+let s3b2 = s3 as! Set<Int>
+// SET-LABEL: s3b2: Set<Int> = 2 values {
+// SET-NEXT:    [0] = {{[12]}}
+// SET-NEXT:    [1] = {{[12]}}
+// SET-NEXT:  }
+
+// Test formatters in Objective-C context.
+
+// Empty singleton
+let s4 = NSArray(object: [] as Set<NSNumber> as NSSet)
+// SET-LABEL: s4: NSArray = 1 element {
+// SET-NEXT:    [0] = 0 values
+// SET-NEXT:  }
+
+// Verbatim bridging
+let s5 = NSArray(object: [1] as Set<NSNumber> as NSSet)
+// SET-LABEL: s5: NSArray = 1 element {
+// SET-NEXT:    [0] = 1 value {
+// SET-NEXT:      [0] = Int64(1)
+// SET-NEXT:    }
+// SET-NEXT:  }
+
+// Non-verbatim bridging
+let s6 = NSArray(object: [1] as Set<Int> as NSSet)
+// SET-LABEL: s6: NSArray = 1 element {
+// SET-NEXT:    [0] = 1 value {
+// SET-NEXT:      [0] = 1
+// SET-NEXT:    }
+// SET-NEXT:  }

--- a/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -26,95 +26,42 @@ using namespace lldb_private;
 using namespace lldb_private::formatters;
 using namespace lldb_private::formatters::swift;
 
-namespace lldb_private {
-namespace formatters {
-namespace swift {
-class SwiftDictionaryNativeBufferHandler
-    : public SwiftHashedContainerNativeBufferHandler {
-public:
-  SwiftHashedContainerBufferHandler::Kind GetKind() {
-    return Kind::eDictionary;
-  }
-
-  static ConstString GetMangledStorageTypeName();
-
-  static ConstString GetDemangledStorageTypeName();
-
-  SwiftDictionaryNativeBufferHandler(ValueObjectSP nativeStorage_sp,
-                                     CompilerType key_type,
-                                     CompilerType value_type)
-      : SwiftHashedContainerNativeBufferHandler(nativeStorage_sp, key_type,
-                                                value_type) {}
-  friend class SwiftHashedContainerBufferHandler;
-
-private:
-};
-
-class SwiftDictionarySyntheticFrontEndBufferHandler
-    : public SwiftHashedContainerSyntheticFrontEndBufferHandler {
-public:
-  SwiftHashedContainerBufferHandler::Kind GetKind() {
-    return Kind::eDictionary;
-  }
-
-  virtual ~SwiftDictionarySyntheticFrontEndBufferHandler() {}
-
-  SwiftDictionarySyntheticFrontEndBufferHandler(lldb::ValueObjectSP valobj_sp)
-      : SwiftHashedContainerSyntheticFrontEndBufferHandler(valobj_sp) {}
-  friend class SwiftHashedContainerBufferHandler;
-
-private:
-};
-
-class DictionarySyntheticFrontEnd : public HashedContainerSyntheticFrontEnd {
-public:
-  DictionarySyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
-      : HashedContainerSyntheticFrontEnd(valobj_sp) {}
-
-  virtual bool Update();
-
-  virtual ~DictionarySyntheticFrontEnd() = default;
-};
-}
-}
+const DictionaryConfig &
+DictionaryConfig::Get() {
+  static DictionaryConfig g_config{};
+  return g_config;
 }
 
-SyntheticChildrenFrontEnd *
-lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator(
-    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
-  if (!valobj_sp)
-    return NULL;
-  return (new DictionarySyntheticFrontEnd(valobj_sp));
+DictionaryConfig::DictionaryConfig()
+  : HashedCollectionConfig() {
+  m_summaryProviderName =
+    ConstString("Swift.Dictionary summary provider");
+  m_syntheticChildrenName =
+    ConstString("Swift.Dictionary synthetic children");
+  m_collection_demangledRegex =
+    ConstString("^Swift\\.Dictionary<.+,.+>$");
+
+  // Native storage class
+  m_nativeStorage_demangledPrefix =
+    ConstString("Swift._HashableTypedNativeDictionaryStorage<");
+  m_nativeStorage_demangledRegex =
+    ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$");
+
+  // Type-punned empty dictionary
+  m_emptyStorage_demangled
+    = ConstString("Swift._RawNativeDictionaryStorage");
+
+  // Deferred non-verbatim bridged dictionary
+  m_deferredBridgedStorage_demangledPrefix
+    = ConstString("Swift._SwiftDeferredNSDictionary<");
+  m_deferredBridgedStorage_demangledRegex
+    = ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$");
 }
 
-bool lldb_private::formatters::swift::DictionarySyntheticFrontEnd::Update() {
-  m_buffer = SwiftHashedContainerBufferHandler::CreateBufferHandler(
-      m_backend,
-      [](ValueObjectSP a, CompilerType b,
-         CompilerType c) -> SwiftHashedContainerBufferHandler * {
-        return new SwiftDictionaryNativeBufferHandler(a, b, c);
-      },
-      [](ValueObjectSP a) -> SwiftHashedContainerBufferHandler * {
-        return new SwiftDictionarySyntheticFrontEndBufferHandler(a);
-      },
-      SwiftDictionaryNativeBufferHandler::GetMangledStorageTypeName(),
-      SwiftDictionaryNativeBufferHandler::GetDemangledStorageTypeName());
-  return false;
-}
-
-bool lldb_private::formatters::swift::Dictionary_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  auto handler = SwiftHashedContainerBufferHandler::CreateBufferHandler(
-      valobj,
-      [](ValueObjectSP a, CompilerType b,
-         CompilerType c) -> SwiftHashedContainerBufferHandler * {
-        return new SwiftDictionaryNativeBufferHandler(a, b, c);
-      },
-      [](ValueObjectSP a) -> SwiftHashedContainerBufferHandler * {
-        return new SwiftDictionarySyntheticFrontEndBufferHandler(a);
-      },
-      SwiftDictionaryNativeBufferHandler::GetMangledStorageTypeName(),
-      SwiftDictionaryNativeBufferHandler::GetDemangledStorageTypeName());
+bool
+DictionaryConfig::SummaryProvider(
+  ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  auto handler = DictionaryConfig::Get().CreateHandler(valobj);
 
   if (!handler)
     return false;
@@ -126,13 +73,11 @@ bool lldb_private::formatters::swift::Dictionary_SummaryProvider(
   return true;
 };
 
-ConstString SwiftDictionaryNativeBufferHandler::GetMangledStorageTypeName() {
-  static ConstString g_name(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs29_NativeDictionaryStorageOwner"));
-  return g_name;
-}
-
-ConstString SwiftDictionaryNativeBufferHandler::GetDemangledStorageTypeName() {
-  static ConstString g_name(
-      "Swift._NativeDictionaryStorageOwner");
-  return g_name;
+SyntheticChildrenFrontEnd *
+DictionaryConfig::SyntheticChildrenCreator(
+  CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+  return new HashedSyntheticChildrenFrontEnd(
+    DictionaryConfig::Get(), valobj_sp);
 }

--- a/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -41,17 +41,26 @@ DictionaryConfig::DictionaryConfig()
   m_collection_demangledRegex =
     ConstString("^Swift\\.Dictionary<.+,.+>$");
 
+  // Note: We need have use the old _Tt names here because those are
+  // still used to name classes in the ObjC runtime.
+
   // Native storage class
+  m_nativeStorage_mangledRegex_ObjC =
+    ConstString("^_TtGCs37_HashableTypedNativeDictionaryStorage.*");
   m_nativeStorage_demangledPrefix =
     ConstString("Swift._HashableTypedNativeDictionaryStorage<");
   m_nativeStorage_demangledRegex =
     ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$");
 
   // Type-punned empty dictionary
+  m_emptyStorage_mangled_ObjC =
+    ConstString("_TtCs27_RawNativeDictionaryStorage");
   m_emptyStorage_demangled
     = ConstString("Swift._RawNativeDictionaryStorage");
 
   // Deferred non-verbatim bridged dictionary
+  m_deferredBridgedStorage_mangledRegex_ObjC
+    = ConstString("^_TtGCs26_SwiftDeferredNSDictionary.*");
   m_deferredBridgedStorage_demangledPrefix
     = ConstString("Swift._SwiftDeferredNSDictionary<");
   m_deferredBridgedStorage_demangledRegex

--- a/source/Plugins/Language/Swift/SwiftDictionary.h
+++ b/source/Plugins/Language/Swift/SwiftDictionary.h
@@ -23,14 +23,43 @@
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Target/Target.h"
 
+#include "Plugins/Language/ObjC/NSDictionary.h"
+
 namespace lldb_private {
 namespace formatters {
 namespace swift {
-bool Dictionary_SummaryProvider(ValueObject &valobj, Stream &stream,
-                                const TypeSummaryOptions &options);
 
-SyntheticChildrenFrontEnd *
-DictionarySyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
+class DictionaryConfig: public HashedCollectionConfig {
+public:
+  static const DictionaryConfig &Get();
+
+  static bool
+  SummaryProvider(ValueObject &valobj, Stream &stream,
+                  const TypeSummaryOptions &options);
+
+  static SyntheticChildrenFrontEnd *
+  SyntheticChildrenCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
+
+private:
+  DictionaryConfig();
+
+protected:
+  virtual CXXFunctionSummaryFormat::Callback
+  GetSummaryProvider() const override {
+    return DictionaryConfig::SummaryProvider;
+  }
+  
+  virtual CXXSyntheticChildren::CreateFrontEndCallback
+  GetSyntheticChildrenCreator() const override {
+    return DictionaryConfig::SyntheticChildrenCreator;
+  }
+
+  virtual CXXSyntheticChildren::CreateFrontEndCallback
+  GetCocoaSyntheticChildrenCreator() const override {
+    return NSDictionarySyntheticFrontEndCreator;
+  }
+};    
+
 }
 }
 }

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -322,20 +322,27 @@ HashedCollectionConfig::CocoaObjectAtAddress(
 }
 
 HashedStorageHandlerUP
-HashedCollectionConfig::CreateNativeHandler(
-  ValueObjectSP value_sp,
-  ValueObjectSP storage_sp) const {
+HashedCollectionConfig::CreateNativeHandler(ValueObjectSP storage_sp) const {
   if (!storage_sp)
     return nullptr;
 
-  // FIXME: To prevent reading uninitialized data, get the runtime
-  // class of storage_sp and verify that it's the type we expect
-  // (m_nativeStorage_mangledPrefix).  Also, get the correct key_type
-  // and value_type directly from its generic arguments instead of
-  // using value_sp.
-  CompilerType type(value_sp->GetCompilerType());
-  CompilerType key_type = type.GetGenericArgumentType(0);
-  CompilerType value_type = type.GetGenericArgumentType(1);
+  storage_sp = storage_sp->GetQualifiedRepresentationIfAvailable(
+    lldb::eDynamicCanRunTarget, false);
+
+  auto type = storage_sp->GetCompilerType();
+
+  auto typeName = type.GetTypeName().GetStringRef();
+  if (typeName == m_emptyStorage_demangled.GetStringRef()) {
+    return CreateEmptyHandler();
+  }
+  
+  if (!typeName.startswith(m_nativeStorage_demangledPrefix.GetStringRef())) {
+    return nullptr; // Wrong class
+  }
+
+  auto key_type = type.GetGenericArgumentType(0);
+  auto value_type = type.GetGenericArgumentType(1);
+
   auto handler = HashedStorageHandlerUP(
     new NativeHashedStorageHandler(storage_sp, key_type, value_type));
   if (!handler->IsValid())
@@ -550,7 +557,7 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   ConstString type_name_cs(valobj_sp->GetTypeName());
 
   if (IsNativeStorageName(type_name_cs)) {
-    return CreateNativeHandler(valobj_sp, valobj_sp);
+    return CreateNativeHandler(valobj_sp);
   }
   if (IsEmptyStorageName(type_name_cs)) {
     return CreateEmptyHandler();
@@ -558,7 +565,7 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   if (IsDeferredBridgedStorageName(type_name_cs)) {
     auto storage_sp
       = valobj_sp->GetChildAtNamePath({g_nativeBuffer, g__storage});
-    return CreateNativeHandler(valobj_sp, storage_sp);
+    return CreateNativeHandler(storage_sp);
   }
 
   ValueObjectSP variant_sp(
@@ -599,7 +606,7 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   }
   if (g_native == variant_cs) {
     auto storage_sp = variant_sp->GetChildAtNamePath({g_native, g__storage});
-    return CreateNativeHandler(valobj_sp, storage_sp);
+    return CreateNativeHandler(storage_sp);
   }
 
   return nullptr;

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -182,6 +182,7 @@ HashedCollectionConfig::RegisterSummaryProviders(
   AddCXXSummary(swift_category_sp, summaryProvider,
                 m_summaryProviderName.AsCString(),
                 m_collection_demangledRegex, flags, true);
+
   AddCXXSummary(swift_category_sp, summaryProvider,
                 m_summaryProviderName.AsCString(),
                 m_nativeStorage_demangledRegex, flags, true);
@@ -191,6 +192,18 @@ HashedCollectionConfig::RegisterSummaryProviders(
   AddCXXSummary(swift_category_sp, summaryProvider,
                 m_summaryProviderName.AsCString(),
                 m_deferredBridgedStorage_demangledRegex, flags, true);
+
+  flags.SetSkipPointers(false);
+  AddCXXSummary(swift_category_sp, summaryProvider,
+                m_summaryProviderName.AsCString(),
+                m_nativeStorage_mangledRegex_ObjC, flags, true);
+  AddCXXSummary(swift_category_sp, summaryProvider,
+                m_summaryProviderName.AsCString(),
+                m_emptyStorage_mangled_ObjC, flags, false);
+  AddCXXSummary(swift_category_sp, summaryProvider,
+                m_summaryProviderName.AsCString(),
+                m_deferredBridgedStorage_mangledRegex_ObjC, flags, true);
+
 #endif // LLDB_DISABLE_PYTHON
 }
 
@@ -206,6 +219,7 @@ HashedCollectionConfig::RegisterSyntheticChildrenCreators(
   AddCXXSynthetic(swift_category_sp, creator,
                   m_syntheticChildrenName.AsCString(),
                   m_collection_demangledRegex, flags, true);
+
   AddCXXSynthetic(swift_category_sp, creator,
                   m_syntheticChildrenName.AsCString(),
                   m_nativeStorage_demangledRegex, flags, true);
@@ -215,6 +229,17 @@ HashedCollectionConfig::RegisterSyntheticChildrenCreators(
   AddCXXSynthetic(swift_category_sp, creator,
                   m_syntheticChildrenName.AsCString(),
                   m_deferredBridgedStorage_demangledRegex, flags, true);
+
+  flags.SetSkipPointers(false);
+  AddCXXSynthetic(swift_category_sp, creator,
+                  m_syntheticChildrenName.AsCString(),
+                  m_nativeStorage_mangledRegex_ObjC, flags, true);
+  AddCXXSynthetic(swift_category_sp, creator,
+                  m_syntheticChildrenName.AsCString(),
+                  m_emptyStorage_mangled_ObjC, flags, false);
+  AddCXXSynthetic(swift_category_sp, creator,
+                  m_syntheticChildrenName.AsCString(),
+                  m_deferredBridgedStorage_mangledRegex_ObjC, flags, true);
 #endif // LLDB_DISABLE_PYTHON
 }
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -56,9 +56,7 @@ private:
   CreateEmptyHandler(CompilerType elem_type = CompilerType()) const;
 
   HashedStorageHandlerUP
-  CreateNativeHandler(
-    lldb::ValueObjectSP value_sp,
-    lldb::ValueObjectSP storage_sp) const;
+  CreateNativeHandler(lldb::ValueObjectSP storage_sp) const;
 
   HashedStorageHandlerUP
   CreateCocoaHandler(lldb::ValueObjectSP storage_sp) const;

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -28,162 +28,110 @@ namespace lldb_private {
 namespace formatters {
 namespace swift {
 
+class HashedStorageHandler;
+typedef std::unique_ptr<HashedStorageHandler> HashedStorageHandlerUP;
+
+class HashedCollectionConfig {
+public:
+  void RegisterSummaryProviders(
+    lldb::TypeCategoryImplSP swift_category_sp,
+    TypeSummaryImpl::Flags flags) const;
+  void RegisterSyntheticChildrenCreators(
+    lldb::TypeCategoryImplSP swift_category_sp,
+    SyntheticChildren::Flags flags) const;
+
+  bool IsNativeStorageName(ConstString name) const;
+
+  bool IsEmptyStorageName(ConstString name) const;
+
+  bool IsDeferredBridgedStorageName(ConstString name) const;
+
+  HashedStorageHandlerUP
+  CreateHandler(ValueObject &valobj) const;
+
+  virtual ~HashedCollectionConfig() = default;
+
+private:
+  HashedStorageHandlerUP
+  CreateEmptyHandler(CompilerType elem_type = CompilerType()) const;
+
+  HashedStorageHandlerUP
+  CreateNativeHandler(lldb::ValueObjectSP storage_sp,
+                      CompilerType key_type,
+                      CompilerType value_type) const;
+
+  HashedStorageHandlerUP
+  CreateCocoaHandler(lldb::ValueObjectSP cocoaStorage_sp) const;
+
+protected:
+  HashedCollectionConfig() {}
+
+  virtual CXXFunctionSummaryFormat::Callback
+  GetSummaryProvider() const = 0;
+
+  virtual CXXSyntheticChildren::CreateFrontEndCallback
+  GetSyntheticChildrenCreator() const = 0;
+
+  virtual CXXSyntheticChildren::CreateFrontEndCallback
+  GetCocoaSyntheticChildrenCreator() const = 0;
+
+  HashedStorageHandlerUP
+  CreateNativeStorageHandler(ValueObject &valobj,
+                             lldb::addr_t storage_ptr,
+                             bool fail_on_no_children) const;
+
+  ConstString m_summaryProviderName;
+  ConstString m_syntheticChildrenName;
+
+  ConstString m_collection_demangledRegex;
+  
+  ConstString m_nativeStorage_demangledPrefix;
+  ConstString m_nativeStorage_demangledRegex;
+
+  ConstString m_emptyStorage_demangled;
+
+  ConstString m_deferredBridgedStorage_demangledPrefix;
+  ConstString m_deferredBridgedStorage_demangledRegex;
+};
+
 // Some part of the buffer handling logic needs to be shared between summary and
 // synthetic children
 // If I was only making synthetic children, this would be best modelled as
 // different FrontEnds
-class SwiftHashedContainerBufferHandler {
+class HashedStorageHandler {
 public:
-  enum class Kind { eDictionary, eSet };
-
-  virtual Kind GetKind() = 0;
-
   virtual size_t GetCount() = 0;
 
-  virtual lldb_private::CompilerType GetElementType() = 0;
+  virtual CompilerType GetElementType() = 0;
 
   virtual lldb::ValueObjectSP GetElementAtIndex(size_t) = 0;
 
-  typedef std::function<SwiftHashedContainerBufferHandler *(
-      lldb::ValueObjectSP, CompilerType, CompilerType)>
-      NativeCreatorFunction;
-
-  typedef std::function<SwiftHashedContainerBufferHandler *(
-      lldb::ValueObjectSP)>
-      SyntheticCreatorFunction;
-
-  static std::unique_ptr<SwiftHashedContainerBufferHandler>
-  CreateBufferHandler(ValueObject &valobj, NativeCreatorFunction Native,
-                      SyntheticCreatorFunction Synthetic, ConstString mangled,
-                      ConstString demangled);
-
-  virtual ~SwiftHashedContainerBufferHandler() {}
-
-protected:
   virtual bool IsValid() = 0;
 
-  static std::unique_ptr<SwiftHashedContainerBufferHandler>
-  CreateBufferHandlerForNativeStorageOwner(ValueObject &valobj,
-                                           lldb::addr_t storage_ptr,
-                                           bool fail_on_no_children,
-                                           NativeCreatorFunction Native);
+  virtual ~HashedStorageHandler() {}
 };
 
-class SwiftHashedContainerEmptyBufferHandler
-    : public SwiftHashedContainerBufferHandler {
+class HashedSyntheticChildrenFrontEnd : public SyntheticChildrenFrontEnd {
 public:
-  virtual size_t GetCount() { return 0; }
-
-  virtual lldb_private::CompilerType GetElementType() { return m_elem_type; }
-
-  virtual lldb::ValueObjectSP GetElementAtIndex(size_t) {
-    return lldb::ValueObjectSP();
-  }
-
-  virtual ~SwiftHashedContainerEmptyBufferHandler() {}
-
-protected:
-  SwiftHashedContainerEmptyBufferHandler(CompilerType elem_type)
-      : m_elem_type(elem_type) {}
-  friend class SwiftHashedContainerBufferHandler;
-
-  virtual bool IsValid() { return true; }
-
-private:
-  lldb_private::CompilerType m_elem_type;
-};
-
-class SwiftHashedContainerNativeBufferHandler
-    : public SwiftHashedContainerBufferHandler {
-public:
-  virtual size_t GetCount();
-
-  virtual lldb_private::CompilerType GetElementType();
-
-  virtual lldb::ValueObjectSP GetElementAtIndex(size_t);
-
-  virtual ~SwiftHashedContainerNativeBufferHandler() {}
-
-protected:
-  typedef uint64_t Index;
-  typedef uint64_t Cell;
-
-  SwiftHashedContainerNativeBufferHandler(lldb::ValueObjectSP nativeStorage_sp,
-                                          CompilerType key_type,
-                                          CompilerType value_type);
-  friend class SwiftHashedContainerBufferHandler;
-
-  virtual bool IsValid();
-
-  bool ReadBitmaskAtIndex(Index, Status &error);
-
-  lldb::addr_t GetLocationOfKeyAtCell(Cell);
-
-  lldb::addr_t GetLocationOfValueAtCell(Cell);
-
-  bool GetDataForKeyAtCell(Cell, void *);
-
-  bool GetDataForValueAtCell(Cell, void *);
-
-private:
-  ValueObject *m_nativeStorage;
-  Process *m_process;
-  uint32_t m_ptr_size;
-  uint64_t m_count;
-  uint64_t m_capacity;
-  lldb::addr_t m_bitmask_ptr;
-  lldb::addr_t m_keys_ptr;
-  lldb::addr_t m_values_ptr;
-  CompilerType m_element_type;
-  uint64_t m_key_stride;
-  uint64_t m_value_stride;
-  uint64_t m_key_stride_padded;
-  std::map<lldb::addr_t, uint64_t> m_bitmask_cache;
-};
-
-class SwiftHashedContainerSyntheticFrontEndBufferHandler
-    : public SwiftHashedContainerBufferHandler {
-public:
-  virtual size_t GetCount();
-
-  virtual lldb_private::CompilerType GetElementType();
-
-  virtual lldb::ValueObjectSP GetElementAtIndex(size_t);
-
-  virtual ~SwiftHashedContainerSyntheticFrontEndBufferHandler() {}
-
-protected:
-  SwiftHashedContainerSyntheticFrontEndBufferHandler(
-      lldb::ValueObjectSP valobj_sp);
-  friend class SwiftHashedContainerBufferHandler;
-
-  virtual bool IsValid();
-
-private:
-  lldb::ValueObjectSP m_valobj_sp; // reader beware: this entails you must only
-                                   // pass self-rooted valueobjects to this
-                                   // class
-  std::unique_ptr<SyntheticChildrenFrontEnd> m_frontend;
-};
-
-class HashedContainerSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
-public:
-  HashedContainerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
+  HashedSyntheticChildrenFrontEnd(
+    const HashedCollectionConfig &config,
+    lldb::ValueObjectSP valobj_sp);
 
   virtual size_t CalculateNumChildren();
 
   virtual lldb::ValueObjectSP GetChildAtIndex(size_t idx);
 
-  virtual bool Update() = 0;
+  virtual bool Update();
 
   virtual bool MightHaveChildren();
 
   virtual size_t GetIndexOfChildWithName(const ConstString &name);
 
-  virtual ~HashedContainerSyntheticFrontEnd() = default;
+  virtual ~HashedSyntheticChildrenFrontEnd() = default;
 
-protected:
-  std::unique_ptr<SwiftHashedContainerBufferHandler> m_buffer;
+private:
+  const HashedCollectionConfig &m_config;
+  HashedStorageHandlerUP m_buffer;
 };
 }
 }

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -56,7 +56,9 @@ private:
   CreateEmptyHandler(CompilerType elem_type = CompilerType()) const;
 
   HashedStorageHandlerUP
-  CreateNativeHandler(lldb::ValueObjectSP storage_sp) const;
+  CreateNativeHandler(
+    lldb::ValueObjectSP value_sp,
+    lldb::ValueObjectSP storage_sp) const;
 
   HashedStorageHandlerUP
   CreateCocoaHandler(lldb::ValueObjectSP storage_sp) const;

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -63,6 +63,16 @@ private:
   HashedStorageHandlerUP
   CreateCocoaHandler(lldb::ValueObjectSP storage_sp) const;
 
+  lldb::ValueObjectSP
+  SwiftObjectAtAddress(
+    const ExecutionContext &exe_ctx,
+    lldb::addr_t address) const;
+
+  lldb::ValueObjectSP
+  CocoaObjectAtAddress(
+    const ExecutionContext &exe_ctx,
+    lldb::addr_t address) const;
+
 protected:
   HashedCollectionConfig() {}
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -80,11 +80,14 @@ protected:
 
   ConstString m_collection_demangledRegex;
   
+  ConstString m_nativeStorage_mangledRegex_ObjC;
   ConstString m_nativeStorage_demangledPrefix;
   ConstString m_nativeStorage_demangledRegex;
 
+  ConstString m_emptyStorage_mangled_ObjC;
   ConstString m_emptyStorage_demangled;
 
+  ConstString m_deferredBridgedStorage_mangledRegex_ObjC;
   ConstString m_deferredBridgedStorage_demangledPrefix;
   ConstString m_deferredBridgedStorage_demangledRegex;
 };

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -56,12 +56,12 @@ private:
   CreateEmptyHandler(CompilerType elem_type = CompilerType()) const;
 
   HashedStorageHandlerUP
-  CreateNativeHandler(lldb::ValueObjectSP storage_sp,
-                      CompilerType key_type,
-                      CompilerType value_type) const;
+  CreateNativeHandler(
+    lldb::ValueObjectSP value_sp,
+    lldb::ValueObjectSP storage_sp) const;
 
   HashedStorageHandlerUP
-  CreateCocoaHandler(lldb::ValueObjectSP cocoaStorage_sp) const;
+  CreateCocoaHandler(lldb::ValueObjectSP storage_sp) const;
 
 protected:
   HashedCollectionConfig() {}
@@ -74,11 +74,6 @@ protected:
 
   virtual CXXSyntheticChildren::CreateFrontEndCallback
   GetCocoaSyntheticChildrenCreator() const = 0;
-
-  HashedStorageHandlerUP
-  CreateNativeStorageHandler(ValueObject &valobj,
-                             lldb::addr_t storage_ptr,
-                             bool fail_on_no_children) const;
 
   ConstString m_summaryProviderName;
   ConstString m_syntheticChildrenName;

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -42,8 +42,6 @@
 #include "llvm/Support/ConvertUTF.h"
 
 #include "Plugins/Language/ObjC/Cocoa.h"
-#include "Plugins/Language/ObjC/NSDictionary.h"
-#include "Plugins/Language/ObjC/NSSet.h"
 #include "Plugins/Language/ObjC/NSString.h"
 
 using namespace lldb;
@@ -58,21 +56,6 @@ using lldb_private::formatters::AddStringSummary;
 using lldb_private::formatters::AddSummary;
 
 void SwiftLanguage::Initialize() {
-  static ConstString g_NSDictionaryClass1(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCSs29_NativeDictionaryStorageOwner"));
-  static ConstString g_NSDictionaryClass2(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs29_NativeDictionaryStorageOwner"));
-  static ConstString g_NSDictionaryClass3Old(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtGCs29_NativeDictionaryStorageOwner"));
-  static ConstString g_NSDictionaryClass3(
-      SwiftLanguageRuntime::GetCurrentMangledName(MANGLING_PREFIX_STR "s29_NativeDictionaryStorageOwner"));
-  static ConstString g_NSDictionaryClass4Old(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtGCs26_SwiftDeferredNSDictionary"));
-  static ConstString g_NSDictionaryClass4(
-      SwiftLanguageRuntime::GetCurrentMangledName(MANGLING_PREFIX_STR "s26_SwiftDeferredNSDictionary"));
-
-  static ConstString g_NSSetClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCSs22_NativeSetStorageOwner"));
-  static ConstString g_NSSetClass2(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22_NativeSetStorageOwner"));
   static ConstString g_NSStringClass1(SwiftLanguageRuntime::GetCurrentMangledName("_NSContiguousString"));
   static ConstString g_NSStringClass2(SwiftLanguageRuntime::GetCurrentMangledName("_TtCSs19_NSContiguousString"));
   static ConstString g_NSStringClass3Old("_TtCs19_NSContiguousString");
@@ -82,84 +65,6 @@ void SwiftLanguage::Initialize() {
 
   PluginManager::RegisterPlugin(GetPluginNameStatic(), "Swift Language",
                                 CreateInstance);
-
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSummaries()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetFullMatch(g_NSDictionaryClass1),
-                  lldb_private::formatters::swift::Dictionary_SummaryProvider});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSummaries()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetFullMatch(g_NSDictionaryClass2),
-                  lldb_private::formatters::swift::Dictionary_SummaryProvider});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSummaries()
-  .push_back({lldb_private::formatters::NSDictionary_Additionals::
-    AdditionalFormatterMatching()
-    .GetPrefixMatch(g_NSDictionaryClass3Old),
-    lldb_private::formatters::swift::Dictionary_SummaryProvider});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSummaries()
-  .push_back({lldb_private::formatters::NSDictionary_Additionals::
-    AdditionalFormatterMatching()
-    .GetPrefixMatch(g_NSDictionaryClass3),
-    lldb_private::formatters::swift::Dictionary_SummaryProvider});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSummaries()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetPrefixMatch(g_NSDictionaryClass4Old),
-                  lldb_private::formatters::swift::Dictionary_SummaryProvider});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSummaries()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetPrefixMatch(g_NSDictionaryClass4),
-                  lldb_private::formatters::swift::Dictionary_SummaryProvider});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSynthetics()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetFullMatch(g_NSDictionaryClass1),
-                  lldb_private::formatters::swift::
-                      DictionarySyntheticFrontEndCreator});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSynthetics()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetFullMatch(g_NSDictionaryClass2),
-                  lldb_private::formatters::swift::
-                      DictionarySyntheticFrontEndCreator});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSynthetics()
-  .push_back({lldb_private::formatters::NSDictionary_Additionals::
-    AdditionalFormatterMatching()
-    .GetPrefixMatch(g_NSDictionaryClass3Old),
-    lldb_private::formatters::swift::
-    DictionarySyntheticFrontEndCreator});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSynthetics()
-  .push_back({lldb_private::formatters::NSDictionary_Additionals::
-    AdditionalFormatterMatching()
-    .GetPrefixMatch(g_NSDictionaryClass3),
-    lldb_private::formatters::swift::
-    DictionarySyntheticFrontEndCreator});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSynthetics()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetPrefixMatch(g_NSDictionaryClass4Old),
-                  lldb_private::formatters::swift::
-                      DictionarySyntheticFrontEndCreator});
-  lldb_private::formatters::NSDictionary_Additionals::GetAdditionalSynthetics()
-      .push_back({lldb_private::formatters::NSDictionary_Additionals::
-                      AdditionalFormatterMatching()
-                          .GetPrefixMatch(g_NSDictionaryClass4),
-                  lldb_private::formatters::swift::
-                      DictionarySyntheticFrontEndCreator});
-
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSummaries().emplace(
-      g_NSSetClass1, lldb_private::formatters::swift::Set_SummaryProvider);
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSynthetics()
-      .emplace(g_NSSetClass1,
-               lldb_private::formatters::swift::SetSyntheticFrontEndCreator);
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSummaries().emplace(
-      g_NSSetClass2, lldb_private::formatters::swift::Set_SummaryProvider);
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSynthetics()
-      .emplace(g_NSSetClass2,
-               lldb_private::formatters::swift::SetSyntheticFrontEndCreator);
 
   lldb_private::formatters::NSString_Additionals::GetAdditionalSummaries()
       .emplace(
@@ -191,27 +96,12 @@ void SwiftLanguage::Initialize() {
 
 void SwiftLanguage::Terminate() {
   // FIXME: Duplicating this list from Initialize seems error-prone.
-  static ConstString g_NSDictionaryClass1(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCSs29_NativeDictionaryStorageOwner"));
-  static ConstString g_NSDictionaryClass2(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs29_NativeDictionaryStorageOwner"));
-  static ConstString g_NSSetClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCSs22_NativeSetStorageOwner"));
-  static ConstString g_NSSetClass2(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22_NativeSetStorageOwner"));
   static ConstString g_NSStringClass1(SwiftLanguageRuntime::GetCurrentMangledName("_NSContiguousString"));
   static ConstString g_NSStringClass2(SwiftLanguageRuntime::GetCurrentMangledName("_TtCSs19_NSContiguousString"));
   static ConstString g_NSStringClass3Old("_TtCs19_NSContiguousString");
   static ConstString g_NSStringClass3(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs19_NSContiguousString"));
   static ConstString g_NSArrayClass1Old("_TtCs21_SwiftDeferredNSArray");
   static ConstString g_NSArrayClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21_SwiftDeferredNSArray"));
-
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSummaries().erase(
-      g_NSSetClass1);
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSynthetics().erase(
-      g_NSSetClass1);
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSummaries().erase(
-      g_NSSetClass2);
-  lldb_private::formatters::NSSet_Additionals::GetAdditionalSynthetics().erase(
-      g_NSSetClass2);
 
   lldb_private::formatters::NSString_Additionals::GetAdditionalSummaries()
       .erase(g_NSStringClass1);

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -338,26 +338,21 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::Dictionary_SummaryProvider,
                 "Swift.Dictionary summary provider",
-                ConstString("^Swift.Dictionary<.+,.+>$"), summary_flags, true);
+                ConstString("^Swift\\.Dictionary<.+,.+>$"), summary_flags, true);
   AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::NSDictionarySummaryProvider<false>,
-                "Swift.Dictionary synthetic children",
-                ConstString("^Swift._SwiftDeferredNSDictionary<.+>$"),
+                lldb_private::formatters::swift::Dictionary_SummaryProvider,
+                "Swift.Dictionary summary provider",
+                ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$"),
                 summary_flags, true);
   AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::NSDictionarySummaryProvider<false>,
-                "Swift.Dictionary synthetic children",
-                ConstString("^_TtGCs29_NativeDictionaryStorageOwner.*_$"),
+                lldb_private::formatters::swift::Dictionary_SummaryProvider,
+                "Swift.Dictionary summary provider",
+                ConstString("^Swift\\._RawNativeDictionaryStorage$"),
                 summary_flags, true);
   AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::NSDictionarySummaryProvider<false>,
-                "Swift.Dictionary synthetic children",
-                ConstString("^_TtGCs29_NativeDictionaryStorageOwner.*_$"),
-                summary_flags, true);
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::NSDictionarySummaryProvider<false>,
-                "Swift.Dictionary synthetic children",
-                ConstString("^Swift._NativeDictionaryStorageOwner.*$"),
+                lldb_private::formatters::swift::Dictionary_SummaryProvider,
+                "Swift.Dictionary summary provider",
+                ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$"),
                 summary_flags, true);
 
   summary_flags.SetDontShowChildren(true);
@@ -418,46 +413,46 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
       "Swift.Dictionary synthetic children",
-      ConstString("^Swift.Dictionary<.+,.+>$"), synth_flags, true);
+      ConstString("^Swift\\.Dictionary<.+,.+>$"), synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
-      lldb_private::formatters::NSDictionarySyntheticFrontEndCreator,
+      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
       "Swift.Dictionary synthetic children",
-      ConstString("^_TtCs29_NativeDictionaryStorageOwner[A-Fa-f0-9]+$"),
+      ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$"), synth_flags, true);
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
+      "Swift.Dictionary synthetic children",
+      ConstString("^Swift\\._RawNativeDictionaryStorage$"), synth_flags, true);
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
+      "Swift.Dictionary synthetic children",
+      ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$"), synth_flags, true);
+
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
+      "Swift.Set synthetic children",
+      ConstString("^Swift\\.Set<.+>$"), synth_flags, true);
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
+      "Swift.Set synthetic children",
+      ConstString("^Swift\\._HashableTypedNativeSetStorage<.+>$"),
       synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
-      lldb_private::formatters::NSDictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^Swift._SwiftDeferredNSDictionary<.+>$"), synth_flags, true);
+      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
+      "Swift.Set synthetic children",
+      ConstString("^Swift\\._RawNativeSetStorage$"),
+      synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
-      lldb_private::formatters::NSDictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^_TtGCs29_NativeDictionaryStorageOwner.*_$"), synth_flags,
-      true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::NSDictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^Swift._NativeDictionaryStorageOwner.*$"), synth_flags,
-      true);
-
-  // FIXME: _Set and Set seem to be coexisting on different trains - support
-  // both for a while
-  AddCXXSynthetic(swift_category_sp,
-                  lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
-                  "Swift.Set synthetic children",
-                  ConstString("^Swift.Set<.+>$"), synth_flags, true);
-  AddCXXSynthetic(swift_category_sp,
-                  lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
-                  "Swift.Set synthetic children",
-                  ConstString("^Swift._Set<.+>$"), synth_flags, true);
-  AddCXXSynthetic(swift_category_sp,
-                  lldb_private::formatters::NSSetSyntheticFrontEndCreator,
-                  "Swift.Set synthetic children",
-                  ConstString("^_TtCs22_NativeSetStorageOwner[A-Fa-f0-9]+$"),
-                  synth_flags, true);
+      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
+      "Swift.Set synthetic children",
+      ConstString("^Swift\\._SwiftDeferredNSSet<.+>$"),
+      synth_flags, true);
 
   synth_flags.SetSkipPointers(true);
 

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -54,6 +54,8 @@ using lldb_private::formatters::AddCXXSynthetic;
 using lldb_private::formatters::AddFormat;
 using lldb_private::formatters::AddStringSummary;
 using lldb_private::formatters::AddSummary;
+using lldb_private::formatters::swift::DictionaryConfig;
+using lldb_private::formatters::swift::SetConfig;
 
 void SwiftLanguage::Initialize() {
   static ConstString g_NSStringClass1(SwiftLanguageRuntime::GetCurrentMangledName("_NSContiguousString"));
@@ -335,25 +337,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Swift.Array summary provider",
       ConstString("_TtCs21_SwiftDeferredNSArray"), summary_flags, false);
 
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::Dictionary_SummaryProvider,
-                "Swift.Dictionary summary provider",
-                ConstString("^Swift\\.Dictionary<.+,.+>$"), summary_flags, true);
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::Dictionary_SummaryProvider,
-                "Swift.Dictionary summary provider",
-                ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$"),
-                summary_flags, true);
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::Dictionary_SummaryProvider,
-                "Swift.Dictionary summary provider",
-                ConstString("^Swift\\._RawNativeDictionaryStorage$"),
-                summary_flags, true);
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::Dictionary_SummaryProvider,
-                "Swift.Dictionary summary provider",
-                ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$"),
-                summary_flags, true);
+  DictionaryConfig::Get()
+    .RegisterSummaryProviders(swift_category_sp, summary_flags);
+  SetConfig::Get()
+    .RegisterSummaryProviders(swift_category_sp, summary_flags);
 
   summary_flags.SetDontShowChildren(true);
   summary_flags.SetSkipPointers(true);
@@ -408,51 +395,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                   synth_flags,
                   false);
 
-
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^Swift\\.Dictionary<.+,.+>$"), synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$"), synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^Swift\\._RawNativeDictionaryStorage$"), synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::DictionarySyntheticFrontEndCreator,
-      "Swift.Dictionary synthetic children",
-      ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$"), synth_flags, true);
-
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
-      "Swift.Set synthetic children",
-      ConstString("^Swift\\.Set<.+>$"), synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
-      "Swift.Set synthetic children",
-      ConstString("^Swift\\._HashableTypedNativeSetStorage<.+>$"),
-      synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
-      "Swift.Set synthetic children",
-      ConstString("^Swift\\._RawNativeSetStorage$"),
-      synth_flags, true);
-  AddCXXSynthetic(
-      swift_category_sp,
-      lldb_private::formatters::swift::SetSyntheticFrontEndCreator,
-      "Swift.Set synthetic children",
-      ConstString("^Swift\\._SwiftDeferredNSSet<.+>$"),
-      synth_flags, true);
+  DictionaryConfig::Get()
+    .RegisterSyntheticChildrenCreators(swift_category_sp, synth_flags);
+  SetConfig::Get()
+    .RegisterSyntheticChildrenCreators(swift_category_sp, synth_flags);
 
   synth_flags.SetSkipPointers(true);
 

--- a/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -42,16 +42,24 @@ SetConfig::SetConfig()
   m_collection_demangledRegex =
     ConstString("^Swift\\.Set<.+>$");
 
+  // Note: We need to have the old _Tt names here because those are
+  // still used to name classes in the ObjC runtime.
+
   // Native storage class                                                
+  m_nativeStorage_mangledRegex_ObjC =
+    ConstString("^_TtGCs30_HashableTypedNativeSetStorage.*");
   m_nativeStorage_demangledPrefix =
     ConstString("Swift._HashableTypedNativeSetStorage<");
   m_nativeStorage_demangledRegex =
     ConstString("^Swift\\._HashableTypedNativeSetStorage<.+>$");
 
   // Type-punned empty set
+  m_emptyStorage_mangled_ObjC = ConstString("_TtCs20_RawNativeSetStorage");
   m_emptyStorage_demangled = ConstString("Swift._RawNativeSetStorage");
 
   // Deferred non-verbatim bridged set
+  m_deferredBridgedStorage_mangledRegex_ObjC
+    = ConstString("^_TtGCs19_SwiftDeferredNSSet.*");
   m_deferredBridgedStorage_demangledPrefix
     = ConstString("Swift._SwiftDeferredNSSet<");
   m_deferredBridgedStorage_demangledRegex

--- a/source/Plugins/Language/Swift/SwiftSet.h
+++ b/source/Plugins/Language/Swift/SwiftSet.h
@@ -23,14 +23,43 @@
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Target/Target.h"
 
+#include "Plugins/Language/ObjC/NSSet.h"
+
 namespace lldb_private {
 namespace formatters {
 namespace swift {
-bool Set_SummaryProvider(ValueObject &valobj, Stream &stream,
-                         const TypeSummaryOptions &options);
 
-SyntheticChildrenFrontEnd *SetSyntheticFrontEndCreator(CXXSyntheticChildren *,
-                                                       lldb::ValueObjectSP);
+class SetConfig: public HashedCollectionConfig {
+public:
+  static const SetConfig &Get();
+
+  static bool
+  SummaryProvider(ValueObject &valobj, Stream &stream,
+                  const TypeSummaryOptions &options);
+
+  static SyntheticChildrenFrontEnd *
+  SyntheticChildrenCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
+
+private:
+  SetConfig();
+
+protected:
+  virtual CXXFunctionSummaryFormat::Callback
+  GetSummaryProvider() const override {
+    return SetConfig::SummaryProvider;
+  }
+  
+  virtual CXXSyntheticChildren::CreateFrontEndCallback
+  GetSyntheticChildrenCreator() const override {
+    return SetConfig::SyntheticChildrenCreator;
+  }
+
+  virtual CXXSyntheticChildren::CreateFrontEndCallback
+  GetCocoaSyntheticChildrenCreator() const override {
+    return NSSetSyntheticFrontEndCreator;
+  }
+};    
+
 }
 }
 }


### PR DESCRIPTION
This PR updates lldb's Swift Set and Dictionary data formatters, removing obsolete paths, simplifying code structure and fixing edge cases.

rdar://problem/43045289

Partial list of fixes:
- Fixes summary formatters for Swift sets -- they should be summaried as `<n> values`, like arrays.
    ```
    $ lldb --repl
    1> import Foundation

    // Before: ❌
    2> [1, 2] as Set<Int>
    $R0: Set<Int> = {  // Note: no summary
      [0] = 1
      [1] = 2
    }
    // After: 👍
    2> [1, 2] as Set<Int>
    $R0: Set<Int> = 2 values {
       [0] = 1
       [1] = 2
     }
    ```
- Empty sets and dictionaries using the type-punned singleton storage instance are now formatted correctly. This also works when the storage instance is verbatim bridged to Objective-C.
    ```
    // Before: ❌
    2> Set<Int>()
    $R0: Set<Int> = {} 
    3> $R0 as NSSet
    $R1: _RawNativeSetStorage = {
      Swift._SwiftNativeNSSet = {}
      bucketCount = 1
      count = 0
      ... more gobbledygook ...
    }

    // After: 👍
    2> Set<Int>()
    $R0: Set<Int> = 0 values
    3> $R0 as NSSet
    $R1: _RawNativeSetStorage = 0 values
    ```

- Swift sets and dictionaries that are bridged to Objective-C now use the proper formatter, rather than a raw data dump:
    ```
    // Before: ❌
    2> [1, 2] as Set<Int> as NSSet
    $R0: _SwiftDeferredNSSet<Int> = {
       Swift._SwiftNativeNSSet = {}
       _heapStorageBridged_DoNotUse = nil
       nativeBuffer = {
         _storage = {
           ... more gobbledygook ...
         }
       }
    }
    3> [NSNumber(value: 1), NSNumber(value: 2)] as Set<NSObject> as NSSet
    $R1: _HashableTypedNativeSetStorage<NSObject> = {
      Swift._TypedNativeSetStorage = {
        Swift._RawNativeSetStorage = {
          Swift._SwiftNativeNSSet = {}
          bucketCount = 4
           ... more gobbledygook ...
        }
      }
    }

    // After: 👍
    2> [1, 2] as Set<Int> as NSSet
    $R0: _SwiftDeferredNSSet<Int> = 2 values {
      [0] = 1
      [1] = 2
    }
    3> [NSNumber(value: 1), NSNumber(value: 2)] as Set<NSObject> as NSSet
    $R1: _HashableTypedNativeSetStorage<NSObject> = 2 values {
      [0] = Int64(2)
      [1] = Int64(1)
    }
    ```
- Cocoa NSSet and NSDictionary instances that are verbatim-bridged to Swift are now formatted correctly:
    ```
    // Before: ❌
    2> NSSet(array: [NSNumber(value: 1), NSNumber(value: 2)]) as! Set<NSObject>
    $R0: Set<NSObject> = {}

    // After: 👍
    2> NSSet(array: [NSNumber(value: 1), NSNumber(value: 2)]) as! Set<NSObject>
    $R0: Set<NSObject> = 2 values {
      [0] = Int64(1)
      [1] = Int64(2)
    }
    ```
