### PR TITLE
[TestNSError] Update and remove expected failure

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/nserror/TestNSError.py
+++ b/packages/Python/lldbsuite/test/lang/swift/nserror/TestNSError.py
@@ -25,8 +25,6 @@ class SwiftNSErrorTest(TestBase):
 
     @decorators.skipUnlessDarwin
     @decorators.swiftTest
-    @decorators.expectedFailureAll(
-        bugnumber="https://bugs.swift.org/browse/SR-782")
     def test_swift_nserror(self):
         """Tests that Swift displays NSError correctly"""
         self.build()
@@ -48,12 +46,21 @@ class SwiftNSErrorTest(TestBase):
             "thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs=['stopped', 'stop reason = breakpoint'])
 
-        self.expect("frame variable -d run --ptr-depth=2", substrs=[
-            '0 = " "', '1 = 0x', 'domain: "lldbrocks" - code: 3133079277 {',
-            '_userInfo = ', '2 key/value pairs {',
-            '0 = ', ' "x"', '1 = ', ' Int64(0)', '0 = ', ' "y"', '1 = ',
-            ' Int64(0)', '0 = "x+y"', 'domain: "lldbrocks" - code: 0 {',
-            '1 = ', ' Int64(3)', '1 = ', ' Int64(4)'])
+        self.expect(
+            "frame variable -d run --ptr-depth=2",
+            substrs=[
+              '0 = " "',
+              '0 = "x+y"',
+              '1 = 0x', 'domain: "lldbrocks" - code: 3133079277 {',
+                        'domain: "lldbrocks" - code: 0 {',
+                '_userInfo = 2 key/value pairs {',
+                  '[0] = {',
+                  '[1] = {',
+                    'key = "x"',
+                    'key = "y"',
+                    'value = 0',
+                    'value = 3',
+                    'value = 4'])
 
 if __name__ == '__main__':
     import atexit


### PR DESCRIPTION
`TestNSError`'s actual output looks okay to me now. Update expectations to match reality and remove expected failure from this test. Discrepancies seem due to integers being printed as `3` and `4` instead of `Int64(3)` and `Int64(4)`.

For reference, this is the current output of this test case:

```
(lldb) frame variable -d run --ptr-depth=2 
(String, NSError) call1 = {
  0 = " "
  1 = 0x0000000101700880 domain: "lldbrocks" - code: 3133079277 {
    _userInfo = 2 key/value pairs {
      [0] = {
        key = "y"
        value = 0
      }
      [1] = {
        key = "x"
        value = 0
      }
    }
  }
}
(String, NSError) call2 = {
  0 = "x+y"
  1 = 0x0000000101700d70 domain: "lldbrocks" - code: 0 {
    _userInfo = 2 key/value pairs {
      [0] = {
        key = "y"
        value = 4
      }
      [1] = {
        key = "x"
        value = 3
      }
    }
  }
}
```

Note that hash table ordering is unstable, so exact string matches won't work.