### PR TITLE
Fix a bug in VMRange

### DIFF
--- a/include/lldb/Utility/VMRange.h
+++ b/include/lldb/Utility/VMRange.h
@@ -87,24 +87,6 @@ public:
   void Dump(Stream *s, lldb::addr_t base_addr = 0,
             uint32_t addr_width = 8) const;
 
-  class ValueInRangeUnaryPredicate {
-  public:
-    ValueInRangeUnaryPredicate(lldb::addr_t value) : _value(value) {}
-    bool operator()(const VMRange &range) const {
-      return range.Contains(_value);
-    }
-    lldb::addr_t _value;
-  };
-
-  class RangeInRangeUnaryPredicate {
-  public:
-    RangeInRangeUnaryPredicate(VMRange range) : _range(range) {}
-    bool operator()(const VMRange &range) const {
-      return range.Contains(_range);
-    }
-    const VMRange &_range;
-  };
-
   static bool ContainsValue(const VMRange::collection &coll,
                             lldb::addr_t value);
 

--- a/source/Utility/VMRange.cpp
+++ b/source/Utility/VMRange.cpp
@@ -24,14 +24,16 @@ using namespace lldb_private;
 
 bool VMRange::ContainsValue(const VMRange::collection &coll,
                             lldb::addr_t value) {
-  ValueInRangeUnaryPredicate in_range_predicate(value);
-  return llvm::find_if(coll, in_range_predicate) != coll.end();
+  return llvm::find_if(coll, [&](const VMRange &r) {
+           return r.Contains(value);
+         }) != coll.end();
 }
 
 bool VMRange::ContainsRange(const VMRange::collection &coll,
                             const VMRange &range) {
-  RangeInRangeUnaryPredicate in_range_predicate(range);
-  return llvm::find_if(coll, in_range_predicate) != coll.end();
+  return llvm::find_if(coll, [&](const VMRange &r) {
+           return r.Contains(range);
+         }) != coll.end();
 }
 
 void VMRange::Dump(Stream *s, lldb::addr_t offset, uint32_t addr_width) const {


### PR DESCRIPTION
I noticed a suspicious failure:

[ RUN ] VMRange.CollectionContains
llvm/src/tools/lldb/unittests/Utility/VMRangeTest.cpp:146: Failure
Value of: VMRange::ContainsRange(collection, VMRange(0x100, 0x104))

Actual: false
Expected: true

Looking at the code, it is a very real bug:

class RangeInRangeUnaryPredicate {
public:
  RangeInRangeUnaryPredicate(VMRange range) : _range(range) {} // note that _range binds to a temporary!
  bool operator()(const VMRange &range) const {
    return range.Contains(_range);
  }
  const VMRange &_range;
};

This change fixes the bug.

Differential Revision: https://reviews.llvm.org/D50290

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@338949 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e171e48dd7b84ab1444601dc8f0e5c3366971842)