### PR TITLE
[IRInterpreter] Fall back to JIT with 128-bit values.

### DIFF
--- a/packages/Python/lldbsuite/test/expression_command/rdar44436068/Makefile
+++ b/packages/Python/lldbsuite/test/expression_command/rdar44436068/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../make
+C_SOURCES := main.c
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/expression_command/rdar44436068/Test128BitsInteger.py
+++ b/packages/Python/lldbsuite/test/expression_command/rdar44436068/Test128BitsInteger.py
@@ -1,0 +1,4 @@
+from lldbsuite.test import lldbinline
+from lldbsuite.test import decorators
+
+lldbinline.MakeInlineTest(__file__, globals(), None)

--- a/packages/Python/lldbsuite/test/expression_command/rdar44436068/main.c
+++ b/packages/Python/lldbsuite/test/expression_command/rdar44436068/main.c
@@ -1,0 +1,8 @@
+int main(void)
+{
+    __int128_t n = 1;
+    n = n + n;
+    return n; //%self.expect("p n", substrs=['(__int128_t) $0 = 2'])
+              //%self.expect("p n + 6", substrs=['(__int128) $1 = 8'])
+              //%self.expect("p n + n", substrs=['(__int128) $2 = 4'])
+}

--- a/source/Expression/IRInterpreter.cpp
+++ b/source/Expression/IRInterpreter.cpp
@@ -624,6 +624,18 @@ bool IRInterpreter::CanInterpret(llvm::Module &module, llvm::Function &function,
         }
         }
 
+        // The IR interpreter currently doesn't know about
+        // 128-bit integers. As they're not that frequent,
+        // we can just fall back to the JIT rather than
+        // choking.
+        if (operand_type->getPrimitiveSizeInBits() > 64) {
+          if (log)
+            log->Printf("Unsupported operand type: %s",
+                        PrintType(operand_type).c_str());
+          error.SetErrorString(unsupported_operand_error);
+          return false;
+        }
+
         if (Constant *constant = llvm::dyn_cast<Constant>(operand)) {
           if (!CanResolveConstant(constant)) {
             if (log)


### PR DESCRIPTION
They're not that common, and falling back is definitely
better than throwing an error instead of the result. If we
feel motivated, we might end up implementing support for these,
but it's unclear whether it's worth the effort/complexity.

Fixes PR38925.

<rdar://problem/44436068>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342262 91177308-0d34-0410-b5e6-96231b3b80d8