### PR TITLE
Disable exceptions for TestDataFormatterLibcxxOptional.py

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/optional/Makefile
@@ -4,4 +4,4 @@ CXX_SOURCES := main.cpp
 
 USE_LIBCPP := 1
 include $(LEVEL)/Makefile.rules
-CXXFLAGS += -std=c++17
+CXXFLAGS += -std=c++17 -fno-exceptions


### PR DESCRIPTION
Some of the optional APIs are available only starting on macOS 10.14
if exceptions are available. Disable exceptions so that these APIs are
availble on older systems too.

rdar://problem/43700544.