### PR TITLE
Update Swift Set/Dictionary formatters in preparation of upcoming changes

### DIFF
--- a/lit/SwiftREPL/DictBridging.test
+++ b/lit/SwiftREPL/DictBridging.test
@@ -11,7 +11,7 @@ let d0: Dictionary<Int, Int> = [:]
 
 // All empty dictionaries use the same type-punned storage class.
 let d0b = d0 as NSDictionary
-// DICT-LABEL: d0b: _RawNativeDictionaryStorage = 0 key/value pairs
+// DICT-LABEL: d0b: {{(_RawNativeDictionaryStorage|_EmptyDictionarySingleton)}} = 0 key/value pairs
 
 // Baseline case: native Dictionary of non-verbatim bridged elements
 let d1: Dictionary<Int,Int> = [1:2]
@@ -44,7 +44,7 @@ let d2: Dictionary<NSObject,AnyObject> = [
 
 // Verbatim bridging from Swift to Objective-C
 let d2b = d2 as NSDictionary
-// DICT-LABEL: d2b: _HashableTypedNativeDictionaryStorage<NSObject, AnyObject> = 1 key/value pair {
+// DICT-LABEL: d2b: {{(_HashableTypedNativeDictionaryStorage|_DictionaryStorage)}}<NSObject, AnyObject> = 1 key/value pair {
 // DICT-NEXT:    [0] = {
 // DICT-NEXT:      key = Int64(1)
 // DICT-NEXT:      value = Int64(2)

--- a/lit/SwiftREPL/SetBridging.test
+++ b/lit/SwiftREPL/SetBridging.test
@@ -11,7 +11,7 @@ let s0: Set<Int> = []
 
 // All empty sets use the same type-punned storage class.
 let s0b = s0 as NSSet
-// DICT-LABEL: s0b: _RawNativeSetStorage = 0 values
+// DICT-LABEL: s0b: {{(_RawNativeSetStorage|_EmptySetSingleton)}} = 0 values
 
 // Baseline case: native Set of non-verbatim bridged elements
 let s1: Set<Int> = [1]
@@ -33,7 +33,7 @@ let s2: Set<NSObject> = [NSNumber(value: 1)]
 
 // Verbatim bridging from Swift to Objective-C
 let s2b = s2 as NSSet
-// SET-LABEL: s2b: _HashableTypedNativeSetStorage<NSObject> = 1 value {
+// SET-LABEL: s2b: {{(_HashableTypedNativeSetStorage|_SetStorage)}}<NSObject> = 1 value {
 // SET-NEXT:    [0] = Int64(1)
 // SET-NEXT:  }
 

--- a/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -44,19 +44,22 @@ DictionaryConfig::DictionaryConfig()
   // Note: We need have use the old _Tt names here because those are
   // still used to name classes in the ObjC runtime.
 
+  m_nativeStorageRoot_demangled =
+    ConstString("Swift._RawDictionaryStorage");
+
   // Native storage class
   m_nativeStorage_mangledRegex_ObjC =
-    ConstString("^_TtGCs37_HashableTypedNativeDictionaryStorage.*");
+    ConstString("^_TtGCs18_DictionaryStorage.*");
   m_nativeStorage_demangledPrefix =
-    ConstString("Swift._HashableTypedNativeDictionaryStorage<");
+    ConstString("Swift._DictionaryStorage<");
   m_nativeStorage_demangledRegex =
-    ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$");
+    ConstString("^Swift\\._DictionaryStorage<.+,.+>$");
 
   // Type-punned empty dictionary
   m_emptyStorage_mangled_ObjC =
-    ConstString("_TtCs27_RawNativeDictionaryStorage");
+    ConstString("_TtCs25_EmptyDictionarySingleton");
   m_emptyStorage_demangled
-    = ConstString("Swift._RawNativeDictionaryStorage");
+    = ConstString("Swift._EmptyDictionarySingleton");
 
   // Deferred non-verbatim bridged dictionary
   m_deferredBridgedStorage_mangledRegex_ObjC
@@ -65,6 +68,18 @@ DictionaryConfig::DictionaryConfig()
     = ConstString("Swift._SwiftDeferredNSDictionary<");
   m_deferredBridgedStorage_demangledRegex
     = ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$");
+
+  // Legacy Swift 4.2 storage class names
+  m_legacy_nativeStorage_mangledRegex_ObjC =
+    ConstString("^_TtGCs37_HashableTypedNativeDictionaryStorage.*");
+  m_legacy_nativeStorage_demangledPrefix =
+    ConstString("Swift._HashableTypedNativeDictionaryStorage<");
+  m_legacy_nativeStorage_demangledRegex =
+    ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$");
+  m_legacy_emptyStorage_mangled_ObjC =
+    ConstString("_TtCs27_RawNativeDictionaryStorage");
+  m_legacy_emptyStorage_demangled
+    = ConstString("Swift._RawNativeDictionaryStorage");
 }
 
 bool

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -56,6 +56,18 @@ private:
   CreateEmptyHandler(CompilerType elem_type = CompilerType()) const;
 
   HashedStorageHandlerUP
+  _CreateNativeHandler(
+    lldb::ValueObjectSP storage_sp,
+    CompilerType key_type,
+    CompilerType value_type) const;
+
+  HashedStorageHandlerUP
+  _CreateLegacyNativeHandler(
+    lldb::ValueObjectSP storage_sp,
+    CompilerType key_type,
+    CompilerType value_type) const;
+  
+  HashedStorageHandlerUP
   CreateNativeHandler(
     lldb::ValueObjectSP value_sp,
     lldb::ValueObjectSP storage_sp) const;
@@ -90,6 +102,8 @@ protected:
 
   ConstString m_collection_demangledRegex;
   
+  ConstString m_nativeStorageRoot_demangled;
+
   ConstString m_nativeStorage_mangledRegex_ObjC;
   ConstString m_nativeStorage_demangledPrefix;
   ConstString m_nativeStorage_demangledRegex;
@@ -100,6 +114,14 @@ protected:
   ConstString m_deferredBridgedStorage_mangledRegex_ObjC;
   ConstString m_deferredBridgedStorage_demangledPrefix;
   ConstString m_deferredBridgedStorage_demangledRegex;
+
+  // Legacy Swift 4.2 storage class names
+  ConstString m_legacy_nativeStorage_mangledRegex_ObjC;
+  ConstString m_legacy_nativeStorage_demangledPrefix;
+  ConstString m_legacy_nativeStorage_demangledRegex;
+
+  ConstString m_legacy_emptyStorage_mangled_ObjC;
+  ConstString m_legacy_emptyStorage_demangled;
 };
 
 // Some part of the buffer handling logic needs to be shared between summary and

--- a/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -45,17 +45,20 @@ SetConfig::SetConfig()
   // Note: We need to have the old _Tt names here because those are
   // still used to name classes in the ObjC runtime.
 
-  // Native storage class                                                
+  m_nativeStorageRoot_demangled =
+    ConstString("Swift._RawSetStorage");
+
+    // Native storage class
   m_nativeStorage_mangledRegex_ObjC =
-    ConstString("^_TtGCs30_HashableTypedNativeSetStorage.*");
+    ConstString("^_TtGCs11_SetStorage.*");
   m_nativeStorage_demangledPrefix =
-    ConstString("Swift._HashableTypedNativeSetStorage<");
+    ConstString("Swift._SetStorage<");
   m_nativeStorage_demangledRegex =
-    ConstString("^Swift\\._HashableTypedNativeSetStorage<.+>$");
+    ConstString("^Swift\\._SetStorage<.+>$");
 
   // Type-punned empty set
-  m_emptyStorage_mangled_ObjC = ConstString("_TtCs20_RawNativeSetStorage");
-  m_emptyStorage_demangled = ConstString("Swift._RawNativeSetStorage");
+  m_emptyStorage_mangled_ObjC = ConstString("_TtCs18_EmptySetSingleton");
+  m_emptyStorage_demangled = ConstString("Swift._EmptySetSingleton");
 
   // Deferred non-verbatim bridged set
   m_deferredBridgedStorage_mangledRegex_ObjC
@@ -64,6 +67,16 @@ SetConfig::SetConfig()
     = ConstString("Swift._SwiftDeferredNSSet<");
   m_deferredBridgedStorage_demangledRegex
     = ConstString("^Swift\\._SwiftDeferredNSSet<.+>$");
+
+  // Legacy Swift 4.2 storage class names
+  m_legacy_nativeStorage_mangledRegex_ObjC =
+    ConstString("^_TtGCs30_HashableTypedNativeSetStorage.*");
+  m_legacy_nativeStorage_demangledPrefix =
+    ConstString("Swift._HashableTypedNativeSetStorage<");
+  m_legacy_nativeStorage_demangledRegex =
+    ConstString("^Swift\\._HashableTypedNativeSetStorage<.+>$");
+  m_legacy_emptyStorage_mangled_ObjC = ConstString("_TtCs20_RawNativeSetStorage");
+  m_legacy_emptyStorage_demangled = ConstString("Swift._RawNativeSetStorage");
 }
 
 bool


### PR DESCRIPTION
https://github.com/apple/swift/pull/19213 will change the internal layout of Set/Dictionary. Prepare for this by adding lldb support for the new storage layouts.

Bonus change: fix the new synthetic children frontend so that enumerating all children takes linear time. (It was quadratic with the old formatters.)