### PR TITLE
File completion bugfix

### DIFF
--- a/source/Commands/CommandCompletions.cpp
+++ b/source/Commands/CommandCompletions.cpp
@@ -166,7 +166,11 @@ static int DiskFilesOrDirectories(const llvm::Twine &partial_name,
   size_t FullPrefixLen = CompletionBuffer.size();
 
   PartialItem = path::filename(CompletionBuffer);
-  if (PartialItem == ".")
+
+  // path::filename() will return "." when the passed path ends with a
+  // directory separator. We have to filter those out, but only when the
+  // "." doesn't come from the completion request itself.
+  if (PartialItem == "." && path::is_separator(CompletionBuffer.back()))
     PartialItem = llvm::StringRef();
 
   if (SearchDir.empty()) {

--- a/unittests/Interpreter/TestCompletion.cpp
+++ b/unittests/Interpreter/TestCompletion.cpp
@@ -174,6 +174,11 @@ TEST_F(CompletionTest, DirCompletionAbsolute) {
   ASSERT_EQ(Count, Results.GetSize());
   EXPECT_TRUE(HasEquivalentFile(BaseDir, Results));
 
+  Count =
+    CommandCompletions::DiskDirectories(Twine(BaseDir) + "/.", Results, Resolver);
+  ASSERT_EQ(0u, Count);
+  ASSERT_EQ(Count, Results.GetSize());
+
   // When the same directory ends with a slash, it finds all children.
   Count = CommandCompletions::DiskDirectories(Prefixes[0], Results, Resolver);
   ASSERT_EQ(7u, Count);


### PR DESCRIPTION
If you tried to complete somwthing like ~/., lldb would come up with a lot
of non-existent filenames by concatenating every exisitng file in the directory
with an initial '.'.

This was due to a workaround for an llvm::fs::path::filename behavior that
was not applied selectively enough.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@341268 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 733a51f0a31cc32a3a73027df376777f6868c951)