### PR TITLE
Make SwiftASTContext::EitherComparator::operator() const.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -57,7 +57,7 @@ public:
 
 private:
   struct EitherComparator {
-    bool operator()(const TypeOrDecl &r1, const TypeOrDecl &r2) {
+    bool operator()(const TypeOrDecl &r1, const TypeOrDecl &r2) const {
       auto r1_as1 = r1.GetAs<CompilerType>();
       auto r1_as2 = r1.GetAs<swift::Decl *>();
 


### PR DESCRIPTION
Our build of swift-lldb within Google is transitioning to libc++,
which is stricter than libstdc++ about the const-ness of comparators
used with std collections.