### PR TITLE
[MIPS] Fix signed overflow in DADDIU emulation

### DIFF
--- a/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
+++ b/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
@@ -1105,13 +1105,24 @@ bool EmulateInstructionMIPS64::Emulate_DADDiu(llvm::MCInst &insn) {
     Context context;
 
     /* read <src> register */
-    const int64_t src_opd_val = ReadRegisterUnsigned(
+    const uint64_t src_opd_val = ReadRegisterUnsigned(
         eRegisterKindDWARF, dwarf_zero_mips64 + src, 0, &success);
     if (!success)
       return false;
 
     /* Check if this is daddiu sp, sp, imm16 */
     if (dst == dwarf_sp_mips64) {
+      /*
+       * From the MIPS IV spec:
+       *
+       * The term “unsigned” in the instruction name is a misnomer; this
+       * operation is 64-bit modulo arithmetic that does not trap on overflow.
+       * It is appropriate for arithmetic which is not signed, such as address
+       * arithmetic, or integer arithmetic environments that ignore overflow,
+       * such as “C” language arithmetic.
+       *
+       * Assume 2's complement and rely on unsigned overflow here.
+       */
       uint64_t result = src_opd_val + imm;
       RegisterInfo reg_info_sp;
 


### PR DESCRIPTION
This fixes a signed integer overflow diagnostic reported by ubsan.

rdar://44353380

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342008 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit db5c77d1bbebce4ee572a9725813be27f5822364)