### PR TITLE
Address failures in swift-lldb Linux testing due to running the wrong set of tests

### DIFF
--- a/packages/Python/lldbsuite/test/configuration.py
+++ b/packages/Python/lldbsuite/test/configuration.py
@@ -115,9 +115,13 @@ lldb_platform_working_dir = None
 # The base directory in which the tests are being built.
 test_build_dir = None
 
+# The only directory to scan for tests. If multiple test directories are
+# specified, and an exclusive test subdirectory is specified, the latter option
+# takes precedence.
+exclusive_test_subdir = None
+
 # Parallel execution settings
 is_inferior_test_runner = False
-multiprocess_test_subdir = None
 num_threads = None
 no_multiprocess_test_runner = False
 test_runner_name = None
@@ -149,3 +153,34 @@ def shouldSkipBecauseOfCategories(test_categories):
             return True
 
     return False
+
+
+def get_absolute_path_to_exclusive_test_subdir():
+    """
+    If an exclusive test subdirectory is specified, return its absolute path.
+    Otherwise return None.
+    """
+    test_directory = os.path.dirname(os.path.realpath(__file__))
+
+    if not exclusive_test_subdir:
+        return
+
+    if len(exclusive_test_subdir) > 0:
+        test_subdir = os.path.join(test_directory, exclusive_test_subdir)
+        if os.path.isdir(test_subdir):
+            return test_subdir
+
+        print('specified test subdirectory {} is not a valid directory\n'
+                .format(test_subdir))
+
+
+def get_absolute_path_to_root_test_dir():
+    """
+    If an exclusive test subdirectory is specified, return its absolute path.
+    Otherwise, return the absolute path of the root test directory.
+    """
+    test_subdir = get_absolute_path_to_exclusive_test_subdir()
+    if test_subdir:
+        return test_subdir
+
+    return os.path.dirname(os.path.realpath(__file__))

--- a/packages/Python/lldbsuite/test/dosep.py
+++ b/packages/Python/lldbsuite/test/dosep.py
@@ -1595,7 +1595,7 @@ def rerun_tests(test_subdir, tests_for_rerun, dotest_argv, session_dir,
     print("\nTest rerun complete\n")
 
 
-def main(num_threads, test_subdir, test_runner_name, results_formatter):
+def main(num_threads, test_runner_name, results_formatter):
     """Run dotest.py in inferior mode in parallel.
 
     @param num_threads the parsed value of the num-threads command line
@@ -1637,16 +1637,7 @@ def main(num_threads, test_subdir, test_runner_name, results_formatter):
 
     session_dir = os.path.join(os.getcwd(), dotest_options.s)
 
-    # The root directory was specified on the command line
-    test_directory = os.path.dirname(os.path.realpath(__file__))
-    if test_subdir and len(test_subdir) > 0:
-        test_subdir = os.path.join(test_directory, test_subdir)
-        if not os.path.isdir(test_subdir):
-            print(
-                'specified test subdirectory {} is not a valid directory\n'
-                .format(test_subdir))
-    else:
-        test_subdir = test_directory
+    test_subdir = configuration.get_absolute_path_to_root_test_dir()
 
     # clean core files in test tree from previous runs (Linux)
     cores = find('core.*', test_subdir)

--- a/packages/Python/lldbsuite/test/dotest.py
+++ b/packages/Python/lldbsuite/test/dotest.py
@@ -445,7 +445,7 @@ def parseOptionsAndInitTestdirs():
         configuration.num_threads = args.num_threads
 
     if args.test_subdir:
-        configuration.multiprocess_test_subdir = args.test_subdir
+        configuration.exclusive_test_subdir = args.test_subdir
 
     if args.test_runner_name:
         configuration.test_runner_name = args.test_runner_name
@@ -926,6 +926,7 @@ def visit_file(dir, name):
             unittest2.defaultTestLoader.loadTestsFromName(base))
 
 
+# TODO: This should be replaced with a call to find_test_files_in_dir_tree.
 def visit(prefix, dir, names):
     """Visitor function for os.path.walk(path, visit, arg)."""
 
@@ -1215,7 +1216,6 @@ def run_suite():
         from . import dosep
         dosep.main(
             configuration.num_threads,
-            configuration.multiprocess_test_subdir,
             configuration.test_runner_name,
             configuration.results_formatter_object)
         raise Exception("should never get here")
@@ -1310,10 +1310,15 @@ def run_suite():
     # Don't do lldb-server (llgs) tests on anything except Linux.
     configuration.dont_do_llgs_test = not ("linux" in target_platform)
 
-    #
-    # Walk through the testdirs while collecting tests.
-    #
-    for testdir in configuration.testdirs:
+    # Collect tests from the specified testing directories. If a test
+    # subdirectory filter is explicitly specified, limit the search to that
+    # subdirectory.
+    exclusive_test_subdir = configuration.get_absolute_path_to_exclusive_test_subdir()
+    if exclusive_test_subdir:
+        dirs_to_search = [exclusive_test_subdir]
+    else:
+        dirs_to_search = configuration.testdirs
+    for testdir in dirs_to_search:
         for (dirpath, dirnames, filenames) in os.walk(testdir):
             visit('Test', dirpath, filenames)
 

--- a/packages/Python/lldbsuite/test/functionalities/command_script_immediate_output/TestCommandScriptImmediateOutput.py
+++ b/packages/Python/lldbsuite/test/functionalities/command_script_immediate_output/TestCommandScriptImmediateOutput.py
@@ -28,6 +28,7 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
         oslist=["windows"],
         bugnumber="llvm.org/pr22274: need a pexpect replacement for windows")
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr26139")
+    @skipIfDarwin
     def test_command_script_immediate_output_console(self):
         """Test that LLDB correctly allows scripted commands to set immediate output to the console."""
         self.makeBuildDir()
@@ -51,6 +52,7 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
         oslist=["windows"],
         bugnumber="llvm.org/pr22274: need a pexpect replacement for windows")
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr26139")
+    @skipIfDarwin
     def test_command_script_immediate_output_file(self):
         """Test that LLDB correctly allows scripted commands to set immediate output to a file."""
         self.makeBuildDir()

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
@@ -18,6 +18,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_target_create(self):
         """Test that 'lldb-mi --interpreter' can create target by 'target create' command."""
 
@@ -36,9 +37,30 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^running")
         self.expect("\*stopped,reason=\"breakpoint-hit\"")
 
+    @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows.
+    @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races.
+    @skipIfDarwin
+    def test_lldbmi_target_list(self):
+        """Test that 'lldb-mi --interpreter' can list targets by 'target list' command."""
+
+        self.spawnLldbMi(args=None)
+
+        # Test that initially there are no targets.
+        self.runCmd("-interpreter-exec console \"target list\"")
+        self.expect(r"~\"No targets.\\n\"")
+
+        # Add target.
+        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+
+        # Test that "target list" lists added target.
+        self.runCmd("-interpreter-exec console \"target list\"")
+        self.expect(r"~\"Current targets:\\n\* target #0: %s" % self.myexe)
+
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_breakpoint_set(self):
         """Test that 'lldb-mi --interpreter' can set breakpoint by 'breakpoint set' command."""
 
@@ -63,6 +85,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @expectedFlakeyLinux(bugnumber="llvm.org/pr25470")
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_settings_set_target_run_args_before(self):
         """Test that 'lldb-mi --interpreter' can set target arguments by 'setting set target.run-args' command before than target was created."""
 
@@ -155,6 +178,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfWindows  # llvm.org/pr24452: Get lldb-mi tests working on Windows
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_thread_step_over(self):
         """Test that 'lldb-mi --interpreter' can step over by "thread step-over" command."""
 
@@ -181,6 +205,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
     @skipIfFreeBSD  # llvm.org/pr22411: Failure presumably due to known thread races
     @expectedFlakeyLinux("llvm.org/pr25470")
     @skipIfRemote   # We do not currently support remote debugging via the MI.
+    @skipIfDarwin
     def test_lldbmi_thread_continue(self):
         """Test that 'lldb-mi --interpreter' can continue execution by "thread continue" command."""
 


### PR DESCRIPTION
These tests are sporadically timing out on our bots, e.g here:

  https://ci.swift.org/job/swift-PR-Linux/6841

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@339914 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 3009f7cbc69f79d2d1d849432235a5800230fef0)