### PR TITLE
[lldbtest] Fix self.filecheck check file lookup

### DIFF
--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -2163,11 +2163,7 @@ class TestBase(Base):
         # a file within the inline test directory.
         if check_file.endswith('.pyc'):
             check_file = check_file[:-1]
-        if hasattr(self, 'test_filename'):
-            check_file_abs = os.path.join(os.path.dirname(self.test_filename),
-                    check_file)
-        else:
-            check_file_abs = os.path.abspath(check_file)
+        check_file_abs = os.path.abspath(check_file)
 
         # Run FileCheck.
         filecheck_bin = configuration.get_filecheck_path()
@@ -2178,10 +2174,9 @@ class TestBase(Base):
         cmd_stdout, cmd_stderr = subproc.communicate(input=output)
         cmd_status = subproc.returncode
 
-        if cmd_status != 0:
-            filecheck_cmd = " ".join(filecheck_args)
-            self.assertTrue(cmd_status == 0, """
---- FileCheck failed (code={0}) ---
+        filecheck_cmd = " ".join(filecheck_args)
+        filecheck_trace = """
+--- FileCheck trace (code={0}) ---
 {1}
 
 FileCheck input:
@@ -2190,7 +2185,13 @@ FileCheck input:
 FileCheck output:
 {3}
 {4}
-""".format(cmd_status, filecheck_cmd, output, cmd_stdout, cmd_stderr))
+""".format(cmd_status, filecheck_cmd, output, cmd_stdout, cmd_stderr)
+
+        trace = cmd_status != 0 or traceAlways
+        with recording(self, trace) as sbuf:
+            print(filecheck_trace, file=sbuf)
+
+        self.assertTrue(cmd_status == 0)
 
     def expect(
             self,


### PR DESCRIPTION
The 'test_filename' property in TestBase changes over time, so
attempting to find a check file relative to the directory containing
'test_filename' is flaky.

Use the absolute path of the check file as that's always correct (and
simpler). This relies on the test driver changing into the test
directory, which it seems we can safely assume.

As a drive-by, make self.filecheck respect the trace (-t) option.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342699 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 3eeca50886b4bca5ffbaf14d6f282bc0c0ef339d)