### PR TITLE
Temporarily disable tests that contain race conditions.

### DIFF
--- a/lit/tools/lldb-mi/exec/exec-next-instruction.test
+++ b/lit/tools/lldb-mi/exec/exec-next-instruction.test
@@ -1,5 +1,6 @@
 # XFAIL: windows
 # -> llvm.org/pr24452
+# REQUIRES: FIX_FOR_RACE_CONDITION
 #
 # RUN: %cc -o %t %p/inputs/main.c -g
 # RUN: %lldbmi %t < %s | FileCheck %s

--- a/lit/tools/lldb-mi/exec/exec-next.test
+++ b/lit/tools/lldb-mi/exec/exec-next.test
@@ -1,5 +1,7 @@
 # XFAIL: windows
 # -> llvm.org/pr24452
+# REQUIRES: FIX_FOR_RACE_CONDITION
+#
 #
 # RUN: %cc -o %t %p/inputs/main.c -g
 # RUN: %lldbmi %t < %s | FileCheck %s

--- a/lit/tools/lldb-mi/exec/exec-step-instruction.test
+++ b/lit/tools/lldb-mi/exec/exec-step-instruction.test
@@ -1,5 +1,6 @@
 # XFAIL: windows
 # -> llvm.org/pr24452
+# REQUIRES: FIX_FOR_RACE_CONDITION
 #
 # RUN: %cc -o %t %p/inputs/main.c -g
 # RUN: %lldbmi %t < %s | FileCheck %s

--- a/lit/tools/lldb-mi/exec/exec-step.test
+++ b/lit/tools/lldb-mi/exec/exec-step.test
@@ -1,5 +1,6 @@
 # XFAIL: windows
 # -> llvm.org/pr24452
+# REQUIRES: FIX_FOR_RACE_CONDITION
 #
 # RUN: %cc -o %t %p/inputs/main.c -g
 # RUN: %lldbmi %t < %s | FileCheck %s


### PR DESCRIPTION
It looks like there is a race condition in some of the LIT-based lldb-mi tests.

```
For example, exec-next.test:

 # Test lldb-mi -exec-next command.

 # Check that we have a valid target created via '%lldbmi %t'.
 # CHECK: ^done

 -break-insert main
 # CHECK: ^done,bkpt={number="1"

 -exec-run
 # CHECK: ^running
 # CHECK: *stopped,reason="breakpoint-hit"

 -exec-next --thread 0
 # Check that exec-next can process the case of invalid thread ID.
 # CHECK: ^error,msg="Command 'exec-next'. Thread ID invalid"

 ...

Here we are not actually waiting for the breakpoint to be hit. Synchronous mode ensures that the lldb-mi driver waits for each command to be completed, but that only means that -exec-run only returns after the process has been launched and does not include waiting for the program to actually hit a breakpoint. So if the program runs very slowly (such as often happens on a very busy bot), the -exec-next and subsequent commands are scheduled before the breakpoint is hit. In order to fix this we either need to move any tests that schedule commands after hitting breakpoints back to Python, or we need to add a new -wait-for-breakpoint MI command for testing only to force a synchronization point.

```