### PR TITLE
Prevent the Swift scratch AST context to be reset while it is being u…

### DIFF
--- a/include/lldb/Core/SwiftASTContextReader.h
+++ b/include/lldb/Core/SwiftASTContextReader.h
@@ -1,0 +1,104 @@
+//===-- SwiftASTContextReader.h ---------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SwiftASTContextReader_h_
+#define liblldb_SwiftASTContextReader_h_
+
+#include "llvm/Support/RWMutex.h"
+
+namespace lldb_private {
+
+class SwiftASTContext;
+class ExecutionContext;
+class ExecutionContextRef;
+
+/// This is like llvm::sys::SmartRWMutex<false>, but with a try_lock method.
+///
+/// FIXME: Replace this with a C++14 shared_timed_mutex or a C++17
+/// share_mutex as soon as possible. This implementation still allows
+/// for a race condition in \c try_lock() between the checking of
+/// m_readers and the lock acquisition.
+class SharedMutex {
+  llvm::sys::RWMutexImpl m_impl;
+  unsigned m_readers = 0;
+public:
+  SharedMutex() = default;
+  SharedMutex(const SharedMutex &) = delete;
+  SharedMutex &operator=(const SharedMutex &) = delete;
+  bool lock_shared() { ++m_readers; return m_impl.reader_acquire(); }
+  bool unlock_shared() { --m_readers; return m_impl.reader_release(); }
+  bool try_lock() { return m_readers ? false : m_impl.writer_acquire(); }
+  bool unlock() { return m_impl.writer_release(); }
+};
+
+/// RAII acquisition of a reader lock.
+struct ScopedSharedMutexReader {
+  SharedMutex *m_mutex;
+  ScopedSharedMutexReader(const ScopedSharedMutexReader&) = default;
+  explicit ScopedSharedMutexReader(SharedMutex *m) : m_mutex(m) {
+    if (m_mutex)
+      m_mutex->lock_shared();
+  }
+
+  ~ScopedSharedMutexReader() {
+    if (m_mutex)
+      m_mutex->unlock_shared();
+  }
+};
+
+/// A scratch Swift AST context pointer and its reader lock.
+/// The Swift scratch context may need to be replaced when it gets corrupted,
+/// for example due to incompatible ClangImporter options. This locking
+/// mechanism guarantees that this won't happen while a client is using the
+/// context.
+///
+/// In Swift there are three use-cases for ASTContexts with
+/// different requirements and guarantees.
+///
+/// - Module ASTContexts are used for the static type system. They
+///   are created once for each lldb::Module and live forever.
+///
+/// - Scratch AST Contexts are used for expressions
+///   (thus far everything is like in the Clang language support)
+///
+/// - Scratch AST Contexts are also used to express the results of
+///    any dynamic type resolution done by RemoteAST or Archetype
+///    binding.
+///
+/// Because expressions and dynamic type resolution may trigger the
+/// import of another module, the scratch context may become
+/// unusable. When a scratch context is in a fatal error state,
+/// GetScratchSwiftASTContext() will create a fresh global context,
+/// or even separate scratch contexts for each lldb::Module. But it
+/// will only do this if no client holds on to a read lock on \b
+/// m_scratch_typesystem_lock.
+struct SwiftASTContextReader : ScopedSharedMutexReader {
+  SwiftASTContext *m_ptr = nullptr;
+  SwiftASTContextReader() : ScopedSharedMutexReader(nullptr) {}
+  SwiftASTContextReader(SharedMutex &mutex, SwiftASTContext *ctx)
+      : ScopedSharedMutexReader(&mutex), m_ptr(ctx) {}
+  SwiftASTContextReader(const SwiftASTContextReader &copy)
+      : ScopedSharedMutexReader(copy.m_mutex), m_ptr(copy.m_ptr) {}
+  SwiftASTContext *get() { return m_ptr; }
+  operator bool() const { return m_ptr; }
+  SwiftASTContext *operator->() { return m_ptr; }
+  SwiftASTContext &operator*() { return *m_ptr; }
+};
+
+/// An RAII object that just acquires the reader lock.
+struct SwiftASTContextLock : ScopedSharedMutexReader {
+  SwiftASTContextLock(const ExecutionContextRef *exe_ctx_ref);
+  SwiftASTContextLock(const ExecutionContext *exe_ctx);
+};
+
+} // namespace lldb_private
+#endif

--- a/include/lldb/Core/ValueObject.h
+++ b/include/lldb/Core/ValueObject.h
@@ -10,6 +10,7 @@
 #ifndef liblldb_ValueObject_h_
 #define liblldb_ValueObject_h_
 
+#include "lldb/Core/SwiftASTContextReader.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/Type.h" // for TypeImpl
@@ -615,7 +616,7 @@ public:
   virtual bool HasSyntheticValue();
 
   SwiftASTContext *GetSwiftASTContext();
-  SwiftASTContext *GetScratchSwiftASTContext();
+  SwiftASTContextReader GetScratchSwiftASTContext();
 
   virtual bool IsSynthetic() { return false; }
 

--- a/include/lldb/Core/ValueObjectDynamicValue.h
+++ b/include/lldb/Core/ValueObjectDynamicValue.h
@@ -123,6 +123,10 @@ protected:
 
   bool HasDynamicValueTypeInfo() override { return true; }
 
+  /// Determine whether the scratch AST context has been replaced
+  /// since this dynamic type has been created.
+  bool DynamicValueTypeInfoNeedsUpdate();
+
   CompilerType GetCompilerTypeImpl() override;
 
   Address m_address; ///< The variable that this value object is based upon

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -922,10 +922,12 @@ public:
 
     Status type_system_error;
     TypeSystem *type_system;
-    
+
     if (lang == lldb::eLanguageTypeSwift)
+      // We already acquired the lock in the UserExpression.
       type_system =
-          target_sp->GetScratchSwiftASTContext(type_system_error, *frame_sp);
+          target_sp->GetScratchSwiftASTContext(type_system_error, *frame_sp)
+              .get();
     else
       type_system = target_sp->GetScratchTypeSystemForLanguage(
         &type_system_error, m_type.GetMinimumLanguage());

--- a/source/Expression/UserExpression.cpp
+++ b/source/Expression/UserExpression.cpp
@@ -261,6 +261,11 @@ lldb::ExpressionResults UserExpression::Evaluate(
     execution_results = lldb::eExpressionParseError;
     if (fixed_expression && !fixed_expression->empty() &&
         options.GetAutoApplyFixIts()) {
+      // Swift: temporarily release scratch context lock held by
+      // SwiftUserExpression, so the context can be restored if necessary.
+      if (expr == *fixed_expression)
+        user_expression_sp = nullptr;
+
       lldb::UserExpressionSP fixed_expression_sp(
           target->GetUserExpressionForLanguage(exe_ctx,
                                                fixed_expression->c_str(),

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -160,7 +160,7 @@ private:
   /// The container for the IR, to be JIT-compiled or interpreted.
   lldb::IRExecutionUnitSP m_execution_unit_sp;
   /// The AST context to build the expression into.
-  SwiftASTContext *m_swift_ast_context;
+  std::unique_ptr<SwiftASTContextReader> m_swift_ast_context;
   /// Used to manage the memory of a potential on-off context.
   //lldb::TypeSystemSP m_typesystem_sp;
   /// The symbol context to use when parsing.

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -363,6 +363,15 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                  "couldn't start parsing (no target)");
     return false;
   }
+  if (auto *persistent_state = GetPersistentState(target, exe_ctx)) {
+    persistent_state->AddHandLoadedModule(ConstString("Swift"));
+    m_result_delegate.RegisterPersistentState(persistent_state);
+    m_error_delegate.RegisterPersistentState(persistent_state);
+  } else {
+    diagnostic_manager.PutString(eDiagnosticSeverityError,
+                                 "couldn't start parsing (no persistent data)");
+    return false;
+  }
 
   ScanContext(exe_ctx, err);
 
@@ -437,21 +446,6 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
 
   m_parser =
       llvm::make_unique<SwiftExpressionParser>(exe_scope, *this, m_options);
-  
-  // Don't set the persistent state in the result & error delegates till after
-  // you have made the expression parser.  Doing that could invalidate the 
-  // Target ScratchASTContext, which would destroy the old persistent state, 
-  // leaving the delegates holding onto a dangling pointer.
-  
-  if (auto *persistent_state = GetPersistentState(target, exe_ctx)) {
-    persistent_state->AddHandLoadedModule(ConstString("Swift"));
-    m_result_delegate.RegisterPersistentState(persistent_state);
-    m_error_delegate.RegisterPersistentState(persistent_state);
-  } else {
-    diagnostic_manager.PutString(eDiagnosticSeverityError,
-                                 "couldn't start parsing (no persistent data)");
-    return false;
-  }
 
   unsigned error_code = m_parser->Parse(
       diagnostic_manager, first_body_line,

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -137,8 +137,7 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
     // we need to make sure the Target's SwiftASTContext has been setup BEFORE
     // we do any Swift name lookups
     if (m_target) {
-      SwiftASTContext *swift_ast_ctx = m_target->GetScratchSwiftASTContext(
-          err, *frame);
+      auto swift_ast_ctx = m_target->GetScratchSwiftASTContext(err, *frame);
       if (!swift_ast_ctx) {
         if (log)
           log->Printf("  [SUE::SC] NULL Swift AST Context");

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -513,8 +513,9 @@ bool lldb_private::formatters::swift::NSContiguousString_SummaryProvider(
 
   ExecutionContext exe_ctx(process_sp);
   ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
-  SwiftASTContext *lldb_swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
-      process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope));
+  auto reader =
+      process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope);
+  SwiftASTContext *lldb_swift_ast = reader.get();
   if (!lldb_swift_ast)
     return false;
   CompilerType string_guts_type = lldb_swift_ast->GetTypeFromMangledTypename(

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -326,8 +326,9 @@ SwiftHashedContainerBufferHandler::CreateBufferHandlerForNativeStorageOwner(
       // (AnyObject,AnyObject)?
       ExecutionContext exe_ctx(process_sp);
       ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
-      SwiftASTContext *swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
-          process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope));
+      auto reader =
+          process_sp->GetTarget().GetScratchSwiftASTContext(error, *exe_scope);
+      SwiftASTContext *swift_ast_ctx = reader.get();
       if (swift_ast_ctx) {
         CompilerType element_type(swift_ast_ctx->GetTypeFromMangledTypename(
             SwiftLanguageRuntime::GetCurrentMangledName(


### PR DESCRIPTION
Soliciting early feedback to the approach before going down too far the rabbit hole.

Prevent the Swift scratch AST context to be reset while it is being used.
    
This patch introduces a Reader-Writer-Lock around the scratch
context. Users of a scratch context acquire a read lock while they are
depending on a scratch context. Only if no readers a around is Target
allowed to reset a Swift scratch context and delete the old one.
    
The Swift scratch context may need to be replaced when it gets corrupted,
for example due to incompatible ClangImporter options. This locking
mechanism guarantees that this won't happen while a client is using the
context.
    
In Swift there are three use-cases for ASTContexts with
different requirements and guarantees.
    
- Module ASTContexts are used for the static type system. They
  are created once for each lldb::Module and live forever.
    
- Scratch AST Contexts are used for expressions
  (thus far everything is like in the Clang language support)
    
- Scratch AST Contexts are also used to express the results of
   any dynamic type resolution done by RemoteAST or Archetype
   binding.
    
Because expressions and dynamic type resolution may trigger the
import of another module, the scratch context may become
unusable. When a scratch context is in a fatal error state,
GetScratchSwiftASTContext() will create a fresh global context,
or even separate scratch contexts for each lldb::Module. But it
will only do this if no client holds on to a read lock on \b
m_scratch_typesystem_lock.

<rdar://problem/42399818>