### PR TITLE
Fix a little thinko in generating ___lldb_unnamed_symbol symbols

### DIFF
--- a/packages/Python/lldbsuite/test/macosx/function-starts/Makefile
+++ b/packages/Python/lldbsuite/test/macosx/function-starts/Makefile
@@ -1,0 +1,10 @@
+LEVEL = ../../make
+
+CXX_SOURCES := main.cpp
+EXE := StripMe
+MAKE_DSYM := NO
+
+include $(LEVEL)/Makefile.rules
+
+main.o: main.cpp
+	$(CC) $(CFLAGS_NO_DEBUG) -c $< -o $@

--- a/packages/Python/lldbsuite/test/macosx/function-starts/TestFunctionStarts.py
+++ b/packages/Python/lldbsuite/test/macosx/function-starts/TestFunctionStarts.py
@@ -1,0 +1,76 @@
+"""
+Test that we read the function starts section.
+"""
+
+from __future__ import print_function
+
+
+import os
+import time
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+exe_name = "StripMe"  # Must match Makefile
+
+class FunctionStartsTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipIfRemote
+    @skipUnlessDarwin
+    def test_function_starts_binary(self):
+        """Test that we make synthetic symbols when we have the binary."""
+        self.build()
+        self.do_function_starts(False)
+
+    @skipIfRemote
+    @skipUnlessDarwin
+    def test_function_starts_no_binary(self):
+        """Test that we make synthetic symbols when we don't have the binary"""
+        self.build()
+        self.do_function_starts(True)
+
+    def do_function_starts(self, in_memory):
+        """Run the binary, stop at our unstripped function, 
+           make sure the caller has synthetic symbols"""
+
+        exe = self.getBuildArtifact(exe_name)
+        # Now strip the binary, but leave externals so we can break on dont_strip_me.
+        try:
+            fail_str = system([["strip", "-u", "-x", "-S", exe]])
+        except CalledProcessError as cmd_error:
+            self.fail("Strip failed: %d"%(cmd_error.returncode))
+
+        popen = self.spawnSubprocess(exe)
+        self.addTearDownHook(self.cleanupSubprocesses)
+        if in_memory:
+          remove_file(exe)            
+
+        target = self.dbg.CreateTarget(None)
+        self.assertTrue(target.IsValid(), "Got a vaid empty target.")
+        error = lldb.SBError()
+        attach_info = lldb.SBAttachInfo()
+        attach_info.SetProcessID(popen.pid)
+        attach_info.SetIgnoreExisting(False)
+        process = target.Attach(attach_info, error)
+        self.assertTrue(error.Success(), "Didn't attach successfully to %d: %s"%(popen.pid, error.GetCString()))
+        
+        bkpt = target.BreakpointCreateByName("dont_strip_me", exe)
+        self.assertTrue(bkpt.GetNumLocations() > 0, "Didn't set the dont_strip_me bkpt.")
+        
+        threads = lldbutil.continue_to_breakpoint(process, bkpt)
+        self.assertEqual(len(threads), 1, "Didn't hit my breakpoint.")
+
+        # Our caller frame should have been stripped.  Make sure we made a synthetic symbol
+        # for it:
+        thread = threads[0]
+        self.assertTrue(thread.num_frames > 1, "Couldn't backtrace.")
+        name = thread.frame[1].GetFunctionName()
+        self.assertEqual("___lldb_unnamed_symbol1$$StripMe", name, "Frame name not synthetic")
+        
+
+        

--- a/packages/Python/lldbsuite/test/macosx/function-starts/main.cpp
+++ b/packages/Python/lldbsuite/test/macosx/function-starts/main.cpp
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <chrono>
+#include <thread>
+
+extern void dont_strip_me()
+{
+  printf("I wasn't stripped\n");
+}
+
+static void *a_function()
+{
+    while (1)
+    {
+        std::this_thread::sleep_for(std::chrono::microseconds(100)); 
+        dont_strip_me();
+    }
+    return 0;
+}
+
+int main(int argc, char const *argv[])
+{
+    a_function();
+    return 0;
+}

--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2477,7 +2477,8 @@ size_t ObjectFileMachO::ParseSymtab() {
                     indirect_syms_data_sp, 0,
                     indirect_syms_data_sp->GetByteSize());
             }
-          } else if (memory_module_load_level >=
+          }
+          if (memory_module_load_level >=
                      eMemoryModuleLoadLevelPartial) {
             if (function_starts_load_command.cmd) {
               const addr_t func_start_addr =


### PR DESCRIPTION
when we have only an in-memory copy of the binary.

Also added a test for the generation of these symbols in the 
in-memory and regular cases.

<rdar://problem/43160401>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@339833 91177308-0d34-0410-b5e6-96231b3b80d8