### PR TITLE
Fix a typo in mac SIP workaround

### DIFF
--- a/lit/Suite/lldbtest.py
+++ b/lit/Suite/lldbtest.py
@@ -71,8 +71,8 @@ class LLDBTest(TestFormat):
         # libraries into system binaries, but this can be worked around by
         # copying the binary into a different location.
         if 'DYLD_INSERT_LIBRARIES' in test.config.environment and \
-                sys.executable.startswith('/System/') or \
-                sys.executable.startswith('/usr/'):
+                (sys.executable.startswith('/System/') or \
+                sys.executable.startswith('/usr/')):
             builddir = getBuildDir(cmd)
             mkdir_p(builddir)
             copied_python = os.path.join(builddir, 'copied-system-python')


### PR DESCRIPTION
presumably the or subexpression was meant to be evaluated first. The way
it is now means that we apply the workaround for any python in `/usr`,
which matches pretty much every unix system.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@341167 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 8bcb5e7f073ebc8f0e93d3666c83672fafe43243)