### PR TITLE
fix ambiguous reference when you redefine something

### DIFF
--- a/packages/Python/lldbsuite/test/repl/redefinition/TestRedefinition.py
+++ b/packages/Python/lldbsuite/test/repl/redefinition/TestRedefinition.py
@@ -1,0 +1,58 @@
+# TestREPLBreakpoints.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""Test that redefining things in the repl works as desired."""
+
+import lldbsuite.test.lldbrepl as lldbrepl
+
+class TestRedefinition (lldbrepl.REPLTest):
+
+    mydir = lldbrepl.REPLTest.compute_mydir(__file__)
+
+    def doTest(self):
+        # Define some *DefinedInREPL things.
+        self.command('var varDefinedInREPL: Int = 1')
+        self.command('func funcDefinedInREPL() -> Int { return 1 }')
+        self.command('struct StructDefinedInREPL { var field: Int = 1 }')
+
+        # Assert that the REPL can refer to the *DefinedInRepl things.
+        self.command('varDefinedInREPL', patterns=[r'\$R[0-9]+: Int = 1'])
+        self.command('funcDefinedInREPL()', patterns=[r'\$R[0-9]+: Int = 1'])
+        self.command('StructDefinedInREPL().field',
+                     patterns=[r'\$R[0-9]+: Int = 1'])
+
+        # Redefine the *DefinedInREPL things.
+        self.command('var varDefinedInREPL: Int = 2')
+        self.command('func funcDefinedInREPL() -> Int { return 2 }')
+        self.command('struct StructDefinedInREPL { var field: Int = 2 }')
+
+        # Assert that the REPL refers to the redefinitions of the
+        # *DefinedInREPL things.
+        self.command('varDefinedInREPL', patterns=[r'\$R[0-9]+: Int = 2'])
+        self.command('funcDefinedInREPL()', patterns=[r'\$R[0-9]+: Int = 2'])
+        self.command('StructDefinedInREPL().field',
+                     patterns=[r'\$R[0-9]+: Int = 2'])
+
+        # Redefine the *DefinedInREPL things, and refer to them in the same
+        # unit of code. Assert that the references refer to the new
+        # redefinitions.
+        self.command('''
+                     var varDefinedInREPL: Int = 3
+                     varDefinedInREPL
+                     ''', patterns=[r'\$R[0-9]+: Int = 3'])
+        self.command('''
+                     func funcDefinedInREPL() -> Int { return 3 }
+                     funcDefinedInREPL()
+                     ''', patterns=[r'\$R[0-9]+: Int = 3'])
+        self.command('''
+                     struct StructDefinedInREPL { var field: Int = 3 }
+                     StructDefinedInREPL().field
+                     ''', patterns=[r'\$R[0-9]+: Int = 3'])

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -166,10 +166,11 @@ void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
 
 bool SwiftPersistentExpressionState::SwiftDeclMap::FindMatchingDecls(
     const ConstString &name,
-    std::vector<swift::ValueDecl *> excluding_equivalents,
+    const std::vector<swift::ValueDecl *> &excluding_equivalents,
     std::vector<swift::ValueDecl *> &matches) {
   std::string name_str(name.AsCString());
   size_t start_num_items = matches.size();
+  size_t start_num_excluding_equivalents = excluding_equivalents.size();
 
   std::pair<SwiftDeclMapTy::iterator, SwiftDeclMapTy::iterator> found_range =
       m_swift_decls.equal_range(name_str);
@@ -178,8 +179,10 @@ bool SwiftPersistentExpressionState::SwiftDeclMap::FindMatchingDecls(
     bool add_it = true;
     swift::ValueDecl *cur_decl = (*cur_item).second;
 
-    for (auto excluding_equivalent : excluding_equivalents) {
-      if (DeclsAreEquivalent(excluding_equivalent, cur_decl)) {
+    // Iterate over only the elements of `excluding_equivalents` that were
+    // originally there, in case `matches` aliases it.
+    for (size_t idx = 0; idx < start_num_excluding_equivalents; idx++) {
+      if (DeclsAreEquivalent(excluding_equivalents[idx], cur_decl)) {
         add_it = false;
         break;
       }
@@ -213,7 +216,7 @@ void SwiftPersistentExpressionState::CopyInSwiftPersistentDecls(
 
 bool SwiftPersistentExpressionState::GetSwiftPersistentDecls(
     const ConstString &name,
-    std::vector<swift::ValueDecl *> excluding_equivalents,
+    const std::vector<swift::ValueDecl *> &excluding_equivalents,
     std::vector<swift::ValueDecl *> &matches) {
   return m_swift_persistent_decls.FindMatchingDecls(name, excluding_equivalents,
                                                     matches);

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -165,10 +165,11 @@ void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
 }
 
 bool SwiftPersistentExpressionState::SwiftDeclMap::FindMatchingDecls(
-    const ConstString &name, std::vector<swift::ValueDecl *> &matches) {
-  std::vector<swift::ValueDecl *> found_elements;
-  size_t start_num_items = matches.size();
+    const ConstString &name,
+    std::vector<swift::ValueDecl *> excluding_equivalents,
+    std::vector<swift::ValueDecl *> &matches) {
   std::string name_str(name.AsCString());
+  size_t start_num_items = matches.size();
 
   std::pair<SwiftDeclMapTy::iterator, SwiftDeclMapTy::iterator> found_range =
       m_swift_decls.equal_range(name_str);
@@ -177,8 +178,8 @@ bool SwiftPersistentExpressionState::SwiftDeclMap::FindMatchingDecls(
     bool add_it = true;
     swift::ValueDecl *cur_decl = (*cur_item).second;
 
-    for (size_t idx = 0; idx < start_num_items; idx++) {
-      if (DeclsAreEquivalent(matches[idx], cur_decl)) {
+    for (auto excluding_equivalent : excluding_equivalents) {
+      if (DeclsAreEquivalent(excluding_equivalent, cur_decl)) {
         add_it = false;
         break;
       }
@@ -211,6 +212,9 @@ void SwiftPersistentExpressionState::CopyInSwiftPersistentDecls(
 }
 
 bool SwiftPersistentExpressionState::GetSwiftPersistentDecls(
-    const ConstString &name, std::vector<swift::ValueDecl *> &matches) {
-  return m_swift_persistent_decls.FindMatchingDecls(name, matches);
+    const ConstString &name,
+    std::vector<swift::ValueDecl *> excluding_equivalents,
+    std::vector<swift::ValueDecl *> &matches) {
+  return m_swift_persistent_decls.FindMatchingDecls(name, excluding_equivalents,
+                                                    matches);
 }

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -48,7 +48,7 @@ public:
     /// Return true if there are any results.
     bool FindMatchingDecls(
         const ConstString &name,
-        std::vector<swift::ValueDecl *> excluding_equivalents,
+        const std::vector<swift::ValueDecl *> &excluding_equivalents,
         std::vector<swift::ValueDecl *> &matches);
 
     void CopyDeclsTo(SwiftDeclMap &target_map);
@@ -102,7 +102,7 @@ public:
   /// if there are any results.
   bool GetSwiftPersistentDecls(
       const ConstString &name,
-      std::vector<swift::ValueDecl *> excluding_equivalents,
+      const std::vector<swift::ValueDecl *> &excluding_equivalents,
       std::vector<swift::ValueDecl *> &matches);
 
   // This just adds this module to the list of hand-loaded modules, it doesn't

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -42,8 +42,15 @@ public:
   public:
     void AddDecl(swift::ValueDecl *decl, bool check_existing,
                  const ConstString &name);
-    bool FindMatchingDecls(const ConstString &name,
-                           std::vector<swift::ValueDecl *> &matches);
+
+    /// Find decls matching `name`, excluding decls that are equivalent to
+    /// decls in `excluding_equivalents`, and put the results in `matches`.
+    /// Return true if there are any results.
+    bool FindMatchingDecls(
+        const ConstString &name,
+        std::vector<swift::ValueDecl *> excluding_equivalents,
+        std::vector<swift::ValueDecl *> &matches);
+
     void CopyDeclsTo(SwiftDeclMap &target_map);
     static bool DeclsAreEquivalent(swift::Decl *lhs, swift::Decl *rhs);
 
@@ -90,8 +97,13 @@ public:
 
   void CopyInSwiftPersistentDecls(SwiftDeclMap &source_map);
 
-  bool GetSwiftPersistentDecls(const ConstString &name,
-                               std::vector<swift::ValueDecl *> &matches);
+  /// Find decls matching `name`, excluding decls that are equivalent to decls
+  /// in `excluding_equivalents`, and put the results in `matches`.  Return true
+  /// if there are any results.
+  bool GetSwiftPersistentDecls(
+      const ConstString &name,
+      std::vector<swift::ValueDecl *> excluding_equivalents,
+      std::vector<swift::ValueDecl *> &matches);
 
   // This just adds this module to the list of hand-loaded modules, it doesn't
   // actually load it.


### PR DESCRIPTION
This may not be quite the right way to fix this, so I'm posting this PR to demonstrate what I figured out, and to get advice on how to proceed.

## Example of bug

```
  1> let x = 1; print(x)
1
x: Int = 1
  2> let x = 2; print(x)
error: repl.swift:2:18: error: ambiguous use of 'x'
let x = 2; print(x)
                 ^

repl.swift:2:5: note: found this candidate
let x = 2; print(x)
    ^
```

## My discoveries so far
* `LLDBNameLookup::lookupAdditions` is a function responsible for looking up decls from previous lines (aka "persistent decls").
* When line 2 of the above example executes, the parser finds the line-2-declaration of `x` before calling `lookupAdditions`. `lookupAdditions` proceeds to find the line-1-declaration of `x`, and adds it to the set of results. Now there are 2 declarations and we get the ambiguous use error.
* `lookupAdditions` already contains some logic that looks intended to prevent it from adding the line-1-declaration of `x` to `RV`. Specifically, decls present in `m_staged_decls` take precedence over decls from `m_persistent_decls`. It looks like `m_staged_decls` is intended to contain decls made in the currently-compiling code. Unfortunately, `m_staged_decls` is empty when `lookupAdditions` gets called in the above example.

## My fix

My fix to `lookupAdditions` works by adding the currently-compiling code's decls to `results` before `lookupAdditions` proceeds to add persistent decls. This causes the currently-compiling code's decls to take precedence.

I'm unsure if the decls that my fix adds should have been in `m_staged_decls` in the first place. If so, then a better fix would be to fix the problem that's preventing them from getting into `m_staged_decls`. @jimingham, do you know if decls should show up in `m_staged_decls`? If so, do you have any idea why they're not?

## Some m_staged_decls tracing

`DebuggerContextChange` is the only thing that adds `m_staged_decls`, [by calling debug_client->didGlobalize()](https://github.com/apple/swift/blob/98e95bdbef20ee33b7efba4f1d12cb5ae5ac81e2/lib/Parse/ParseDecl.cpp#L175). But this never actually happens in the above example for at least two reasons:
1. parseDeclVar never instantiates a DebuggerContextChange
2. The DebuggerContextChange wouldn't do anything, because [DebuggerContextChange::inDebuggerContext](https://github.com/apple/swift/blob/98e95bdbef20ee33b7efba4f1d12cb5ae5ac81e2/lib/Parse/ParseDecl.cpp#L150) is returning false.

## Links

Discussed in this forum post: https://forums.swift.org/t/implementing-a-jupyter-kernel-for-swift-using-lldb-questions-about-declaration-behavior-and-code-completion/14513

JIRA: https://bugs.swift.org/browse/SR-8289