### PR TITLE
Update the construction call of swift::PersistentParserState

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1547,7 +1547,7 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
   // them in.
   swift_ast_context->AddDebuggerClient(external_lookup);
 
-  swift::PersistentParserState persistent_state;
+  swift::PersistentParserState persistent_state(*ast_context);
 
   while (!done) {
     swift::parseIntoSourceFile(*source_file, buffer_id, &done, nullptr,

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -300,7 +300,8 @@ bool SwiftREPL::SourceIsComplete(const std::string &source) {
   std::unique_ptr<llvm::MemoryBuffer> source_buffer_ap(
       llvm::MemoryBuffer::getMemBuffer(source));
   swift::ide::SourceCompleteResult result =
-      swift::ide::isSourceInputComplete(std::move(source_buffer_ap));
+      swift::ide::isSourceInputComplete(std::move(source_buffer_ap),
+                                        swift::SourceFileKind::REPL);
   return result.IsComplete;
 }
 
@@ -334,7 +335,8 @@ lldb::offset_t SwiftREPL::GetDesiredIndentation(const StringList &lines,
   std::unique_ptr<llvm::MemoryBuffer> source_buffer_ap(
       llvm::MemoryBuffer::getMemBuffer(source_string));
   swift::ide::SourceCompleteResult result =
-      swift::ide::isSourceInputComplete(std::move(source_buffer_ap));
+      swift::ide::isSourceInputComplete(std::move(source_buffer_ap),
+                                        swift::SourceFileKind::REPL);
 
   int desired_indent =
       (result.IndentLevel * tab_size) + result.IndentPrefix.length();


### PR DESCRIPTION
This is a necessary change to make lldb build after the change from #19104. Since the original compiler PR is still WIP, please don't merge this PR until that one is merged.