### PR TITLE
[SwiftASTContext] Don't swallow the sugar when getting the type.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/TestTypealiasExpressionParser.py
+++ b/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/TestTypealiasExpressionParser.py
@@ -1,0 +1,3 @@
+import lldbsuite.test.lldbinline as lldbinline
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/typealias_expression_parser/main.swift
@@ -1,0 +1,7 @@
+func main() -> Int {
+  typealias Pair<T> = (T, T)
+  let patatino : Pair<Int> = (1, 2)
+  return 0 //%self.expect('expr -d run -- patatino', substrs=['Pair<Int>'])
+}
+
+main()

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5129,12 +5129,12 @@ SwiftASTContext::GetReferentType(const CompilerType &compiler_type) {
 
   if (compiler_type.IsValid() &&
       llvm::dyn_cast_or_null<SwiftASTContext>(compiler_type.GetTypeSystem())) {
-    swift::CanType swift_can_type(GetCanonicalSwiftType(compiler_type));
-    swift::TypeBase *swift_type = swift_can_type.getPointer();
-    if (swift_type && llvm::isa<swift::WeakStorageType>(swift_type))
+    swift::Type swift_type(GetSwiftType(compiler_type));
+    swift::TypeBase *swift_typebase = swift_type.getPointer();
+    if (swift_type && llvm::isa<swift::WeakStorageType>(swift_typebase))
       return compiler_type;
 
-    auto ref_type = swift_can_type->getReferenceStorageReferent();
+    auto ref_type = swift_type->getReferenceStorageReferent();
     return CompilerType(GetASTContext(), ref_type);
   }
 


### PR DESCRIPTION
This is important for generic typealiases, which we printed
desuagared before this change.

<rdar://problem/44305917>