### PR TITLE
[Swift] Stop emitting bogus warnings when we run a process again.

### DIFF
--- a/lit/Swift/Inputs/ContextError.swift
+++ b/lit/Swift/Inputs/ContextError.swift
@@ -1,0 +1,12 @@
+func use<T>(_ t : T) {}
+
+func string_tuple<T, U>(_ t : (T, U)) {
+  let (_, y) = t // here
+  use(y)
+}
+
+
+let s = "patatino"
+string_tuple((s, s))
+
+// CHECK-NOT: warning

--- a/lit/Swift/astcontext_error.test
+++ b/lit/Swift/astcontext_error.test
@@ -1,0 +1,7 @@
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: %target-swiftc -g %S/Inputs/ContextError.swift
+# RUN: %lldb ContextError -s %s | FileCheck %S/Inputs/ContextError.swift
+
+br set -p "here"
+run
+run

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -2159,19 +2159,21 @@ TypeSystem *Target::GetScratchTypeSystemForLanguage(
           if (m_use_scratch_typesystem_per_module)
             DisplayFallbackSwiftContextErrors(swift_ast_ctx);
           else if (StreamSP errs = GetDebugger().GetAsyncErrorStream()) {
-            errs->Printf(
-                "warning: Swift error in scratch context: %s.\n",
-                swift_ast_ctx->GetFatalErrors().AsCString("unknown error"));
-            auto *module_name = GetExecutableModule()
-                                    ->GetPlatformFileSpec()
-                                    .GetFilename()
-                                    .AsCString();
-            errs->Printf("Shared Swift state for %s has developed fatal "
-                         "errors and is being discarded.\n",
-                         module_name);
-            errs->PutCString("REPL definitions and persistent names/types "
-                             "will be lost.\n\n");
-            errs->Flush();
+            if (swift_ast_ctx->HasFatalErrors()) {
+              errs->Printf(
+                  "warning: Swift error in scratch context: %s.\n",
+                  swift_ast_ctx->GetFatalErrors().AsCString("unknown error"));
+              auto *module_name = GetExecutableModule()
+                                      ->GetPlatformFileSpec()
+                                      .GetFilename()
+                                      .AsCString();
+              errs->Printf("Shared Swift state for %s has developed fatal "
+                           "errors and is being discarded.\n",
+                           module_name);
+              errs->PutCString("REPL definitions and persistent names/types "
+                               "will be lost.\n\n");
+              errs->Flush();
+            }
           }
 
           m_scratch_type_system_map.RemoveTypeSystemsForLanguage(language);


### PR DESCRIPTION
We should only emit an error, if there's a fatal one.

<rdar://problem/44766464>