### PR TITLE
[NFC] Fixed enum constant in boolean context error

### DIFF
--- a/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -652,11 +652,12 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::ReadMemoryModule(
 
   llvm::MachO::mach_header mh;
   size_t size_to_read = 512;
-  if (ReadMachHeader (m_load_address, process, mh)) {
-    if (mh.magic == llvm::MachO::MH_CIGAM || llvm::MachO::MH_MAGIC)
-      size_to_read = sizeof (llvm::MachO::mach_header) + mh.sizeofcmds;
-    if (mh.magic == llvm::MachO::MH_CIGAM_64 || llvm::MachO::MH_MAGIC_64)
-      size_to_read = sizeof (llvm::MachO::mach_header_64) + mh.sizeofcmds;
+  if (ReadMachHeader(m_load_address, process, mh)) {
+    if (mh.magic == llvm::MachO::MH_CIGAM || mh.magic == llvm::MachO::MH_MAGIC)
+      size_to_read = sizeof(llvm::MachO::mach_header) + mh.sizeofcmds;
+    if (mh.magic == llvm::MachO::MH_CIGAM_64 ||
+        mh.magic == llvm::MachO::MH_MAGIC_64)
+      size_to_read = sizeof(llvm::MachO::mach_header_64) + mh.sizeofcmds;
   }
 
   ModuleSP memory_module_sp =


### PR DESCRIPTION
[NFC] Fixed enum constant in boolean context error
Summary:
/home/xbolva00/LLVM/llvm/tools/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp:656:59: warning: enum constant in boolean context [-Wint-in-bool-context]
     if (mh.magic == llvm::MachO::MH_CIGAM || llvm::MachO::MH_MAGIC)
                                                           ^~~~~~~~
/home/xbolva00/LLVM/llvm/tools/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp:658:62: warning: enum constant in boolean context [-Wint-in-bool-context]
     if (mh.magic == llvm::MachO::MH_CIGAM_64 || llvm::MachO::MH_MAGIC_64)

Reviewers: JDevlieghere, teemperor

Reviewed By: teemperor

Subscribers: abidh, lldb-commits

Differential Revision: https://reviews.llvm.org/D51600

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@341340 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit a6f47fd015cc5bc23c2c8bf152952bc90a260468)