### PR TITLE
[SwiftLanguageRuntime] Don't throw away a valid type already resolved.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/Makefile
@@ -1,5 +1,3 @@
 LEVEL = ../../../../make
-
 SWIFT_SOURCES := main.swift
-
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/TestClassConstrainedProtocolArgument.py
+++ b/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/TestClassConstrainedProtocolArgument.py
@@ -2,43 +2,6 @@
 Test that variables passed in as a class constrained protocol type
 are correctly printed.
 """
+import lldbsuite.test.lldbinline as lldbinline
 
-from __future__ import print_function
-
-
-import os
-import time
-import re
-import lldb
-import lldbsuite.test.lldbutil as lldbutil
-from lldbsuite.test.lldbtest import *
-import lldbsuite.test.decorators as decorators
-
-class TestClassConstrainedProtocolArgument(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
-    NO_DEBUG_INFO_TESTCASE = True
-
-    @decorators.expectedFailureAll("https://bugs.swift.org/browse/SR-6657")
-    def test_class_constrained_protocol(self):
-        """Test that class constrained protocol types are correctly printed."""
-        self.build()
-        self.main_source_file = lldb.SBFileSpec("main.swift")
-        self.do_class_constrained()
-
-    def setUp(self):
-        # Call super's setUp().
-        TestBase.setUp(self)
-
-    def do_class_constrained(self):
-        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
-                                   "Break here and print input", self.main_source_file) 
-
-        frame = thread.GetFrameAtIndex(0)
-        input_var = frame.FindVariable("input")
-        self.assertTrue(input_var.GetError().Success(), "Failed to fetch test_var")
-        input_typename = input_var.GetTypeName()
-        self.assertTrue(input_typename != "T", "Couldn't get the real type.")
-        
-
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/TestClassConstrainedProtocolArgument.py
+++ b/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/TestClassConstrainedProtocolArgument.py
@@ -3,5 +3,7 @@ Test that variables passed in as a class constrained protocol type
 are correctly printed.
 """
 import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/protocols/class_protocol/main.swift
@@ -22,7 +22,7 @@ class ClassByWhy<T> where T : ClassHasWhy
   let myWhy : Int
   init(input : T)
   {
-    myWhy = input.why  // Break here and print input
+    myWhy = input.why // FIXME <rdar://problem/43057063>
   }
 }
 
@@ -31,7 +31,8 @@ class ByWhy<T> where T : HasWhy
   let myWhy : Int
   init(input : T)
   {
-    myWhy = input.why  // Break here and print input
+    myWhy = input.why //%self.expect('expr -d run -- input', substrs=['a.ShouldBeWhy', 'isa = a.ShouldBeWhy', 'before_why = 4277009102', 'why = 10'])
+                      //%self.expect('expr -d run -- input', substrs=['a.ShouldBeWhy', 'isa = a.ShouldBeWhy', 'before_why = 4277009102', 'why = 10'])
   }
 }
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2173,11 +2173,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_GenericTypeParam(
   auto instance_type =
       remote_ast.getTypeForRemoteTypeMetadata(metadata_address,
                                               /*skipArtificial*/ true);
-  if (!instance_type)
-    return false;
-  // The read lock must have been acquired by the caller.
-  class_type_or_name.SetCompilerType(
-      {&scratch_ctx, instance_type.getValue().getPointer()});
+  if (instance_type)
+    class_type_or_name.SetCompilerType(
+        {&scratch_ctx, instance_type.getValue().getPointer()});
   return true;
 }
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2173,6 +2173,10 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_GenericTypeParam(
   auto instance_type =
       remote_ast.getTypeForRemoteTypeMetadata(metadata_address,
                                               /*skipArtificial*/ true);
+
+  // If we got this far, we know we already have a valid dynamic type
+  // in our hand. If RemoteAST gives us a different answer, update the
+  // type, otherwise return what we have.
   if (instance_type)
     class_type_or_name.SetCompilerType(
         {&scratch_ctx, instance_type.getValue().getPointer()});


### PR DESCRIPTION
The logic here was backwards, so we ended up not displaying the value
correctly. This is another step towards a saner and more reliable
dynamic type resolution in the debugger. More to come!

<rdar://problem/36256619>