### PR TITLE
[4.2] [REPL] Set the correct rpath when installing.

### DIFF
--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -5,6 +5,7 @@ if (LLDB_BUILD_FRAMEWORK)
 elseif( CMAKE_SYSTEM_NAME MATCHES "Linux" )
   # Set the correct rpath to locate libswiftCore
   set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-x86_64/lib${LLVM_LIBDIR_SUFFIX}/swift/linux -Wl,-ldl")
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib/swift/linux:${CMAKE_INSTALL_RPATH}")
 endif()
 
 add_lldb_tool(repl_swift


### PR DESCRIPTION
$ORIGIN represents the location of the REPL at runtime,
whenever the binary is located. So, this makes sure
that when we generate the toolchain on one machine and
transfer to another, the repl keeps working, as it needs
to `dlopen` libSwiftCore, which sits in a path relative
to the executable itself.

<rdar://problem/42863249>