### PR TITLE
Allow use of self.filecheck in LLDB tests (c.f self.expect)

### DIFF
--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -7075,7 +7075,7 @@
 /* Begin PBXLegacyTarget section */
 		2387551E1C24974600CCE8C3 /* lldb-python-test-suite */ = {
 			isa = PBXLegacyTarget;
-			buildArgumentsString = "-u $(SRCROOT)/test/dotest.py --apple-sdk $(PLATFORM_NAME) --executable=$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/lldb -C $(LLDB_PYTHON_TESTSUITE_CC) --session-file-format fm --results-formatter lldbsuite.test_event.formatter.xunit.XunitFormatter --build-dir $(BUILD_DIR)/lldb-test-build.noindex --results-file $(BUILD_DIR)/test-results.xml --rerun-all-issues --env TERM=vt100 -O--xpass=ignore";
+			buildArgumentsString = "-u $(SRCROOT)/test/dotest.py --apple-sdk $(PLATFORM_NAME) --executable=$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/lldb -C $(LLDB_PYTHON_TESTSUITE_CC) --filecheck $(LLVM_BUILD_DIR)/x86_64/bin/FileCheck --session-file-format fm --results-formatter lldbsuite.test_event.formatter.xunit.XunitFormatter --build-dir $(BUILD_DIR)/lldb-test-build.noindex --results-file $(BUILD_DIR)/test-results.xml --rerun-all-issues --env TERM=vt100 -O--xpass=ignore";
 			buildConfigurationList = 238755241C24974600CCE8C3 /* Build configuration list for PBXLegacyTarget "lldb-python-test-suite" */;
 			buildPhases = (
 			);

--- a/packages/Python/lldbsuite/test/configuration.py
+++ b/packages/Python/lldbsuite/test/configuration.py
@@ -51,6 +51,9 @@ compiler = None    # Must be initialized after option parsing
 swiftCompiler = None
 swiftLibrary = None
 
+# Path to the FileCheck testing tool. Not optional.
+filecheck = None
+
 # The arch might dictate some specific CFLAGS to be passed to the toolchain to build
 # the inferior programs.  The global variable cflags_extras provides a hook to do
 # just that.
@@ -184,3 +187,11 @@ def get_absolute_path_to_root_test_dir():
         return test_subdir
 
     return os.path.dirname(os.path.realpath(__file__))
+
+
+def get_filecheck_path():
+    """
+    Get the path to the FileCheck testing tool.
+    """
+    assert os.path.lexists(filecheck)
+    return filecheck

--- a/packages/Python/lldbsuite/test/dotest.py
+++ b/packages/Python/lldbsuite/test/dotest.py
@@ -307,6 +307,13 @@ def parseOptionsAndInitTestdirs():
       os.environ['DSYMUTIL'] = seven.get_command_output(
           'xcrun -find -toolchain default dsymutil')
 
+    if args.filecheck:
+        # The CMake build passes in a path to a working FileCheck binary.
+        configuration.filecheck = os.path.abspath(args.filecheck)
+    else:
+        logging.error('No valid FileCheck executable; aborting...')
+        sys.exit(-1)
+
     if args.channels:
         lldbtest_config.channels = args.channels
 

--- a/packages/Python/lldbsuite/test/dotest_args.py
+++ b/packages/Python/lldbsuite/test/dotest_args.py
@@ -93,6 +93,8 @@ def create_parser():
 
     group.add_argument('--dsymutil', metavar='dsymutil', dest='dsymutil', help=textwrap.dedent('Specify which dsymutil to use.'))
 
+    group.add_argument('--filecheck', metavar='filecheck', dest='filecheck', help=textwrap.dedent('Specify which FileCheck binary to use.'))
+
     # Test filtering options
     group = parser.add_argument_group('Test filtering options')
     group.add_argument(

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/typedef_array/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/typedef_array/main.cpp
@@ -9,6 +9,11 @@
 typedef int Foo;
 
 int main() {
+    // CHECK: (Foo [3]) array = {
+    // CHECK-NEXT: (Foo) [0] = 1
+    // CHECK-NEXT: (Foo) [1] = 2
+    // CHECK-NEXT: (Foo) [2] = 3
+    // CHECK-NEXT: }
     Foo array[3] = {1,2,3};
-    return 0; //% self.expect("frame variable array --show-types --", substrs = ['(Foo [3]) array = {','(Foo) [0] = 1','(Foo) [1] = 2','(Foo) [2] = 3'])
+    return 0; //% self.filecheck("frame variable array --show-types --", 'main.cpp')
 }

--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -2171,6 +2171,54 @@ class TestBase(Base):
 
         return match_object
 
+    def filecheck(
+            self,
+            command,
+            check_file,
+            filecheck_options = ''):
+        # Run the command.
+        self.runCmd(
+                command,
+                msg="FileCheck'ing result of `{0}`".format(command))
+
+        # Get the error text if there was an error, and the regular text if not.
+        output = self.res.GetOutput() if self.res.Succeeded() \
+                else self.res.GetError()
+
+        # Assemble the absolute path to the check file. As a convenience for
+        # LLDB inline tests, assume that the check file is a relative path to
+        # a file within the inline test directory.
+        if check_file.endswith('.pyc'):
+            check_file = check_file[:-1]
+        if hasattr(self, 'test_filename'):
+            check_file_abs = os.path.join(os.path.dirname(self.test_filename),
+                    check_file)
+        else:
+            check_file_abs = os.path.abspath(check_file)
+
+        # Run FileCheck.
+        filecheck_bin = configuration.get_filecheck_path()
+        filecheck_args = [filecheck_bin, check_file_abs]
+        if filecheck_options:
+            filecheck_args.append(filecheck_options)
+        subproc = Popen(filecheck_args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        cmd_stdout, cmd_stderr = subproc.communicate(input=output)
+        cmd_status = subproc.returncode
+
+        if cmd_status != 0:
+            filecheck_cmd = " ".join(filecheck_args)
+            self.assertTrue(cmd_status == 0, """
+--- FileCheck failed (code={0}) ---
+{1}
+
+FileCheck input:
+{2}
+
+FileCheck output:
+{3}
+{4}
+""".format(cmd_status, filecheck_cmd, output, cmd_stdout, cmd_stderr))
+
     def expect(
             self,
             str,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(LLDB_TEST_COMMON_ARGS
   --arch=${LLDB_TEST_ARCH}
   --executable $<TARGET_FILE:lldb>
   --dsymutil $<TARGET_FILE:llvm-dsymutil>
+  --filecheck $<TARGET_FILE:FileCheck>
   -s
   ${CMAKE_BINARY_DIR}/lldb-test-traces
   --build-dir


### PR DESCRIPTION
Add a "filecheck" method to the LLDB test base. This allows test authors
to pattern match command output using FileCheck, making it possible to
write stricter tests than what `self.expect` allows.

For context (motivation, examples of stricter checking, etc), see the
lldb-dev thread: "Using FileCheck in lldb inline tests".

Differential Revision: https://reviews.llvm.org/D50751

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342508 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 6413d140911303169f38613be07aaf9f7217abfa)

 Conflicts:
	CMakeLists.txt
	lldb.xcodeproj/project.pbxproj
	packages/Python/lldbsuite/test/lldbtest.py
	test/CMakeLists.txt