### PR TITLE
Print column info in backtraces et al. if available

### DIFF
--- a/include/lldb/Core/FormatEntity.h
+++ b/include/lldb/Core/FormatEntity.h
@@ -104,6 +104,7 @@ public:
       FunctionIsOptimized,
       LineEntryFile,
       LineEntryLineNumber,
+      LineEntryColumn,
       LineEntryStartAddress,
       LineEntryEndAddress,
       CurrentPCArrow

--- a/packages/Python/lldbsuite/test/functionalities/asan/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/asan/Makefile
@@ -1,6 +1,6 @@
 LEVEL = ../../make
 
 C_SOURCES := main.c
-CFLAGS_EXTRAS := -fsanitize=address -g
+CFLAGS_EXTRAS := -fsanitize=address -g -gcolumn-info
 
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
+++ b/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
@@ -37,6 +37,7 @@ class AsanTestReportDataCase(TestBase):
         self.line_free = line_number('main.c', '// free line')
         self.line_breakpoint = line_number('main.c', '// break line')
         self.line_crash = line_number('main.c', '// BOOM line')
+        self.col_crash = 16
 
     def asan_tests(self):
         exe = self.getBuildArtifact("a.out")
@@ -63,7 +64,7 @@ class AsanTestReportDataCase(TestBase):
             lldb.eStopReasonInstrumentation)
 
         self.expect("bt", "The backtrace should show the crashing line",
-                    substrs=['main.c:%d' % self.line_crash])
+                    substrs=['main.c:%d:%d' % (self.line_crash, self.col_crash)])
 
         self.expect(
             "thread info -s",

--- a/source/Core/Debugger.cpp
+++ b/source/Core/Debugger.cpp
@@ -198,7 +198,8 @@ OptionEnumValueElement g_language_enumerators[] = {
   "${module.file.basename}{`${function.name-without-args}"                     \
   "{${frame.no-debug}${function.pc-offset}}}}"
 
-#define FILE_AND_LINE "{ at ${line.file.basename}:${line.number}}"
+#define FILE_AND_LINE                                                          \
+  "{ at ${line.file.basename}:${line.number}{:${line.column}}}"
 #define IS_OPTIMIZED "{${function.is-optimized} [opt]}"
 
 #define DEFAULT_THREAD_FORMAT                                                  \

--- a/source/Core/FormatEntity.cpp
+++ b/source/Core/FormatEntity.cpp
@@ -146,6 +146,7 @@ static FormatEntity::Entry::Definition g_function_child_entries[] = {
 static FormatEntity::Entry::Definition g_line_child_entries[] = {
     ENTRY_CHILDREN("file", LineEntryFile, None, g_file_child_entries),
     ENTRY("number", LineEntryLineNumber, UInt32),
+    ENTRY("column", LineEntryColumn, UInt32),
     ENTRY("start-addr", LineEntryStartAddress, UInt64),
     ENTRY("end-addr", LineEntryEndAddress, UInt64),
 };
@@ -372,6 +373,7 @@ const char *FormatEntity::Entry::TypeToCString(Type t) {
     ENUM_TO_CSTR(FunctionIsOptimized);
     ENUM_TO_CSTR(LineEntryFile);
     ENUM_TO_CSTR(LineEntryLineNumber);
+    ENUM_TO_CSTR(LineEntryColumn);
     ENUM_TO_CSTR(LineEntryStartAddress);
     ENUM_TO_CSTR(LineEntryEndAddress);
     ENUM_TO_CSTR(CurrentPCArrow);
@@ -1816,6 +1818,16 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
       if (!entry.printf_format.empty())
         format = entry.printf_format.c_str();
       s.Printf(format, sc->line_entry.line);
+      return true;
+    }
+    return false;
+
+  case Entry::Type::LineEntryColumn:
+    if (sc && sc->line_entry.IsValid() && sc->line_entry.column) {
+      const char *format = "%" PRIu32;
+      if (!entry.printf_format.empty())
+        format = entry.printf_format.c_str();
+      s.Printf(format, sc->line_entry.column);
       return true;
     }
     return false;


### PR DESCRIPTION
This patch allows LLDB to print column info in backtraces et al. if
available, which is useful when the backtrace contains a frame like
the following:

  f(can_crash(0), can_crash(1));

Differential Revision: https://reviews.llvm.org/D51661

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@341506 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 91d709c7af26b9fa394ae7a20e95e721044b8703)