### PR TITLE
[SwiftLanguageRuntime] Catch up with changes for swift_willThrow.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -246,9 +246,8 @@ public:
 
   SwiftExceptionPrecondition *GetExceptionPrecondition();
 
-  static lldb::ValueObjectSP
-  CalculateErrorValueFromFirstArgument(lldb::StackFrameSP frame_sp,
-                                       ConstString name);
+  static lldb::ValueObjectSP CalculateErrorValue(lldb::StackFrameSP frame_sp,
+                                                 ConstString name);
 
   lldb::ValueObjectSP CalculateErrorValueObjectFromValue(Value &value,
                                                          ConstString name,

--- a/source/Target/ThreadPlanCallFunction.cpp
+++ b/source/Target/ThreadPlanCallFunction.cpp
@@ -540,9 +540,8 @@ bool ThreadPlanCallFunction::BreakpointsExplainStop() {
         ConstString persistent_variable_name(
             persistent_state->GetNextPersistentVariableName(GetTarget(),
                                                             prefix));
-        m_return_valobj_sp =
-            SwiftLanguageRuntime::CalculateErrorValueFromFirstArgument(
-                frame_sp, persistent_variable_name);
+        m_return_valobj_sp = SwiftLanguageRuntime::CalculateErrorValue(
+            frame_sp, persistent_variable_name);
 
         DataExtractor data;
         Status data_error;


### PR DESCRIPTION
The compiler as size optimizations stores the error object in the
error return register. This commits update(s) lldb to look in the
right place (before, it was the first argument to the function).

<rdar://problem/44303855>