### PR TITLE
Add libc++ data formatters for std::optional.

### DIFF
--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 		945261C11B9A11FC00BF138D /* LibCxxInitializerList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 945261B71B9A11E800BF138D /* LibCxxInitializerList.cpp */; };
 		945261C21B9A11FC00BF138D /* LibCxxList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 945261B81B9A11E800BF138D /* LibCxxList.cpp */; };
 		945261C31B9A11FC00BF138D /* LibCxxMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 945261B91B9A11E800BF138D /* LibCxxMap.cpp */; };
+		E4A63A9120F55D28000D9548 /* LibCxxOptional.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A63A9020F55D27000D9548 /* LibCxxOptional.cpp */; };
 		AF9FF1F71FAA79FE00474976 /* LibCxxQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AF9FF1F61FAA79FE00474976 /* LibCxxQueue.cpp */; };
 		AF9FF1F51FAA79A400474976 /* LibCxxTuple.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AF9FF1F41FAA79A400474976 /* LibCxxTuple.cpp */; };
 		945261C41B9A11FC00BF138D /* LibCxxUnorderedMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 945261BA1B9A11E800BF138D /* LibCxxUnorderedMap.cpp */; };
@@ -2155,6 +2156,7 @@
 		945261B71B9A11E800BF138D /* LibCxxInitializerList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxInitializerList.cpp; path = Language/CPlusPlus/LibCxxInitializerList.cpp; sourceTree = "<group>"; };
 		945261B81B9A11E800BF138D /* LibCxxList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxList.cpp; path = Language/CPlusPlus/LibCxxList.cpp; sourceTree = "<group>"; };
 		945261B91B9A11E800BF138D /* LibCxxMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxMap.cpp; path = Language/CPlusPlus/LibCxxMap.cpp; sourceTree = "<group>"; };
+		E4A63A9020F55D27000D9548 /* LibCxxOptional.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxOptional.cpp; path = Language/CPlusPlus/LibCxxOptional.cpp; sourceTree = "<group>"; };
 		AF9FF1F61FAA79FE00474976 /* LibCxxQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxQueue.cpp; path = Language/CPlusPlus/LibCxxQueue.cpp; sourceTree = "<group>"; };
 		AF9FF1F41FAA79A400474976 /* LibCxxTuple.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxTuple.cpp; path = Language/CPlusPlus/LibCxxTuple.cpp; sourceTree = "<group>"; };
 		945261BA1B9A11E800BF138D /* LibCxxUnorderedMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LibCxxUnorderedMap.cpp; path = Language/CPlusPlus/LibCxxUnorderedMap.cpp; sourceTree = "<group>"; };
@@ -6538,6 +6540,7 @@
 				945261B71B9A11E800BF138D /* LibCxxInitializerList.cpp */,
 				945261B81B9A11E800BF138D /* LibCxxList.cpp */,
 				945261B91B9A11E800BF138D /* LibCxxMap.cpp */,
+				E4A63A9020F55D27000D9548 /* LibCxxOptional.cpp */,
 				AF9FF1F61FAA79FE00474976 /* LibCxxQueue.cpp */,
 				AF9FF1F41FAA79A400474976 /* LibCxxTuple.cpp */,
 				945261BA1B9A11E800BF138D /* LibCxxUnorderedMap.cpp */,
@@ -8466,6 +8469,7 @@
 				AF26703B1852D01E00B6CC36 /* QueueList.cpp in Sources */,
 				267C012B136880DF006E963E /* OptionGroupValueObjectDisplay.cpp in Sources */,
 				49CA96FE1E6AACC900C03FEE /* DataEncoder.cpp in Sources */,
+				E4A63A9120F55D28000D9548 /* LibCxxOptional.cpp in Sources */,
 				26BCFC521368AE38006DC050 /* OptionGroupFormat.cpp in Sources */,
 				2654A6901E552ED500DA1013 /* VASprintf.cpp in Sources */,
 				AF81DEFA1828A23F0042CF19 /* SystemRuntime.cpp in Sources */,

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../../../make
+
+CXX_SOURCES := main.cpp
+
+USE_LIBCPP := 1
+include $(LEVEL)/Makefile.rules
+CXXFLAGS += -std=c++17

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/TestDataFormatterLibcxxOptional.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/TestDataFormatterLibcxxOptional.py
@@ -1,0 +1,75 @@
+"""
+Test lldb data formatter subsystem.
+"""
+
+from __future__ import print_function
+
+
+import os
+import time
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class LibcxxOptionalDataFormatterTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @add_test_categories(["libc++"])
+    ## We are skipping clang version less that 5.0 since this test requires -std=c++17
+    @skipIf(oslist=no_match(["macosx"]), compiler="clang", compiler_version=['<', '5.0'])
+    ## We are skipping gcc version less that 5.1 since this test requires -std=c++17
+    @skipIf(compiler="gcc", compiler_version=['<', '5.1'])
+
+    def test_with_run_command(self):
+        """Test that that file and class static variables display correctly."""
+        self.build()
+        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
+
+        bkpt = self.target().FindBreakpointByID(
+            lldbutil.run_break_set_by_source_regexp(
+                self, "break here"))
+
+        self.runCmd("run", RUN_SUCCEEDED)
+
+        # The stop reason of the thread should be breakpoint.
+        self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
+                    substrs=['stopped',
+                             'stop reason = breakpoint'])
+
+        self.runCmd( "frame variable has_optional" )
+
+        output = self.res.GetOutput()
+
+        ## The variable has_optional tells us if the test program
+        ## detected we have a sufficient libc++ version to support optional
+        ## false means we do not and therefore should skip the test
+        if output.find("(bool) has_optional = false") != -1 :
+           self.skipTest( "Optional not supported" ) 
+
+        lldbutil.continue_to_breakpoint(self.process(), bkpt)
+
+        self.expect("frame variable number_not_engaged",
+                    substrs=['Has Value=false'])
+
+        self.expect("frame variable number_engaged",
+                    substrs=['Has Value=true',
+                             'Value = 42',
+                             '}'])
+
+        self.expect("frame var numbers",
+                    substrs=['(optional_int_vect) numbers =  Has Value=true  {',
+                             'Value = size=4 {',
+                               '[0] = 1',
+                               '[1] = 2',
+                               '[2] = 3',
+                               '[3] = 4',
+                               '}',
+                             '}'])
+
+        self.expect("frame var ostring",
+                    substrs=['(optional_string) ostring =  Has Value=true  {',
+                        'Value = "hello"',
+                        '}'])

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/main.cpp
@@ -1,0 +1,42 @@
+#include <cstdio>
+#include <string>
+#include <vector>
+
+// If we have libc++ 4.0 or greater we should have <optional>
+// According to libc++ C++1z status page https://libcxx.llvm.org/cxx1z_status.html
+#if _LIBCPP_VERSION >= 4000
+#include <optional>
+#define HAVE_OPTIONAL 1
+#else
+#define HAVE_OPTIONAL 0
+#endif
+
+
+int main()
+{
+    bool has_optional = HAVE_OPTIONAL ;
+
+    printf( "%d\n", has_optional ) ; // break here
+
+#if HAVE_OPTIONAL == 1
+    using int_vect = std::vector<int> ;
+    using optional_int = std::optional<int> ;
+    using optional_int_vect = std::optional<int_vect> ;
+    using optional_string = std::optional<std::string> ;
+
+    optional_int number_not_engaged ;
+    optional_int number_engaged = 42 ;
+
+    printf( "%d\n", *number_engaged) ;
+
+    optional_int_vect numbers{{1,2,3,4}} ;
+
+    printf( "%d %d\n", numbers.value()[0], numbers.value()[1] ) ;
+
+    optional_string ostring = "hello" ;
+
+    printf( "%s\n", ostring->c_str() ) ;
+#endif
+
+    return 0; // break here
+}

--- a/source/Plugins/Language/CPlusPlus/CMakeLists.txt
+++ b/source/Plugins/Language/CPlusPlus/CMakeLists.txt
@@ -9,6 +9,7 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
   LibCxxInitializerList.cpp
   LibCxxList.cpp
   LibCxxMap.cpp
+  LibCxxOptional.cpp
   LibCxxQueue.cpp
   LibCxxTuple.cpp
   LibCxxUnorderedMap.cpp

--- a/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -251,14 +251,14 @@ std::string CPlusPlusLanguage::MethodName::GetScopeQualifiedName() {
 bool CPlusPlusLanguage::IsCPPMangledName(const char *name) {
   // FIXME!! we should really run through all the known C++ Language plugins
   // and ask each one if this is a C++ mangled name
-  
+
   if (name == nullptr)
     return false;
-  
-  // MSVC style mangling 
+
+  // MSVC style mangling
   if (name[0] == '?')
     return true;
-  
+
   return (name[0] != '\0' && name[0] == '_' && name[1] == 'Z');
 }
 
@@ -512,6 +512,10 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
                   "libc++ std::tuple synthetic children",
                   ConstString("^std::__(ndk)?1::tuple<.*>(( )?&)?$"), stl_synth_flags,
                   true);
+  AddCXXSynthetic(cpp_category_sp, LibcxxOptionalFrontEndCreator,
+                  "libc++ std::optional synthetic children",
+                  ConstString("^std::__(ndk)?1::optional<.+>(( )?&)?$"),
+                  stl_synth_flags, true);
   AddCXXSynthetic(
       cpp_category_sp,
       lldb_private::formatters::LibcxxAtomicSyntheticFrontEndCreator,
@@ -603,6 +607,11 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       cpp_category_sp, lldb_private::formatters::LibCxxAtomicSummaryProvider,
       "libc++ std::atomic summary provider",
       ConstString("^std::__(ndk)?1::atomic<.+>$"), stl_summary_flags, true);
+  AddCXXSummary(cpp_category_sp,
+                lldb_private::formatters::LibcxxOptionalSummaryProvider,
+                "libc++ std::optional summary provider",
+                ConstString("^std::__(ndk)?1::optional<.+>(( )?&)?$"),
+                stl_summary_flags, true);
 
   stl_summary_flags.SetSkipPointers(true);
 

--- a/source/Plugins/Language/CPlusPlus/LibCxx.h
+++ b/source/Plugins/Language/CPlusPlus/LibCxx.h
@@ -27,6 +27,10 @@ bool LibcxxWStringSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // libc++ std::wstring
 
+bool LibcxxOptionalSummaryProvider(
+    ValueObject &valobj, Stream &stream,
+    const TypeSummaryOptions &options); // libc++ std::optional<>
+
 bool LibcxxSmartPointerSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions
@@ -132,6 +136,10 @@ SyntheticChildrenFrontEnd *LibcxxQueueFrontEndCreator(CXXSyntheticChildren *,
 
 SyntheticChildrenFrontEnd *LibcxxTupleFrontEndCreator(CXXSyntheticChildren *,
                                                       lldb::ValueObjectSP);
+
+SyntheticChildrenFrontEnd *
+LibcxxOptionalFrontEndCreator(CXXSyntheticChildren *,
+                              lldb::ValueObjectSP valobj_sp);
 
 } // namespace formatters
 } // namespace lldb_private

--- a/source/Plugins/Language/CPlusPlus/LibCxxOptional.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxxOptional.cpp
@@ -1,0 +1,85 @@
+//===-- LibCxxOptional.cpp --------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "LibCxx.h"
+#include "lldb/DataFormatters/FormattersHelpers.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+namespace {
+
+class OptionalFrontEnd : public SyntheticChildrenFrontEnd {
+public:
+  OptionalFrontEnd(ValueObject &valobj) : SyntheticChildrenFrontEnd(valobj) {
+    Update();
+  }
+
+  size_t GetIndexOfChildWithName(const ConstString &name) override {
+    return formatters::ExtractIndexFromString(name.GetCString());
+  }
+
+  bool MightHaveChildren() override { return true; }
+  bool Update() override;
+  size_t CalculateNumChildren() override { return m_size; }
+  ValueObjectSP GetChildAtIndex(size_t idx) override;
+
+private:
+  size_t m_size = 0;
+  ValueObjectSP m_base_sp;
+};
+} // namespace
+
+bool OptionalFrontEnd::Update() {
+  ValueObjectSP engaged_sp(
+      m_backend.GetChildMemberWithName(ConstString("__engaged_"), true));
+
+  if (!engaged_sp)
+    return false;
+
+  // __engaged_ is a bool flag and is true if the optional contains a value.
+  // Converting it to unsigned gives us a size of 1 if it contains a value
+  // and 0 if not.
+  m_size = engaged_sp->GetValueAsUnsigned(0);
+
+  return false;
+}
+
+ValueObjectSP OptionalFrontEnd::GetChildAtIndex(size_t idx) {
+  if (idx >= m_size)
+    return ValueObjectSP();
+
+  // __val_ contains the underlying value of an optional if it has one.
+  // Currently because it is part of an anonymous union GetChildMemberWithName()
+  // does not peer through and find it unless we are at the parent itself.
+  // We can obtain the parent through __engaged_.
+  ValueObjectSP val_sp(
+      m_backend.GetChildMemberWithName(ConstString("__engaged_"), true)
+          ->GetParent()
+          ->GetChildAtIndex(0, true)
+          ->GetChildMemberWithName(ConstString("__val_"), true));
+
+  if (!val_sp)
+    return ValueObjectSP();
+
+  CompilerType holder_type = val_sp->GetCompilerType();
+
+  if (!holder_type)
+    return ValueObjectSP();
+
+  return val_sp->Clone(ConstString(llvm::formatv("Value").str()));
+}
+
+SyntheticChildrenFrontEnd *
+formatters::LibcxxOptionalFrontEndCreator(CXXSyntheticChildren *,
+                                          lldb::ValueObjectSP valobj_sp) {
+  if (valobj_sp)
+    return new OptionalFrontEnd(*valobj_sp);
+  return nullptr;
+}


### PR DESCRIPTION
Patch by Shafik Yaghmour!

This reapplies an earlier version after addressing some post-commit feedback.

Differential Revision: https://reviews.llvm.org/D49271

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@339828 91177308-0d34-0410-b5e6-96231b3b80d8