### PR TITLE
[SwiftASTContext] Improve an error message.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3876,8 +3876,7 @@ SwiftASTContext::GetTypeFromMangledTypename(const char *mangled_typename,
   if (!mangled_typename ||
       !SwiftLanguageRuntime::IsSwiftMangledName(mangled_typename)) {
     error.SetErrorStringWithFormat(
-        "typename '%s' is not a valid Swift mangled "
-        "typename, it should begin with " MANGLING_PREFIX_STR,
+        "typename '%s' is not a valid Swift mangled name",
         mangled_typename);
     return CompilerType();
   }


### PR DESCRIPTION
No need to show the users so many details. Discussed with
Jim/Adrian.