### PR TITLE
Fix PRODUCT_NAME for lldb-gtest and lldb-gtest-build in Xcode project

### DIFF
--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -9535,7 +9535,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PATH = /opt/local/bin;
-				PRODUCT_NAME = "lib$(TARGET_NAME)";
+				PRODUCT_NAME = "lldb-gtest";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
@@ -9954,7 +9954,7 @@
 					"-framework",
 					Foundation,
 				);
-				PRODUCT_NAME = LLDB;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/source $(LLVM_SOURCE_DIR)/include $(LLVM_SOURCE_DIR)/tools/clang/include $(LLVM_BUILD_DIR)/$(LLVM_BUILD_DIR_ARCH)/include $(LLVM_BUILD_DIR)/$(LLVM_BUILD_DIR_ARCH)/tools/clang/include $(LLVM_BUILD_DIR)/$(LLVM_BUILD_DIR_ARCH)/lib/Target/ARM";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -9996,7 +9996,7 @@
 					"-framework",
 					Foundation,
 				);
-				PRODUCT_NAME = LLDB;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/include $(SRCROOT)/source $(LLVM_SOURCE_DIR)/include $(LLVM_SOURCE_DIR)/tools/clang/include $(LLVM_BUILD_DIR)/$(LLVM_BUILD_DIR_ARCH)/include $(LLVM_BUILD_DIR)/$(LLVM_BUILD_DIR_ARCH)/tools/clang/include $(LLVM_BUILD_DIR)/$(LLVM_BUILD_DIR_ARCH)/lib/Target/ARM";
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
Fix PRODUCT_NAME to match setting in other configurations:
* In lldb-gtest (DebugClang & Release): must be "lldb-gtest" and not "LLDB"
* In lldb-gtest-build (Debug): must be "lldb-gtest" and not "liblldb-gtest-build"