### PR TITLE
 Add a Swift backwards-compatibility test category.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
+++ b/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
@@ -1,0 +1,44 @@
+# TestSwiftBackwardsCompatibilitySimple.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldb
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftBackwardsCompatibilitySimple(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr", "swift-history"])
+    def test_simple(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        # FIXME: Removing the next line breaks subsequent expressions
+        #        when the swiftmodules can't be loaded.
+        self.expect("fr v")
+        self.expect("fr v number", substrs=['23'])
+        self.expect("fr v array", substrs=['1', '2', '3'])
+        self.expect("fr v string", substrs=['"hello"'])
+        self.expect("fr v tuple", substrs=['42', '"abc"'])
+        # FIXME: This doesn't work.
+        #self.expect("fr v generic", substrs=['-1'])
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/main.swift
@@ -1,0 +1,21 @@
+// This test contains a subset of Swift that is expected to work in
+// LLDB even when compiled with (slightly) older versions of the Swift
+// compiler.
+
+func use<T>(_ t: T) {}
+
+func f<T>(_ t: T) {
+  let number = 23
+  let array = [1, 2, 3]
+  let string = "hello"
+  let tuple = (42, "abc")
+  let generic = t
+  print(number) // break here
+  use(number)
+  use(array)
+  use(string)
+  use(tuple)
+  use(generic)
+}
+
+f(-1)

--- a/packages/Python/lldbsuite/test/test_categories.py
+++ b/packages/Python/lldbsuite/test/test_categories.py
@@ -20,6 +20,7 @@ debug_info_categories = [
 
 all_categories = {
     'swiftpr': 'Tests that may run as a part of Swift pull-request testing',
+    'swift-history': 'Tests that work even when compiled older versions of swiftc',
     'dataformatters': 'Tests related to the type command and the data formatters subsystem',
     'dwarf': 'Tests that can be run with DWARF debug information',
     'dwo': 'Tests that can be run with DWO debug information',


### PR DESCRIPTION
These tests contains a subset of Swift that is expected to work in
LLDB even when compiled with (slightly) older versions of the Swift
compiler.

<rdar://problem/36031662>