### PR TITLE
 Support tuples of generic values.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_tuple/TestSwiftGenericTuple.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_tuple/TestSwiftGenericTuple.py
@@ -11,4 +11,4 @@
 # ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
 
-lldbinline.MakeInlineTest(__file__, globals(), [lldbinline.expectedFailureAll()])
+lldbinline.MakeInlineTest(__file__, globals(), [])

--- a/packages/Python/lldbsuite/test/lang/swift/generic_tuple/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_tuple/main.swift
@@ -9,22 +9,36 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-func single<T>(_ t : T) -> T {
+func use<T>(_ t : T) {}
+
+func single<T>(_ t : T) {
   let x = t
-  return x //% self.expect('expr   t', substrs=['hello'])
-           //% self.expect('fr var t', substrs=['hello'])
-           //% self.expect('expr   x', substrs=['hello'])
-           //% self.expect('fr var x', substrs=['hello'])
+  use(x) //% self.expect('expr -d run-target -- t', substrs=['hello'])
+         //% self.expect('expr -d run-target -- x', substrs=['hello'])
+         //% self.expect('fr var -d run-target t', substrs=['String', 'hello'])
+         //% self.expect('fr var -d run-target x', substrs=['hello'])
 }
 
-func tuple<T, U>(_ t : (T, U)) -> U {
+func string_tuple<T, U>(_ t : (T, U)) {
   let (_, y) = t
-  return y //% self.expect('expr   t', substrs=['hello', 'hello'])
-           //% self.expect('fr var t', substrs=['hello', 'hello'])
-           //% self.expect('expr   y', substrs=['hello'])
-           //% self.expect('fr var y', substrs=['hello'])
+  use(y) //% self.expect('expr -d run-target -- t', substrs=['hello', 'hello'])
+         //% self.expect('expr -d run-target -- y', substrs=['hello'])
+         //% self.expect('fr var -d run-target t',
+         //%             substrs=['(String, String)', 'hello', 'hello'])
+         //% self.expect('fr var -d run-target y', substrs=['hello'])
+}
+
+func int_tuple<T, U>(_ t : (T, U)) {
+  let (_, y) = t
+  use(y) //% self.expect('expr -d run-target -- t',
+         //%             substrs=['(Int32, Int64)', '111', '222'])
+         //% self.expect('expr -d run-target -- y', substrs=['222'])
+         //% self.expect('fr var -d run-target t',
+         //%             substrs=['(Int32, Int64)', '111', '222'])
+         //% self.expect('fr var -d run-target y', substrs=['222'])
 }
 
 let s = "hello"
-print(single(s))
-print(tuple((s, s)))
+single(s)
+string_tuple((s, s))
+int_tuple((Int32(111), Int64(222)))

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2199,9 +2199,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Struct(
     ValueObject &in_value, CompilerType &bound_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
     Address &address) {
-  // struct can't inherit from each other, but they can be generic, in which
-  // case
-  // we need to turn MyStruct<U> into MyStruct<$swift.type.U>
   std::vector<CompilerType> generic_args;
   class_type_or_name.SetCompilerType(bound_type);
 
@@ -2221,15 +2218,13 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Enum(
     ValueObject &in_value, CompilerType &bound_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
     Address &address) {
-  // enums can't inherit from each other, but they can be generic, in which case
-  // we need to turn MyEnum<U> into MyEnum<$swift.type.U>
   std::vector<CompilerType> generic_args;
   class_type_or_name.SetCompilerType(bound_type);
 
   lldb::addr_t enum_address = in_value.GetPointerValue();
-  if (0 == enum_address || LLDB_INVALID_ADDRESS == enum_address)
+  if (!enum_address || LLDB_INVALID_ADDRESS == enum_address)
     enum_address = in_value.GetAddressOf(true, nullptr);
-  if (0 == enum_address || LLDB_INVALID_ADDRESS == enum_address) {
+  if (!enum_address || LLDB_INVALID_ADDRESS == enum_address) {
     if (false == SwiftASTContext::IsPossibleZeroSizeType(
                      class_type_or_name.GetCompilerType()))
       return false;


### PR DESCRIPTION
This patch has two parts:
1. Perform generic parameter binding in GetMemberVariableOffset()
   before handing the type over to RemoteAST
2. Fix GetDynamicTypeAndAddress_Tuple() to support scalar element types

<rdar://problem/37410759>