### PR TITLE
[lldb-mi] Disable flakey pexpect tests on linux as well

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiCliSupport.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiCliSupport.py
@@ -38,6 +38,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows.
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races.
     @skipIfDarwin
+    @skipIfLinux
     def test_lldbmi_target_list(self):
         """Test that 'lldb-mi --interpreter' can list targets by 'target list' command."""
 

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
@@ -40,6 +40,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows.
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races.
     @skipIfDarwin
+    @skipIfLinux
     def test_lldbmi_target_list(self):
         """Test that 'lldb-mi --interpreter' can list targets by 'target list' command."""
 


### PR DESCRIPTION
We previously disabled these two tests on Darwin, but disable them on
Linux as well as they're faleky there too.