### PR TITLE
[lldbinline] Set directory attribute on test-specific classes

### DIFF
--- a/packages/Python/lldbsuite/test/lldbinline.py
+++ b/packages/Python/lldbsuite/test/lldbinline.py
@@ -199,7 +199,6 @@ def MakeInlineTest(__file, __globals, decorators=None):
 
     # Derive the test name from the current file name
     file_basename = os.path.basename(__file)
-    InlineTest.mydir = TestBase.compute_mydir(__file)
 
     test_name, _ = os.path.splitext(file_basename)
 
@@ -213,4 +212,5 @@ def MakeInlineTest(__file, __globals, decorators=None):
     # Keep track of the original test filename so we report it
     # correctly in test results.
     test_class.test_filename = __file
+    test_class.mydir = TestBase.compute_mydir(__file)
     return test_class


### PR DESCRIPTION
Set the "mydir" attribute of an inline test on the test-specific class,
instead of on the base InlineTest class.

This makes it possible to run dotest.py on a directory containing inline
tests. This wasn't really possible prior to this patch, because what
would happen is that one test would just run over and over again, even
though the test infrastructure would claim that different tests were
being run.

Example:

The test infrastructure claimed that all of these different tests were passing,
which couldn't be true --

$ ./bin/lldb-dotest /Users/vsk/src/tailcall/lldb/test/testcases/functionalities/tail_call_frames/ -G dwarf -t 2>&1 | grep PASS
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestDisambiguateTailCallSeq)
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestArtificialFrameStepOutMessage)
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestAmbiguousTailCallSeq1)
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestDisambiguatePathsToCommonSink)
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestDisambiguateCallSite)
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestUnambiguousTailCalls)
PASS: LLDB (/Users/vsk/src/builds/tailcall-RA/bin/clang-8-x86_64) :: test_dwarf (lldbsuite.test.lldbtest.TestAmbiguousTailCallSeq2)
RESULT: PASSED (7 passes, 0 failures, 0 errors, 24 skipped, 0 expected failures, 0 unexpected successes)

... because it wasn't even looking at some of these tests:

$ ./bin/lldb-dotest /Users/vsk/src/tailcall/lldb/test/testcases/functionalities/tail_call_frames/ -G dwarf -t 2>&1 | grep "Change dir"
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/sbapi_support
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/thread_step_out_or_return
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2
Change dir to: /Users/vsk/src/tailcall/lldb/packages/Python/lldbsuite/test/functionalities/tail_call_frames/ambiguous_tail_call_seq2

E.g it was only building one of them:

$ ls lldb-test-build.noindex/functionalities/tail_call_frames/                        
ambiguous_tail_call_seq2

Differential Revision: https://reviews.llvm.org/D52516

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@343023 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 2de34ed940c6374f27d8bf7ac3b9523df8b315e9)