### PR TITLE
Fix crash in Set/Dictionary formatters

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -294,6 +294,8 @@ public:
   CompilerType GetTypeFromMangledTypename(const char *mangled_typename,
                                           Status &error);
 
+  CompilerType GetAnyObjectType();
+
   // Get a function type that returns nothing and take no parameters
   CompilerType GetVoidFunctionType();
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -294,6 +294,7 @@ public:
   CompilerType GetTypeFromMangledTypename(const char *mangled_typename,
                                           Status &error);
 
+  // Retrieve the Swift.AnyObject type.
   CompilerType GetAnyObjectType();
 
   // Get a function type that returns nothing and take no parameters

--- a/packages/Python/lldbsuite/test/lang/swift/nserror/TestNSError.py
+++ b/packages/Python/lldbsuite/test/lang/swift/nserror/TestNSError.py
@@ -24,7 +24,6 @@ class SwiftNSErrorTest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.skipUnlessDarwin
-    @decorators.skipIfDarwin
     @decorators.swiftTest
     @decorators.expectedFailureAll(
         bugnumber="https://bugs.swift.org/browse/SR-782")

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -543,8 +543,10 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   ValueObjectSP valobj_sp = valobj.GetSP();
   if (valobj_sp->GetObjectRuntimeLanguage() != eLanguageTypeSwift &&
       valobj_sp->IsPointerType()) {
-    valobj_sp = SwiftObjectAtAddress(valobj_sp->GetExecutionContextRef(),
-                                     valobj_sp->GetPointerValue());
+    if (auto swiftval_sp = SwiftObjectAtAddress(
+          valobj_sp->GetExecutionContextRef(),
+          valobj_sp->GetPointerValue()))
+      valobj_sp = swiftval_sp;
   }
   valobj_sp = valobj_sp->GetQualifiedRepresentationIfAvailable(
     lldb::eDynamicCanRunTarget, false);

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -292,7 +292,7 @@ HashedCollectionConfig::SwiftObjectAtAddress(
   if (error.Fail())
     return nullptr;
 
-  CompilerType anyObject_type = ast_ctx->FindQualifiedType("Swift.AnyObject");
+  CompilerType anyObject_type = ast_ctx->GetAnyObjectType();
   if (!anyObject_type)
     return nullptr;
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3929,6 +3929,12 @@ SwiftASTContext::GetTypeFromMangledTypename(const char *mangled_typename,
   return CompilerType();
 }
 
+CompilerType SwiftASTContext::GetAnyObjectType() {
+  VALID_OR_RETURN(CompilerType());
+  swift::ASTContext *ast = GetASTContext();
+  return CompilerType(ast, ast->getAnyObjectType());
+}
+
 CompilerType SwiftASTContext::GetVoidFunctionType() {
   VALID_OR_RETURN(CompilerType());
 


### PR DESCRIPTION
This improves error handling in Swift/Dictionary formatters, and makes `id` -> `AnyObject` conversion more robust.

Fixes rdar://problem/43569527