### PR TITLE
Retry: Emit a precise error message when lldb can't load a swift AST

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -44,6 +44,10 @@ namespace irgen {
 class FixedTypeInfo;
 class TypeInfo;
 }
+namespace serialization {
+struct ValidationInfo;
+struct ExtendedValidationInfo;
+}
 }
 
 class DWARFASTParser;
@@ -906,6 +910,12 @@ public:
 private:
   std::unique_ptr<SwiftPersistentExpressionState> m_persistent_state_up;
 };
+
+void printASTValidationInfo(
+    const swift::serialization::ValidationInfo &ast_info,
+    const swift::serialization::ExtendedValidationInfo &ext_ast_info,
+    const Module &module, llvm::StringRef module_buf);
+
 }
 
 #endif // #ifndef liblldb_SwiftASTContext_h_

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -1336,6 +1336,15 @@ public:
     return m_use_scratch_typesystem_per_module;
   }
 
+private:
+  std::mutex m_swift_messages_mutex;
+  std::unordered_set<std::string> m_swift_messages_issued;
+
+public:
+  /// Register that a message (uniquely identified by \p Key) about a Swift
+  /// context is about to be displayed to the user. Returns true iff the message
+  /// has not already been displayed.
+  bool RegisterSwiftContextMessageKey(std::string Key);
 
 protected:
   //------------------------------------------------------------------

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -47,6 +47,8 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/Utils.h"
 #include "swift/IRGen/Linking.h"
+#include "swift/Serialization/ModuleFile.h"
+#include "swift/Serialization/Validation.h"
 #include "swift/SIL/SILModule.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclObjC.h"
@@ -987,13 +989,29 @@ static bool DeserializeAllCompilerFlags(SwiftASTContext &swift_ast,
                         ast_file_data_sp->GetByteSize());
     while (!buf.empty()) {
       std::string last_sdk_path;
-      auto info = swift::serialization::validateSerializedAST(buf);
-      if ((info.status != swift::serialization::Status::Valid) ||
-          (info.bytes == 0) || (info.bytes > buf.size())) {
-        if (log)
-          log->Printf("Unable to load AST for module %s from library: %s.",
-                      info.name.str().c_str(),
-                      module.GetSpecificationDescription().c_str());
+      swift::serialization::ExtendedValidationInfo extended_validation_info;
+      swift::serialization::ValidationInfo info =
+          swift::serialization::validateSerializedAST(
+              buf, &extended_validation_info);
+      bool InvalidAST = info.status != swift::serialization::Status::Valid;
+      bool InvalidSize = (info.bytes == 0) || (info.bytes > buf.size());
+      if (InvalidAST) {
+        swift::ASTContext &ast_ctx = *swift_ast.GetASTContext();
+        StringRef module_spec = module.GetSpecificationDescription();
+        swift::Identifier module_id = ast_ctx.getIdentifier(module_spec);
+        std::unique_ptr<swift::ModuleFile> loaded_module_file;
+        std::unique_ptr<llvm::MemoryBuffer> module_input_buffer =
+            llvm::MemoryBuffer::getMemBuffer(buf, module_spec,
+                                             /*NullTerminator=*/false);
+        swift::ModuleFile::load(std::move(module_input_buffer), {}, false,
+                                loaded_module_file);
+        swift::serialization::diagnoseSerializedASTLoadFailure(
+            ast_ctx, swift::SourceLoc(), info, extended_validation_info,
+            module_spec, "<invalid-doc-id>", loaded_module_file.get(),
+            module_id);
+      }
+      if (InvalidAST || InvalidSize) {
+        printASTValidationInfo(info, extended_validation_info, module, buf);
         return true;
       }
 
@@ -1368,12 +1386,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
       // this is the only reliable point where we can show this.
       // But only do it once per UUID so we don't overwhelm the user with
       // warnings...
-      std::unordered_set<std::string> m_swift_warnings_issued;
-
       UUID module_uuid(module_sp->GetUUID());
-      std::pair<std::unordered_set<std::string>::iterator, bool> result(
-          m_swift_warnings_issued.insert(module_uuid.GetAsString()));
-      if (result.second) {
+      bool unique_message =
+          target.RegisterSwiftContextMessageKey(module_uuid.GetAsString());
+      if (unique_message) {
         StreamString ss;
         module_sp->GetDescription(&ss, eDescriptionLevelBrief);
         if (module_swift_ast && module_swift_ast->HasFatalErrors())
@@ -1381,7 +1397,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
              << module_swift_ast->GetFatalErrors().AsCString("unknown error");
 
         target.GetDebugger().GetErrorFile()->Printf(
-            "warning: Swift error in module %s.\n"
+            "Error while loading Swift module:\n%s\n"
             "Debug info from this module will be unavailable in the "
             "debugger.\n\n",
             ss.GetData());
@@ -8006,4 +8022,23 @@ UserExpression *SwiftASTContextForExpressions::GetUserExpression(
 PersistentExpressionState *
 SwiftASTContextForExpressions::GetPersistentExpressionState() {
   return m_persistent_state_up.get();
+}
+
+void lldb_private::printASTValidationInfo(
+    const swift::serialization::ValidationInfo &ast_info,
+    const swift::serialization::ExtendedValidationInfo &ext_ast_info,
+    const Module &module, StringRef module_buf) {
+  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+  LLDB_LOG(log, R"(Unable to load AST for module {0} from library: {1}.
+  - targetTriple: {2}
+  - shortVersion: {3}
+  - bytes: {4} (module_buf bytes: {5})
+  - SDK path: {6}
+  - Clang Importer Options:
+)",
+           ast_info.name, module.GetSpecificationDescription(),
+           ast_info.targetTriple, ast_info.shortVersion, ast_info.bytes,
+           module_buf.size(), ext_ast_info.getSDKPath());
+  for (StringRef ExtraOpt : ext_ast_info.getExtraClangImporterOptions())
+    LLDB_LOG(log, "  -- {0}", ExtraOpt);
 }

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -4651,3 +4651,8 @@ Target::TargetEventData::GetModuleListFromEvent(const Event *event_ptr) {
     module_list = event_data->m_module_list;
   return module_list;
 }
+
+bool Target::RegisterSwiftContextMessageKey(std::string Key) {
+  std::unique_lock<std::mutex> guard{m_swift_messages_mutex};
+  return m_swift_messages_issued.insert(std::move(Key)).second;
+}


### PR DESCRIPTION
Emit the same diagnostics the swift compiler would emit, and make sure
to actually unique these diagnostics (previously they would be emitted
each time lldb tried to create a context).

Absent a good way to attach to & attempt to evaluate expressions in a
program compiled with an old version of swiftc, check this in without a
test.