### PR TITLE
[SwiftLanguageRuntime] Map into context before IRGen'ing.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
+++ b/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/frame_var_object_fully_realized/main.swift
@@ -1,0 +1,16 @@
+func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
+  let temporaryA = a //%self.expect('frame variable -d run -O -- a', substrs=['(UInt8) a = 97'])
+  a = b
+  b = temporaryA
+}
+
+func getASCIIUTF8() -> (UnsafeMutablePointer<UInt8>, dealloc: () -> ()) {
+  let up = UnsafeMutablePointer<UInt8>.allocate(capacity: 100)
+  up[0] = 0x61
+  up[1] = 0x62
+  swapTwoValues(&up[0], &up[1])
+  return (up, { up.deallocate() })
+}
+
+let (_, dealloc) = getASCIIUTF8()
+dealloc()


### PR DESCRIPTION
IRGen expects the type to be fully realized, and asserts
otherwise. Note that this has been broken for quite a while,
we just didn't crash but printed garbage before because IRGen
was less strict.

<rdar://problem/39050802>