### PR TITLE
Revert "XFAIL TestSwiftGenericStructDebugInfoGenericFlatMap.py as it …

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 import lldbsuite.test.decorators as decorators
 
 lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[lldbinline.expectedFailureAll()])
+        decorators=[])


### PR DESCRIPTION
…seems falky"

This reverts commit 698229f8b1efae501b6847b80c3fc290938bb054.

rdar://problem/43340670