### PR TITLE
Fix an LLDB Swift expression evaluator bug that prevents any

### DIFF
--- a/source/Expression/ExpressionSourceCode.cpp
+++ b/source/Expression/ExpressionSourceCode.cpp
@@ -480,15 +480,16 @@ bool ExpressionSourceCode::GetText(
     case lldb::eLanguageTypeSwift: {
       llvm::SmallString<16> buffer;
       llvm::raw_svector_ostream os_vers(buffer);
-      auto platform = target->GetPlatform();
-      auto arch_spec = platform->GetSystemArchitecture();
+
+      auto arch_spec = target->GetArchitecture();
       auto triple = arch_spec.GetTriple();
       if (triple.isOSDarwin()) {
-        uint32_t major, minor, patch;
-        platform->GetOSVersion(major, minor, patch,
-                               target->GetProcessSP().get());
-        os_vers << getAvailabilityName(triple.getOS()) << " ";
-        os_vers << major << "." << minor << "." << patch;
+        if (auto process_sp = exe_ctx.GetProcessSP()) {
+          uint32_t major, minor, patch;
+          process_sp->GetHostOSVersion(major, minor, patch);
+          os_vers << getAvailabilityName(triple.getOS()) << " ";
+          os_vers << major << "." << minor << "." << patch;
+        }
       }
       SwiftASTManipulator::WrapExpression(wrap_stream, m_body.c_str(),
                                           language_flags, options, generic_info,


### PR DESCRIPTION
expressions from being run that use API that is @available in an SDK
with a major version number >10, while debugging in a simulator.

LLDB knows how to correctly parse the deployment target out of the
load commands. This fixed a critical performance problem. To still be
able to run expressions containing API newer than the deployment
target in LLDB, we started marking up LLDB expressions with
availability annotations. The code to compute the SDK version used in
the availability markup had a bug for iOS devices. We fixed
that bug in b34a153. Unfortunately the bugfix that fixed
devices introduced a regression for simulators that caused the host
macOS version instead of the simulator version to be used when
debugging on a simulator. This makes it impossible to run any
expressions that contain API from an iOS/tvOS version greater than
10.13.

rdar://problem/42884412