### PR TITLE
Revert "[Swift] Link against the swift reflection library. (#904)"

### DIFF
--- a/source/Target/CMakeLists.txt
+++ b/source/Target/CMakeLists.txt
@@ -1,23 +1,3 @@
-include_directories(../Plugins/Process/Utility)
-
-set(REFLECTION_LIB "")
-
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(REFLECTION_LIB "swiftReflection-linux-x86_64")
-endif()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    # libswiftReflection is placed in a subdirectory which depends
-    # on the host we're currently running on.
-    # FIXME: There must be a better way to get at libswiftReflection.a
-    string(REPLACE "-" ";" TRIPLE_LIST "${LLVM_HOST_TRIPLE}")
-    list(GET TRIPLE_LIST 0 ARCH)
-    list(GET TRIPLE_LIST 2 HOST_OS_VERSION)
-    string(REGEX MATCHALL "[a-z]+" HOST_OS "${HOST_OS_VERSION}")
-    set(REFLECTION_LIB "${REFLECTION_LIB}-${HOST_OS}-${ARCH}")
-    message("Building for non-linux host, setting reflection lib to ${REFLECTION_LIB}")
-endif()
-
 add_lldb_library(lldbTarget
   ABI.cpp
   CPPLanguageRuntime.cpp
@@ -85,7 +65,6 @@ add_lldb_library(lldbTarget
     swiftBasic
     swiftFrontend
     swiftRemoteAST
-    ${REFLECTION_LIB}
     lldbBreakpoint
     lldbCore
     lldbExpression


### PR DESCRIPTION
This reverts commit d018ae834ff5fd23ab445383bb0a04e703221298 as
it broke the MacOS swift-lldb bots.

<rdar://problem/42444994>