### PR TITLE
Fix: ConstString::GetConstCStringAndSetMangledCounterPart()

### DIFF
--- a/source/Utility/ConstString.cpp
+++ b/source/Utility/ConstString.cpp
@@ -121,11 +121,16 @@ public:
         const uint8_t h = hash(string_ref);
         llvm::sys::SmartScopedWriter<false> wlock(m_string_pools[h].m_mutex);
 
-        // Make string pool entry with the mangled counterpart already set
-        StringPoolEntryType &entry =
-            *m_string_pools[h]
-                 .m_string_map.insert(std::make_pair(string_ref, mangled_ccstr))
-                 .first;
+        // Make or update string pool entry with the mangled counterpart
+        StringPool &map = m_string_pools[h].m_string_map;
+        StringPoolEntryType &entry = *map.try_emplace(demangled).first;
+
+        assert((entry.second == nullptr || entry.second == mangled_ccstr ||
+                strlen(entry.second) == 0) &&
+              "The demangled string must have a unique counterpart or otherwise "
+              "it must be empty");
+
+        entry.second = mangled_ccstr;
 
         // Extract the const version of the demangled_cstr
         demangled_ccstr = entry.getKeyData();


### PR DESCRIPTION
Fix: ConstString::GetConstCStringAndSetMangledCounterPart() should update the value if the key exists already

This cherry-pick doesn't include the required tests, as they depend on another change that can't go in without his fix.

Summary:
This issue came up because it caused problems in our unit tests. The StringPool did connect counterparts only once and silently ignored the values passed in subsequent calls.
The simplest solution for the unit tests would be silent overwrite. In practice, however, it seems useful to assert that we never overwrite a different mangled counterpart.
If we ever have mangled counterparts for other languages than C++, this makes it more likely to notice collisions.

I added an assertion that allows the following cases:
* inserting a new value
* overwriting the empty string
* overwriting with an identical value

I fixed the unit tests, which used "random" strings and thus produced collisions.
It would be even better if there was a way to reset or isolate the StringPool, but that's a different story.

Reviewers: jingham, friss, labath

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D50536

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@339669 91177308-0d34-0410-b5e6-96231b3b80d8