### PR TITLE
Re-instate a bit of code that was commented out in r188246 which

### DIFF
--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2457,14 +2457,6 @@ size_t ObjectFileMachO::ParseSymtab() {
             if (nlist_data_sp)
               nlist_data.SetData(nlist_data_sp, 0,
                                  nlist_data_sp->GetByteSize());
-            // Load strings individually from memory when loading from memory
-            // since shared cache string tables contain strings for all symbols
-            // from all shared cached libraries DataBufferSP strtab_data_sp
-            // (ReadMemory (process_sp, strtab_addr,
-            // strtab_data_byte_size));
-            // if (strtab_data_sp)
-            //    strtab_data.SetData (strtab_data_sp, 0,
-            //    strtab_data_sp->GetByteSize());
             if (m_dysymtab.nindirectsyms != 0) {
               const addr_t indirect_syms_addr = linkedit_load_addr +
                                                 m_dysymtab.indirectsymoff -
@@ -2476,6 +2468,22 @@ size_t ObjectFileMachO::ParseSymtab() {
                 indirect_symbol_index_data.SetData(
                     indirect_syms_data_sp, 0,
                     indirect_syms_data_sp->GetByteSize());
+              // If this binary is outside the shared cache, 
+              // cache the string table.
+              // Binaries in the shared cache all share a giant string table, and
+              // we can't share the string tables across multiple ObjectFileMachO's,
+              // so we'd end up re-reading this mega-strtab for every binary
+              // in the shared cache - it would be a big perf problem.
+              // For binaries outside the shared cache, it's faster to read the
+              // entire strtab at once instead of piece-by-piece as we process
+              // the nlist records.
+              if ((m_header.flags & 0x80000000u) == 0) {
+                DataBufferSP strtab_data_sp (ReadMemory (process_sp, strtab_addr, 
+                      strtab_data_byte_size));
+                if (strtab_data_sp) {
+                  strtab_data.SetData (strtab_data_sp, 0, strtab_data_sp->GetByteSize());
+                }
+              }
             }
           }
           if (memory_module_load_level >=

--- a/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -803,6 +803,8 @@ JSONGenerator::ObjectSP MachProcess::FormatDynamicLibrariesIntoJSON(
         (uint32_t)image_infos[i].macho_info.mach_header.cpusubtype);
     mach_header_dict_sp->AddIntegerItem(
         "filetype", image_infos[i].macho_info.mach_header.filetype);
+    mach_header_dict_sp->AddIntegerItem ("flags", 
+                         image_infos[i].macho_info.mach_header.flags);
 
     //          DynamicLoaderMacOSX doesn't currently need these fields, so
     //          don't send them.
@@ -810,8 +812,6 @@ JSONGenerator::ObjectSP MachProcess::FormatDynamicLibrariesIntoJSON(
     //            image_infos[i].macho_info.mach_header.ncmds);
     //            mach_header_dict_sp->AddIntegerItem ("sizeofcmds",
     //            image_infos[i].macho_info.mach_header.sizeofcmds);
-    //            mach_header_dict_sp->AddIntegerItem ("flags",
-    //            image_infos[i].macho_info.mach_header.flags);
     image_info_dict_sp->AddItem("mach_header", mach_header_dict_sp);
 
     JSONGenerator::ArraySP segments_sp(new JSONGenerator::Array());


### PR DESCRIPTION
Re-instate a bit of code that was commented out in r188246 which
reads an ObjectFileMachO's string table in one chunk.  Originally
this was commented out because binaries in the system's shared cache
all share a mega-string table and so reading the entire mega-strtab
for each binary was a performance problem.

In the reinstated code, I add a check that the binary we're reading
from memory is not in the shared cache (there isn't a constant in
<mach-o/loader.h> for this bit yet; we hardcode the value in one
other place in ObjectFileMachO alread).  For binaries that we're
reading out of memory that are NOT in the shared cache, reading 
the string table in one chunk is a big performance improvement.

Also have debugserver send up the flags value for binaries in its
response to the jGetLoadedDynamicLibrariesInfos request.

NFC.

<rdar://problem/33604496> 



git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@341511 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit a8d7125bb8eb189cd6a0edc0c1fb43f3f3d511c5)
(cherry picked from commit a8e4762ee4dcc92ba23918ade5d96bafc187cf12)