### PR TITLE
Only load dependent files for executables

### DIFF
--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -71,6 +71,11 @@ typedef enum LoadCWDlldbinitFile {
   eLoadCWDlldbinitWarn
 } LoadCWDlldbinitFile;
 
+typedef enum LoadDependentFiles {
+  eLoadDependentsDefault,
+  eLoadDependentsYes,
+  eLoadDependentsNo,
+} LoadDependentFiles;
 
 //----------------------------------------------------------------------
 // TargetProperties
@@ -708,7 +713,6 @@ public:
                                const BreakpointOptions &options,
                                const BreakpointName::Permissions &permissions);
  void ApplyNameToBreakpoints(BreakpointName &bp_name);
-   
   
   // This takes ownership of the name obj passed in.
   void AddBreakpointName(BreakpointName *bp_name);
@@ -796,9 +800,9 @@ public:
   /// that doesn't have code in it, LLDB_INVALID_ADDRESS will be
   /// returned.
   //------------------------------------------------------------------
-  lldb::addr_t GetOpcodeLoadAddress(
-      lldb::addr_t load_addr,
-      AddressClass addr_class = AddressClass::eInvalid) const;
+  lldb::addr_t
+  GetOpcodeLoadAddress(lldb::addr_t load_addr,
+                       AddressClass addr_class = AddressClass::eInvalid) const;
 
   // Get load_addr as breakable load address for this target. Take a addr and
   // check if for any reason there is a better address than this to put a
@@ -869,14 +873,16 @@ public:
   ///     A shared pointer reference to the module that will become
   ///     the main executable for this process.
   ///
-  /// @param[in] get_dependent_files
+  /// @param[in] load_dependent_files
   ///     If \b true then ask the object files to track down any
   ///     known dependent files.
   ///
   /// @see ObjectFile::GetDependentModules (FileSpecList&)
   /// @see Process::GetImages()
   //------------------------------------------------------------------
-  void SetExecutableModule(lldb::ModuleSP &module_sp, bool get_dependent_files);
+  void SetExecutableModule(
+      lldb::ModuleSP &module_sp,
+      LoadDependentFiles load_dependent_files = eLoadDependentsDefault);
 
   bool LoadScriptingResources(std::list<Status> &errors,
                               Stream *feedback_stream = nullptr,

--- a/include/lldb/Target/TargetList.h
+++ b/include/lldb/Target/TargetList.h
@@ -92,7 +92,8 @@ public:
   ///     An error object that indicates success or failure
   //------------------------------------------------------------------
   Status CreateTarget(Debugger &debugger, llvm::StringRef user_exe_path,
-                      llvm::StringRef triple_str, bool get_dependent_modules,
+                      llvm::StringRef triple_str,
+                      LoadDependentFiles get_dependent_modules,
                       const OptionGroupPlatform *platform_options,
                       lldb::TargetSP &target_sp);
 
@@ -103,7 +104,8 @@ public:
   /// platform you will be using
   //------------------------------------------------------------------
   Status CreateTarget(Debugger &debugger, llvm::StringRef user_exe_path,
-                      const ArchSpec &arch, bool get_dependent_modules,
+                      const ArchSpec &arch,
+                      LoadDependentFiles get_dependent_modules,
                       lldb::PlatformSP &platform_sp, lldb::TargetSP &target_sp);
 
   //------------------------------------------------------------------
@@ -217,12 +219,13 @@ private:
 
   Status CreateTargetInternal(Debugger &debugger, llvm::StringRef user_exe_path,
                               llvm::StringRef triple_str,
-                              bool get_dependent_files,
+                              LoadDependentFiles load_dependent_files,
                               const OptionGroupPlatform *platform_options,
                               lldb::TargetSP &target_sp, bool is_dummy_target);
 
   Status CreateTargetInternal(Debugger &debugger, llvm::StringRef user_exe_path,
-                              const ArchSpec &arch, bool get_dependent_modules,
+                              const ArchSpec &arch,
+                              LoadDependentFiles get_dependent_modules,
                               lldb::PlatformSP &platform_sp,
                               lldb::TargetSP &target_sp, bool is_dummy_target);
 

--- a/packages/Python/lldbsuite/test/functionalities/target_create_deps/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/target_create_deps/Makefile
@@ -1,0 +1,16 @@
+LEVEL := ../../make
+
+LIB_PREFIX := load_
+
+LD_EXTRAS := -L. -l$(LIB_PREFIX)a
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules
+
+a.out: lib_a
+
+lib_%:
+	$(MAKE) VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/$*.mk
+
+clean::
+	$(MAKE) -f $(SRCDIR)/a.mk clean

--- a/packages/Python/lldbsuite/test/functionalities/target_create_deps/TestTargetCreateDeps.py
+++ b/packages/Python/lldbsuite/test/functionalities/target_create_deps/TestTargetCreateDeps.py
@@ -1,0 +1,96 @@
+"""
+Test that loading of dependents works correctly for all the potential
+combinations.
+"""
+
+from __future__ import print_function
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TargetDependentsTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.build()
+
+    def has_exactly_one_image(self, matching, msg=""):
+        self.expect(
+            "image list",
+            "image list should contain at least one image",
+            substrs=['[  0]'])
+        should_match = not matching
+        self.expect(
+            "image list", msg, matching=should_match, substrs=['[  1]'])
+
+    def test_dependents_implicit_default_exe(self):
+        """Test default behavior"""
+        exe = self.getBuildArtifact("a.out")
+        self.runCmd("target create  " + exe, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(False)
+
+    def test_dependents_explicit_default_exe(self):
+        """Test default behavior"""
+        exe = self.getBuildArtifact("a.out")
+        self.runCmd("target create -ddefault " + exe, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(False)
+
+    def test_dependents_explicit_true_exe(self):
+        """Test default behavior"""
+        exe = self.getBuildArtifact("a.out")
+        self.runCmd("target create -dtrue " + exe, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(True)
+
+    def test_dependents_explicit_false_exe(self):
+        """Test default behavior"""
+        exe = self.getBuildArtifact("a.out")
+        self.runCmd("target create -dfalse " + exe, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(False)
+
+    def test_dependents_implicit_false_exe(self):
+        """Test default behavior"""
+        exe = self.getBuildArtifact("a.out")
+        self.runCmd("target create  -d " + exe, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(True)
+
+    def test_dependents_implicit_default_lib(self):
+        ctx = self.platformContext
+        dylibName = ctx.shlib_prefix + 'load_a.' + ctx.shlib_extension
+        lib = self.getBuildArtifact(dylibName)
+        self.runCmd("target create " + lib, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(True)
+
+    def test_dependents_explicit_default_lib(self):
+        ctx = self.platformContext
+        dylibName = ctx.shlib_prefix + 'load_a.' + ctx.shlib_extension
+        lib = self.getBuildArtifact(dylibName)
+        self.runCmd("target create -ddefault " + lib, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(True)
+
+    def test_dependents_explicit_true_lib(self):
+        ctx = self.platformContext
+        dylibName = ctx.shlib_prefix + 'load_a.' + ctx.shlib_extension
+        lib = self.getBuildArtifact(dylibName)
+        self.runCmd("target create -dtrue " + lib, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(True)
+
+    def test_dependents_explicit_false_lib(self):
+        ctx = self.platformContext
+        dylibName = ctx.shlib_prefix + 'load_a.' + ctx.shlib_extension
+        lib = self.getBuildArtifact(dylibName)
+        self.runCmd("target create -dfalse " + lib, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(False)
+
+    def test_dependents_implicit_false_lib(self):
+        ctx = self.platformContext
+        dylibName = ctx.shlib_prefix + 'load_a.' + ctx.shlib_extension
+        lib = self.getBuildArtifact(dylibName)
+        self.runCmd("target create -d " + lib, CURRENT_EXECUTABLE_SET)
+        self.has_exactly_one_image(True)

--- a/packages/Python/lldbsuite/test/functionalities/target_create_deps/a.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/target_create_deps/a.cpp
@@ -1,0 +1,13 @@
+//===-- b.c -----------------------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+int a_function ()
+{
+    return 500;
+}

--- a/packages/Python/lldbsuite/test/functionalities/target_create_deps/a.mk
+++ b/packages/Python/lldbsuite/test/functionalities/target_create_deps/a.mk
@@ -1,0 +1,9 @@
+LEVEL := ../../make
+
+LIB_PREFIX := load_
+
+DYLIB_NAME := $(LIB_PREFIX)a
+DYLIB_CXX_SOURCES := a.cpp
+DYLIB_ONLY := YES
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/target_create_deps/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/target_create_deps/main.cpp
@@ -1,0 +1,17 @@
+//===-- main.c --------------------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+extern int a_function ();
+extern int b_function ();
+
+int
+main (int argc, char const *argv[])
+{
+    return a_function();
+}

--- a/source/API/SBDebugger.cpp
+++ b/source/API/SBDebugger.cpp
@@ -558,7 +558,8 @@ lldb::SBTarget SBDebugger::CreateTarget(const char *filename,
     platform_options.SetPlatformName(platform_name);
 
     sb_error.ref() = m_opaque_sp->GetTargetList().CreateTarget(
-        *m_opaque_sp, filename, target_triple, add_dependent_modules,
+        *m_opaque_sp, filename, target_triple,
+        add_dependent_modules ? eLoadDependentsYes : eLoadDependentsNo,
         &platform_options, target_sp);
 
     if (sb_error.Success())
@@ -587,7 +588,8 @@ SBDebugger::CreateTargetWithFileAndTargetTriple(const char *filename,
   if (m_opaque_sp) {
     const bool add_dependent_modules = true;
     Status error(m_opaque_sp->GetTargetList().CreateTarget(
-        *m_opaque_sp, filename, target_triple, add_dependent_modules, nullptr,
+        *m_opaque_sp, filename, target_triple,
+        add_dependent_modules ? eLoadDependentsYes : eLoadDependentsNo, nullptr,
         target_sp));
     sb_target.SetSP(target_sp);
   }
@@ -613,7 +615,8 @@ SBTarget SBDebugger::CreateTargetWithFileAndArch(const char *filename,
     const bool add_dependent_modules = true;
 
     error = m_opaque_sp->GetTargetList().CreateTarget(
-        *m_opaque_sp, filename, arch_cstr, add_dependent_modules, nullptr,
+        *m_opaque_sp, filename, arch_cstr,
+        add_dependent_modules ? eLoadDependentsYes : eLoadDependentsNo, nullptr,
         target_sp);
 
     if (error.Success()) {
@@ -638,7 +641,9 @@ SBTarget SBDebugger::CreateTarget(const char *filename) {
     Status error;
     const bool add_dependent_modules = true;
     error = m_opaque_sp->GetTargetList().CreateTarget(
-        *m_opaque_sp, filename, "", add_dependent_modules, nullptr, target_sp);
+        *m_opaque_sp, filename, "",
+        add_dependent_modules ? eLoadDependentsYes : eLoadDependentsNo, nullptr,
+        target_sp);
 
     if (error.Success()) {
       m_opaque_sp->GetTargetList().SetSelectedTarget(target_sp.get());

--- a/source/Commands/CommandObjectProcess.cpp
+++ b/source/Commands/CommandObjectProcess.cpp
@@ -459,7 +459,7 @@ protected:
       Status error;
 
       error = m_interpreter.GetDebugger().GetTargetList().CreateTarget(
-          m_interpreter.GetDebugger(), "", "", false,
+          m_interpreter.GetDebugger(), "", "", eLoadDependentsNo,
           nullptr, // No platform options
           new_target_sp);
       target = new_target_sp.get();

--- a/source/Commands/CommandObjectTarget.cpp
+++ b/source/Commands/CommandObjectTarget.cpp
@@ -262,7 +262,8 @@ protected:
       const bool get_dependent_files =
           m_add_dependents.GetOptionValue().GetCurrentValue();
       Status error(debugger.GetTargetList().CreateTarget(
-          debugger, file_path, arch_cstr, get_dependent_files, nullptr,
+          debugger, file_path, arch_cstr,
+          get_dependent_files ? eLoadDependentsYes : eLoadDependentsNo, nullptr,
           target_sp));
 
       if (target_sp) {

--- a/source/Core/DynamicLoader.cpp
+++ b/source/Core/DynamicLoader.cpp
@@ -101,8 +101,7 @@ ModuleSP DynamicLoader::GetTargetExecutable() {
         if (executable.get() != target.GetExecutableModulePointer()) {
           // Don't load dependent images since we are in dyld where we will
           // know and find out about all images that are loaded
-          const bool get_dependent_images = false;
-          target.SetExecutableModule(executable, get_dependent_images);
+          target.SetExecutableModule(executable, eLoadDependentsNo);
         }
       }
     }

--- a/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -848,7 +848,7 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::LoadImageUsingMemoryModule(
         target.GetImages().AppendIfNeeded(m_module_sp);
         if (IsKernel() &&
             target.GetExecutableModulePointer() != m_module_sp.get()) {
-          target.SetExecutableModule(m_module_sp, false);
+          target.SetExecutableModule(m_module_sp, eLoadDependentsNo);
         }
       }
     }

--- a/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
+++ b/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
@@ -205,8 +205,7 @@ ModuleSP DynamicLoaderHexagonDYLD::GetTargetExecutable() {
   if (executable.get() != target.GetExecutableModulePointer()) {
     // Don't load dependent images since we are in dyld where we will know and
     // find out about all images that are loaded
-    const bool get_dependent_images = false;
-    target.SetExecutableModule(executable, get_dependent_images);
+    target.SetExecutableModule(executable, eLoadDependentsNo);
   }
 
   return executable;

--- a/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -555,8 +555,7 @@ void DynamicLoaderDarwin::UpdateSpecialBinariesFromNewImageInfos(
       target.GetImages().AppendIfNeeded(exe_module_sp);
       UpdateImageLoadAddress(exe_module_sp.get(), image_infos[exe_idx]);
       if (exe_module_sp.get() != target.GetExecutableModulePointer()) {
-        const bool get_dependent_images = false;
-        target.SetExecutableModule(exe_module_sp, get_dependent_images);
+        target.SetExecutableModule(exe_module_sp, eLoadDependentsNo);
       }
     }
   }

--- a/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
+++ b/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.cpp
@@ -975,9 +975,8 @@ void DynamicLoaderMacOSXDYLD::UpdateImageInfosHeaderAndLoadCommands(
         // re-add it back to make sure it is always in the list.
         ModuleSP dyld_module_sp(GetDYLDModule());
 
-        const bool get_dependent_images = false;
         m_process->GetTarget().SetExecutableModule(exe_module_sp,
-                                                   get_dependent_images);
+                                                   eLoadDependentsNo);
 
         if (dyld_module_sp) {
           if (target.GetImages().AppendIfNeeded(dyld_module_sp)) {

--- a/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -756,7 +756,7 @@ void DynamicLoaderPOSIXDYLD::ResolveExecutableModule(
     return;
   }
 
-  target.SetExecutableModule(module_sp, false);
+  target.SetExecutableModule(module_sp, eLoadDependentsNo);
 }
 
 bool DynamicLoaderPOSIXDYLD::AlwaysRelyOnEHUnwindInfo(

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -128,17 +128,16 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
   os << version.getAsString();
   target_triple.setOSName(os.str());
 
-  bool add_dependent_modules = true;
   TargetSP target_sp;
   err = debugger.GetTargetList().CreateTarget(
       debugger, repl_exe_path.c_str(), target_triple.getTriple(),
-      add_dependent_modules, nullptr, target_sp);
+      eLoadDependentsYes, nullptr, target_sp);
   if (!err.Success()) {
     err.SetErrorStringWithFormat("failed to create REPL target: %s",
                                  err.AsCString());
     return nullptr;
   }
-  
+
   // Limit the breakpoint to our executable module
   ModuleSP exe_module_sp(target_sp->GetExecutableModule());
   if (!exe_module_sp) {

--- a/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.cpp
+++ b/source/Plugins/Platform/FreeBSD/PlatformFreeBSD.cpp
@@ -274,9 +274,9 @@ lldb::ProcessSP PlatformFreeBSD::Attach(ProcessAttachInfo &attach_info,
       TargetSP new_target_sp;
       ArchSpec emptyArchSpec;
 
-      error = debugger.GetTargetList().CreateTarget(debugger, "", emptyArchSpec,
-                                                    false, m_remote_platform_sp,
-                                                    new_target_sp);
+      error = debugger.GetTargetList().CreateTarget(
+          debugger, "", emptyArchSpec, eLoadDependentsNo, m_remote_platform_sp,
+          new_target_sp);
       target = new_target_sp.get();
     } else
       error.Clear();

--- a/source/Plugins/Platform/Linux/PlatformLinux.cpp
+++ b/source/Plugins/Platform/Linux/PlatformLinux.cpp
@@ -302,8 +302,8 @@ PlatformLinux::DebugProcess(ProcessLaunchInfo &launch_info, Debugger &debugger,
   if (target == nullptr) {
     LLDB_LOG(log, "creating new target");
     TargetSP new_target_sp;
-    error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                  nullptr, new_target_sp);
+    error = debugger.GetTargetList().CreateTarget(
+        debugger, "", "", eLoadDependentsNo, nullptr, new_target_sp);
     if (error.Fail()) {
       LLDB_LOG(log, "failed to create new target: {0}", error);
       return process_sp;

--- a/source/Plugins/Platform/NetBSD/PlatformNetBSD.cpp
+++ b/source/Plugins/Platform/NetBSD/PlatformNetBSD.cpp
@@ -271,8 +271,8 @@ PlatformNetBSD::DebugProcess(ProcessLaunchInfo &launch_info, Debugger &debugger,
   if (target == nullptr) {
     LLDB_LOG(log, "creating new target");
     TargetSP new_target_sp;
-    error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                  nullptr, new_target_sp);
+    error = debugger.GetTargetList().CreateTarget(
+        debugger, "", "", eLoadDependentsNo, nullptr, new_target_sp);
     if (error.Fail()) {
       LLDB_LOG(log, "failed to create new target: {0}", error);
       return process_sp;

--- a/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -813,8 +813,8 @@ lldb::ProcessSP PlatformPOSIX::Attach(ProcessAttachInfo &attach_info,
     if (target == NULL) {
       TargetSP new_target_sp;
 
-      error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                    NULL, new_target_sp);
+      error = debugger.GetTargetList().CreateTarget(
+          debugger, "", "", eLoadDependentsNo, NULL, new_target_sp);
       target = new_target_sp.get();
       if (log)
         log->Printf("PlatformPOSIX::%s created new target", __FUNCTION__);

--- a/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -470,8 +470,8 @@ lldb::ProcessSP PlatformWindows::Attach(ProcessAttachInfo &attach_info,
     FileSpec emptyFileSpec;
     ArchSpec emptyArchSpec;
 
-    error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                  nullptr, new_target_sp);
+    error = debugger.GetTargetList().CreateTarget(
+        debugger, "", "", eLoadDependentsNo, nullptr, new_target_sp);
     target = new_target_sp.get();
   }
 

--- a/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -488,8 +488,8 @@ lldb::ProcessSP PlatformRemoteGDBServer::DebugProcess(
         if (target == NULL) {
           TargetSP new_target_sp;
 
-          error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                        NULL, new_target_sp);
+          error = debugger.GetTargetList().CreateTarget(
+              debugger, "", "", eLoadDependentsNo, NULL, new_target_sp);
           target = new_target_sp.get();
         } else
           error.Clear();
@@ -574,8 +574,8 @@ lldb::ProcessSP PlatformRemoteGDBServer::Attach(
         if (target == NULL) {
           TargetSP new_target_sp;
 
-          error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                        NULL, new_target_sp);
+          error = debugger.GetTargetList().CreateTarget(
+              debugger, "", "", eLoadDependentsNo, NULL, new_target_sp);
           target = new_target_sp.get();
         } else
           error.Clear();

--- a/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
+++ b/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
@@ -319,7 +319,7 @@ Status ProcessKDP::DoConnectRemote(Stream *strm, llvm::StringRef remote_url) {
                   // Make sure you don't already have the right module loaded
                   // and they will be uniqued
                   if (exe_module_sp.get() != module_sp.get())
-                    target.SetExecutableModule(module_sp, false);
+                    target.SetExecutableModule(module_sp, eLoadDependentsNo);
                 }
               }
             }

--- a/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -254,7 +254,7 @@ Status ProcessElfCore::DoLoadCore() {
       if (exe_module_spec.GetFileSpec()) {
         exe_module_sp = GetTarget().GetSharedModule(exe_module_spec);
         if (exe_module_sp)
-          GetTarget().SetExecutableModule(exe_module_sp, false);
+          GetTarget().SetExecutableModule(exe_module_sp, eLoadDependentsNo);
       }
     }
   }

--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4802,7 +4802,7 @@ size_t ProcessGDBRemote::LoadModules(LoadedModuleInfoList &module_list) {
         return true;
 
       lldb::ModuleSP module_copy_sp = module_sp;
-      target.SetExecutableModule(module_copy_sp, false);
+      target.SetExecutableModule(module_copy_sp, eLoadDependentsNo);
       return false;
     });
 

--- a/source/Target/Platform.cpp
+++ b/source/Target/Platform.cpp
@@ -1803,8 +1803,8 @@ lldb::ProcessSP Platform::ConnectProcess(llvm::StringRef connect_url,
 
   if (!target) {
     TargetSP new_target_sp;
-    error = debugger.GetTargetList().CreateTarget(debugger, "", "", false,
-                                                  nullptr, new_target_sp);
+    error = debugger.GetTargetList().CreateTarget(
+        debugger, "", "", eLoadDependentsNo, nullptr, new_target_sp);
     target = new_target_sp.get();
   }
 

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -3345,7 +3345,8 @@ void Process::CompleteAttach() {
     }
   }
   if (new_executable_module_sp) {
-    GetTarget().SetExecutableModule(new_executable_module_sp, false);
+    GetTarget().SetExecutableModule(new_executable_module_sp,
+                                    eLoadDependentsNo);
     if (log) {
       ModuleSP exe_module_sp = GetTarget().GetExecutableModule();
       log->Printf(

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -1397,7 +1397,7 @@ void Target::DidExec() {
 }
 
 void Target::SetExecutableModule(ModuleSP &executable_sp,
-                                 bool get_dependent_files) {
+                                 LoadDependentFiles load_dependent_files) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TARGET));
   ClearModules(false);
 
@@ -1421,8 +1421,20 @@ void Target::SetExecutableModule(ModuleSP &executable_sp,
 
     FileSpecList dependent_files;
     ObjectFile *executable_objfile = executable_sp->GetObjectFile();
+    bool load_dependens;
+    switch (load_dependent_files) {
+    case eLoadDependentsDefault:
+      load_dependens = executable_sp->IsExecutable();
+      break;
+    case eLoadDependentsYes:
+      load_dependens = true;
+      break;
+    case eLoadDependentsNo:
+      load_dependens = false;
+      break;
+    }
 
-    if (executable_objfile && get_dependent_files) {
+    if (executable_objfile && load_dependens) {
       executable_objfile->GetDependentModules(dependent_files);
       for (uint32_t i = 0; i < dependent_files.GetSize(); i++) {
         FileSpec dependent_file_spec(
@@ -1507,7 +1519,7 @@ bool Target::SetArchitecture(const ArchSpec &arch_spec) {
                                                nullptr, nullptr);
 
     if (!error.Fail() && executable_sp) {
-      SetExecutableModule(executable_sp, true);
+      SetExecutableModule(executable_sp, eLoadDependentsYes);
       return true;
     }
   }
@@ -2087,7 +2099,7 @@ void Target::ImageSearchPathsChanged(const PathMappingList &path_list,
   Target *target = (Target *)baton;
   ModuleSP exe_module_sp(target->GetExecutableModule());
   if (exe_module_sp)
-    target->SetExecutableModule(exe_module_sp, true);
+    target->SetExecutableModule(exe_module_sp, eLoadDependentsYes);
 }
 
 #ifdef __clang_analyzer__

--- a/source/Target/TargetList.cpp
+++ b/source/Target/TargetList.cpp
@@ -58,27 +58,27 @@ TargetList::~TargetList() {
 Status TargetList::CreateTarget(Debugger &debugger,
                                 llvm::StringRef user_exe_path,
                                 llvm::StringRef triple_str,
-                                bool get_dependent_files,
+                                LoadDependentFiles load_dependent_files,
                                 const OptionGroupPlatform *platform_options,
                                 TargetSP &target_sp) {
   return CreateTargetInternal(debugger, user_exe_path, triple_str,
-                              get_dependent_files, platform_options, target_sp,
+                              load_dependent_files, platform_options, target_sp,
                               false);
 }
 
 Status TargetList::CreateTarget(Debugger &debugger,
                                 llvm::StringRef user_exe_path,
                                 const ArchSpec &specified_arch,
-                                bool get_dependent_files,
+                                LoadDependentFiles load_dependent_files,
                                 PlatformSP &platform_sp, TargetSP &target_sp) {
   return CreateTargetInternal(debugger, user_exe_path, specified_arch,
-                              get_dependent_files, platform_sp, target_sp,
+                              load_dependent_files, platform_sp, target_sp,
                               false);
 }
 
 Status TargetList::CreateTargetInternal(
     Debugger &debugger, llvm::StringRef user_exe_path,
-    llvm::StringRef triple_str, bool get_dependent_files,
+    llvm::StringRef triple_str, LoadDependentFiles load_dependent_files,
     const OptionGroupPlatform *platform_options, TargetSP &target_sp,
     bool is_dummy_target) {
   Status error;
@@ -292,7 +292,7 @@ Status TargetList::CreateTargetInternal(
     platform_arch = arch;
 
   error = TargetList::CreateTargetInternal(
-      debugger, user_exe_path, platform_arch, get_dependent_files, platform_sp,
+      debugger, user_exe_path, platform_arch, load_dependent_files, platform_sp,
       target_sp, is_dummy_target);
   return error;
 }
@@ -315,14 +315,14 @@ Status TargetList::CreateDummyTarget(Debugger &debugger,
                                      lldb::TargetSP &target_sp) {
   PlatformSP host_platform_sp(Platform::GetHostPlatform());
   return CreateTargetInternal(
-      debugger, (const char *)nullptr, specified_arch_name, false,
+      debugger, (const char *)nullptr, specified_arch_name, eLoadDependentsNo,
       (const OptionGroupPlatform *)nullptr, target_sp, true);
 }
 
 Status TargetList::CreateTargetInternal(Debugger &debugger,
                                         llvm::StringRef user_exe_path,
                                         const ArchSpec &specified_arch,
-                                        bool get_dependent_files,
+                                        LoadDependentFiles load_dependent_files,
                                         lldb::PlatformSP &platform_sp,
                                         lldb::TargetSP &target_sp,
                                         bool is_dummy_target) {
@@ -401,7 +401,7 @@ Status TargetList::CreateTargetInternal(Debugger &debugger,
         return error;
       }
       target_sp.reset(new Target(debugger, arch, platform_sp, is_dummy_target));
-      target_sp->SetExecutableModule(exe_module_sp, get_dependent_files);
+      target_sp->SetExecutableModule(exe_module_sp, load_dependent_files);
       if (user_exe_path_is_bundle)
         exe_module_sp->GetFileSpec().GetPath(resolved_bundle_exe_path,
                                              sizeof(resolved_bundle_exe_path));

--- a/tools/lldb-test/lldb-test.cpp
+++ b/tools/lldb-test/lldb-test.cpp
@@ -214,10 +214,9 @@ static Error make_string_error(const char *Format, Args &&... args) {
 
 TargetSP opts::createTarget(Debugger &Dbg, const std::string &Filename) {
   TargetSP Target;
-  Status ST =
-      Dbg.GetTargetList().CreateTarget(Dbg, Filename, /*triple*/ "",
-                                       /*get_dependent_modules*/ false,
-                                       /*platform_options*/ nullptr, Target);
+  Status ST = Dbg.GetTargetList().CreateTarget(
+      Dbg, Filename, /*triple*/ "", eLoadDependentsNo,
+      /*platform_options*/ nullptr, Target);
   if (ST.Fail()) {
     errs() << formatv("Failed to create target '{0}: {1}\n", Filename, ST);
     exit(1);


### PR DESCRIPTION
Unless explicitly requested, only load dependent files when the target is an executable.

rdar://problem/43721382