### PR TITLE
Allow IRInterpreter to deal with non-power-of-2 sized types to suppor…

### DIFF
--- a/packages/Python/lldbsuite/test/lang/c/bitfields/TestBitfields.py
+++ b/packages/Python/lldbsuite/test/lang/c/bitfields/TestBitfields.py
@@ -116,6 +116,38 @@ class BitfieldsTestCase(TestBase):
         self.expect("expr/x (packed.c)", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs=['uint32_t', "7112233"])
 
+        for bit in range(1,18):
+            expected = "1" if bit in [1, 5, 7, 13] else "0"
+            self.expect("expr even_more_bits.b" + str(bit), VARIABLES_DISPLAYED_CORRECTLY,
+                    substrs=['uint8_t', expected])
+
+        for bit in [3, 10, 14]:
+            self.expect("expr even_more_bits.b" + str(bit) + " = 1", VARIABLES_DISPLAYED_CORRECTLY,
+                    substrs=['uint8_t', "1"])
+
+        self.expect(
+            "frame variable --show-types even_more_bits",
+            VARIABLES_DISPLAYED_CORRECTLY,
+            substrs=[
+                '(uint8_t:1) b1 = \'\\x01\'',
+                '(uint8_t:1) b2 = \'\\0\'',
+                '(uint8_t:1) b3 = \'\\x01\'',
+                '(uint8_t:1) b4 = \'\\0\'',
+                '(uint8_t:1) b5 = \'\\x01\'',
+                '(uint8_t:1) b6 = \'\\0\'',
+                '(uint8_t:1) b7 = \'\\x01\'',
+                '(uint8_t:1) b8 = \'\\0\'',
+                '(uint8_t:1) b9 = \'\\0\'',
+                '(uint8_t:1) b10 = \'\\x01\'',
+                '(uint8_t:1) b12 = \'\\0\'',
+                '(uint8_t:1) b13 = \'\\x01\'',
+                '(uint8_t:1) b14 = \'\\x01\'',
+                '(uint8_t:1) b15 = \'\\0\'',
+                '(uint8_t:1) b16 = \'\\0\'',
+                '(uint8_t:1) b17 = \'\\0\'',
+                ])
+
+
     @add_test_categories(['pyapi'])
     # BitFields exhibit crashes in record layout on Windows
     # (http://llvm.org/pr21800)

--- a/packages/Python/lldbsuite/test/lang/c/bitfields/main.c
+++ b/packages/Python/lldbsuite/test/lang/c/bitfields/main.c
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 int main (int argc, char const *argv[])
 {
@@ -62,6 +63,20 @@ int main (int argc, char const *argv[])
     more_bits.b = 0;
     more_bits.c = 1;
     more_bits.d = 0;
+
+    struct EvenMoreBits
+    {
+        uint8_t b1  : 1, b2  : 1, b3  : 1, b4  : 1, b5  : 1, b6  : 1,
+                b7  : 1, b8  : 1, b9  : 1, b10 : 1, b11 : 1, b12 : 1,
+                b13 : 1, b14 : 1, b15 : 1, b16 : 1, b17 : 1;
+    };
+
+    struct EvenMoreBits even_more_bits;
+    memset(&even_more_bits, 0, sizeof(even_more_bits));
+    even_more_bits.b1 = 1;
+    even_more_bits.b5 = 1;
+    even_more_bits.b7 = 1;
+    even_more_bits.b13 = 1;
 
 #pragma pack(1)
     struct PackedBits

--- a/source/Expression/IRInterpreter.cpp
+++ b/source/Expression/IRInterpreter.cpp
@@ -152,17 +152,13 @@ public:
                          Type *type) {
     size_t type_size = m_target_data.getTypeStoreSize(type);
 
-    switch (type_size) {
-    case 1:
-    case 2:
-    case 4:
-    case 8:
-      scalar = llvm::APInt(type_size*8, u64value);
-      break;
-    default:
+    if (type_size > 8)
       return false;
-    }
 
+    if (type_size != 1)
+      type_size = PowerOf2Ceil(type_size);
+
+    scalar = llvm::APInt(type_size*8, u64value);
     return true;
   }
 
@@ -192,8 +188,7 @@ public:
         return false;
 
       lldb::offset_t offset = 0;
-      if (value_size == 1 || value_size == 2 || value_size == 4 ||
-          value_size == 8) {
+      if (value_size <= 8) {
         uint64_t u64value = value_extractor.GetMaxU64(&offset, value_size);
         return AssignToMatchType(scalar, u64value, value->getType());
       }


### PR DESCRIPTION
…t some bitfield accesses.

Summary:
For some bitfield patterns (like the one added by this commit), Clang will
generate non-regular data types like i24 or i48. This patch follows a
pretty naive approach of just bumping the type size to the next power of 2.
DataExtractor know how to deal with weird sizes. The operations on Scalar
do not know how to deal with those types though, so we have to legalize the
size when creating a Scalar.

Reviewers: jingham, clayborg

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D51245

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@340880 91177308-0d34-0410-b5e6-96231b3b80d8