### PR TITLE
[DWARFExpression] Read literars as unsigned values.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/c/local_variables/Makefile
+++ b/packages/Python/lldbsuite/test/lang/c/local_variables/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../make
+
+C_SOURCES := main.c
+
+CFLAGS_EXTRAS += -O1
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/c/local_variables/TestLocalVariables.py
+++ b/packages/Python/lldbsuite/test/lang/c/local_variables/TestLocalVariables.py
@@ -1,0 +1,55 @@
+"""Show local variables and check that they can be inspected.
+
+This test was added after we made a change in clang to normalize
+DW_OP_constu(X < 32) to DW_OP_litX which broke the debugger because
+it didn't read the value as an unsigned.
+"""
+
+from __future__ import print_function
+
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class LocalVariablesTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+        # Find the line number to break inside main().
+        self.source = 'main.c'
+        self.line = line_number(
+            self.source, '// Set break point at this line.')
+
+    def test_c_local_variables(self):
+        """Test local variable value."""
+        self.build()
+
+        # Create a target by the debugger.
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+
+        # Break inside the main.
+        lldbutil.run_break_set_by_file_and_line(
+            self, self.source, self.line, num_expected_locations=1, loc_exact=True)
+
+        # Now launch the process, and do not stop at entry point.
+        process = target.LaunchSimple(
+            None, None, self.get_process_working_directory())
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # The stop reason of the thread should be breakpoint.
+        self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
+                    substrs=['stopped',
+                             'stop reason = breakpoint'])
+
+        # The breakpoint should have a hit count of 1.
+        self.expect("breakpoint list -f", BREAKPOINT_HIT_ONCE,
+                    substrs=[' resolved, hit count = 1'])
+
+        self.expect("frame variable i", VARIABLES_DISPLAYED_CORRECTLY,
+                    substrs=['(unsigned int) i = 10'])

--- a/packages/Python/lldbsuite/test/lang/c/local_variables/main.c
+++ b/packages/Python/lldbsuite/test/lang/c/local_variables/main.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+void bar(unsigned i)
+{
+  printf("%d\n", i);
+}
+
+void foo(unsigned j)
+{
+  unsigned i = j;
+  bar(i);
+  i = 10;
+  bar(i); // Set break point at this line.
+}
+
+int main(int argc, char** argv)
+{
+  foo(argc);
+}

--- a/source/Expression/DWARFExpression.cpp
+++ b/source/Expression/DWARFExpression.cpp
@@ -2369,7 +2369,7 @@ bool DWARFExpression::Evaluate(
     case DW_OP_lit29:
     case DW_OP_lit30:
     case DW_OP_lit31:
-      stack.push_back(Scalar(op - DW_OP_lit0));
+      stack.push_back(Scalar((uint64_t)(op - DW_OP_lit0)));
       break;
 
     //----------------------------------------------------------------------


### PR DESCRIPTION
After landing r341457, we started seeing a failure on the swift-lldb
bots. The change was correct and pretty straightforward, a DW_OP_constu
was replaced with DW_OP_lit23, the value remaining identical.

  0x000000f4: DW_TAG_variable
		DW_AT_location    (0x00000000
		  [0x0000000100000a51,  0x0000000100000d47): DW_OP_lit23, DW_OP_stack_value)
		DW_AT_name        ("number")

However, this broke LLDB.

  (Int) number = <extracting data from value failed>

The value was read correctly, but apparently the value's type was different.
When reading a constu it was reading a uint64 (m_type = e_ulonglong) while for
the literal, it got a signed int (m_type = e_sint). This change makes sure we
read the value as an unsigned.

Differential revision: https://reviews.llvm.org/D51730

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342142 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit a87f4cb64d8130367e2c07b524acb44ac87adbbe)