### PR TITLE
[REPL] Test the new optimized layout for Optional<T>

### DIFF
--- a/lit/SwiftREPL/Optional.test
+++ b/lit/SwiftREPL/Optional.test
@@ -1,0 +1,22 @@
+// RUN: %lldb --repl < %s | FileCheck %s
+
+enum Patatino {
+  case first
+  case second
+}
+
+struct Test {
+  var a : Int
+  var b : Patatino
+}
+
+let x : Optional<Test> = nil
+
+// CHECK: {{x}}: Test? = nil
+
+let y : Optional<Test> = Test(a: 1, b: Patatino.first)
+
+// CHECK-NEXT: {{y}}: Test? = some {
+// CHECK-NEXT: a = 1
+// CHECK-NEXT: b = first
+// CHECK-NEXT: }


### PR DESCRIPTION
where <T> is a struct with an extra-inhabitant-bearing field
anywhere in its definition, not only in the beginning.

Add a test in lldb to make sure the formatter is right for
Optional (and won't bitrot over time).

<rdar://problem/19690160>