### PR TITLE
Revert "Support building DWARF-only (no .dSYM) Swift testcases."

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/meta/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/meta/Makefile
@@ -1,6 +1,0 @@
-LEVEL = ../../../make
-
-SWIFT_SOURCES := hello.swift
-
-include $(LEVEL)/Makefile.rules
-

--- a/packages/Python/lldbsuite/test/lang/swift/meta/TestSwiftMeta.py
+++ b/packages/Python/lldbsuite/test/lang/swift/meta/TestSwiftMeta.py
@@ -14,7 +14,6 @@ Test the Swift test decorator itself.
 """
 import lldbsuite.test.decorators as decorators
 import lldbsuite.test.lldbtest as lldbtest
-import os
 
 class TestSwiftMeta(lldbtest.TestBase):
 
@@ -24,15 +23,3 @@ class TestSwiftMeta(lldbtest.TestBase):
     def test_swiftDecorator(self):
         self.assertTrue(self.getDebugInfo() <> "gmodules")
 
-    @decorators.swiftTest
-    def test_swiftBuild(self):
-        self.build()
-        exe = self.getBuildArtifact()
-        dsym = exe+'.dSYM'
-        self.assertTrue(os.path.isfile(exe))
-        if self.getDebugInfo() == "dwarf":
-            self.assertFalse(os.path.isdir(dsym),
-                             'testing DWARF, but .dSYM present')
-        if self.getDebugInfo() == "dsym":
-            self.assertTrue(os.path.isdir(dsym),
-                            '.dSYM is missing in dsym config')

--- a/packages/Python/lldbsuite/test/lang/swift/meta/hello.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/meta/hello.swift
@@ -1,1 +1,0 @@
-print("Hello World")

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -261,7 +261,7 @@ endif
 DEBUG_INFO_FLAG ?= -g
 
 CFLAGS ?= $(DEBUG_INFO_FLAG) -O0 -fno-builtin
-SWIFTFLAGS ?= -g -Onone -Xfrontend -serialize-debugging-options
+SWIFTFLAGS ?= -g -Onone -save-temps -Xfrontend -serialize-debugging-options
 
 # Setup a default per-user Swift module cache directory.
 SWIFT_MODULE_CACHE_PATH ?= /tmp/lldbtest.swift.modulecache.$(USER)
@@ -598,27 +598,8 @@ endif
 # Compile the executable from all the objects.
 #----------------------------------------------------------------------
 ifeq "$(USESWIFTDRIVER)" "1"
-MODULENAME=$(shell basename $(EXE) .out)
-VPATHSOURCES=$(patsubst %,$(VPATH)/%,$(SWIFT_SOURCES))
-%.o: %.swift
-	@echo "### Compiling" $<
-	$(SWIFT_FE) $(SWIFT_FEFLAGS) -c -primary-file $^ \
-          $(filter-out $(VPATH)/$^,$(filter-out $^,$(VPATHSOURCES))) \
-          -o $(BUILDDIR)/$@ \
-          -module-name $(MODULENAME) -emit-module-path \
-	  $(patsubst %.o,$(BUILDDIR)/%.partial.swiftmodule,$@)
-
-$(EXE) : $(patsubst %.swift,%.o,$(SWIFT_SOURCES))
-	@echo "### Merging swift modules"
-	$(SWIFT_FE) $(SWIFT_FEFLAGS) -merge-modules \
-	  -emit-module $(patsubst %.o,%.partial.swiftmodule,$^) \
-	  -parse-as-library -sil-merge-partial-modules \
-          -disable-diagnostic-passes -disable-sil-perf-optzns \
-          -module-name $(MODULENAME) \
-	  -o $(BUILDDIR)/$@.swiftmodule
-	@echo "### Linking" $(EXE)
-	$(SWIFTC) $^ $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)" \
-	  -Xlinker -add_ast_path -Xlinker $(BUILDDIR)/$@.swiftmodule
+$(EXE) : $(SWIFT_SOURCES)
+	$(SWIFTC) $^ $(SWIFTFLAGS) -o "$(EXE)"
 else
 ifneq "$(DYLIB_NAME)" ""
 ifeq "$(DYLIB_ONLY)" ""


### PR DESCRIPTION
This reverts commit b8a750f175b436bc4b66ad03cd7dfb6c07eddd07.

It broke linux.