### PR TITLE
[CMake] Fix reflection lib name on non-x86_64 Linux platforms.

### DIFF
--- a/source/Target/CMakeLists.txt
+++ b/source/Target/CMakeLists.txt
@@ -3,7 +3,8 @@ include_directories(../Plugins/Process/Utility)
 set(REFLECTION_LIB "swiftReflection")
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(REFLECTION_LIB "swiftReflection-linux-x86_64")
+    # CMAKE_SYSTEM_PROCESSOR is equivalent to `uname -p` on Linux.
+    set(REFLECTION_LIB "swiftReflection-linux-${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")


### PR DESCRIPTION
Remove the hardcoded instance of 'x86_64' and query the platform's
processor name instead.

Note: this uses `CMAKE_SYSTEM_PROCESSOR` to identify the target processor name. This is equivalent to `uname -p`, which on Linux does the right thing (for Darwin targets it returns `i386` on `x86_64` processors).

The Darwin code appears to query the *target* OS (`CMAKE_SYSTEM_NAME`) and then use the *host* processor/OS (`LLVM_HOST_TRIPLE`)... I assume we need the *target* here but I'm not 100% sure, so please review carefully!

Thanks.