### PR TITLE
[Swift] Add support for BridgeObject-based Set/Dictionary

### DIFF
--- a/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -68,18 +68,6 @@ DictionaryConfig::DictionaryConfig()
     = ConstString("Swift._SwiftDeferredNSDictionary<");
   m_deferredBridgedStorage_demangledRegex
     = ConstString("^Swift\\._SwiftDeferredNSDictionary<.+,.+>$");
-
-  // Legacy Swift 4.2 storage class names
-  m_legacy_nativeStorage_mangledRegex_ObjC =
-    ConstString("^_TtGCs37_HashableTypedNativeDictionaryStorage.*");
-  m_legacy_nativeStorage_demangledPrefix =
-    ConstString("Swift._HashableTypedNativeDictionaryStorage<");
-  m_legacy_nativeStorage_demangledRegex =
-    ConstString("^Swift\\._HashableTypedNativeDictionaryStorage<.+,.+>$");
-  m_legacy_emptyStorage_mangled_ObjC =
-    ConstString("_TtCs28__RawNativeDictionaryStorage");
-  m_legacy_emptyStorage_demangled
-    = ConstString("Swift.__RawNativeDictionaryStorage");
 }
 
 bool

--- a/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -44,6 +44,8 @@ DictionaryConfig::DictionaryConfig()
   // Note: We need have use the old _Tt names here because those are
   // still used to name classes in the ObjC runtime.
 
+  m_nativeStorageRoot_mangled =
+    ConstString("_TtCs21_RawDictionaryStorage");
   m_nativeStorageRoot_demangled =
     ConstString("Swift._RawDictionaryStorage");
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -145,84 +145,6 @@ private:
   bool m_failedToGetBuckets;
 };
 
-// Storage handler for Swift 4.2 storage class instances
-class LegacyNativeHashedStorageHandler: public HashedStorageHandler {
-public:
-  LegacyNativeHashedStorageHandler(ValueObjectSP storage_sp,
-                                   CompilerType key_type,
-                                   CompilerType value_type);
-
-  virtual size_t GetCount() override { return m_count; }
-
-  virtual CompilerType GetElementType() override { return m_element_type; }
-
-  virtual ValueObjectSP GetElementAtIndex(size_t) override;
-
-  virtual bool IsValid() override;
-
-  virtual ~LegacyNativeHashedStorageHandler() override {}
-
-protected:
-  typedef uint64_t Index;
-  typedef uint64_t Cell;
-
-  bool ReadBitmaskAtIndex(Index, Status &error);
-
-  lldb::addr_t GetLocationOfKeyAtCell(Cell i) {
-    return m_keys_ptr + (i * m_key_stride);
-  }
-
-  lldb::addr_t GetLocationOfValueAtCell(Cell i) {
-    return m_value_stride
-      ? m_values_ptr + (i * m_value_stride)
-      : LLDB_INVALID_ADDRESS;
-  }
-
-  // these are sharp tools that assume that the Cell contains valid data and the
-  // destination buffer
-  // has enough room to store the data to - use with caution
-  bool GetDataForKeyAtCell(Cell i, void *data_ptr) {
-    if (!data_ptr)
-      return false;
-
-    lldb::addr_t addr = GetLocationOfKeyAtCell(i);
-    Status error;
-    m_process->ReadMemory(addr, data_ptr, m_key_stride, error);
-    if (error.Fail())
-      return false;
-
-    return true;
-  }
-
-  bool GetDataForValueAtCell(Cell i, void *data_ptr) {
-    if (!data_ptr || !m_value_stride)
-      return false;
-
-    lldb::addr_t addr = GetLocationOfValueAtCell(i);
-    Status error;
-    m_process->ReadMemory(addr, data_ptr, m_value_stride, error);
-    if (error.Fail())
-      return false;
-
-    return true;
-  }
-
-private:
-  ValueObject *m_nativeStorage;
-  Process *m_process;
-  uint32_t m_ptr_size;
-  uint64_t m_count;
-  uint64_t m_bucketCount;
-  lldb::addr_t m_bitmask_ptr;
-  lldb::addr_t m_keys_ptr;
-  lldb::addr_t m_values_ptr;
-  CompilerType m_element_type;
-  uint64_t m_key_stride;
-  uint64_t m_value_stride;
-  uint64_t m_key_stride_padded;
-  std::map<lldb::addr_t, uint64_t> m_bitmask_cache;
-};
-
 class CocoaHashedStorageHandler: public HashedStorageHandler {
 public:
   CocoaHashedStorageHandler(
@@ -282,12 +204,6 @@ HashedCollectionConfig::RegisterSummaryProviders(
   AddCXXSummary(swift_category_sp, summaryProvider,
                 m_summaryProviderName.AsCString(),
                 m_deferredBridgedStorage_demangledRegex, flags, true);
-  AddCXXSummary(swift_category_sp, summaryProvider,
-                m_summaryProviderName.AsCString(),
-                m_legacy_nativeStorage_demangledRegex, flags, true);
-  AddCXXSummary(swift_category_sp, summaryProvider,
-                m_summaryProviderName.AsCString(),
-                m_legacy_emptyStorage_demangled, flags, false);
 
   flags.SetSkipPointers(false);
   AddCXXSummary(swift_category_sp, summaryProvider,
@@ -299,12 +215,6 @@ HashedCollectionConfig::RegisterSummaryProviders(
   AddCXXSummary(swift_category_sp, summaryProvider,
                 m_summaryProviderName.AsCString(),
                 m_deferredBridgedStorage_mangledRegex_ObjC, flags, true);
-  AddCXXSummary(swift_category_sp, summaryProvider,
-                m_summaryProviderName.AsCString(),
-                m_legacy_nativeStorage_mangledRegex_ObjC, flags, true);
-  AddCXXSummary(swift_category_sp, summaryProvider,
-                m_summaryProviderName.AsCString(),
-                m_legacy_emptyStorage_mangled_ObjC, flags, false);
 
 #endif // LLDB_DISABLE_PYTHON
 }
@@ -331,12 +241,6 @@ HashedCollectionConfig::RegisterSyntheticChildrenCreators(
   AddCXXSynthetic(swift_category_sp, creator,
                   m_syntheticChildrenName.AsCString(),
                   m_deferredBridgedStorage_demangledRegex, flags, true);
-  AddCXXSynthetic(swift_category_sp, creator,
-                  m_syntheticChildrenName.AsCString(),
-                  m_legacy_nativeStorage_demangledRegex, flags, true);
-  AddCXXSynthetic(swift_category_sp, creator,
-                  m_syntheticChildrenName.AsCString(),
-                  m_legacy_emptyStorage_demangled, flags, false);
 
   flags.SetSkipPointers(false);
   AddCXXSynthetic(swift_category_sp, creator,
@@ -348,12 +252,6 @@ HashedCollectionConfig::RegisterSyntheticChildrenCreators(
   AddCXXSynthetic(swift_category_sp, creator,
                   m_syntheticChildrenName.AsCString(),
                   m_deferredBridgedStorage_mangledRegex_ObjC, flags, true);
-  AddCXXSynthetic(swift_category_sp, creator,
-                  m_syntheticChildrenName.AsCString(),
-                  m_legacy_nativeStorage_mangledRegex_ObjC, flags, true);
-  AddCXXSynthetic(swift_category_sp, creator,
-                  m_syntheticChildrenName.AsCString(),
-                  m_legacy_emptyStorage_mangled_ObjC, flags, false);
 #endif // LLDB_DISABLE_PYTHON
 }
 
@@ -361,17 +259,13 @@ bool
 HashedCollectionConfig::IsNativeStorageName(ConstString name) const {
   assert(m_nativeStorage_demangledPrefix);
   auto n = name.GetStringRef();
-  if (n.startswith(m_nativeStorage_demangledPrefix.GetStringRef()))
-    return true;
-  if (n.startswith(m_legacy_nativeStorage_demangledPrefix.GetStringRef()))
-    return true;
-  return false;     
+  return n.startswith(m_nativeStorage_demangledPrefix.GetStringRef());
 }
 
 bool
 HashedCollectionConfig::IsEmptyStorageName(ConstString name) const {
   assert(m_emptyStorage_demangled);
-  return name == m_emptyStorage_demangled || name == m_legacy_emptyStorage_demangled;
+  return name == m_emptyStorage_demangled;
 }
 
 bool
@@ -452,18 +346,6 @@ HashedCollectionConfig::_CreateNativeHandler(
 }
 
 HashedStorageHandlerUP
-HashedCollectionConfig::_CreateLegacyNativeHandler(
-  lldb::ValueObjectSP storage_sp,
-  CompilerType key_type,
-  CompilerType value_type) const {
-  auto handler = HashedStorageHandlerUP(
-    new LegacyNativeHashedStorageHandler(storage_sp, key_type, value_type));
-  if (!handler->IsValid())
-    return nullptr;
-  return handler;  
-}
-
-HashedStorageHandlerUP
 HashedCollectionConfig::CreateNativeHandler(
   ValueObjectSP value_sp,
   ValueObjectSP storage_sp) const {
@@ -492,25 +374,12 @@ HashedCollectionConfig::CreateNativeHandler(
     }
   }
 
-  if (typeName.startswith(m_legacy_nativeStorage_demangledPrefix.GetStringRef())) {
-    auto key_type = type.GetGenericArgumentType(0);
-    auto value_type = type.GetGenericArgumentType(1);
-    if (key_type.IsValid()) {
-      return _CreateLegacyNativeHandler(storage_sp, key_type, value_type);
-    }
-  }    
-  
   // Fallback: If we couldn't get the dynamic type, assume storage_sp
   // is some valid storage class instance, and attempt to get
   // key/value types from value_sp.
   type = value_sp->GetCompilerType();
   CompilerType key_type = type.GetGenericArgumentType(0);
   CompilerType value_type = type.GetGenericArgumentType(1);
-  if (typeName == m_legacy_emptyStorage_demangled.GetStringRef()) {
-    // In Swift 4.2, the empty storage singleton had the storage root
-    // class as its dynamic type.
-    return _CreateLegacyNativeHandler(storage_sp, key_type, value_type);
-  }
   if (typeName == m_nativeStorageRoot_demangled.GetStringRef()) {
     return _CreateNativeHandler(storage_sp, key_type, value_type);
   }
@@ -734,187 +603,12 @@ NativeHashedStorageHandler::GetElementAtIndex(size_t idx) {
 
 //===----------------------------------------------------------------------===//
 
-ValueObjectSP
-LegacyNativeHashedStorageHandler::GetElementAtIndex(size_t idx) {
-  ValueObjectSP null_valobj_sp;
-  if (idx >= m_count)
-    return null_valobj_sp;
-  if (!IsValid())
-    return null_valobj_sp;
-  int64_t found_idx = -1;
-  Status error;
-  for (Cell cell_idx = 0; cell_idx < m_bucketCount; cell_idx++) {
-    const bool used = ReadBitmaskAtIndex(cell_idx, error);
-    if (error.Fail()) {
-      Status bitmask_error;
-      bitmask_error.SetErrorStringWithFormat(
-              "Failed to read bit-mask index from Dictionary: %s",
-              error.AsCString());
-      return ValueObjectConstResult::Create(m_process, bitmask_error);
-    }
-    if (!used)
-      continue;
-    if (++found_idx == idx) {
-      // you found it!!!
-      DataBufferSP full_buffer_sp(
-          new DataBufferHeap(m_key_stride_padded + m_value_stride, 0));
-      uint8_t *key_buffer_ptr = full_buffer_sp->GetBytes();
-      uint8_t *value_buffer_ptr =
-          m_value_stride ? (key_buffer_ptr + m_key_stride_padded) : nullptr;
-      if (GetDataForKeyAtCell(cell_idx, key_buffer_ptr) &&
-          (value_buffer_ptr == nullptr ||
-           GetDataForValueAtCell(cell_idx, value_buffer_ptr))) {
-        DataExtractor full_data;
-        full_data.SetData(full_buffer_sp);
-        StreamString name;
-        name.Printf("[%zu]", idx);
-        return ValueObjectConstResult::Create(
-            m_process, m_element_type, ConstString(name.GetData()), full_data);
-      }
-    }
-  }
-  return null_valobj_sp;
-}
-
-bool LegacyNativeHashedStorageHandler::ReadBitmaskAtIndex(Index i, Status &error) {
-  if (i >= m_bucketCount)
-    return false;
-  const size_t word = i / (8 * m_ptr_size);
-  const size_t offset = i % (8 * m_ptr_size);
-  const lldb::addr_t effective_ptr = m_bitmask_ptr + (word * m_ptr_size);
-  uint64_t data = 0;
-
-  auto cached = m_bitmask_cache.find(effective_ptr);
-  if (cached != m_bitmask_cache.end()) {
-    data = cached->second;
-  } else {
-    data = m_process->ReadUnsignedIntegerFromMemory(effective_ptr, m_ptr_size,
-                                                    0, error);
-    if (error.Fail())
-      return false;
-    m_bitmask_cache[effective_ptr] = data;
-  }
-
-  const uint64_t mask = static_cast<uint64_t>(1UL << offset);
-  const uint64_t value = (data & mask);
-  return (0 != value);
-}
-
-LegacyNativeHashedStorageHandler::LegacyNativeHashedStorageHandler(
-  ValueObjectSP nativeStorage_sp,
-  CompilerType key_type,
-  CompilerType value_type
-) : m_nativeStorage(nativeStorage_sp.get()), m_process(nullptr),
-    m_ptr_size(0), m_count(0), m_bucketCount(0),
-    m_bitmask_ptr(LLDB_INVALID_ADDRESS), m_keys_ptr(LLDB_INVALID_ADDRESS),
-    m_values_ptr(LLDB_INVALID_ADDRESS), m_element_type(),
-    m_key_stride(key_type.GetByteStride()), m_value_stride(0),
-    m_key_stride_padded(m_key_stride), m_bitmask_cache() {
-  static ConstString g_initializedEntries("initializedEntries");
-  static ConstString g_values("values");
-  static ConstString g__rawValue("_rawValue");
-  static ConstString g_keys("keys");
-
-  static ConstString g_key("key");
-  static ConstString g_value("value");
-  static ConstString g__value("_value");
-
-  static ConstString g_capacity("capacity");
-  static ConstString g_bucketCount("bucketCount");
-  static ConstString g_count("count");
-
-  if (!m_nativeStorage)
-    return;
-  if (!key_type)
-    return;
-
-  if (value_type) {
-    m_value_stride = value_type.GetByteStride();
-    if (SwiftASTContext *swift_ast =
-            llvm::dyn_cast_or_null<SwiftASTContext>(key_type.GetTypeSystem())) {
-      std::vector<SwiftASTContext::TupleElement> tuple_elements{
-          {g_key, key_type}, {g_value, value_type}};
-      m_element_type = swift_ast->CreateTupleType(tuple_elements);
-      m_key_stride_padded = m_element_type.GetByteStride() - m_value_stride;
-    }
-  } else {
-    m_element_type = key_type;
-  }
-
-  if (!m_element_type)
-    return;
-
-  m_process = m_nativeStorage->GetProcessSP().get();
-  if (!m_process)
-    return;
-
-  m_ptr_size = m_process->GetAddressByteSize();
-
-  auto bucketCount_sp =
-    m_nativeStorage->GetChildAtNamePath({g_bucketCount, g__value});
-  if (!bucketCount_sp) // <4.1: bucketCount was called capacity.
-    bucketCount_sp = m_nativeStorage->GetChildAtNamePath({g_capacity, g__value});
-  if (!bucketCount_sp)
-    return;
-  m_bucketCount = bucketCount_sp->GetValueAsUnsigned(0);
-  auto count_sp = m_nativeStorage->GetChildAtNamePath({g_count, g__value});
-  if (!count_sp)
-    return;
-  m_count = count_sp->GetValueAsUnsigned(0);
-
-  m_nativeStorage = nativeStorage_sp.get();
-  m_bitmask_ptr =
-      m_nativeStorage
-          ->GetChildAtNamePath({g_initializedEntries, g_values, g__rawValue})
-          ->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-
-  if (ValueObjectSP value_child_sp =
-          m_nativeStorage->GetChildAtNamePath({g_values, g__rawValue})) {
-    // it is fine not to pass a value_type, but if the value child exists, then
-    // you have to pass one
-    if (!value_type)
-      return;
-    m_values_ptr = value_child_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-  }
-  m_keys_ptr = m_nativeStorage->GetChildAtNamePath({g_keys, g__rawValue})
-                   ->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-  // Make sure we can read the bitmask at the ount index.  
-  // and this will keep us from trying
-  // to reconstruct many bajillions of invalid children.
-  // Don't bother if the native buffer handler is invalid already, however. 
-  if (IsValid())
-  {
-    Status error;
-    ReadBitmaskAtIndex(m_bucketCount - 1, error);
-    if (error.Fail())
-    {
-      m_bitmask_ptr = LLDB_INVALID_ADDRESS;
-    }
-  }
-}
-
-bool LegacyNativeHashedStorageHandler::IsValid() {
-  return (m_nativeStorage != nullptr) && (m_process != nullptr) &&
-         m_element_type.IsValid() && m_bitmask_ptr != LLDB_INVALID_ADDRESS &&
-         m_keys_ptr != LLDB_INVALID_ADDRESS &&
-         /*m_values_ptr != LLDB_INVALID_ADDRESS && you can't check values
-            because some containers have only keys*/
-         // The bucket count must be a power of two.
-         m_bucketCount >= 1 && (m_bucketCount & (m_bucketCount - 1)) == 0 &&
-         m_bucketCount >= m_count;
-}
-
-//===----------------------------------------------------------------------===//
-
 HashedStorageHandlerUP
 HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
-  static ConstString g__variant("_variant"); // Swift 5
-  static ConstString g__variantBuffer("_variantBuffer"); // Swift 4
-  static ConstString g_native("native"); // Swift 4.2
-  static ConstString g_cocoa("cocoa"); // Swift 4.2
-  static ConstString g_object("object"); // Swift 5
-  static ConstString g_rawValue("rawValue"); // Swift 5
-  static ConstString g_nativeBuffer("nativeBuffer"); // Swift 4
+  static ConstString g_native("native");
+  static ConstString g__variant("_variant");
+  static ConstString g_object("object");
+  static ConstString g_rawValue("rawValue");
   static ConstString g__storage("_storage");
 
   Status error;
@@ -940,62 +634,16 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   }
   if (IsDeferredBridgedStorageName(type_name_cs)) {
     auto storage_sp = valobj_sp->GetChildAtNamePath({g_native, g__storage});
-    if (!storage_sp) // try Swift 4 name
-      storage_sp = valobj_sp->GetChildAtNamePath({g_nativeBuffer, g__storage});
     return CreateNativeHandler(valobj_sp, storage_sp);
   }
 
   ValueObjectSP variant_sp =
     valobj_sp->GetChildMemberWithName(g__variant, true);
-  if (!variant_sp) // try Swift 4 name
-    variant_sp = valobj_sp->GetChildMemberWithName(g__variantBuffer, true);
   if (!variant_sp)
     return nullptr;
 
   ValueObjectSP bobject_sp =
     variant_sp->GetChildAtNamePath({g_object, g_rawValue});
-
-  if (!bobject_sp) { // FIXME: Remove (Legacy Swift 4.2 path)
-    ConstString variant_cs(variant_sp->GetValueAsCString());
-    if (!variant_cs)
-      return nullptr;
-
-    if (g_cocoa == variant_cs) {
-      // it's an NSDictionary/NSSet in disguise
-      static ConstString g_object("object"); // Swift 5
-      static ConstString g_cocoaDictionary("cocoaDictionary"); // Swift 4
-      static ConstString g_cocoaSet("cocoaSet"); // Swift 4
-    
-      ValueObjectSP child_sp =
-        variant_sp->GetChildAtNamePath({g_cocoa, g_object});
-      if (!child_sp) // try Swift 4 name for dictionaries
-        child_sp = variant_sp->GetChildAtNamePath({g_cocoa, g_cocoaDictionary});
-      if (!child_sp) // try Swift 4 name for sets
-        child_sp = variant_sp->GetChildAtNamePath({g_cocoa, g_cocoaSet});
-      if (!child_sp)
-        return nullptr;
-      // child_sp is the _NSDictionary/_NSSet reference.
-      ValueObjectSP ref_sp = child_sp->GetChildAtIndex(0, true); // instance
-      if (!ref_sp)
-        return nullptr;
-
-      uint64_t cocoa_ptr = ref_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-      if (cocoa_ptr == LLDB_INVALID_ADDRESS)
-        return nullptr;
-      // FIXME: for some reason I need to zero out the MSB; figure out why
-      cocoa_ptr &= 0x00FFFFFFFFFFFFFF;
-
-      auto cocoa_sp = CocoaObjectAtAddress(exe_ctx, cocoa_ptr);
-      if (!cocoa_sp)
-        return nullptr;
-      return CreateCocoaHandler(cocoa_sp);
-    }
-    if (g_native == variant_cs) {
-      auto storage_sp = variant_sp->GetChildAtNamePath({g_native, g__storage});
-      return CreateNativeHandler(valobj_sp, storage_sp);
-    }
-    return nullptr;
-  }
 
   lldb::addr_t storage_location =
     bobject_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -606,9 +606,10 @@ NativeHashedStorageHandler::GetElementAtIndex(size_t idx) {
 HashedStorageHandlerUP
 HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   static ConstString g_native("native");
-  static ConstString g__variant("_variant");
-  static ConstString g_object("object");
-  static ConstString g_rawValue("rawValue");
+  static ConstString g__variant("_variant"); // Swift 5
+  static ConstString g_cocoa("cocoa"); // Swift 4.2
+  static ConstString g_object("object"); // Swift 5
+  static ConstString g_rawValue("rawValue"); // Swift 5
   static ConstString g__storage("_storage");
 
   Status error;
@@ -644,6 +645,48 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
 
   ValueObjectSP bobject_sp =
     variant_sp->GetChildAtNamePath({g_object, g_rawValue});
+
+  if (!bobject_sp) { // FIXME: Remove (Legacy Swift 4.2 path)
+    ConstString variant_cs(variant_sp->GetValueAsCString());
+    if (!variant_cs)
+      return nullptr;
+
+    if (g_cocoa == variant_cs) {
+      // it's an NSDictionary/NSSet in disguise
+      static ConstString g_object("object"); // Swift 5
+      static ConstString g_cocoaDictionary("cocoaDictionary"); // Swift 4
+      static ConstString g_cocoaSet("cocoaSet"); // Swift 4
+    
+      ValueObjectSP child_sp =
+        variant_sp->GetChildAtNamePath({g_cocoa, g_object});
+      if (!child_sp) // try Swift 4 name for dictionaries
+        child_sp = variant_sp->GetChildAtNamePath({g_cocoa, g_cocoaDictionary});
+      if (!child_sp) // try Swift 4 name for sets
+        child_sp = variant_sp->GetChildAtNamePath({g_cocoa, g_cocoaSet});
+      if (!child_sp)
+        return nullptr;
+      // child_sp is the _NSDictionary/_NSSet reference.
+      ValueObjectSP ref_sp = child_sp->GetChildAtIndex(0, true); // instance
+      if (!ref_sp)
+        return nullptr;
+
+      uint64_t cocoa_ptr = ref_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+      if (cocoa_ptr == LLDB_INVALID_ADDRESS)
+        return nullptr;
+      // FIXME: for some reason I need to zero out the MSB; figure out why
+      cocoa_ptr &= 0x00FFFFFFFFFFFFFF;
+
+      auto cocoa_sp = CocoaObjectAtAddress(exe_ctx, cocoa_ptr);
+      if (!cocoa_sp)
+        return nullptr;
+      return CreateCocoaHandler(cocoa_sp);
+    }
+    if (g_native == variant_cs) {
+      auto storage_sp = variant_sp->GetChildAtNamePath({g_native, g__storage});
+      return CreateNativeHandler(valobj_sp, storage_sp);
+    }
+    return nullptr;
+  }
 
   lldb::addr_t storage_location =
     bobject_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -62,12 +62,6 @@ private:
     CompilerType value_type) const;
 
   HashedStorageHandlerUP
-  _CreateLegacyNativeHandler(
-    lldb::ValueObjectSP storage_sp,
-    CompilerType key_type,
-    CompilerType value_type) const;
-  
-  HashedStorageHandlerUP
   CreateNativeHandler(
     lldb::ValueObjectSP value_sp,
     lldb::ValueObjectSP storage_sp) const;
@@ -114,14 +108,6 @@ protected:
   ConstString m_deferredBridgedStorage_mangledRegex_ObjC;
   ConstString m_deferredBridgedStorage_demangledPrefix;
   ConstString m_deferredBridgedStorage_demangledRegex;
-
-  // Legacy Swift 4.2 storage class names
-  ConstString m_legacy_nativeStorage_mangledRegex_ObjC;
-  ConstString m_legacy_nativeStorage_demangledPrefix;
-  ConstString m_legacy_nativeStorage_demangledRegex;
-
-  ConstString m_legacy_emptyStorage_mangled_ObjC;
-  ConstString m_legacy_emptyStorage_demangled;
 };
 
 // Some part of the buffer handling logic needs to be shared between summary and

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -70,7 +70,7 @@ private:
   CreateCocoaHandler(lldb::ValueObjectSP storage_sp) const;
 
   lldb::ValueObjectSP
-  SwiftObjectAtAddress(
+  StorageObjectAtAddress(
     const ExecutionContext &exe_ctx,
     lldb::addr_t address) const;
 
@@ -96,6 +96,7 @@ protected:
 
   ConstString m_collection_demangledRegex;
   
+  ConstString m_nativeStorageRoot_mangled;
   ConstString m_nativeStorageRoot_demangled;
 
   ConstString m_nativeStorage_mangledRegex_ObjC;

--- a/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -67,16 +67,6 @@ SetConfig::SetConfig()
     = ConstString("Swift._SwiftDeferredNSSet<");
   m_deferredBridgedStorage_demangledRegex
     = ConstString("^Swift\\._SwiftDeferredNSSet<.+>$");
-
-  // Legacy Swift 4.2 storage class names
-  m_legacy_nativeStorage_mangledRegex_ObjC =
-    ConstString("^_TtGCs30_HashableTypedNativeSetStorage.*");
-  m_legacy_nativeStorage_demangledPrefix =
-    ConstString("Swift._HashableTypedNativeSetStorage<");
-  m_legacy_nativeStorage_demangledRegex =
-    ConstString("^Swift\\._HashableTypedNativeSetStorage<.+>$");
-  m_legacy_emptyStorage_mangled_ObjC = ConstString("_TtCs21__RawNativeSetStorage");
-  m_legacy_emptyStorage_demangled = ConstString("Swift.__RawNativeSetStorage");
 }
 
 bool

--- a/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -45,6 +45,8 @@ SetConfig::SetConfig()
   // Note: We need to have the old _Tt names here because those are
   // still used to name classes in the ObjC runtime.
 
+  m_nativeStorageRoot_mangled =
+    ConstString("_TtCs14_RawSetStorage");
   m_nativeStorageRoot_demangled =
     ConstString("Swift._RawSetStorage");
 


### PR DESCRIPTION
In https://github.com/apple/swift/pull/19688, we’re switching the variant type of Set and Dictionary from a custom enum to a BridgeObject. Add support for this to lldb.
