### PR TITLE
Cherry-pick refactoring for PropertyDefinition

### DIFF
--- a/include/lldb/Interpreter/OptionArgParser.h
+++ b/include/lldb/Interpreter/OptionArgParser.h
@@ -24,7 +24,7 @@ struct OptionArgParser {
   static char ToChar(llvm::StringRef s, char fail_value, bool *success_ptr);
 
   static int64_t ToOptionEnum(llvm::StringRef s,
-                              OptionEnumValueElement *enum_values,
+                              const OptionEnumValues &enum_values,
                               int32_t fail_value, Status &error);
 
   static lldb::ScriptLanguage ToScriptLanguage(llvm::StringRef s,

--- a/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -30,8 +30,7 @@ public:
   typedef UniqueCStringMap<EnumeratorInfo> EnumerationMap;
   typedef EnumerationMap::Entry EnumerationMapEntry;
 
-  OptionValueEnumeration(const OptionEnumValueElement *enumerators,
-                         enum_type value);
+  OptionValueEnumeration(const OptionEnumValues &enumerators, enum_type value);
 
   ~OptionValueEnumeration() override;
 
@@ -80,7 +79,7 @@ public:
   void SetDefaultValue(enum_type value) { m_default_value = value; }
 
 protected:
-  void SetEnumerations(const OptionEnumValueElement *enumerators);
+  void SetEnumerations(const OptionEnumValues &enumerators);
 
   enum_type m_current_value;
   enum_type m_default_value;

--- a/include/lldb/Interpreter/OptionValueProperties.h
+++ b/include/lldb/Interpreter/OptionValueProperties.h
@@ -62,7 +62,7 @@ public:
   void Apropos(llvm::StringRef keyword,
                std::vector<const Property *> &matching_properties) const;
 
-  void Initialize(const PropertyDefinition *setting_definitions);
+  void Initialize(const PropertyDefinitions &setting_definitions);
 
   //    bool
   //    GetQualifiedName (Stream &strm);

--- a/include/lldb/Interpreter/Property.h
+++ b/include/lldb/Interpreter/Property.h
@@ -32,6 +32,8 @@ struct PropertyDefinition {
   const char *description;
 };
 
+using PropertyDefinitions = llvm::ArrayRef<PropertyDefinition>;
+
 class Property {
 public:
   Property(const PropertyDefinition &definition);

--- a/include/lldb/Interpreter/Property.h
+++ b/include/lldb/Interpreter/Property.h
@@ -28,7 +28,7 @@ struct PropertyDefinition {
   bool global; // false == this setting is a global setting by default
   uintptr_t default_uint_value;
   const char *default_cstr_value;
-  OptionEnumValueElement *enum_values;
+  OptionEnumValues enum_values;
   const char *description;
 };
 

--- a/include/lldb/Target/Platform.h
+++ b/include/lldb/Target/Platform.h
@@ -1131,10 +1131,6 @@ public:
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 
-  // Options table: Required for subclasses of Options.
-
-  static lldb_private::OptionDefinition g_option_table[];
-
   // Instance variables to hold the values for command options.
 
   bool m_rsync;
@@ -1160,10 +1156,6 @@ public:
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
 
-  // Options table: Required for subclasses of Options.
-
-  static lldb_private::OptionDefinition g_option_table[];
-
   // Instance variables to hold the values for command options.
 
   bool m_ssh;
@@ -1186,10 +1178,6 @@ public:
   void OptionParsingStarting(ExecutionContext *execution_context) override;
 
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override;
-
-  // Options table: Required for subclasses of Options.
-
-  static lldb_private::OptionDefinition g_option_table[];
 
   // Instance variables to hold the values for command options.
 

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -51,7 +51,7 @@
 
 namespace lldb_private {
 
-extern OptionEnumValueElement g_dynamic_value_types[];
+OptionEnumValues GetDynamicValueTypes();
 
 typedef enum InlineStrategy {
   eInlineBreakpointsNever = 0,

--- a/include/lldb/lldb-private-types.h
+++ b/include/lldb/lldb-private-types.h
@@ -95,6 +95,8 @@ struct OptionEnumValueElement {
   const char *usage;
 };
 
+using OptionEnumValues = llvm::ArrayRef<OptionEnumValueElement>;
+
 struct OptionValidator {
   virtual ~OptionValidator() {}
   virtual bool IsValid(Platform &platform,
@@ -112,9 +114,8 @@ struct OptionDefinition {
   int short_option;        // Single character for this option.
   int option_has_arg; // no_argument, required_argument or optional_argument
   OptionValidator *validator; // If non-NULL, option is valid iff
-                              // |validator->IsValid()|, otherwise always
-                              // valid.
-  OptionEnumValueElement *enum_values; // If non-NULL an array of enum values.
+                              // |validator->IsValid()|, otherwise always valid.
+  OptionEnumValues enum_values; // If not empty, an array of enum values.
   uint32_t completion_type; // Cookie the option class can use to do define the
                             // argument completion.
   lldb::CommandArgumentType argument_type; // Type of argument this option takes

--- a/source/Commands/CommandObjectBreakpoint.cpp
+++ b/source/Commands/CommandObjectBreakpoint.cpp
@@ -50,19 +50,19 @@ static void AddBreakpointDescription(Stream *s, Breakpoint *bp,
 // Modifiable Breakpoint Options
 //-------------------------------------------------------------------------
 #pragma mark Modify::CommandOptions
-static OptionDefinition g_breakpoint_modify_options[] = {
+static constexpr OptionDefinition g_breakpoint_modify_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "ignore-count", 'i', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount,       "Set the number of times this breakpoint is skipped before stopping." },
-  { LLDB_OPT_SET_1, false, "one-shot",     'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,     "The breakpoint is deleted the first time it stop causes a stop." },
-  { LLDB_OPT_SET_1, false, "thread-index", 'x', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeThreadIndex, "The breakpoint stops only for the thread whose index matches this argument." },
-  { LLDB_OPT_SET_1, false, "thread-id",    't', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeThreadID,    "The breakpoint stops only for the thread whose TID matches this argument." },
-  { LLDB_OPT_SET_1, false, "thread-name",  'T', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeThreadName,  "The breakpoint stops only for the thread whose thread name matches this argument." },
-  { LLDB_OPT_SET_1, false, "queue-name",   'q', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeQueueName,   "The breakpoint stops only for threads in the queue whose name is given by this argument." },
-  { LLDB_OPT_SET_1, false, "condition",    'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeExpression,  "The breakpoint stops only if this condition expression evaluates to true." },
-  { LLDB_OPT_SET_1, false, "auto-continue",'G', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,     "The breakpoint will auto-continue after running its commands." },
-  { LLDB_OPT_SET_2, false, "enable",       'e', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Enable the breakpoint." },
-  { LLDB_OPT_SET_3, false, "disable",      'd', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Disable the breakpoint." },
-  { LLDB_OPT_SET_4, false, "command",      'C', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCommand,     "A command to run when the breakpoint is hit, can be provided more than once, the commands will get run in order left to right." },
+  { LLDB_OPT_SET_1, false, "ignore-count", 'i', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,       "Set the number of times this breakpoint is skipped before stopping." },
+  { LLDB_OPT_SET_1, false, "one-shot",     'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,     "The breakpoint is deleted the first time it stop causes a stop." },
+  { LLDB_OPT_SET_1, false, "thread-index", 'x', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeThreadIndex, "The breakpoint stops only for the thread whose index matches this argument." },
+  { LLDB_OPT_SET_1, false, "thread-id",    't', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeThreadID,    "The breakpoint stops only for the thread whose TID matches this argument." },
+  { LLDB_OPT_SET_1, false, "thread-name",  'T', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeThreadName,  "The breakpoint stops only for the thread whose thread name matches this argument." },
+  { LLDB_OPT_SET_1, false, "queue-name",   'q', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeQueueName,   "The breakpoint stops only for threads in the queue whose name is given by this argument." },
+  { LLDB_OPT_SET_1, false, "condition",    'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeExpression,  "The breakpoint stops only if this condition expression evaluates to true." },
+  { LLDB_OPT_SET_1, false, "auto-continue",'G', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,     "The breakpoint will auto-continue after running its commands." },
+  { LLDB_OPT_SET_2, false, "enable",       'e', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Enable the breakpoint." },
+  { LLDB_OPT_SET_3, false, "disable",      'd', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Disable the breakpoint." },
+  { LLDB_OPT_SET_4, false, "command",      'C', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCommand,     "A command to run when the breakpoint is hit, can be provided more than once, the commands will get run in order left to right." },
     // clang-format on
 };
 class lldb_private::BreakpointOptionGroup : public OptionGroup
@@ -198,9 +198,9 @@ public:
   BreakpointOptions m_bp_opts;
 
 };
-static OptionDefinition g_breakpoint_dummy_options[] = {
+static constexpr OptionDefinition g_breakpoint_dummy_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Act on Dummy breakpoints - i.e. breakpoints set before a file is provided, "
+  { LLDB_OPT_SET_1, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Act on Dummy breakpoints - i.e. breakpoints set before a file is provided, "
   "which prime new targets." },
     // clang-format on
 };
@@ -252,16 +252,16 @@ public:
 #define LLDB_OPT_MOVE_TO_NEAREST_CODE (LLDB_OPT_SET_1 | LLDB_OPT_SET_9)
 #define LLDB_OPT_EXPR_LANGUAGE (LLDB_OPT_SET_FROM_TO(3, 8))
 
-static OptionDefinition g_breakpoint_set_options[] = {
+static constexpr OptionDefinition g_breakpoint_set_options[] = {
     // clang-format off
-  { LLDB_OPT_NOT_10,               false, "shlib",                  's', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eModuleCompletion,     eArgTypeShlibName,           "Set the breakpoint only in this shared library.  Can repeat this option "
+  { LLDB_OPT_NOT_10,               false, "shlib",                  's', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eModuleCompletion,     eArgTypeShlibName,           "Set the breakpoint only in this shared library.  Can repeat this option "
   "multiple times to specify multiple shared libraries." },
-  { LLDB_OPT_SET_ALL,              false, "hardware",               'H', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                         eArgTypeNone,                "Require the breakpoint to use hardware breakpoints." },
-  { LLDB_OPT_FILE,                 false, "file",                   'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "Specifies the source file in which to set this breakpoint.  Note, by default "
+  { LLDB_OPT_SET_ALL,              false, "hardware",               'H', OptionParser::eNoArgument,       nullptr, {}, 0,                                         eArgTypeNone,                "Require the breakpoint to use hardware breakpoints." },
+  { LLDB_OPT_FILE,                 false, "file",                   'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "Specifies the source file in which to set this breakpoint.  Note, by default "
   "lldb only looks for files that are #included if they use the standard include "
   "file extensions.  To set breakpoints on .c/.cpp/.m/.mm files that are "
   "#included, set target.inline-breakpoint-strategy to \"always\"." },
-  { LLDB_OPT_SET_1,                true,  "line",                   'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLineNum,             "Specifies the line number on which to set this breakpoint." },
+  { LLDB_OPT_SET_1,                true,  "line",                   'l', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLineNum,             "Specifies the line number on which to set this breakpoint." },
 
   // Comment out this option for the moment, as we don't actually use it, but
   // will in the future. This way users won't see it, but the infrastructure is
@@ -269,7 +269,7 @@ static OptionDefinition g_breakpoint_set_options[] = {
   //    { 0, false, "column",     'C', OptionParser::eRequiredArgument, nullptr, "<column>",
   //    "Set the breakpoint by source location at this particular column."},
 
-  { LLDB_OPT_SET_2,                true,  "address",                'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeAddressOrExpression, "Set the breakpoint at the specified address.  If the address maps uniquely to "
+  { LLDB_OPT_SET_2,                true,  "address",                'a', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeAddressOrExpression, "Set the breakpoint at the specified address.  If the address maps uniquely to "
   "a particular binary, then the address will be converted to a \"file\" "
   "address, so that the breakpoint will track that binary+offset no matter where "
   "the binary eventually loads.  Alternately, if you also specify the module - "
@@ -278,47 +278,50 @@ static OptionDefinition g_breakpoint_set_options[] = {
   "that offset on subsequent reloads.  The module need not have been loaded at "
   "the time you specify this breakpoint, and will get resolved when the module "
   "is loaded." },
-  { LLDB_OPT_SET_3,                true,  "name",                   'n', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion,     eArgTypeFunctionName,        "Set the breakpoint by function name.  Can be repeated multiple times to make "
+  { LLDB_OPT_SET_3,                true,  "name",                   'n', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion,     eArgTypeFunctionName,        "Set the breakpoint by function name.  Can be repeated multiple times to make "
   "one breakpoint for multiple names" },
-  { LLDB_OPT_SET_9,                false, "source-regexp-function", 'X', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion,     eArgTypeFunctionName,        "When used with '-p' limits the source regex to source contained in the named "
+  { LLDB_OPT_SET_9,                false, "source-regexp-function", 'X', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion,     eArgTypeFunctionName,        "When used with '-p' limits the source regex to source contained in the named "
   "functions.  Can be repeated multiple times." },
-  { LLDB_OPT_SET_4,                true,  "fullname",               'F', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion,     eArgTypeFullName,            "Set the breakpoint by fully qualified function names. For C++ this means "
+  { LLDB_OPT_SET_4,                true,  "fullname",               'F', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion,     eArgTypeFullName,            "Set the breakpoint by fully qualified function names. For C++ this means "
   "namespaces and all arguments, and for Objective-C this means a full function "
   "prototype with class and selector.  Can be repeated multiple times to make "
   "one breakpoint for multiple names." },
-  { LLDB_OPT_SET_5,                true,  "selector",               'S', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeSelector,            "Set the breakpoint by ObjC selector name. Can be repeated multiple times to "
+  { LLDB_OPT_SET_5,                true,  "selector",               'S', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeSelector,            "Set the breakpoint by ObjC selector name. Can be repeated multiple times to "
   "make one breakpoint for multiple Selectors." },
-  { LLDB_OPT_SET_6,                true,  "method",                 'M', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeMethod,              "Set the breakpoint by C++ method names.  Can be repeated multiple times to "
+  { LLDB_OPT_SET_6,                true,  "method",                 'M', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeMethod,              "Set the breakpoint by C++ method names.  Can be repeated multiple times to "
   "make one breakpoint for multiple methods." },
-  { LLDB_OPT_SET_7,                true,  "func-regex",             'r', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeRegularExpression,   "Set the breakpoint by function name, evaluating a regular-expression to find "
+  { LLDB_OPT_SET_7,                true,  "func-regex",             'r', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeRegularExpression,   "Set the breakpoint by function name, evaluating a regular-expression to find "
   "the function name(s)." },
-  { LLDB_OPT_SET_8,                true,  "basename",               'b', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion,     eArgTypeFunctionName,        "Set the breakpoint by function basename (C++ namespaces and arguments will be "
+  { LLDB_OPT_SET_8,                true,  "basename",               'b', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion,     eArgTypeFunctionName,        "Set the breakpoint by function basename (C++ namespaces and arguments will be "
   "ignored).  Can be repeated multiple times to make one breakpoint for multiple "
   "symbols." },
-  { LLDB_OPT_SET_9,                true,  "source-pattern-regexp",  'p', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeRegularExpression,   "Set the breakpoint by specifying a regular expression which is matched "
+  { LLDB_OPT_SET_9,                true,  "source-pattern-regexp",  'p', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeRegularExpression,   "Set the breakpoint by specifying a regular expression which is matched "
   "against the source text in a source file or files specified with the -f "
   "option.  The -f option can be specified more than once.  If no source files "
   "are specified, uses the current \"default source file\".  If you want to "
   "match against all source files, pass the \"--all-files\" option." },
-  { LLDB_OPT_SET_9,                false, "all-files",              'A', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                         eArgTypeNone,                "All files are searched for source pattern matches." },
-  { LLDB_OPT_SET_10,               true,  "language-exception",     'E', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLanguage,            "Set the breakpoint on exceptions thrown by the specified language (without "
+  { LLDB_OPT_SET_9,                false, "all-files",              'A', OptionParser::eNoArgument,       nullptr, {}, 0,                                         eArgTypeNone,                "All files are searched for source pattern matches." },
+  { LLDB_OPT_SET_11,               true, "python-class",            'P', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypePythonClass,       "The name of the class that implement a scripted breakpoint." },
+  { LLDB_OPT_SET_11,               false, "python-class-key",       'k', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeNone,                "The key for a key/value pair passed to the class that implements a scripted breakpoint.  Can be specified more    305  than once." },
+  { LLDB_OPT_SET_11,               false, "python-class-value",     'v', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeNone,                "The value for the previous key in the pair passed to the class that implements a scripted breakpoint.    Can b    306 e specified more than once." },
+  { LLDB_OPT_SET_10,               true,  "language-exception",     'E', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLanguage,            "Set the breakpoint on exceptions thrown by the specified language (without "
   "options, on throw but not catch.)" },
-  { LLDB_OPT_SET_10,               false, "on-throw",               'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeBoolean,             "Set the breakpoint on exception throW." },
-  { LLDB_OPT_SET_10,               false, "on-catch",               'h', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeBoolean,             "Set the breakpoint on exception catcH." },
-  { LLDB_OPT_SET_10,               false, "exception-typename",     'O', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeTypeName,
+  { LLDB_OPT_SET_10,               false, "on-throw",               'w', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeBoolean,             "Set the breakpoint on exception throW." },
+  { LLDB_OPT_SET_10,               false, "on-catch",               'h', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeBoolean,             "Set the breakpoint on exception catcH." },
+  { LLDB_OPT_SET_10,               false, "exception-typename",     'O', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeTypeName,
     "The breakpoint will only stop if an exception Object of this type is thrown.  Can be repeated multiple times to stop "
     "for multiple object types.  If you just specify the type's base name it will match against that type in all modules,"
     " or you can specify the full type name including modules.  Other submatches are not supported at present."
     "Only supported for Swift at present."},
-  { LLDB_OPT_EXPR_LANGUAGE,        false, "language",               'L', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLanguage,            "Specifies the Language to use when interpreting the breakpoint's expression "
+  { LLDB_OPT_EXPR_LANGUAGE,        false, "language",               'L', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLanguage,            "Specifies the Language to use when interpreting the breakpoint's expression "
   "(note: currently only implemented for setting breakpoints on identifiers).  "
   "If not set the target.language setting is used." },
-  { LLDB_OPT_SKIP_PROLOGUE,        false, "skip-prologue",          'K', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeBoolean,             "sKip the prologue if the breakpoint is at the beginning of a function.  "
+  { LLDB_OPT_SKIP_PROLOGUE,        false, "skip-prologue",          'K', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeBoolean,             "sKip the prologue if the breakpoint is at the beginning of a function.  "
   "If not set the target.skip-prologue setting is used." },
-  { LLDB_OPT_SET_ALL,              false, "breakpoint-name",        'N', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeBreakpointName,      "Adds this to the list of names for this breakpoint." },
-  { LLDB_OPT_OFFSET_APPLIES,       false, "address-slide",          'R', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeAddress,             "Add the specified offset to whatever address(es) the breakpoint resolves to.  "
+  { LLDB_OPT_SET_ALL,              false, "breakpoint-name",        'N', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeBreakpointName,      "Adds this to the list of names for this breakpoint." },
+  { LLDB_OPT_OFFSET_APPLIES,       false, "address-slide",          'R', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeAddress,             "Add the specified offset to whatever address(es) the breakpoint resolves to.  "
   "At present this applies the offset directly as given, and doesn't try to align it to instruction boundaries." },
-  { LLDB_OPT_MOVE_TO_NEAREST_CODE, false, "move-to-nearest-code", 'm', OptionParser::eRequiredArgument,   nullptr, nullptr, 0,                                         eArgTypeBoolean,             "Move breakpoints to nearest code. If not set the target.move-to-nearest-code "
+  { LLDB_OPT_MOVE_TO_NEAREST_CODE, false, "move-to-nearest-code", 'm', OptionParser::eRequiredArgument,   nullptr, {}, 0,                                         eArgTypeBoolean,             "Move breakpoints to nearest code. If not set the target.move-to-nearest-code "
   "setting is used." },
     // clang-format on
 };
@@ -1212,15 +1215,15 @@ protected:
 //-------------------------------------------------------------------------
 
 #pragma mark List::CommandOptions
-static OptionDefinition g_breakpoint_list_options[] = {
+static constexpr OptionDefinition g_breakpoint_list_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "internal",          'i', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Show debugger internal breakpoints" },
-  { LLDB_OPT_SET_1,   false, "brief",             'b', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Give a brief description of the breakpoint (no location info)." },
+  { LLDB_OPT_SET_ALL, false, "internal",          'i', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Show debugger internal breakpoints" },
+  { LLDB_OPT_SET_1,   false, "brief",             'b', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Give a brief description of the breakpoint (no location info)." },
   // FIXME: We need to add an "internal" command, and then add this sort of thing to it.
   // But I need to see it for now, and don't want to wait.
-  { LLDB_OPT_SET_2,   false, "full",              'f', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Give a full description of the breakpoint and its locations." },
-  { LLDB_OPT_SET_3,   false, "verbose",           'v', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Explain everything we know about the breakpoint (for debugging debugger bugs)." },
-  { LLDB_OPT_SET_ALL, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "List Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
+  { LLDB_OPT_SET_2,   false, "full",              'f', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Give a full description of the breakpoint and its locations." },
+  { LLDB_OPT_SET_3,   false, "verbose",           'v', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Explain everything we know about the breakpoint (for debugging debugger bugs)." },
+  { LLDB_OPT_SET_ALL, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "List Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
     // clang-format on
 };
 
@@ -1378,10 +1381,10 @@ private:
 //-------------------------------------------------------------------------
 #pragma mark Clear::CommandOptions
 
-static OptionDefinition g_breakpoint_clear_options[] = {
+static constexpr OptionDefinition g_breakpoint_clear_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "file", 'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSourceFileCompletion, eArgTypeFilename, "Specify the breakpoint by source location in this particular file." },
-  { LLDB_OPT_SET_1, true,  "line", 'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLineNum,  "Specify the breakpoint by source location at this particular line." }
+  { LLDB_OPT_SET_1, false, "file", 'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSourceFileCompletion, eArgTypeFilename, "Specify the breakpoint by source location in this particular file." },
+  { LLDB_OPT_SET_1, true,  "line", 'l', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLineNum,  "Specify the breakpoint by source location at this particular line." }
     // clang-format on
 };
 
@@ -1536,10 +1539,10 @@ private:
 //-------------------------------------------------------------------------
 // CommandObjectBreakpointDelete
 //-------------------------------------------------------------------------
-static OptionDefinition g_breakpoint_delete_options[] = {
+static constexpr OptionDefinition g_breakpoint_delete_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "force",             'f', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Delete all breakpoints without querying for confirmation." },
-  { LLDB_OPT_SET_1, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Delete Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
+  { LLDB_OPT_SET_1, false, "force",             'f', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Delete all breakpoints without querying for confirmation." },
+  { LLDB_OPT_SET_1, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Delete Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
     // clang-format on
 };
 
@@ -1693,12 +1696,12 @@ private:
 // CommandObjectBreakpointName
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_breakpoint_name_options[] = {
+static constexpr OptionDefinition g_breakpoint_name_options[] = {
     // clang-format off
-  {LLDB_OPT_SET_1, false, "name",              'N', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBreakpointName, "Specifies a breakpoint name to use."},
-  {LLDB_OPT_SET_2, false, "breakpoint-id",     'B', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBreakpointID,   "Specify a breakpoint ID to use."},
-  {LLDB_OPT_SET_3, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Operate on Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets."},
-  {LLDB_OPT_SET_4, false, "help-string",  'H', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeNone, "A help string describing the purpose of this name."},
+  {LLDB_OPT_SET_1, false, "name",              'N', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBreakpointName, "Specifies a breakpoint name to use."},
+  {LLDB_OPT_SET_2, false, "breakpoint-id",     'B', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBreakpointID,   "Specify a breakpoint ID to use."},
+  {LLDB_OPT_SET_3, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Operate on Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets."},
+  {LLDB_OPT_SET_4, false, "help-string",       'H', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeNone,           "A help string describing the purpose of this name."},
     // clang-format on
 };
 class BreakpointNameOptionGroup : public OptionGroup {
@@ -1762,23 +1765,20 @@ public:
   OptionValueString m_help_string;
 };
 
-static OptionDefinition g_breakpoint_access_options[] = {
+static constexpr OptionDefinition g_breakpoint_access_options[] = {
     // clang-format off
-  {LLDB_OPT_SET_1,   false, "allow-list",    'L', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Determines whether the breakpoint will show up in break list if not referred to explicitly."},
-  {LLDB_OPT_SET_2,   false, "allow-disable", 'A', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Determines whether the breakpoint can be disabled by name or when all breakpoints are disabled."},
-  {LLDB_OPT_SET_3,   false, "allow-delete",  'D', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Determines whether the breakpoint can be deleted by name or when all breakpoints are deleted."},
+  {LLDB_OPT_SET_1,   false, "allow-list",    'L', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Determines whether the breakpoint will show up in break list if not referred to explicitly."},
+  {LLDB_OPT_SET_2,   false, "allow-disable", 'A', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Determines whether the breakpoint can be disabled by name or when all breakpoints are disabled."},
+  {LLDB_OPT_SET_3,   false, "allow-delete",  'D', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Determines whether the breakpoint can be deleted by name or when all breakpoints are deleted."},
     // clang-format on
 };
 
-class BreakpointAccessOptionGroup : public OptionGroup
-{
+class BreakpointAccessOptionGroup : public OptionGroup {
 public:
-  BreakpointAccessOptionGroup() :
-          OptionGroup()
-   {}
-  
+  BreakpointAccessOptionGroup() : OptionGroup() {}
+
   ~BreakpointAccessOptionGroup() override = default;
-  
+
   llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
     return llvm::makeArrayRef(g_breakpoint_access_options);
   }
@@ -2234,10 +2234,10 @@ public:
 // CommandObjectBreakpointRead
 //-------------------------------------------------------------------------
 #pragma mark Read::CommandOptions
-static OptionDefinition g_breakpoint_read_options[] = {
+static constexpr OptionDefinition g_breakpoint_read_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, true, "file",                   'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eDiskFileCompletion, eArgTypeFilename,       "The file from which to read the breakpoints." },
-  {LLDB_OPT_SET_ALL, false, "breakpoint-name",        'N', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                       eArgTypeBreakpointName, "Only read in breakpoints with this name."},
+  {LLDB_OPT_SET_ALL, true,  "file",                   'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eDiskFileCompletion, eArgTypeFilename,       "The file from which to read the breakpoints." },
+  {LLDB_OPT_SET_ALL, false, "breakpoint-name",        'N', OptionParser::eRequiredArgument, nullptr, {}, 0,                                       eArgTypeBreakpointName, "Only read in breakpoints with this name."},
     // clang-format on
 };
 
@@ -2364,10 +2364,10 @@ private:
 // CommandObjectBreakpointWrite
 //-------------------------------------------------------------------------
 #pragma mark Write::CommandOptions
-static OptionDefinition g_breakpoint_write_options[] = {
+static constexpr OptionDefinition g_breakpoint_write_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, true,  "file",  'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eDiskFileCompletion, eArgTypeFilename,    "The file into which to write the breakpoints." },
-  { LLDB_OPT_SET_ALL, false, "append",'a', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                       eArgTypeNone,        "Append to saved breakpoints file if it exists."},
+  { LLDB_OPT_SET_ALL, true,  "file",  'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eDiskFileCompletion, eArgTypeFilename,    "The file into which to write the breakpoints." },
+  { LLDB_OPT_SET_ALL, false, "append",'a', OptionParser::eNoArgument,       nullptr, {}, 0,                                       eArgTypeNone,        "Append to saved breakpoints file if it exists."},
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectBreakpoint.cpp
+++ b/source/Commands/CommandObjectBreakpoint.cpp
@@ -301,9 +301,6 @@ static constexpr OptionDefinition g_breakpoint_set_options[] = {
   "are specified, uses the current \"default source file\".  If you want to "
   "match against all source files, pass the \"--all-files\" option." },
   { LLDB_OPT_SET_9,                false, "all-files",              'A', OptionParser::eNoArgument,       nullptr, {}, 0,                                         eArgTypeNone,                "All files are searched for source pattern matches." },
-  { LLDB_OPT_SET_11,               true, "python-class",            'P', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypePythonClass,       "The name of the class that implement a scripted breakpoint." },
-  { LLDB_OPT_SET_11,               false, "python-class-key",       'k', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeNone,                "The key for a key/value pair passed to the class that implements a scripted breakpoint.  Can be specified more    305  than once." },
-  { LLDB_OPT_SET_11,               false, "python-class-value",     'v', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeNone,                "The value for the previous key in the pair passed to the class that implements a scripted breakpoint.    Can b    306 e specified more than once." },
   { LLDB_OPT_SET_10,               true,  "language-exception",     'E', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLanguage,            "Set the breakpoint on exceptions thrown by the specified language (without "
   "options, on throw but not catch.)" },
   { LLDB_OPT_SET_10,               false, "on-throw",               'w', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeBoolean,             "Set the breakpoint on exception throW." },

--- a/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -40,21 +40,24 @@ using namespace lldb_private;
 // language to lldb and have it pickable here without having to change this
 // enumeration by hand and rebuild lldb proper.
 
-static OptionEnumValueElement g_script_option_enumeration[4] = {
+static constexpr OptionEnumValueElement g_script_option_enumeration[] = {
     {eScriptLanguageNone, "command",
      "Commands are in the lldb command interpreter language"},
     {eScriptLanguagePython, "python", "Commands are in the Python language."},
     {eSortOrderByName, "default-script",
-     "Commands are in the default scripting language."},
-    {0, nullptr, nullptr}};
+     "Commands are in the default scripting language."} };
 
-static OptionDefinition g_breakpoint_add_options[] = {
+static constexpr OptionEnumValues ScriptOptionEnum() {
+  return OptionEnumValues(g_script_option_enumeration);
+}
+
+static constexpr OptionDefinition g_breakpoint_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1,   false, "one-liner",         'o', OptionParser::eRequiredArgument, nullptr, nullptr,                     0, eArgTypeOneLiner,       "Specify a one-line breakpoint command inline. Be sure to surround it with quotes." },
-  { LLDB_OPT_SET_ALL, false, "stop-on-error",     'e', OptionParser::eRequiredArgument, nullptr, nullptr,                     0, eArgTypeBoolean,        "Specify whether breakpoint command execution should terminate on error." },
-  { LLDB_OPT_SET_ALL, false, "script-type",       's', OptionParser::eRequiredArgument, nullptr, g_script_option_enumeration, 0, eArgTypeNone,           "Specify the language for the commands - if none is specified, the lldb command interpreter will be used." },
-  { LLDB_OPT_SET_2,   false, "python-function",   'F', OptionParser::eRequiredArgument, nullptr, nullptr,                     0, eArgTypePythonFunction, "Give the name of a Python function to run as command for this breakpoint. Be sure to give a module name if appropriate." },
-  { LLDB_OPT_SET_ALL, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument,       nullptr, nullptr,                     0, eArgTypeNone,           "Sets Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
+  { LLDB_OPT_SET_1,   false, "one-liner",         'o', OptionParser::eRequiredArgument, nullptr, {},                 0, eArgTypeOneLiner,       "Specify a one-line breakpoint command inline. Be sure to surround it with quotes." },
+  { LLDB_OPT_SET_ALL, false, "stop-on-error",     'e', OptionParser::eRequiredArgument, nullptr, {},                 0, eArgTypeBoolean,        "Specify whether breakpoint command execution should terminate on error." },
+  { LLDB_OPT_SET_ALL, false, "script-type",       's', OptionParser::eRequiredArgument, nullptr, ScriptOptionEnum(), 0, eArgTypeNone,           "Specify the language for the commands - if none is specified, the lldb command interpreter will be used." },
+  { LLDB_OPT_SET_2,   false, "python-function",   'F', OptionParser::eRequiredArgument, nullptr, {},                 0, eArgTypePythonFunction, "Give the name of a Python function to run as command for this breakpoint. Be sure to give a module name if appropriate." },
+  { LLDB_OPT_SET_ALL, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument,       nullptr, {},                 0, eArgTypeNone,           "Sets Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
     // clang-format on
 };
 
@@ -475,9 +478,9 @@ const char *CommandObjectBreakpointCommandAdd::g_reader_instructions =
 // CommandObjectBreakpointCommandDelete
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_breakpoint_delete_options[] = {
+static constexpr OptionDefinition g_breakpoint_delete_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Delete commands from Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
+  { LLDB_OPT_SET_1, false, "dummy-breakpoints", 'D', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Delete commands from Dummy breakpoints - i.e. breakpoints set before a file is provided, which prime new targets." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectCommands.cpp
+++ b/source/Commands/CommandObjectCommands.cpp
@@ -38,12 +38,12 @@ using namespace lldb_private;
 // CommandObjectCommandsSource
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_history_options[] = {
+static constexpr OptionDefinition g_history_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "count",       'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger, "How many history commands to print." },
-  { LLDB_OPT_SET_1, false, "start-index", 's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger, "Index at which to start printing history commands (or end to mean tail mode)." },
-  { LLDB_OPT_SET_1, false, "end-index",   'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger, "Index at which to stop printing history commands." },
-  { LLDB_OPT_SET_2, false, "clear",       'C', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeBoolean,         "Clears the current command history." },
+  { LLDB_OPT_SET_1, false, "count",       'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger, "How many history commands to print." },
+  { LLDB_OPT_SET_1, false, "start-index", 's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger, "Index at which to start printing history commands (or end to mean tail mode)." },
+  { LLDB_OPT_SET_1, false, "end-index",   'e', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger, "Index at which to stop printing history commands." },
+  { LLDB_OPT_SET_2, false, "clear",       'C', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeBoolean,         "Clears the current command history." },
     // clang-format on
 };
 
@@ -197,11 +197,11 @@ protected:
 // CommandObjectCommandsSource
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_source_options[] = {
+static constexpr OptionDefinition g_source_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "stop-on-error",    'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "If true, stop executing commands on error." },
-  { LLDB_OPT_SET_ALL, false, "stop-on-continue", 'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "If true, stop executing commands on continue." },
-  { LLDB_OPT_SET_ALL, false, "silent-run",       's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "If true don't echo commands while executing." },
+  { LLDB_OPT_SET_ALL, false, "stop-on-error",    'e', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "If true, stop executing commands on error." },
+  { LLDB_OPT_SET_ALL, false, "stop-on-continue", 'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "If true, stop executing commands on continue." },
+  { LLDB_OPT_SET_ALL, false, "silent-run",       's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "If true don't echo commands while executing." },
     // clang-format on
 };
 
@@ -340,10 +340,10 @@ protected:
 // CommandObjectCommandsAlias
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_alias_options[] = {
+static constexpr OptionDefinition g_alias_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "help",      'h', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeHelpText, "Help text for this command" },
-  { LLDB_OPT_SET_ALL, false, "long-help", 'H', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeHelpText, "Long help text for this command" },
+  { LLDB_OPT_SET_ALL, false, "help",      'h', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeHelpText, "Help text for this command" },
+  { LLDB_OPT_SET_ALL, false, "long-help", 'H', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeHelpText, "Long help text for this command" },
     // clang-format on
 };
 
@@ -914,10 +914,10 @@ protected:
 // CommandObjectCommandsAddRegex
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_regex_options[] = {
+static constexpr OptionDefinition g_regex_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "help"  , 'h', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeNone, "The help text to display for this command." },
-  { LLDB_OPT_SET_1, false, "syntax", 's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeNone, "A syntax string showing the typical usage syntax." },
+  { LLDB_OPT_SET_1, false, "help"  , 'h', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeNone, "The help text to display for this command." },
+  { LLDB_OPT_SET_1, false, "syntax", 's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeNone, "A syntax string showing the typical usage syntax." },
     // clang-format on
 };
 
@@ -1408,9 +1408,9 @@ private:
 // CommandObjectCommandsScriptImport
 //-------------------------------------------------------------------------
 
-OptionDefinition g_script_import_options[] = {
+static constexpr OptionDefinition g_script_import_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "allow-reload", 'r', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Allow the script to be loaded even if it was already loaded before. This argument exists for backwards compatibility, but reloading is always allowed, whether you specify it or not." },
+  { LLDB_OPT_SET_1, false, "allow-reload", 'r', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Allow the script to be loaded even if it was already loaded before. This argument exists for backwards compatibility, but reloading is always allowed, whether you specify it or not." },
     // clang-format on
 };
 
@@ -1533,22 +1533,24 @@ protected:
 //-------------------------------------------------------------------------
 // CommandObjectCommandsScriptAdd
 //-------------------------------------------------------------------------
+static constexpr OptionEnumValueElement g_script_synchro_type[] = {
+  {eScriptedCommandSynchronicitySynchronous, "synchronous",
+   "Run synchronous"},
+  {eScriptedCommandSynchronicityAsynchronous, "asynchronous",
+   "Run asynchronous"},
+  {eScriptedCommandSynchronicityCurrentValue, "current",
+   "Do not alter current setting"} };
 
-static OptionEnumValueElement g_script_synchro_type[] = {
-    {eScriptedCommandSynchronicitySynchronous, "synchronous",
-     "Run synchronous"},
-    {eScriptedCommandSynchronicityAsynchronous, "asynchronous",
-     "Run asynchronous"},
-    {eScriptedCommandSynchronicityCurrentValue, "current",
-     "Do not alter current setting"},
-    {0, nullptr, nullptr}};
+static constexpr OptionEnumValues ScriptSynchroType() {
+  return OptionEnumValues(g_script_synchro_type);
+}
 
-static OptionDefinition g_script_add_options[] = {
+static constexpr OptionDefinition g_script_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1,   false, "function",      'f', OptionParser::eRequiredArgument, nullptr, nullptr,               0, eArgTypePythonFunction,               "Name of the Python function to bind to this command name." },
-  { LLDB_OPT_SET_2,   false, "class",         'c', OptionParser::eRequiredArgument, nullptr, nullptr,               0, eArgTypePythonClass,                  "Name of the Python class to bind to this command name." },
-  { LLDB_OPT_SET_1,   false, "help"  ,        'h', OptionParser::eRequiredArgument, nullptr, nullptr,               0, eArgTypeHelpText,                     "The help text to display for this command." },
-  { LLDB_OPT_SET_ALL, false, "synchronicity", 's', OptionParser::eRequiredArgument, nullptr, g_script_synchro_type, 0, eArgTypeScriptedCommandSynchronicity, "Set the synchronicity of this command's executions with regard to LLDB event system." },
+  { LLDB_OPT_SET_1,   false, "function",      'f', OptionParser::eRequiredArgument, nullptr, {},                  0, eArgTypePythonFunction,               "Name of the Python function to bind to this command name." },
+  { LLDB_OPT_SET_2,   false, "class",         'c', OptionParser::eRequiredArgument, nullptr, {},                  0, eArgTypePythonClass,                  "Name of the Python class to bind to this command name." },
+  { LLDB_OPT_SET_1,   false, "help"  ,        'h', OptionParser::eRequiredArgument, nullptr, {},                  0, eArgTypeHelpText,                     "The help text to display for this command." },
+  { LLDB_OPT_SET_ALL, false, "synchronicity", 's', OptionParser::eRequiredArgument, nullptr, ScriptSynchroType(), 0, eArgTypeScriptedCommandSynchronicity, "Set the synchronicity of this command's executions with regard to LLDB event system." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectDisassemble.cpp
+++ b/source/Commands/CommandObjectDisassemble.cpp
@@ -35,30 +35,30 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static OptionDefinition g_disassemble_options[] = {
+static constexpr OptionDefinition g_disassemble_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "bytes",         'b', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                     eArgTypeNone,                "Show opcode bytes when disassembling." },
-  { LLDB_OPT_SET_ALL, false, "context",       'C', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeNumLines,            "Number of context lines of source to show." },
-  { LLDB_OPT_SET_ALL, false, "mixed",         'm', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                     eArgTypeNone,                "Enable mixed source and assembly display." },
-  { LLDB_OPT_SET_ALL, false, "raw",           'r', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                     eArgTypeNone,                "Print raw disassembly with no symbol information." },
-  { LLDB_OPT_SET_ALL, false, "plugin",        'P', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypePlugin,              "Name of the disassembler plugin you want to use." },
-  { LLDB_OPT_SET_ALL, false, "flavor",        'F', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeDisassemblyFlavor,   "Name of the disassembly flavor you want to use.  "
+  { LLDB_OPT_SET_ALL, false, "bytes",         'b', OptionParser::eNoArgument,       nullptr, {}, 0,                                     eArgTypeNone,                "Show opcode bytes when disassembling." },
+  { LLDB_OPT_SET_ALL, false, "context",       'C', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeNumLines,            "Number of context lines of source to show." },
+  { LLDB_OPT_SET_ALL, false, "mixed",         'm', OptionParser::eNoArgument,       nullptr, {}, 0,                                     eArgTypeNone,                "Enable mixed source and assembly display." },
+  { LLDB_OPT_SET_ALL, false, "raw",           'r', OptionParser::eNoArgument,       nullptr, {}, 0,                                     eArgTypeNone,                "Print raw disassembly with no symbol information." },
+  { LLDB_OPT_SET_ALL, false, "plugin",        'P', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypePlugin,              "Name of the disassembler plugin you want to use." },
+  { LLDB_OPT_SET_ALL, false, "flavor",        'F', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeDisassemblyFlavor,   "Name of the disassembly flavor you want to use.  "
   "Currently the only valid options are default, and for Intel "
   "architectures, att and intel." },
-  { LLDB_OPT_SET_ALL, false, "arch",          'A', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeArchitecture,        "Specify the architecture to use from cross disassembly." },
+  { LLDB_OPT_SET_ALL, false, "arch",          'A', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeArchitecture,        "Specify the architecture to use from cross disassembly." },
   { LLDB_OPT_SET_1 |
-  LLDB_OPT_SET_2,   true,  "start-address", 's', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeAddressOrExpression, "Address at which to start disassembling." },
-  { LLDB_OPT_SET_1,   false, "end-address",   'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeAddressOrExpression, "Address at which to end disassembling." },
+  LLDB_OPT_SET_2,   true,  "start-address", 's', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeAddressOrExpression, "Address at which to start disassembling." },
+  { LLDB_OPT_SET_1,   false, "end-address",   'e', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeAddressOrExpression, "Address at which to end disassembling." },
   { LLDB_OPT_SET_2 |
   LLDB_OPT_SET_3 |
   LLDB_OPT_SET_4 |
-  LLDB_OPT_SET_5,   false, "count",         'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeNumLines,            "Number of instructions to display." },
-  { LLDB_OPT_SET_3,   false, "name",          'n', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion, eArgTypeFunctionName,        "Disassemble entire contents of the given function name." },
-  { LLDB_OPT_SET_4,   false, "frame",         'f', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                     eArgTypeNone,                "Disassemble from the start of the current frame's function." },
-  { LLDB_OPT_SET_5,   false, "pc",            'p', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                     eArgTypeNone,                "Disassemble around the current pc." },
-  { LLDB_OPT_SET_6,   false, "line",          'l', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                     eArgTypeNone,                "Disassemble the current frame's current source line instructions if there is debug line "
+  LLDB_OPT_SET_5,   false, "count",         'c', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeNumLines,            "Number of instructions to display." },
+  { LLDB_OPT_SET_3,   false, "name",          'n', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion, eArgTypeFunctionName,        "Disassemble entire contents of the given function name." },
+  { LLDB_OPT_SET_4,   false, "frame",         'f', OptionParser::eNoArgument,       nullptr, {}, 0,                                     eArgTypeNone,                "Disassemble from the start of the current frame's function." },
+  { LLDB_OPT_SET_5,   false, "pc",            'p', OptionParser::eNoArgument,       nullptr, {}, 0,                                     eArgTypeNone,                "Disassemble around the current pc." },
+  { LLDB_OPT_SET_6,   false, "line",          'l', OptionParser::eNoArgument,       nullptr, {}, 0,                                     eArgTypeNone,                "Disassemble the current frame's current source line instructions if there is debug line "
   "table information, else disassemble around the pc." },
-  { LLDB_OPT_SET_7,   false, "address",       'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                     eArgTypeAddressOrExpression, "Disassemble function containing this address." },
+  { LLDB_OPT_SET_7,   false, "address",       'a', OptionParser::eRequiredArgument, nullptr, {}, 0,                                     eArgTypeAddressOrExpression, "Disassemble function containing this address." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectDisassemble.h
+++ b/source/Commands/CommandObjectDisassemble.h
@@ -65,7 +65,6 @@ public:
                                   // "at_pc".  This should be set
     // in SetOptionValue if anything the selects a location is set.
     lldb::addr_t symbol_containing_addr;
-    static OptionDefinition g_option_table[];
   };
 
   CommandObjectDisassemble(CommandInterpreter &interpreter);

--- a/source/Commands/CommandObjectExpression.cpp
+++ b/source/Commands/CommandObjectExpression.cpp
@@ -50,29 +50,32 @@ CommandObjectExpression::CommandOptions::CommandOptions() : OptionGroup() {}
 
 CommandObjectExpression::CommandOptions::~CommandOptions() = default;
 
-static OptionEnumValueElement g_description_verbosity_type[] = {
+static constexpr OptionEnumValueElement g_description_verbosity_type[] = {
     {eLanguageRuntimeDescriptionDisplayVerbosityCompact, "compact",
      "Only show the description string"},
     {eLanguageRuntimeDescriptionDisplayVerbosityFull, "full",
-     "Show the full output, including persistent variable's name and type"},
-    {0, nullptr, nullptr}};
+     "Show the full output, including persistent variable's name and type"} };
 
-static OptionDefinition g_expression_options[] = {
+static constexpr OptionEnumValues DescriptionVerbosityTypes() {
+  return OptionEnumValues(g_description_verbosity_type);
+}
+
+static constexpr OptionDefinition g_expression_options[] = {
     // clang-format off
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "all-threads",           'a', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeBoolean,              "Should we run all threads if the execution doesn't complete on one thread."},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "ignore-breakpoints",    'i', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeBoolean,              "Ignore breakpoint hits while running expressions"},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "timeout",               't', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeUnsignedInteger,      "Timeout value (in microseconds) for running the expression."},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "unwind-on-error",       'u', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeBoolean,              "Clean up program state if the expression causes a crash, or raises a signal.  "
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "all-threads",           'a', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeBoolean,              "Should we run all threads if the execution doesn't complete on one thread."},
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "ignore-breakpoints",    'i', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeBoolean,              "Ignore breakpoint hits while running expressions"},
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "timeout",               't', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeUnsignedInteger,      "Timeout value (in microseconds) for running the expression."},
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "unwind-on-error",       'u', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeBoolean,              "Clean up program state if the expression causes a crash, or raises a signal.  "
                                                                                                                                                                                   "Note, unlike gdb hitting a breakpoint is controlled by another option (-i)."},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "debug",                 'g', OptionParser::eNoArgument,       nullptr, nullptr,                      0, eArgTypeNone,                 "When specified, debug the JIT code by setting a breakpoint on the first instruction "
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "debug",                 'g', OptionParser::eNoArgument,       nullptr, {},                          0, eArgTypeNone,                 "When specified, debug the JIT code by setting a breakpoint on the first instruction "
                                                                                                                                                                                   "and forcing breakpoints to not be ignored (-i0) and no unwinding to happen on error (-u0)."},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "language",              'l', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeLanguage,             "Specifies the Language to use when parsing the expression.  If not set the target.language "
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "language",              'l', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeLanguage,             "Specifies the Language to use when parsing the expression.  If not set the target.language "
                                                                                                                                                                                   "setting is used." },
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "apply-fixits",          'X', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeBoolean,              "If true, simple fix-it hints will be automatically applied to the expression." },
-  {LLDB_OPT_SET_1,                  false, "description-verbosity", 'v', OptionParser::eOptionalArgument, nullptr, g_description_verbosity_type, 0, eArgTypeDescriptionVerbosity, "How verbose should the output of this expression be, if the object description is asked for."},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "top-level",             'p', OptionParser::eNoArgument,       nullptr, nullptr,                      0, eArgTypeNone,                 "Interpret the expression as a complete translation unit, without injecting it into the local "
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "apply-fixits",          'X', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeLanguage,             "If true, simple fix-it hints will be automatically applied to the expression." },
+  {LLDB_OPT_SET_1,                  false, "description-verbosity", 'v', OptionParser::eOptionalArgument, nullptr, DescriptionVerbosityTypes(), 0, eArgTypeDescriptionVerbosity, "How verbose should the output of this expression be, if the object description is asked for."},
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "top-level",             'p', OptionParser::eNoArgument,       nullptr, {},                          0, eArgTypeNone,                 "Interpret the expression as a complete translation unit, without injecting it into the local "
                                                                                                                                                                                   "context.  Allows declaration of persistent, top-level entities without a $ prefix."},
-  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "allow-jit",             'j', OptionParser::eRequiredArgument, nullptr, nullptr,                      0, eArgTypeBoolean,              "Controls whether the expression can fall back to being JITted if it's not supported by "
+  {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "allow-jit",             'j', OptionParser::eRequiredArgument, nullptr, {},                          0, eArgTypeBoolean,              "Controls whether the expression can fall back to being JITted if it's not supported by "
                                                                                                                                                                                   "the interpreter (defaults to true)."}
     // clang-format on
 };

--- a/source/Commands/CommandObjectExpression.h
+++ b/source/Commands/CommandObjectExpression.h
@@ -39,9 +39,6 @@ public:
 
     void OptionParsingStarting(ExecutionContext *execution_context) override;
 
-    // Options table: Required for subclasses of Options.
-
-    static OptionDefinition g_option_table[];
     bool top_level;
     bool unwind_on_error;
     bool ignore_breakpoints;

--- a/source/Commands/CommandObjectFrame.cpp
+++ b/source/Commands/CommandObjectFrame.cpp
@@ -61,11 +61,11 @@ using namespace lldb_private;
 // CommandObjectFrameDiagnose
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_frame_diag_options[] = {
+static constexpr OptionDefinition g_frame_diag_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "register", 'r', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeRegisterName,    "A register to diagnose." },
-  { LLDB_OPT_SET_1, false, "address",  'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeAddress,         "An address to diagnose." },
-  { LLDB_OPT_SET_1, false, "offset",   'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOffset,          "An optional offset.  Requires --register." }
+  { LLDB_OPT_SET_1, false, "register", 'r', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeRegisterName,    "A register to diagnose." },
+  { LLDB_OPT_SET_1, false, "address",  'a', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeAddress,         "An address to diagnose." },
+  { LLDB_OPT_SET_1, false, "offset",   'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOffset,          "An optional offset.  Requires --register." }
     // clang-format on
 };
 
@@ -251,7 +251,7 @@ protected:
 
 static OptionDefinition g_frame_select_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "relative", 'r', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOffset, "A relative frame index offset from the current frame index." },
+  { LLDB_OPT_SET_1, false, "relative", 'r', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOffset, "A relative frame index offset from the current frame index." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectHelp.cpp
+++ b/source/Commands/CommandObjectHelp.cpp
@@ -71,11 +71,11 @@ CommandObjectHelp::CommandObjectHelp(CommandInterpreter &interpreter)
 
 CommandObjectHelp::~CommandObjectHelp() = default;
 
-static OptionDefinition g_help_options[] = {
+static constexpr OptionDefinition g_help_options[] = {
     // clang-format off
-  {LLDB_OPT_SET_ALL, false, "hide-aliases",         'a', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Hide aliases in the command list."},
-  {LLDB_OPT_SET_ALL, false, "hide-user-commands",   'u', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Hide user-defined commands from the list."},
-  {LLDB_OPT_SET_ALL, false, "show-hidden-commands", 'h', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Include commands prefixed with an underscore."},
+  {LLDB_OPT_SET_ALL, false, "hide-aliases",         'a', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Hide aliases in the command list."},
+  {LLDB_OPT_SET_ALL, false, "hide-user-commands",   'u', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Hide user-defined commands from the list."},
+  {LLDB_OPT_SET_ALL, false, "show-hidden-commands", 'h', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Include commands prefixed with an underscore."},
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectLog.cpp
+++ b/source/Commands/CommandObjectLog.cpp
@@ -36,18 +36,18 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static OptionDefinition g_log_options[] = {
+static constexpr OptionDefinition g_log_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "file",       'f', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFilename, "Set the destination file to log to." },
-  { LLDB_OPT_SET_1, false, "threadsafe", 't', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Enable thread safe logging to avoid interweaved log lines." },
-  { LLDB_OPT_SET_1, false, "verbose",    'v', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Enable verbose logging." },
-  { LLDB_OPT_SET_1, false, "sequence",   's', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Prepend all log lines with an increasing integer sequence id." },
-  { LLDB_OPT_SET_1, false, "timestamp",  'T', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Prepend all log lines with a timestamp." },
-  { LLDB_OPT_SET_1, false, "pid-tid",    'p', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Prepend all log lines with the process and thread ID that generates the log line." },
-  { LLDB_OPT_SET_1, false, "thread-name",'n', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Prepend all log lines with the thread name for the thread that generates the log line." },
-  { LLDB_OPT_SET_1, false, "stack",      'S', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Append a stack backtrace to each log line." },
-  { LLDB_OPT_SET_1, false, "append",     'a', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Append to the log file instead of overwriting." },
-  { LLDB_OPT_SET_1, false, "file-function",'F',OptionParser::eNoArgument,      nullptr, nullptr, 0, eArgTypeNone,     "Prepend the names of files and function that generate the logs." },
+  { LLDB_OPT_SET_1, false, "file",       'f', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFilename, "Set the destination file to log to." },
+  { LLDB_OPT_SET_1, false, "threadsafe", 't', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Enable thread safe logging to avoid interweaved log lines." },
+  { LLDB_OPT_SET_1, false, "verbose",    'v', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Enable verbose logging." },
+  { LLDB_OPT_SET_1, false, "sequence",   's', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Prepend all log lines with an increasing integer sequence id." },
+  { LLDB_OPT_SET_1, false, "timestamp",  'T', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Prepend all log lines with a timestamp." },
+  { LLDB_OPT_SET_1, false, "pid-tid",    'p', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Prepend all log lines with the process and thread ID that generates the log line." },
+  { LLDB_OPT_SET_1, false, "thread-name",'n', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Prepend all log lines with the thread name for the thread that generates the log line." },
+  { LLDB_OPT_SET_1, false, "stack",      'S', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Append a stack backtrace to each log line." },
+  { LLDB_OPT_SET_1, false, "append",     'a', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Append to the log file instead of overwriting." },
+  { LLDB_OPT_SET_1, false, "file-function",'F',OptionParser::eNoArgument,      nullptr, {}, 0, eArgTypeNone,     "Prepend the names of files and function that generate the logs." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectMemory.cpp
+++ b/source/Commands/CommandObjectMemory.cpp
@@ -50,16 +50,16 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static OptionDefinition g_read_memory_options[] = {
+static constexpr OptionDefinition g_read_memory_options[] = {
     // clang-format off
-  {LLDB_OPT_SET_1, false, "num-per-line", 'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeNumberPerLine, "The number of items per line to display." },
-  {LLDB_OPT_SET_2, false, "binary",       'b', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,          "If true, memory will be saved as binary. If false, the memory is saved save as an ASCII dump that "
+  {LLDB_OPT_SET_1, false, "num-per-line", 'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeNumberPerLine, "The number of items per line to display." },
+  {LLDB_OPT_SET_2, false, "binary",       'b', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,          "If true, memory will be saved as binary. If false, the memory is saved save as an ASCII dump that "
                                                                                                                             "uses the format, size, count and number per line settings." },
-  {LLDB_OPT_SET_3, true , "type",         't', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeNone,          "The name of a type to view memory as." },
-  {LLDB_OPT_SET_3, false, "offset",       'E', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount,         "How many elements of the specified type to skip before starting to display data." },
+  {LLDB_OPT_SET_3, true , "type",         't', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeNone,          "The name of a type to view memory as." },
+  {LLDB_OPT_SET_3, false, "offset",       'E', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,         "How many elements of the specified type to skip before starting to display data." },
   {LLDB_OPT_SET_1 |
    LLDB_OPT_SET_2 |
-   LLDB_OPT_SET_3, false, "force",        'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,          "Necessary if reading over target.max-memory-read-size bytes." },
+   LLDB_OPT_SET_3, false, "force",        'r', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,          "Necessary if reading over target.max-memory-read-size bytes." },
     // clang-format on
 };
 
@@ -884,12 +884,12 @@ protected:
   CompilerType m_prev_clang_ast_type;
 };
 
-OptionDefinition g_memory_find_option_table[] = {
+static constexpr OptionDefinition g_memory_find_option_table[] = {
     // clang-format off
-  {LLDB_OPT_SET_1,   true,  "expression",  'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeExpression, "Evaluate an expression to obtain a byte pattern."},
-  {LLDB_OPT_SET_2,   true,  "string",      's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,       "Use text to find a byte pattern."},
-  {LLDB_OPT_SET_ALL, false, "count",       'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount,      "How many times to perform the search."},
-  {LLDB_OPT_SET_ALL, false, "dump-offset", 'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOffset,     "When dumping memory for a match, an offset from the match location to start dumping from."},
+  {LLDB_OPT_SET_1,   true,  "expression",  'e', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeExpression, "Evaluate an expression to obtain a byte pattern."},
+  {LLDB_OPT_SET_2,   true,  "string",      's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,       "Use text to find a byte pattern."},
+  {LLDB_OPT_SET_ALL, false, "count",       'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,      "How many times to perform the search."},
+  {LLDB_OPT_SET_ALL, false, "dump-offset", 'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOffset,     "When dumping memory for a match, an offset from the match location to start dumping from."},
     // clang-format on
 };
 
@@ -1179,10 +1179,10 @@ protected:
   OptionGroupFindMemory m_memory_options;
 };
 
-OptionDefinition g_memory_write_option_table[] = {
+static constexpr OptionDefinition g_memory_write_option_table[] = {
     // clang-format off
-  {LLDB_OPT_SET_1, true,  "infile", 'i', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFilename, "Write memory using the contents of a file."},
-  {LLDB_OPT_SET_1, false, "offset", 'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOffset,   "Start writing bytes from an offset within the input file."},
+  {LLDB_OPT_SET_1, true,  "infile", 'i', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFilename, "Write memory using the contents of a file."},
+  {LLDB_OPT_SET_1, false, "offset", 'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOffset,   "Start writing bytes from an offset within the input file."},
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectPlatform.cpp
+++ b/source/Commands/CommandObjectPlatform.cpp
@@ -63,19 +63,19 @@ static mode_t ParsePermissionString(llvm::StringRef permissions) {
   return user | group | world;
 }
 
-static OptionDefinition g_permissions_options[] = {
+static constexpr OptionDefinition g_permissions_options[] = {
     // clang-format off
-  {LLDB_OPT_SET_ALL, false, "permissions-value",   'v', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePermissionsNumber, "Give out the numeric value for permissions (e.g. 757)"},
-  {LLDB_OPT_SET_ALL, false, "permissions-string",  's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePermissionsString, "Give out the string value for permissions (e.g. rwxr-xr--)."},
-  {LLDB_OPT_SET_ALL, false, "user-read",           'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow user to read."},
-  {LLDB_OPT_SET_ALL, false, "user-write",          'w', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow user to write."},
-  {LLDB_OPT_SET_ALL, false, "user-exec",           'x', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow user to execute."},
-  {LLDB_OPT_SET_ALL, false, "group-read",          'R', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow group to read."},
-  {LLDB_OPT_SET_ALL, false, "group-write",         'W', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow group to write."},
-  {LLDB_OPT_SET_ALL, false, "group-exec",          'X', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow group to execute."},
-  {LLDB_OPT_SET_ALL, false, "world-read",          'd', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow world to read."},
-  {LLDB_OPT_SET_ALL, false, "world-write",         't', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow world to write."},
-  {LLDB_OPT_SET_ALL, false, "world-exec",          'e', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Allow world to execute."},
+  {LLDB_OPT_SET_ALL, false, "permissions-value",   'v', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePermissionsNumber, "Give out the numeric value for permissions (e.g. 757)"},
+  {LLDB_OPT_SET_ALL, false, "permissions-string",  's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePermissionsString, "Give out the string value for permissions (e.g. rwxr-xr--)."},
+  {LLDB_OPT_SET_ALL, false, "user-read",           'r', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow user to read."},
+  {LLDB_OPT_SET_ALL, false, "user-write",          'w', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow user to write."},
+  {LLDB_OPT_SET_ALL, false, "user-exec",           'x', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow user to execute."},
+  {LLDB_OPT_SET_ALL, false, "group-read",          'R', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow group to read."},
+  {LLDB_OPT_SET_ALL, false, "group-write",         'W', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow group to write."},
+  {LLDB_OPT_SET_ALL, false, "group-exec",          'X', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow group to execute."},
+  {LLDB_OPT_SET_ALL, false, "world-read",          'd', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow world to read."},
+  {LLDB_OPT_SET_ALL, false, "world-write",         't', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow world to write."},
+  {LLDB_OPT_SET_ALL, false, "world-exec",          'e', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Allow world to execute."},
     // clang-format on
 };
 
@@ -614,10 +614,10 @@ public:
 // "platform fread"
 //----------------------------------------------------------------------
 
-static OptionDefinition g_platform_fread_options[] = {
+static constexpr OptionDefinition g_platform_fread_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "offset", 'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeIndex, "Offset into the file at which to start reading." },
-  { LLDB_OPT_SET_1, false, "count",  'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount, "Number of bytes to read from the file." },
+  { LLDB_OPT_SET_1, false, "offset", 'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeIndex, "Offset into the file at which to start reading." },
+  { LLDB_OPT_SET_1, false, "count",  'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount, "Number of bytes to read from the file." },
     // clang-format on
 };
 
@@ -709,10 +709,10 @@ protected:
 // "platform fwrite"
 //----------------------------------------------------------------------
 
-static OptionDefinition g_platform_fwrite_options[] = {
+static constexpr OptionDefinition g_platform_fwrite_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "offset", 'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeIndex, "Offset into the file at which to start reading." },
-  { LLDB_OPT_SET_1, false, "data",   'd', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeValue, "Text to write to the file." },
+  { LLDB_OPT_SET_1, false, "offset", 'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeIndex, "Offset into the file at which to start reading." },
+  { LLDB_OPT_SET_1, false, "data",   'd', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeValue, "Text to write to the file." },
     // clang-format on
 };
 
@@ -1102,22 +1102,22 @@ protected:
 // "platform process list"
 //----------------------------------------------------------------------
 
-OptionDefinition g_platform_process_list_options[] = {
+static OptionDefinition g_platform_process_list_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1,             false, "pid",         'p', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePid,               "List the process info for a specific process ID." },
-  { LLDB_OPT_SET_2,             true,  "name",        'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeProcessName,       "Find processes with executable basenames that match a string." },
-  { LLDB_OPT_SET_3,             true,  "ends-with",   'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeProcessName,       "Find processes with executable basenames that end with a string." },
-  { LLDB_OPT_SET_4,             true,  "starts-with", 's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeProcessName,       "Find processes with executable basenames that start with a string." },
-  { LLDB_OPT_SET_5,             true,  "contains",    'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeProcessName,       "Find processes with executable basenames that contain a string." },
-  { LLDB_OPT_SET_6,             true,  "regex",       'r', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeRegularExpression, "Find processes with executable basenames that match a regular expression." },
-  { LLDB_OPT_SET_FROM_TO(2, 6), false, "parent",      'P', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePid,               "Find processes that have a matching parent process ID." },
-  { LLDB_OPT_SET_FROM_TO(2, 6), false, "uid",         'u', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching user ID." },
-  { LLDB_OPT_SET_FROM_TO(2, 6), false, "euid",        'U', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching effective user ID." },
-  { LLDB_OPT_SET_FROM_TO(2, 6), false, "gid",         'g', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching group ID." },
-  { LLDB_OPT_SET_FROM_TO(2, 6), false, "egid",        'G', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching effective group ID." },
-  { LLDB_OPT_SET_FROM_TO(2, 6), false, "arch",        'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeArchitecture,      "Find processes that have a matching architecture." },
-  { LLDB_OPT_SET_FROM_TO(1, 6), false, "show-args",   'A', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Show process arguments instead of the process executable basename." },
-  { LLDB_OPT_SET_FROM_TO(1, 6), false, "verbose",     'v', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,              "Enable verbose output." },
+  { LLDB_OPT_SET_1,             false, "pid",         'p', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePid,               "List the process info for a specific process ID." },
+  { LLDB_OPT_SET_2,             true,  "name",        'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeProcessName,       "Find processes with executable basenames that match a string." },
+  { LLDB_OPT_SET_3,             true,  "ends-with",   'e', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeProcessName,       "Find processes with executable basenames that end with a string." },
+  { LLDB_OPT_SET_4,             true,  "starts-with", 's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeProcessName,       "Find processes with executable basenames that start with a string." },
+  { LLDB_OPT_SET_5,             true,  "contains",    'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeProcessName,       "Find processes with executable basenames that contain a string." },
+  { LLDB_OPT_SET_6,             true,  "regex",       'r', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeRegularExpression, "Find processes with executable basenames that match a regular expression." },
+  { LLDB_OPT_SET_FROM_TO(2, 6), false, "parent",      'P', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePid,               "Find processes that have a matching parent process ID." },
+  { LLDB_OPT_SET_FROM_TO(2, 6), false, "uid",         'u', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching user ID." },
+  { LLDB_OPT_SET_FROM_TO(2, 6), false, "euid",        'U', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching effective user ID." },
+  { LLDB_OPT_SET_FROM_TO(2, 6), false, "gid",         'g', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching group ID." },
+  { LLDB_OPT_SET_FROM_TO(2, 6), false, "egid",        'G', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger,   "Find processes that have a matching effective group ID." },
+  { LLDB_OPT_SET_FROM_TO(2, 6), false, "arch",        'a', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeArchitecture,      "Find processes that have a matching architecture." },
+  { LLDB_OPT_SET_FROM_TO(1, 6), false, "show-args",   'A', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Show process arguments instead of the process executable basename." },
+  { LLDB_OPT_SET_FROM_TO(1, 6), false, "verbose",     'v', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,              "Enable verbose output." },
     // clang-format on
 };
 
@@ -1488,12 +1488,12 @@ protected:
   }
 };
 
-static OptionDefinition g_platform_process_attach_options[] = {
+static constexpr OptionDefinition g_platform_process_attach_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "plugin",  'P', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePlugin,      "Name of the process plugin you want to use." },
-  { LLDB_OPT_SET_1,   false, "pid",     'p', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePid,         "The process ID of an existing process to attach to." },
-  { LLDB_OPT_SET_2,   false, "name",    'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeProcessName, "The name of the process to attach to." },
-  { LLDB_OPT_SET_2,   false, "waitfor", 'w', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Wait for the process with <process-name> to launch." },
+  { LLDB_OPT_SET_ALL, false, "plugin",  'P', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePlugin,      "Name of the process plugin you want to use." },
+  { LLDB_OPT_SET_1,   false, "pid",     'p', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePid,         "The process ID of an existing process to attach to." },
+  { LLDB_OPT_SET_2,   false, "name",    'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeProcessName, "The name of the process to attach to." },
+  { LLDB_OPT_SET_2,   false, "waitfor", 'w', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Wait for the process with <process-name> to launch." },
     // clang-format on
 };
 
@@ -1673,9 +1673,9 @@ private:
 //----------------------------------------------------------------------
 // "platform shell"
 //----------------------------------------------------------------------
-static OptionDefinition g_platform_shell_options[] = {
+static constexpr OptionDefinition g_platform_shell_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "timeout", 't', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeValue, "Seconds to wait for the remote host to finish running the command." },
+  { LLDB_OPT_SET_ALL, false, "timeout", 't', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeValue, "Seconds to wait for the remote host to finish running the command." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectProcess.cpp
+++ b/source/Commands/CommandObjectProcess.cpp
@@ -304,14 +304,14 @@ protected:
 // CommandObjectProcessAttach
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_process_attach_options[] = {
+static constexpr OptionDefinition g_process_attach_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "continue",         'c', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,         "Immediately continue the process once attached." },
-  { LLDB_OPT_SET_ALL, false, "plugin",           'P', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePlugin,       "Name of the process plugin you want to use." },
-  { LLDB_OPT_SET_1,   false, "pid",              'p', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePid,          "The process ID of an existing process to attach to." },
-  { LLDB_OPT_SET_2,   false, "name",             'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeProcessName,  "The name of the process to attach to." },
-  { LLDB_OPT_SET_2,   false, "include-existing", 'i', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,         "Include existing processes when doing attach -w." },
-  { LLDB_OPT_SET_2,   false, "waitfor",          'w', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,         "Wait for the process with <process-name> to launch." },
+  { LLDB_OPT_SET_ALL, false, "continue",         'c', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,         "Immediately continue the process once attached." },
+  { LLDB_OPT_SET_ALL, false, "plugin",           'P', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePlugin,       "Name of the process plugin you want to use." },
+  { LLDB_OPT_SET_1,   false, "pid",              'p', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePid,          "The process ID of an existing process to attach to." },
+  { LLDB_OPT_SET_2,   false, "name",             'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeProcessName,  "The name of the process to attach to." },
+  { LLDB_OPT_SET_2,   false, "include-existing", 'i', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,         "Include existing processes when doing attach -w." },
+  { LLDB_OPT_SET_2,   false, "waitfor",          'w', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,         "Wait for the process with <process-name> to launch." },
     // clang-format on
 };
 
@@ -556,9 +556,9 @@ protected:
 // CommandObjectProcessContinue
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_process_continue_options[] = {
+static constexpr OptionDefinition g_process_continue_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "ignore-count",'i', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeUnsignedInteger, "Ignore <N> crossings of the breakpoint (if it exists) for the currently selected thread." }
+  { LLDB_OPT_SET_ALL, false, "ignore-count",'i', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeUnsignedInteger, "Ignore <N> crossings of the breakpoint (if it exists) for the currently selected thread." }
     // clang-format on
 };
 
@@ -719,9 +719,9 @@ protected:
 //-------------------------------------------------------------------------
 // CommandObjectProcessDetach
 //-------------------------------------------------------------------------
-static OptionDefinition g_process_detach_options[] = {
+static constexpr OptionDefinition g_process_detach_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "keep-stopped", 's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Whether or not the process should be kept stopped on detach (if possible)." },
+  { LLDB_OPT_SET_1, false, "keep-stopped", 's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Whether or not the process should be kept stopped on detach (if possible)." },
     // clang-format on
 };
 
@@ -818,9 +818,9 @@ protected:
 // CommandObjectProcessConnect
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_process_connect_options[] = {
+static constexpr OptionDefinition g_process_connect_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "plugin", 'p', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePlugin, "Name of the process plugin you want to use." },
+  { LLDB_OPT_SET_ALL, false, "plugin", 'p', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePlugin, "Name of the process plugin you want to use." },
     // clang-format on
 };
 
@@ -947,9 +947,9 @@ public:
 // CommandObjectProcessLoad
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_process_load_options[] = {
+static constexpr OptionDefinition g_process_load_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "install", 'i', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypePath, "Install the shared library to the target. If specified without an argument then the library will installed in the current working directory." },
+  { LLDB_OPT_SET_ALL, false, "install", 'i', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypePath, "Install the shared library to the target. If specified without an argument then the library will installed in the current working directory." },
     // clang-format on
 };
 
@@ -1343,11 +1343,11 @@ public:
 // CommandObjectProcessHandle
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_process_handle_options[] = {
+static constexpr OptionDefinition g_process_handle_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "stop",   's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Whether or not the process should be stopped if the signal is received." },
-  { LLDB_OPT_SET_1, false, "notify", 'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Whether or not the debugger should notify the user if the signal is received." },
-  { LLDB_OPT_SET_1, false, "pass",   'p', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "Whether or not the signal should be passed to the process." }
+  { LLDB_OPT_SET_1, false, "stop",   's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Whether or not the process should be stopped if the signal is received." },
+  { LLDB_OPT_SET_1, false, "notify", 'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Whether or not the debugger should notify the user if the signal is received." },
+  { LLDB_OPT_SET_1, false, "pass",   'p', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "Whether or not the signal should be passed to the process." }
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectRegister.cpp
+++ b/source/Commands/CommandObjectRegister.cpp
@@ -36,11 +36,11 @@ using namespace lldb_private;
 // "register read"
 //----------------------------------------------------------------------
 
-static OptionDefinition g_register_read_options[] = {
+static constexpr OptionDefinition g_register_read_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "alternate", 'A', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,  "Display register names using the alternate register name if there is one." },
-  { LLDB_OPT_SET_1,   false, "set",       's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeIndex, "Specify which register sets to dump by index." },
-  { LLDB_OPT_SET_2,   false, "all",       'a', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,  "Show all register sets." },
+  { LLDB_OPT_SET_ALL, false, "alternate", 'A', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,  "Display register names using the alternate register name if there is one." },
+  { LLDB_OPT_SET_1,   false, "set",       's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeIndex, "Specify which register sets to dump by index." },
+  { LLDB_OPT_SET_2,   false, "all",       'a', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,  "Show all register sets." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectSettings.cpp
+++ b/source/Commands/CommandObjectSettings.cpp
@@ -28,9 +28,9 @@ using namespace lldb_private;
 // CommandObjectSettingsSet
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_settings_set_options[] = {
+static constexpr OptionDefinition g_settings_set_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_2, false, "global", 'g', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Apply the new value to the global default value." }
+  { LLDB_OPT_SET_2, false, "global", 'g', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Apply the new value to the global default value." }
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectSource.cpp
+++ b/source/Commands/CommandObjectSource.cpp
@@ -41,15 +41,15 @@ using namespace lldb_private;
 // CommandObjectSourceInfo - debug line entries dumping command
 //----------------------------------------------------------------------
 
-static OptionDefinition g_source_info_options[] = {
+static constexpr OptionDefinition g_source_info_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL,                false, "count",    'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeCount,               "The number of line entries to display." },
-  { LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "shlib",    's', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eModuleCompletion,     eArgTypeShlibName,           "Look up the source in the given module or shared library (can be specified more than once)." },
-  { LLDB_OPT_SET_1,                  false, "file",     'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "The file from which to display source." },
-  { LLDB_OPT_SET_1,                  false, "line",     'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLineNum,             "The line number at which to start the displaying lines." },
-  { LLDB_OPT_SET_1,                  false, "end-line", 'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLineNum,             "The line number at which to stop displaying lines." },
-  { LLDB_OPT_SET_2,                  false, "name",     'n', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion,     eArgTypeSymbol,              "The name of a function whose source to display." },
-  { LLDB_OPT_SET_3,                  false, "address",  'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeAddressOrExpression, "Lookup the address and display the source information for the corresponding file and line." },
+  { LLDB_OPT_SET_ALL,                false, "count",    'c', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeCount,               "The number of line entries to display." },
+  { LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "shlib",    's', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eModuleCompletion,     eArgTypeShlibName,           "Look up the source in the given module or shared library (can be specified more than once)." },
+  { LLDB_OPT_SET_1,                  false, "file",     'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "The file from which to display source." },
+  { LLDB_OPT_SET_1,                  false, "line",     'l', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLineNum,             "The line number at which to start the displaying lines." },
+  { LLDB_OPT_SET_1,                  false, "end-line", 'e', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLineNum,             "The line number at which to stop displaying lines." },
+  { LLDB_OPT_SET_2,                  false, "name",     'n', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion,     eArgTypeSymbol,              "The name of a function whose source to display." },
+  { LLDB_OPT_SET_3,                  false, "address",  'a', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeAddressOrExpression, "Lookup the address and display the source information for the corresponding file and line." },
     // clang-format on
 };
 
@@ -653,16 +653,16 @@ protected:
 // CommandObjectSourceList
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_source_list_options[] = {
+static constexpr OptionDefinition g_source_list_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL,                false, "count",            'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeCount,               "The number of source lines to display." },
-  { LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "shlib",            's', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eModuleCompletion,     eArgTypeShlibName,           "Look up the source file in the given shared library." },
-  { LLDB_OPT_SET_ALL,                false, "show-breakpoints", 'b', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                         eArgTypeNone,                "Show the line table locations from the debug information that indicate valid places to set source level breakpoints." },
-  { LLDB_OPT_SET_1,                  false, "file",             'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "The file from which to display source." },
-  { LLDB_OPT_SET_1,                  false, "line",             'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLineNum,             "The line number at which to start the display source." },
-  { LLDB_OPT_SET_2,                  false, "name",             'n', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion,     eArgTypeSymbol,              "The name of a function whose source to display." },
-  { LLDB_OPT_SET_3,                  false, "address",          'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeAddressOrExpression, "Lookup the address and display the source information for the corresponding file and line." },
-  { LLDB_OPT_SET_4,                  false, "reverse",          'r', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                         eArgTypeNone,                "Reverse the listing to look backwards from the last displayed block of source." },
+  { LLDB_OPT_SET_ALL,                false, "count",            'c', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeCount,               "The number of source lines to display." },
+  { LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "shlib",            's', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eModuleCompletion,     eArgTypeShlibName,           "Look up the source file in the given shared library." },
+  { LLDB_OPT_SET_ALL,                false, "show-breakpoints", 'b', OptionParser::eNoArgument,       nullptr, {}, 0,                                         eArgTypeNone,                "Show the line table locations from the debug information that indicate valid places to set source level breakpoints." },
+  { LLDB_OPT_SET_1,                  false, "file",             'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "The file from which to display source." },
+  { LLDB_OPT_SET_1,                  false, "line",             'l', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLineNum,             "The line number at which to start the display source." },
+  { LLDB_OPT_SET_2,                  false, "name",             'n', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion,     eArgTypeSymbol,              "The name of a function whose source to display." },
+  { LLDB_OPT_SET_3,                  false, "address",          'a', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeAddressOrExpression, "Lookup the address and display the source information for the corresponding file and line." },
+  { LLDB_OPT_SET_4,                  false, "reverse",          'r', OptionParser::eNoArgument,       nullptr, {}, 0,                                         eArgTypeNone,                "Reverse the listing to look backwards from the last displayed block of source." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectTarget.cpp
+++ b/source/Commands/CommandObjectTarget.cpp
@@ -140,19 +140,18 @@ static uint32_t DumpTargetList(TargetList &target_list,
 
 // Note that the negation in the argument name causes a slightly confusing
 // mapping of the enum values,
-static OptionEnumValueElement g_dependents_enumaration[4] = {
+static constexpr OptionEnumValueElement g_dependents_enumaration[] = {
     {eLoadDependentsDefault, "default",
      "Only load dependents when the target is an executable."},
     {eLoadDependentsNo, "true",
      "Don't load dependents, even if the target is an executable."},
     {eLoadDependentsYes, "false",
-     "Load dependents, even if the target is not an executable."},
-    {0, nullptr, nullptr}};
+     "Load dependents, even if the target is not an executable."}};
 
-static OptionDefinition g_dependents_options[1] = {
+static constexpr OptionDefinition g_dependents_options[] = {
     {LLDB_OPT_SET_1, false, "no-dependents", 'd',
-     OptionParser::eOptionalArgument, nullptr, g_dependents_enumaration, 0,
-     eArgTypeValue,
+     OptionParser::eOptionalArgument, nullptr,
+     OptionEnumValues(g_dependents_enumaration), 0, eArgTypeValue,
      "Whether or not to load dependents when creating a target. If the option "
      "is not specified, the value is implicitly 'default'. If the option is "
      "specified but without a value, the value is implicitly 'true'."}};
@@ -1985,17 +1984,16 @@ protected:
 
 #pragma mark CommandObjectTargetModulesDumpSymtab
 
-static OptionEnumValueElement g_sort_option_enumeration[4] = {
+static constexpr OptionEnumValueElement g_sort_option_enumeration[] = {
     {eSortOrderNone, "none",
      "No sorting, use the original symbol table order."},
     {eSortOrderByAddress, "address", "Sort output by symbol address."},
-    {eSortOrderByName, "name", "Sort output by symbol name."},
-    {0, nullptr, nullptr}};
+    {eSortOrderByName, "name", "Sort output by symbol name."} };
 
-static OptionDefinition g_target_modules_dump_symtab_options[] = {
+static constexpr OptionDefinition g_target_modules_dump_symtab_options[] = {
     // clang-format off
-    { LLDB_OPT_SET_1, false, "sort",               's', OptionParser::eRequiredArgument, nullptr, g_sort_option_enumeration, 0, eArgTypeSortOrder, "Supply a sort order when dumping the symbol table." },
-    { LLDB_OPT_SET_1, false, "show-mangled-names", 'm', OptionParser::eNoArgument,       nullptr, nullptr,                   0, eArgTypeNone,      "Do not demangle symbol names before showing them." },
+  { LLDB_OPT_SET_1, false, "sort", 's', OptionParser::eRequiredArgument, nullptr, OptionEnumValues(g_sort_option_enumeration), 0, eArgTypeSortOrder, "Supply a sort order when dumping the symbol table." }
+, { LLDB_OPT_SET_1, false, "show-mangled-names", 'm', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone, "Do not demangle symbol names before showing them." },
     // clang-format on
 };
 
@@ -2894,23 +2892,23 @@ protected:
 // List images with associated information
 //----------------------------------------------------------------------
 
-static OptionDefinition g_target_modules_list_options[] = {
+static constexpr OptionDefinition g_target_modules_list_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "address",        'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeAddressOrExpression, "Display the image at this address." },
-  { LLDB_OPT_SET_1, false, "arch",           'A', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the architecture when listing images." },
-  { LLDB_OPT_SET_1, false, "triple",         't', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the triple when listing images." },
-  { LLDB_OPT_SET_1, false, "header",         'h', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Display the image header address as a load address if debugging, a file address otherwise." },
-  { LLDB_OPT_SET_1, false, "offset",         'o', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Display the image header address offset from the header file address (the slide amount)." },
-  { LLDB_OPT_SET_1, false, "uuid",           'u', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Display the UUID when listing images." },
-  { LLDB_OPT_SET_1, false, "fullpath",       'f', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the fullpath to the image object file." },
-  { LLDB_OPT_SET_1, false, "directory",      'd', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the directory with optional width for the image object file." },
-  { LLDB_OPT_SET_1, false, "basename",       'b', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the basename with optional width for the image object file." },
-  { LLDB_OPT_SET_1, false, "symfile",        's', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the fullpath to the image symbol file with optional width." },
-  { LLDB_OPT_SET_1, false, "symfile-unique", 'S', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the symbol file with optional width only if it is different from the executable object file." },
-  { LLDB_OPT_SET_1, false, "mod-time",       'm', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the modification time with optional width of the module." },
-  { LLDB_OPT_SET_1, false, "ref-count",      'r', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeWidth,               "Display the reference count if the module is still in the shared module cache." },
-  { LLDB_OPT_SET_1, false, "pointer",        'p', OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeNone,                "Display the module pointer." },
-  { LLDB_OPT_SET_1, false, "global",         'g', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Display the modules from the global module list, not just the current target." }
+  { LLDB_OPT_SET_1, false, "address",        'a', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeAddressOrExpression, "Display the image at this address." },
+  { LLDB_OPT_SET_1, false, "arch",           'A', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the architecture when listing images." },
+  { LLDB_OPT_SET_1, false, "triple",         't', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the triple when listing images." },
+  { LLDB_OPT_SET_1, false, "header",         'h', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Display the image header address as a load address if debugging, a file address otherwise." },
+  { LLDB_OPT_SET_1, false, "offset",         'o', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Display the image header address offset from the header file address (the slide amount)." },
+  { LLDB_OPT_SET_1, false, "uuid",           'u', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Display the UUID when listing images." },
+  { LLDB_OPT_SET_1, false, "fullpath",       'f', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the fullpath to the image object file." },
+  { LLDB_OPT_SET_1, false, "directory",      'd', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the directory with optional width for the image object file." },
+  { LLDB_OPT_SET_1, false, "basename",       'b', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the basename with optional width for the image object file." },
+  { LLDB_OPT_SET_1, false, "symfile",        's', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the fullpath to the image symbol file with optional width." },
+  { LLDB_OPT_SET_1, false, "symfile-unique", 'S', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the symbol file with optional width only if it is different from the executable object file." },
+  { LLDB_OPT_SET_1, false, "mod-time",       'm', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the modification time with optional width of the module." },
+  { LLDB_OPT_SET_1, false, "ref-count",      'r', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeWidth,               "Display the reference count if the module is still in the shared module cache." },
+  { LLDB_OPT_SET_1, false, "pointer",        'p', OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeNone,                "Display the module pointer." },
+  { LLDB_OPT_SET_1, false, "global",         'g', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Display the modules from the global module list, not just the current target." }
     // clang-format on
 };
 
@@ -3260,10 +3258,10 @@ protected:
 // Lookup unwind information in images
 //----------------------------------------------------------------------
 
-static OptionDefinition g_target_modules_show_unwind_options[] = {
+static constexpr OptionDefinition g_target_modules_show_unwind_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "name",    'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFunctionName,        "Show unwind instructions for a function or symbol name." },
-  { LLDB_OPT_SET_2, false, "address", 'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeAddressOrExpression, "Show unwind instructions for a function or symbol containing an address" }
+  { LLDB_OPT_SET_1, false, "name",    'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFunctionName,        "Show unwind instructions for a function or symbol name." },
+  { LLDB_OPT_SET_2, false, "address", 'a', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeAddressOrExpression, "Show unwind instructions for a function or symbol containing an address" }
     // clang-format on
 };
 
@@ -3566,21 +3564,21 @@ protected:
 // Lookup information in images
 //----------------------------------------------------------------------
 
-static OptionDefinition g_target_modules_lookup_options[] = {
+static constexpr OptionDefinition g_target_modules_lookup_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1,                                  true,  "address",    'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeAddressOrExpression, "Lookup an address in one or more target modules." },
-  { LLDB_OPT_SET_1,                                  false, "offset",     'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOffset,              "When looking up an address subtract <offset> from any addresses before doing the lookup." },
+  { LLDB_OPT_SET_1,                                  true,  "address",    'a', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeAddressOrExpression, "Lookup an address in one or more target modules." },
+  { LLDB_OPT_SET_1,                                  false, "offset",     'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOffset,              "When looking up an address subtract <offset> from any addresses before doing the lookup." },
   /* FIXME: re-enable regex for types when the LookupTypeInModule actually uses the regex option: | LLDB_OPT_SET_6 */
-  { LLDB_OPT_SET_2 | LLDB_OPT_SET_4 | LLDB_OPT_SET_5, false, "regex",      'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "The <name> argument for name lookups are regular expressions." },
-  { LLDB_OPT_SET_2,                                  true,  "symbol",     's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeSymbol,              "Lookup a symbol by name in the symbol tables in one or more target modules." },
-  { LLDB_OPT_SET_3,                                  true,  "file",       'f', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFilename,            "Lookup a file by fullpath or basename in one or more target modules." },
-  { LLDB_OPT_SET_3,                                  false, "line",       'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLineNum,             "Lookup a line number in a file (must be used in conjunction with --file)." },
-  { LLDB_OPT_SET_FROM_TO(3,5),                       false, "no-inlines", 'i', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Ignore inline entries (must be used in conjunction with --file or --function)." },
-  { LLDB_OPT_SET_4,                                  true,  "function",   'F', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFunctionName,        "Lookup a function by name in the debug symbols in one or more target modules." },
-  { LLDB_OPT_SET_5,                                  true,  "name",       'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFunctionOrSymbol,    "Lookup a function or symbol by name in one or more target modules." },
-  { LLDB_OPT_SET_6,                                  true,  "type",       't', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,                "Lookup a type by name in the debug symbols in one or more target modules." },
-  { LLDB_OPT_SET_ALL,                                false, "verbose",    'v', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Enable verbose lookup information." },
-  { LLDB_OPT_SET_ALL,                                false, "all",        'A', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,                "Print all matches, not just the best match, if a best match is available." },
+  { LLDB_OPT_SET_2 | LLDB_OPT_SET_4 | LLDB_OPT_SET_5, false, "regex",      'r', OptionParser::eNoArgument,      nullptr, {}, 0, eArgTypeNone,                "The <name> argument for name lookups are regular expressions." },
+  { LLDB_OPT_SET_2,                                  true,  "symbol",     's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeSymbol,              "Lookup a symbol by name in the symbol tables in one or more target modules." },
+  { LLDB_OPT_SET_3,                                  true,  "file",       'f', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFilename,            "Lookup a file by fullpath or basename in one or more target modules." },
+  { LLDB_OPT_SET_3,                                  false, "line",       'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLineNum,             "Lookup a line number in a file (must be used in conjunction with --file)." },
+  { LLDB_OPT_SET_FROM_TO(3,5),                       false, "no-inlines", 'i', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Ignore inline entries (must be used in conjunction with --file or --function)." },
+  { LLDB_OPT_SET_4,                                  true,  "function",   'F', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFunctionName,        "Lookup a function by name in the debug symbols in one or more target modules." },
+  { LLDB_OPT_SET_5,                                  true,  "name",       'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFunctionOrSymbol,    "Lookup a function or symbol by name in one or more target modules." },
+  { LLDB_OPT_SET_6,                                  true,  "type",       't', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,                "Lookup a type by name in the debug symbols in one or more target modules." },
+  { LLDB_OPT_SET_ALL,                                false, "verbose",    'v', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Enable verbose lookup information." },
+  { LLDB_OPT_SET_ALL,                                false, "all",        'A', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,                "Print all matches, not just the best match, if a best match is available." },
     // clang-format on
 };
 
@@ -4446,19 +4444,19 @@ private:
 // CommandObjectTargetStopHookAdd
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_target_stop_hook_add_options[] = {
+static constexpr OptionDefinition g_target_stop_hook_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "one-liner",    'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOneLiner,                                         "Specify a one-line breakpoint command inline. Be sure to surround it with quotes." },
-  { LLDB_OPT_SET_ALL, false, "shlib",        's', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eModuleCompletion, eArgTypeShlibName,    "Set the module within which the stop-hook is to be run." },
-  { LLDB_OPT_SET_ALL, false, "thread-index", 'x', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeThreadIndex,                                      "The stop hook is run only for the thread whose index matches this argument." },
-  { LLDB_OPT_SET_ALL, false, "thread-id",    't', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeThreadID,                                         "The stop hook is run only for the thread whose TID matches this argument." },
-  { LLDB_OPT_SET_ALL, false, "thread-name",  'T', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeThreadName,                                       "The stop hook is run only for the thread whose thread name matches this argument." },
-  { LLDB_OPT_SET_ALL, false, "queue-name",   'q', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeQueueName,                                        "The stop hook is run only for threads in the queue whose name is given by this argument." },
-  { LLDB_OPT_SET_1,   false, "file",         'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSourceFileCompletion, eArgTypeFilename, "Specify the source file within which the stop-hook is to be run." },
-  { LLDB_OPT_SET_1,   false, "start-line",   'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLineNum,                                          "Set the start of the line range for which the stop-hook is to be run." },
-  { LLDB_OPT_SET_1,   false, "end-line",     'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLineNum,                                          "Set the end of the line range for which the stop-hook is to be run." },
-  { LLDB_OPT_SET_2,   false, "classname",    'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeClassName,                                        "Specify the class within which the stop-hook is to be run." },
-  { LLDB_OPT_SET_3,   false, "name",         'n', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSymbolCompletion, eArgTypeFunctionName, "Set the function name within which the stop hook will be run." },
+  { LLDB_OPT_SET_ALL, false, "one-liner",    'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOneLiner,                                         "Specify a one-line breakpoint command inline. Be sure to surround it with quotes." },
+  { LLDB_OPT_SET_ALL, false, "shlib",        's', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eModuleCompletion, eArgTypeShlibName,    "Set the module within which the stop-hook is to be run." },
+  { LLDB_OPT_SET_ALL, false, "thread-index", 'x', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeThreadIndex,                                      "The stop hook is run only for the thread whose index matches this argument." },
+  { LLDB_OPT_SET_ALL, false, "thread-id",    't', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeThreadID,                                         "The stop hook is run only for the thread whose TID matches this argument." },
+  { LLDB_OPT_SET_ALL, false, "thread-name",  'T', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeThreadName,                                       "The stop hook is run only for the thread whose thread name matches this argument." },
+  { LLDB_OPT_SET_ALL, false, "queue-name",   'q', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeQueueName,                                        "The stop hook is run only for threads in the queue whose name is given by this argument." },
+  { LLDB_OPT_SET_1,   false, "file",         'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSourceFileCompletion, eArgTypeFilename, "Specify the source file within which the stop-hook is to be run." },
+  { LLDB_OPT_SET_1,   false, "start-line",   'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLineNum,                                          "Set the start of the line range for which the stop-hook is to be run." },
+  { LLDB_OPT_SET_1,   false, "end-line",     'e', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLineNum,                                          "Set the end of the line range for which the stop-hook is to be run." },
+  { LLDB_OPT_SET_2,   false, "classname",    'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeClassName,                                        "Specify the class within which the stop-hook is to be run." },
+  { LLDB_OPT_SET_3,   false, "name",         'n', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSymbolCompletion, eArgTypeFunctionName, "Set the function name within which the stop hook will be run." },
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectThread.cpp
+++ b/source/Commands/CommandObjectThread.cpp
@@ -247,11 +247,11 @@ protected:
 // CommandObjectThreadBacktrace
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_thread_backtrace_options[] = {
+static constexpr OptionDefinition g_thread_backtrace_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "count",    'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount,      "How many frames to display (-1 for all)" },
-  { LLDB_OPT_SET_1, false, "start",    's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeFrameIndex, "Frame in which to start the backtrace" },
-  { LLDB_OPT_SET_1, false, "extended", 'e', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,    "Show the extended backtrace, if available" }
+  { LLDB_OPT_SET_1, false, "count",    'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,      "How many frames to display (-1 for all)" },
+  { LLDB_OPT_SET_1, false, "start",    's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeFrameIndex, "Frame in which to start the backtrace" },
+  { LLDB_OPT_SET_1, false, "extended", 'e', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,    "Show the extended backtrace, if available" }
     // clang-format on
 };
 
@@ -402,28 +402,26 @@ protected:
 
 enum StepScope { eStepScopeSource, eStepScopeInstruction };
 
-static OptionEnumValueElement g_tri_running_mode[] = {
+static constexpr OptionEnumValueElement g_tri_running_mode[] = {
     {eOnlyThisThread, "this-thread", "Run only this thread"},
     {eAllThreads, "all-threads", "Run all threads"},
     {eOnlyDuringStepping, "while-stepping",
-     "Run only this thread while stepping"},
-    {0, nullptr, nullptr}};
+     "Run only this thread while stepping"} };
 
-static OptionEnumValueElement g_duo_running_mode[] = {
-    {eOnlyThisThread, "this-thread", "Run only this thread"},
-    {eAllThreads, "all-threads", "Run all threads"},
-    {0, nullptr, nullptr}};
+static constexpr OptionEnumValues TriRunningModes() {
+  return OptionEnumValues(g_tri_running_mode);
+}
 
-static OptionDefinition g_thread_step_scope_options[] = {
+static constexpr OptionDefinition g_thread_step_scope_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "step-in-avoids-no-debug",   'a', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeBoolean,           "A boolean value that sets whether stepping into functions will step over functions with no debug information." },
-  { LLDB_OPT_SET_1, false, "step-out-avoids-no-debug",  'A', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeBoolean,           "A boolean value, if true stepping out of functions will continue to step out till it hits a function with debug information." },
-  { LLDB_OPT_SET_1, false, "count",                     'c', OptionParser::eRequiredArgument, nullptr, nullptr,            1, eArgTypeCount,             "How many times to perform the stepping operation - currently only supported for step-inst and next-inst." },
-  { LLDB_OPT_SET_1, false, "end-linenumber",            'e', OptionParser::eRequiredArgument, nullptr, nullptr,            1, eArgTypeLineNum,           "The line at which to stop stepping - defaults to the next line and only supported for step-in and step-over.  You can also pass the string 'block' to step to the end of the current block.  This is particularly useful in conjunction with --step-target to step through a complex calling sequence." },
-  { LLDB_OPT_SET_1, false, "run-mode",                  'm', OptionParser::eRequiredArgument, nullptr, g_tri_running_mode, 0, eArgTypeRunMode,           "Determine how to run other threads while stepping the current thread." },
-  { LLDB_OPT_SET_1, false, "step-over-regexp",          'r', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeRegularExpression, "A regular expression that defines function names to not to stop at when stepping in." },
-  { LLDB_OPT_SET_1, false, "step-in-target",            't', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeFunctionName,      "The name of the directly called function step in should stop at when stepping into." },
-  { LLDB_OPT_SET_2, false, "python-class",              'C', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypePythonClass,       "The name of the class that will manage this step - only supported for Scripted Step." }
+  { LLDB_OPT_SET_1, false, "step-in-avoids-no-debug",   'a', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeBoolean,           "A boolean value that sets whether stepping into functions will step over functions with no debug information." },
+  { LLDB_OPT_SET_1, false, "step-out-avoids-no-debug",  'A', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeBoolean,           "A boolean value, if true stepping out of functions will continue to step out till it hits a function with debug information." },
+  { LLDB_OPT_SET_1, false, "count",                     'c', OptionParser::eRequiredArgument, nullptr, {},                1, eArgTypeCount,             "How many times to perform the stepping operation - currently only supported for step-inst and next-inst." },
+  { LLDB_OPT_SET_1, false, "end-linenumber",            'e', OptionParser::eRequiredArgument, nullptr, {},                1, eArgTypeLineNum,           "The line at which to stop stepping - defaults to the next line and only supported for step-in and step-over.  You can also pass the string 'block' to step to the end of the current block.  This is particularly useful in conjunction with --step-target to step through a complex calling sequence." },
+  { LLDB_OPT_SET_1, false, "run-mode",                  'm', OptionParser::eRequiredArgument, nullptr, TriRunningModes(), 0, eArgTypeRunMode,           "Determine how to run other threads while stepping the current thread." },
+  { LLDB_OPT_SET_1, false, "step-over-regexp",          'r', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeRegularExpression, "A regular expression that defines function names to not to stop at when stepping in." },
+  { LLDB_OPT_SET_1, false, "step-in-target",            't', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeFunctionName,      "The name of the directly called function step in should stop at when stepping into." },
+  { LLDB_OPT_SET_2, false, "python-class",              'C', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypePythonClass,       "The name of the class that will manage this step - only supported for Scripted Step." }
     // clang-format on
 };
 
@@ -483,8 +481,7 @@ public:
         break;
 
       case 'm': {
-        OptionEnumValueElement *enum_values =
-            GetDefinitions()[option_idx].enum_values;
+        auto enum_values = GetDefinitions()[option_idx].enum_values;
         m_run_mode = (lldb::RunMode)OptionArgParser::ToOptionEnum(
             option_arg, enum_values, eOnlyDuringStepping, error);
       } break;
@@ -997,12 +994,20 @@ public:
 // CommandObjectThreadUntil
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_thread_until_options[] = {
+static constexpr OptionEnumValueElement g_duo_running_mode[] = {
+    {eOnlyThisThread, "this-thread", "Run only this thread"},
+    {eAllThreads, "all-threads", "Run all threads"} };
+
+static constexpr OptionEnumValues DuoRunningModes() {
+  return OptionEnumValues(g_duo_running_mode);
+}
+
+static constexpr OptionDefinition g_thread_until_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "frame",   'f', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeFrameIndex,          "Frame index for until operation - defaults to 0" },
-  { LLDB_OPT_SET_1, false, "thread",  't', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeThreadIndex,         "Thread index for the thread for until operation" },
-  { LLDB_OPT_SET_1, false, "run-mode",'m', OptionParser::eRequiredArgument, nullptr, g_duo_running_mode, 0, eArgTypeRunMode,             "Determine how to run other threads while stepping this one" },
-  { LLDB_OPT_SET_1, false, "address", 'a', OptionParser::eRequiredArgument, nullptr, nullptr,            0, eArgTypeAddressOrExpression, "Run until we reach the specified address, or leave the function - can be specified multiple times." }
+  { LLDB_OPT_SET_1, false, "frame",   'f', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeFrameIndex,          "Frame index for until operation - defaults to 0" },
+  { LLDB_OPT_SET_1, false, "thread",  't', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeThreadIndex,         "Thread index for the thread for until operation" },
+  { LLDB_OPT_SET_1, false, "run-mode",'m', OptionParser::eRequiredArgument, nullptr, DuoRunningModes(), 0, eArgTypeRunMode,             "Determine how to run other threads while stepping this one" },
+  { LLDB_OPT_SET_1, false, "address", 'a', OptionParser::eRequiredArgument, nullptr, {},                0, eArgTypeAddressOrExpression, "Run until we reach the specified address, or leave the function - can be specified multiple times." }
     // clang-format on
 };
 
@@ -1050,8 +1055,7 @@ public:
         }
         break;
       case 'm': {
-        OptionEnumValueElement *enum_values =
-            GetDefinitions()[option_idx].enum_values;
+        auto enum_values = GetDefinitions()[option_idx].enum_values;
         lldb::RunMode run_mode = (lldb::RunMode)OptionArgParser::ToOptionEnum(
             option_arg, enum_values, eOnlyDuringStepping, error);
 
@@ -1419,10 +1423,10 @@ protected:
 // CommandObjectThreadInfo
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_thread_info_options[] = {
+static constexpr OptionDefinition g_thread_info_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "json",      'j', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Display the thread info in JSON format." },
-  { LLDB_OPT_SET_ALL, false, "stop-info", 's', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Display the extended stop info in JSON format." }
+  { LLDB_OPT_SET_ALL, false, "json",      'j', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Display the thread info in JSON format." },
+  { LLDB_OPT_SET_ALL, false, "stop-info", 's', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Display the extended stop info in JSON format." }
     // clang-format on
 };
 
@@ -1514,9 +1518,9 @@ public:
 // CommandObjectThreadReturn
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_thread_return_options[] = {
+static constexpr OptionDefinition g_thread_return_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "from-expression", 'x', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Return from the innermost expression evaluation." }
+  { LLDB_OPT_SET_ALL, false, "from-expression", 'x', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Return from the innermost expression evaluation." }
     // clang-format on
 };
 
@@ -1692,13 +1696,13 @@ protected:
 // CommandObjectThreadJump
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_thread_jump_options[] = {
+static constexpr OptionDefinition g_thread_jump_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1,                                   false, "file",    'f', OptionParser::eRequiredArgument, nullptr, nullptr, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "Specifies the source file to jump to." },
-  { LLDB_OPT_SET_1,                                   true,  "line",    'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeLineNum,             "Specifies the line number to jump to." },
-  { LLDB_OPT_SET_2,                                   true,  "by",      'b', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeOffset,              "Jumps by a relative line offset from the current line." },
-  { LLDB_OPT_SET_3,                                   true,  "address", 'a', OptionParser::eRequiredArgument, nullptr, nullptr, 0,                                         eArgTypeAddressOrExpression, "Jumps to a specific address." },
-  { LLDB_OPT_SET_1 | LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "force",   'r', OptionParser::eNoArgument,       nullptr, nullptr, 0,                                         eArgTypeNone,                "Allows the PC to leave the current function." }
+  { LLDB_OPT_SET_1,                                   false, "file",    'f', OptionParser::eRequiredArgument, nullptr, {}, CommandCompletions::eSourceFileCompletion, eArgTypeFilename,            "Specifies the source file to jump to." },
+  { LLDB_OPT_SET_1,                                   true,  "line",    'l', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeLineNum,             "Specifies the line number to jump to." },
+  { LLDB_OPT_SET_2,                                   true,  "by",      'b', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeOffset,              "Jumps by a relative line offset from the current line." },
+  { LLDB_OPT_SET_3,                                   true,  "address", 'a', OptionParser::eRequiredArgument, nullptr, {}, 0,                                         eArgTypeAddressOrExpression, "Jumps to a specific address." },
+  { LLDB_OPT_SET_1 | LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "force",   'r', OptionParser::eNoArgument,       nullptr, {}, 0,                                         eArgTypeNone,                "Allows the PC to leave the current function." }
     // clang-format on
 };
 
@@ -1844,10 +1848,10 @@ protected:
 // CommandObjectThreadPlanList
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_thread_plan_list_options[] = {
+static constexpr OptionDefinition g_thread_plan_list_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "verbose",  'v', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Display more information about the thread plans" },
-  { LLDB_OPT_SET_1, false, "internal", 'i', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Display internal as well as user thread plans" }
+  { LLDB_OPT_SET_1, false, "verbose",  'v', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Display more information about the thread plans" },
+  { LLDB_OPT_SET_1, false, "internal", 'i', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Display internal as well as user thread plans" }
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectType.cpp
+++ b/source/Commands/CommandObjectType.cpp
@@ -99,23 +99,23 @@ static bool WarnOnPotentialUnquotedUnsignedType(Args &command,
   return false;
 }
 
-static OptionDefinition g_type_summary_add_options[] = {
+static constexpr OptionDefinition g_type_summary_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL,                false, "category",        'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,           "Add this to the given category instead of the default one." },
-  { LLDB_OPT_SET_ALL,                false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,        "If true, cascade through typedef chains." },
-  { LLDB_OPT_SET_ALL,                false, "no-value",        'v', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Don't show the value, just show the summary, for this type." },
-  { LLDB_OPT_SET_ALL,                false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Don't use this format for pointers-to-type objects." },
-  { LLDB_OPT_SET_ALL,                false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Don't use this format for references-to-type objects." },
-  { LLDB_OPT_SET_ALL,                false, "regex",           'x', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Type names are actually regular expressions." },
-  { LLDB_OPT_SET_1,                  true,  "inline-children", 'c', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "If true, inline all child values into summary string." },
-  { LLDB_OPT_SET_1,                  false, "omit-names",      'O', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "If true, omit value names in the summary display." },
-  { LLDB_OPT_SET_2,                  true,  "summary-string",  's', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeSummaryString,  "Summary string used to display text and object contents." },
-  { LLDB_OPT_SET_3,                  false, "python-script",   'o', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePythonScript,   "Give a one-liner Python script as part of the command." },
-  { LLDB_OPT_SET_3,                  false, "python-function", 'F', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePythonFunction, "Give the name of a Python function to use for this type." },
-  { LLDB_OPT_SET_3,                  false, "input-python",    'P', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Input Python code to use for this type manually." },
-  { LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "expand",          'e', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Expand aggregate data types to show children on separate lines." },
-  { LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "hide-empty",      'h', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Do not expand aggregate data types with no children." },
-  { LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "name",            'n', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,           "A name for this summary string." }
+  { LLDB_OPT_SET_ALL,                false, "category",        'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,           "Add this to the given category instead of the default one." },
+  { LLDB_OPT_SET_ALL,                false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,        "If true, cascade through typedef chains." },
+  { LLDB_OPT_SET_ALL,                false, "no-value",        'v', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Don't show the value, just show the summary, for this type." },
+  { LLDB_OPT_SET_ALL,                false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Don't use this format for pointers-to-type objects." },
+  { LLDB_OPT_SET_ALL,                false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Don't use this format for references-to-type objects." },
+  { LLDB_OPT_SET_ALL,                false, "regex",           'x', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Type names are actually regular expressions." },
+  { LLDB_OPT_SET_1,                  true,  "inline-children", 'c', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "If true, inline all child values into summary string." },
+  { LLDB_OPT_SET_1,                  false, "omit-names",      'O', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "If true, omit value names in the summary display." },
+  { LLDB_OPT_SET_2,                  true,  "summary-string",  's', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeSummaryString,  "Summary string used to display text and object contents." },
+  { LLDB_OPT_SET_3,                  false, "python-script",   'o', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePythonScript,   "Give a one-liner Python script as part of the command." },
+  { LLDB_OPT_SET_3,                  false, "python-function", 'F', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePythonFunction, "Give the name of a Python function to use for this type." },
+  { LLDB_OPT_SET_3,                  false, "input-python",    'P', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Input Python code to use for this type manually." },
+  { LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "expand",          'e', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Expand aggregate data types to show children on separate lines." },
+  { LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "hide-empty",      'h', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Do not expand aggregate data types with no children." },
+  { LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "name",            'n', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,           "A name for this summary string." }
     // clang-format on
 };
 
@@ -301,15 +301,15 @@ static const char *g_synth_addreader_instructions =
     "        '''Optional'''\n"
     "class synthProvider:\n";
 
-static OptionDefinition g_type_synth_add_options[] = {
+static constexpr OptionDefinition g_type_synth_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,     "If true, cascade through typedef chains." },
-  { LLDB_OPT_SET_ALL, false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Don't use this format for pointers-to-type objects." },
-  { LLDB_OPT_SET_ALL, false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Don't use this format for references-to-type objects." },
-  { LLDB_OPT_SET_ALL, false, "category",        'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,        "Add this to the given category instead of the default one." },
-  { LLDB_OPT_SET_2,   false, "python-class",    'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePythonClass, "Use this Python class to produce synthetic children." },
-  { LLDB_OPT_SET_3,   false, "input-python",    'P', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Type Python code to generate a class that provides synthetic children." },
-  { LLDB_OPT_SET_ALL, false, "regex",           'x', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,        "Type names are actually regular expressions." }
+  { LLDB_OPT_SET_ALL, false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,     "If true, cascade through typedef chains." },
+  { LLDB_OPT_SET_ALL, false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Don't use this format for pointers-to-type objects." },
+  { LLDB_OPT_SET_ALL, false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Don't use this format for references-to-type objects." },
+  { LLDB_OPT_SET_ALL, false, "category",        'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,        "Add this to the given category instead of the default one." },
+  { LLDB_OPT_SET_2,   false, "python-class",    'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePythonClass, "Use this Python class to produce synthetic children." },
+  { LLDB_OPT_SET_3,   false, "input-python",    'P', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Type Python code to generate a class that provides synthetic children." },
+  { LLDB_OPT_SET_ALL, false, "regex",           'x', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,        "Type names are actually regular expressions." }
     // clang-format on
 };
 
@@ -531,14 +531,14 @@ public:
 // CommandObjectTypeFormatAdd
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_type_format_add_options[] = {
+static constexpr OptionDefinition g_type_format_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "category",        'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,    "Add this to the given category instead of the default one." },
-  { LLDB_OPT_SET_ALL, false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean, "If true, cascade through typedef chains." },
-  { LLDB_OPT_SET_ALL, false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,    "Don't use this format for pointers-to-type objects." },
-  { LLDB_OPT_SET_ALL, false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,    "Don't use this format for references-to-type objects." },
-  { LLDB_OPT_SET_ALL, false, "regex",           'x', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,    "Type names are actually regular expressions." },
-  { LLDB_OPT_SET_2,   false, "type",            't', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,    "Format variables as if they were of this type." }
+  { LLDB_OPT_SET_ALL, false, "category",        'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,    "Add this to the given category instead of the default one." },
+  { LLDB_OPT_SET_ALL, false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean, "If true, cascade through typedef chains." },
+  { LLDB_OPT_SET_ALL, false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,    "Don't use this format for pointers-to-type objects." },
+  { LLDB_OPT_SET_ALL, false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,    "Don't use this format for references-to-type objects." },
+  { LLDB_OPT_SET_ALL, false, "regex",           'x', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,    "Type names are actually regular expressions." },
+  { LLDB_OPT_SET_2,   false, "type",            't', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,    "Format variables as if they were of this type." }
     // clang-format on
 };
 
@@ -754,11 +754,11 @@ protected:
   }
 };
 
-static OptionDefinition g_type_formatter_delete_options[] = {
+static constexpr OptionDefinition g_type_formatter_delete_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "all",      'a', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Delete from every category." },
-  { LLDB_OPT_SET_2, false, "category", 'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,     "Delete from given category." },
-  { LLDB_OPT_SET_3, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLanguage, "Delete from given language's category." }
+  { LLDB_OPT_SET_1, false, "all",      'a', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Delete from every category." },
+  { LLDB_OPT_SET_2, false, "category", 'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,     "Delete from given category." },
+  { LLDB_OPT_SET_3, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Delete from given language's category." }
     // clang-format on
 };
 
@@ -896,9 +896,9 @@ protected:
   }
 };
 
-static OptionDefinition g_type_formatter_clear_options[] = {
+static constexpr OptionDefinition g_type_formatter_clear_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "all", 'a', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Clear every category." }
+  { LLDB_OPT_SET_ALL, false, "all", 'a', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Clear every category." }
     // clang-format on
 };
 
@@ -1055,10 +1055,10 @@ class CommandObjectTypeFormatterList : public CommandObjectParsed {
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
-      static OptionDefinition g_option_table[] = {
+      static constexpr OptionDefinition g_option_table[] = {
           // clang-format off
-            {LLDB_OPT_SET_1, false, "category-regex", 'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,     "Only show categories matching this filter."},
-            {LLDB_OPT_SET_2, false, "language",       'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLanguage, "Only show the category for a specific language."}
+            {LLDB_OPT_SET_1, false, "category-regex", 'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,     "Only show categories matching this filter."},
+            {LLDB_OPT_SET_2, false, "language",       'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Only show the category for a specific language."}
           // clang-format on
       };
       return llvm::ArrayRef<OptionDefinition>(g_option_table);
@@ -1784,10 +1784,10 @@ protected:
 // CommandObjectTypeCategoryDefine
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_type_category_define_options[] = {
+static constexpr OptionDefinition g_type_category_define_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "enabled",  'e', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "If specified, this category will be created enabled." },
-  { LLDB_OPT_SET_ALL, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLanguage, "Specify the language that this category is supported for." }
+  { LLDB_OPT_SET_ALL, false, "enabled",  'e', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "If specified, this category will be created enabled." },
+  { LLDB_OPT_SET_ALL, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Specify the language that this category is supported for." }
     // clang-format on
 };
 
@@ -1891,9 +1891,9 @@ protected:
 // CommandObjectTypeCategoryEnable
 //-------------------------------------------------------------------------
 
-static OptionDefinition g_type_category_enable_options[] = {
+static constexpr OptionDefinition g_type_category_enable_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLanguage, "Enable the category for this language." },
+  { LLDB_OPT_SET_ALL, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Enable the category for this language." },
     // clang-format on
 };
 
@@ -2068,9 +2068,9 @@ protected:
 // CommandObjectTypeCategoryDisable
 //-------------------------------------------------------------------------
 
-OptionDefinition g_type_category_disable_options[] = {
+OptionDefinition constexpr g_type_category_disable_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLanguage, "Enable the category for this language." }
+  { LLDB_OPT_SET_ALL, false, "language", 'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Enable the category for this language." }
     // clang-format on
 };
 
@@ -2492,14 +2492,14 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
 
 #endif // LLDB_DISABLE_PYTHON
 
-static OptionDefinition g_type_filter_add_options[] = {
+static constexpr OptionDefinition g_type_filter_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,        "If true, cascade through typedef chains." },
-  { LLDB_OPT_SET_ALL, false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Don't use this format for pointers-to-type objects." },
-  { LLDB_OPT_SET_ALL, false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Don't use this format for references-to-type objects." },
-  { LLDB_OPT_SET_ALL, false, "category",        'w', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,           "Add this to the given category instead of the default one." },
-  { LLDB_OPT_SET_ALL, false, "child",           'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeExpressionPath, "Include this expression path in the synthetic view." },
-  { LLDB_OPT_SET_ALL, false, "regex",           'x', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,           "Type names are actually regular expressions." }
+  { LLDB_OPT_SET_ALL, false, "cascade",         'C', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,        "If true, cascade through typedef chains." },
+  { LLDB_OPT_SET_ALL, false, "skip-pointers",   'p', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Don't use this format for pointers-to-type objects." },
+  { LLDB_OPT_SET_ALL, false, "skip-references", 'r', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Don't use this format for references-to-type objects." },
+  { LLDB_OPT_SET_ALL, false, "category",        'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,           "Add this to the given category instead of the default one." },
+  { LLDB_OPT_SET_ALL, false, "child",           'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeExpressionPath, "Include this expression path in the synthetic view." },
+  { LLDB_OPT_SET_ALL, false, "regex",           'x', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,           "Type names are actually regular expressions." }
     // clang-format on
 };
 
@@ -2747,10 +2747,10 @@ protected:
 //----------------------------------------------------------------------
 // "type lookup"
 //----------------------------------------------------------------------
-static OptionDefinition g_type_lookup_options[] = {
+static constexpr OptionDefinition g_type_lookup_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "show-help", 'h', OptionParser::eNoArgument,       nullptr, nullptr, 0, eArgTypeNone,     "Display available help for types" },
-  { LLDB_OPT_SET_ALL, false, "language",  'l', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeLanguage, "Which language's types should the search scope be" }
+  { LLDB_OPT_SET_ALL, false, "show-help", 'h', OptionParser::eNoArgument,       nullptr, {}, 0, eArgTypeNone,     "Display available help for types" },
+  { LLDB_OPT_SET_ALL, false, "language",  'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Which language's types should the search scope be" }
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectWatchpoint.cpp
+++ b/source/Commands/CommandObjectWatchpoint.cpp
@@ -158,11 +158,11 @@ bool CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
 //-------------------------------------------------------------------------
 #pragma mark List::CommandOptions
 
-static OptionDefinition g_watchpoint_list_options[] = {
+static constexpr OptionDefinition g_watchpoint_list_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1, false, "brief",   'b', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Give a brief description of the watchpoint (no location info)." },
-  { LLDB_OPT_SET_2, false, "full",    'f', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Give a full description of the watchpoint and its locations." },
-  { LLDB_OPT_SET_3, false, "verbose", 'v', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Explain everything we know about the watchpoint (for debugging debugger bugs)." }
+  { LLDB_OPT_SET_1, false, "brief",   'b', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Give a brief description of the watchpoint (no location info)." },
+  { LLDB_OPT_SET_2, false, "full",    'f', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Give a full description of the watchpoint and its locations." },
+  { LLDB_OPT_SET_3, false, "verbose", 'v', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Explain everything we know about the watchpoint (for debugging debugger bugs)." }
     // clang-format on
 };
 
@@ -529,9 +529,9 @@ protected:
 //-------------------------------------------------------------------------
 
 #pragma mark Ignore::CommandOptions
-static OptionDefinition g_watchpoint_ignore_options[] = {
+static constexpr OptionDefinition g_watchpoint_ignore_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, true, "ignore-count", 'i', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount, "Set the number of times this watchpoint is skipped before stopping." }
+  { LLDB_OPT_SET_ALL, true, "ignore-count", 'i', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount, "Set the number of times this watchpoint is skipped before stopping." }
     // clang-format on
 };
 
@@ -651,9 +651,9 @@ private:
 
 #pragma mark Modify::CommandOptions
 
-static OptionDefinition g_watchpoint_modify_options[] = {
+static constexpr OptionDefinition g_watchpoint_modify_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_ALL, false, "condition", 'c', OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeExpression, "The watchpoint stops only if this condition expression evaluates to true." }
+  { LLDB_OPT_SET_ALL, false, "condition", 'c', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeExpression, "The watchpoint stops only if this condition expression evaluates to true." }
     // clang-format on
 };
 

--- a/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -38,20 +38,23 @@ using namespace lldb_private;
 // language to lldb and have it pickable here without having to change this
 // enumeration by hand and rebuild lldb proper.
 
-static OptionEnumValueElement g_script_option_enumeration[4] = {
+static constexpr OptionEnumValueElement g_script_option_enumeration[] = {
     {eScriptLanguageNone, "command",
      "Commands are in the lldb command interpreter language"},
     {eScriptLanguagePython, "python", "Commands are in the Python language."},
     {eSortOrderByName, "default-script",
-     "Commands are in the default scripting language."},
-    {0, nullptr, nullptr}};
+     "Commands are in the default scripting language."} };
 
-static OptionDefinition g_watchpoint_command_add_options[] = {
+static constexpr OptionEnumValues ScriptOptionEnum() {
+  return OptionEnumValues(g_script_option_enumeration);
+}
+
+static constexpr OptionDefinition g_watchpoint_command_add_options[] = {
     // clang-format off
-  { LLDB_OPT_SET_1,   false, "one-liner",       'o', OptionParser::eRequiredArgument, nullptr, nullptr,                     0, eArgTypeOneLiner,       "Specify a one-line watchpoint command inline. Be sure to surround it with quotes." },
-  { LLDB_OPT_SET_ALL, false, "stop-on-error",   'e', OptionParser::eRequiredArgument, nullptr, nullptr,                     0, eArgTypeBoolean,        "Specify whether watchpoint command execution should terminate on error." },
-  { LLDB_OPT_SET_ALL, false, "script-type",     's', OptionParser::eRequiredArgument, nullptr, g_script_option_enumeration, 0, eArgTypeNone,           "Specify the language for the commands - if none is specified, the lldb command interpreter will be used." },
-  { LLDB_OPT_SET_2,   false, "python-function", 'F', OptionParser::eRequiredArgument, nullptr, nullptr,                     0, eArgTypePythonFunction, "Give the name of a Python function to run as command for this watchpoint. Be sure to give a module name if appropriate." }
+  { LLDB_OPT_SET_1,   false, "one-liner",       'o', OptionParser::eRequiredArgument, nullptr, {},                 0, eArgTypeOneLiner,       "Specify a one-line watchpoint command inline. Be sure to surround it with quotes." },
+  { LLDB_OPT_SET_ALL, false, "stop-on-error",   'e', OptionParser::eRequiredArgument, nullptr, {},                 0, eArgTypeBoolean,        "Specify whether watchpoint command execution should terminate on error." },
+  { LLDB_OPT_SET_ALL, false, "script-type",     's', OptionParser::eRequiredArgument, nullptr, ScriptOptionEnum(), 0, eArgTypeNone,           "Specify the language for the commands - if none is specified, the lldb command interpreter will be used." },
+  { LLDB_OPT_SET_2,   false, "python-function", 'F', OptionParser::eRequiredArgument, nullptr, {},                 0, eArgTypePythonFunction, "Give the name of a Python function to run as command for this watchpoint. Be sure to give a module name if appropriate." }
     // clang-format on
 };
 

--- a/source/Core/Debugger.cpp
+++ b/source/Core/Debugger.cpp
@@ -357,8 +357,7 @@ static constexpr PropertyDefinition g_properties[] = {
     {"frame-format-unique", OptionValue::eTypeFormatEntity, true, 0,
      DEFAULT_FRAME_FORMAT_NO_ARGS, {},
      "The default frame format string to use when displaying stack frame"
-     "information for threads from thread backtrace unique."},
-    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, {}, nullptr}};
+     "information for threads from thread backtrace unique."}};
 
 enum {
   ePropertyAutoConfirm = 0,

--- a/source/Core/Debugger.cpp
+++ b/source/Core/Debugger.cpp
@@ -168,7 +168,7 @@ static std::recursive_mutex *g_debugger_list_mutex_ptr =
 static DebuggerList *g_debugger_list_ptr =
     nullptr; // NOTE: intentional leak to avoid issues with C++ destructor chain
 
-OptionEnumValueElement g_show_disassembly_enum_values[] = {
+static constexpr OptionEnumValueElement g_show_disassembly_enum_values[] = {
     {Debugger::eStopDisassemblyTypeNever, "never",
      "Never show disassembly when displaying a stop context."},
     {Debugger::eStopDisassemblyTypeNoDebugInfo, "no-debuginfo",
@@ -177,16 +177,14 @@ OptionEnumValueElement g_show_disassembly_enum_values[] = {
      "Show disassembly when there is no source information, or the source file "
      "is missing when displaying a stop context."},
     {Debugger::eStopDisassemblyTypeAlways, "always",
-     "Always show disassembly when displaying a stop context."},
-    {0, nullptr, nullptr}};
+     "Always show disassembly when displaying a stop context."} };
 
-OptionEnumValueElement g_language_enumerators[] = {
+static constexpr OptionEnumValueElement g_language_enumerators[] = {
     {eScriptLanguageNone, "none", "Disable scripting languages."},
     {eScriptLanguagePython, "python",
      "Select python as the default scripting language."},
     {eScriptLanguageDefault, "default",
-     "Select the lldb default as the default scripting language."},
-    {0, nullptr, nullptr}};
+     "Select the lldb default as the default scripting language."} };
 
 #define MODULE_WITH_FUNC                                                       \
   "{ "                                                                         \
@@ -259,7 +257,7 @@ OptionEnumValueElement g_language_enumerators[] = {
 // args}}:\n}{${function.changed}\n{${module.file.basename}`}{${function.name-
 // without-args}}:\n}{${current-pc-arrow} }{${addr-file-or-load}}:
 
-static OptionEnumValueElement s_stop_show_column_values[] = {
+static constexpr OptionEnumValueElement s_stop_show_column_values[] = {
     {eStopShowColumnAnsiOrCaret, "ansi-or-caret",
      "Highlight the stop column with ANSI terminal codes when color/ANSI mode "
      "is enabled; otherwise, fall back to using a text-only caret (^) as if "
@@ -271,100 +269,96 @@ static OptionEnumValueElement s_stop_show_column_values[] = {
      "Highlight the stop column with a caret character (^) underneath the stop "
      "column. This method introduces a new line in source listings that "
      "display thread stop locations."},
-    {eStopShowColumnNone, "none", "Do not highlight the stop column."},
-    {0, nullptr, nullptr}};
+    {eStopShowColumnNone, "none", "Do not highlight the stop column."}};
 
-static PropertyDefinition g_properties[] = {
-    {"auto-confirm", OptionValue::eTypeBoolean, true, false, nullptr, nullptr,
+static constexpr PropertyDefinition g_properties[] = {
+    {"auto-confirm", OptionValue::eTypeBoolean, true, false, nullptr, {},
      "If true all confirmation prompts will receive their default reply."},
     {"disassembly-format", OptionValue::eTypeFormatEntity, true, 0,
-     DEFAULT_DISASSEMBLY_FORMAT, nullptr,
+     DEFAULT_DISASSEMBLY_FORMAT, {},
      "The default disassembly format "
      "string to use when disassembling "
      "instruction sequences."},
     {"frame-format", OptionValue::eTypeFormatEntity, true, 0,
-     DEFAULT_FRAME_FORMAT, nullptr,
+     DEFAULT_FRAME_FORMAT, {},
      "The default frame format string to use "
      "when displaying stack frame information "
      "for threads."},
-    {"notify-void", OptionValue::eTypeBoolean, true, false, nullptr, nullptr,
+    {"notify-void", OptionValue::eTypeBoolean, true, false, nullptr, {},
      "Notify the user explicitly if an expression returns void (default: "
      "false)."},
     {"prompt", OptionValue::eTypeString, true,
-     OptionValueString::eOptionEncodeCharacterEscapeSequences, "(lldb) ",
-     nullptr, "The debugger command line prompt displayed for the user."},
+     OptionValueString::eOptionEncodeCharacterEscapeSequences, "(lldb) ", {},
+     "The debugger command line prompt displayed for the user."},
     {"script-lang", OptionValue::eTypeEnum, true, eScriptLanguagePython,
-     nullptr, g_language_enumerators,
+     nullptr, OptionEnumValues(g_language_enumerators),
      "The script language to be used for evaluating user-written scripts."},
-    {"stop-disassembly-count", OptionValue::eTypeSInt64, true, 4, nullptr,
-     nullptr,
+    {"stop-disassembly-count", OptionValue::eTypeSInt64, true, 4, nullptr, {},
      "The number of disassembly lines to show when displaying a "
      "stopped context."},
     {"stop-disassembly-display", OptionValue::eTypeEnum, true,
      Debugger::eStopDisassemblyTypeNoDebugInfo, nullptr,
-     g_show_disassembly_enum_values,
+     OptionEnumValues(g_show_disassembly_enum_values),
      "Control when to display disassembly when displaying a stopped context."},
-    {"stop-line-count-after", OptionValue::eTypeSInt64, true, 3, nullptr,
-     nullptr,
+    {"stop-line-count-after", OptionValue::eTypeSInt64, true, 3, nullptr, {},
      "The number of sources lines to display that come after the "
      "current source line when displaying a stopped context."},
-    {"stop-line-count-before", OptionValue::eTypeSInt64, true, 3, nullptr,
-     nullptr,
+    {"stop-line-count-before", OptionValue::eTypeSInt64, true, 3, nullptr, {},
      "The number of sources lines to display that come before the "
      "current source line when displaying a stopped context."},
-    {"highlight-source", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr, "If true, LLDB will highlight the displayed source code."},
+    {"highlight-source", OptionValue::eTypeBoolean, true, true, nullptr, {},
+     "If true, LLDB will highlight the displayed source code."},
     {"stop-show-column", OptionValue::eTypeEnum, false,
-     eStopShowColumnAnsiOrCaret, nullptr, s_stop_show_column_values,
+     eStopShowColumnAnsiOrCaret, nullptr, OptionEnumValues(s_stop_show_column_values),
      "If true, LLDB will use the column information from the debug info to "
      "mark the current position when displaying a stopped context."},
     {"stop-show-column-ansi-prefix", OptionValue::eTypeString, true, 0,
-     "${ansi.underline}", nullptr,
+     "${ansi.underline}", {},
      "When displaying the column marker in a color-enabled (i.e. ANSI) "
      "terminal, use the ANSI terminal code specified in this format at the "
      "immediately before the column to be marked."},
     {"stop-show-column-ansi-suffix", OptionValue::eTypeString, true, 0,
-     "${ansi.normal}", nullptr,
+     "${ansi.normal}", {},
      "When displaying the column marker in a color-enabled (i.e. ANSI) "
      "terminal, use the ANSI terminal code specified in this format "
      "immediately after the column to be marked."},
-    {"term-width", OptionValue::eTypeSInt64, true, 80, nullptr, nullptr,
+    {"term-width", OptionValue::eTypeSInt64, true, 80, nullptr, {},
      "The maximum number of columns to use for displaying text."},
     {"thread-format", OptionValue::eTypeFormatEntity, true, 0,
-     DEFAULT_THREAD_FORMAT, nullptr,
+     DEFAULT_THREAD_FORMAT, {},
      "The default thread format string to use "
      "when displaying thread information."},
     {"thread-stop-format", OptionValue::eTypeFormatEntity, true, 0,
-     DEFAULT_THREAD_STOP_FORMAT, nullptr,
+     DEFAULT_THREAD_STOP_FORMAT, {},
      "The default thread format  "
      "string to use when displaying thread "
      "information as part of the stop display."},
-    {"use-external-editor", OptionValue::eTypeBoolean, true, false, nullptr,
-     nullptr, "Whether to use an external editor or not."},
-    {"use-color", OptionValue::eTypeBoolean, true, true, nullptr, nullptr,
+    {"use-external-editor", OptionValue::eTypeBoolean, true, false, nullptr, {},
+     "Whether to use an external editor or not."},
+    {"use-color", OptionValue::eTypeBoolean, true, true, nullptr, {},
      "Whether to use Ansi color codes or not."},
     {"auto-one-line-summaries", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr,
+     {},
      "If true, LLDB will automatically display small structs in "
      "one-liner format (default: true)."},
-    {"auto-indent", OptionValue::eTypeBoolean, true, true, nullptr, nullptr,
+    {"auto-indent", OptionValue::eTypeBoolean, true, true, nullptr, {},
      "If true, LLDB will auto indent/outdent code. Currently only supported in "
      "the REPL (default: true)."},
-    {"print-decls", OptionValue::eTypeBoolean, true, true, nullptr, nullptr,
+    {"print-decls", OptionValue::eTypeBoolean, true, true, nullptr, {},
      "If true, LLDB will print the values of variables declared in an "
      "expression. Currently only supported in the REPL (default: true)."},
-    {"tab-size", OptionValue::eTypeUInt64, true, 4, nullptr, nullptr,
+    {"tab-size", OptionValue::eTypeUInt64, true, 4, nullptr, {},
      "The tab size to use when indenting code in multi-line input mode "
      "(default: 4)."},
     {"escape-non-printables", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr,
+     {},
      "If true, LLDB will automatically escape non-printable and "
      "escape characters when formatting strings."},
     {"frame-format-unique", OptionValue::eTypeFormatEntity, true, 0,
-     DEFAULT_FRAME_FORMAT_NO_ARGS, nullptr,
+     DEFAULT_FRAME_FORMAT_NO_ARGS, {},
      "The default frame format string to use when displaying stack frame"
      "information for threads from thread backtrace unique."},
-    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, nullptr, nullptr}};
+    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, {}, nullptr}};
 
 enum {
   ePropertyAutoConfirm = 0,

--- a/source/Core/ModuleList.cpp
+++ b/source/Core/ModuleList.cpp
@@ -68,16 +68,16 @@ static bool KeepLookingInDylinker(SymbolContextList &sc_list, size_t start_idx);
 
 namespace {
 
-PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"enable-external-lookup", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr,
+     {},
      "Control the use of external tools or libraries to locate symbol files. "
      "On macOS, Spotlight is used to locate a matching .dSYM bundle based on "
      "the UUID of the executable."},
     {"clang-modules-cache-path", OptionValue::eTypeFileSpec, true, 0, nullptr,
-     nullptr,
+     {},
      "The path to the clang modules cache directory (-fmodules-cache-path)."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum { ePropertyEnableExternalLookup, ePropertyClangModulesCachePath };
 

--- a/source/Core/ModuleList.cpp
+++ b/source/Core/ModuleList.cpp
@@ -76,8 +76,7 @@ static constexpr PropertyDefinition g_properties[] = {
      "the UUID of the executable."},
     {"clang-modules-cache-path", OptionValue::eTypeFileSpec, true, 0, nullptr,
      {},
-     "The path to the clang modules cache directory (-fmodules-cache-path)."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+     "The path to the clang modules cache directory (-fmodules-cache-path)."}};
 
 enum { ePropertyEnableExternalLookup, ePropertyClangModulesCachePath };
 

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -89,8 +89,7 @@ static constexpr PropertyDefinition g_properties[] = {
      nullptr, {}, "If true, LLDB will stop running a 'command source' "
                   "script upon encountering an error."},
     {"space-repl-prompts", OptionValue::eTypeBoolean, true, false, nullptr, {},
-     "If true, blank lines will be printed between between REPL submissions."},
-    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, {}, nullptr}};
+     "If true, blank lines will be printed between between REPL submissions."}};
 
 enum {
   ePropertyExpandRegexAliases = 0,

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -76,22 +76,21 @@ using namespace lldb_private;
 
 static const char *k_white_space = " \t\v";
 
-static PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"expand-regex-aliases", OptionValue::eTypeBoolean, true, false, nullptr,
-     nullptr, "If true, regular expression alias commands will show the "
+     {}, "If true, regular expression alias commands will show the "
               "expanded command that will be executed. This can be used to "
               "debug new regular expression alias commands."},
-    {"prompt-on-quit", OptionValue::eTypeBoolean, true, true, nullptr, nullptr,
+    {"prompt-on-quit", OptionValue::eTypeBoolean, true, true, nullptr, {},
      "If true, LLDB will prompt you before quitting if there are any live "
      "processes being debugged. If false, LLDB will quit without asking in any "
      "case."},
     {"stop-command-source-on-error", OptionValue::eTypeBoolean, true, true,
-     nullptr, nullptr, "If true, LLDB will stop running a 'command source' "
-                       "script upon encountering an error."},
-    {"space-repl-prompts", OptionValue::eTypeBoolean, true, false, nullptr,
-     nullptr,
+     nullptr, {}, "If true, LLDB will stop running a 'command source' "
+                  "script upon encountering an error."},
+    {"space-repl-prompts", OptionValue::eTypeBoolean, true, false, nullptr, {},
      "If true, blank lines will be printed between between REPL submissions."},
-    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, nullptr, nullptr}};
+    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, {}, nullptr}};
 
 enum {
   ePropertyExpandRegexAliases = 0,

--- a/source/Interpreter/OptionArgParser.cpp
+++ b/source/Interpreter/OptionArgParser.cpp
@@ -46,10 +46,10 @@ char OptionArgParser::ToChar(llvm::StringRef s, char fail_value,
 }
 
 int64_t OptionArgParser::ToOptionEnum(llvm::StringRef s,
-                                      OptionEnumValueElement *enum_values,
+                                      const OptionEnumValues &enum_values,
                                       int32_t fail_value, Status &error) {
   error.Clear();
-  if (!enum_values) {
+  if (enum_values.empty()) {
     error.SetErrorString("invalid enumeration argument");
     return fail_value;
   }
@@ -59,16 +59,18 @@ int64_t OptionArgParser::ToOptionEnum(llvm::StringRef s,
     return fail_value;
   }
 
-  for (int i = 0; enum_values[i].string_value != nullptr; i++) {
-    llvm::StringRef this_enum(enum_values[i].string_value);
+  for (const auto &enum_value : enum_values) {
+    llvm::StringRef this_enum(enum_value.string_value);
     if (this_enum.startswith(s))
-      return enum_values[i].value;
+      return enum_value.value;
   }
 
   StreamString strm;
   strm.PutCString("invalid enumeration value, valid values are: ");
-  for (int i = 0; enum_values[i].string_value != nullptr; i++) {
-    strm.Printf("%s\"%s\"", i > 0 ? ", " : "", enum_values[i].string_value);
+  bool is_first = true;
+  for (const auto &enum_value : enum_values) {
+    strm.Printf("%s\"%s\"",
+        is_first ? is_first = false,"" : ", ", enum_value.string_value);
   }
   error.SetErrorString(strm.GetString());
   return fail_value;

--- a/source/Interpreter/OptionGroupArchitecture.cpp
+++ b/source/Interpreter/OptionGroupArchitecture.cpp
@@ -18,9 +18,9 @@ OptionGroupArchitecture::OptionGroupArchitecture() : m_arch_str() {}
 
 OptionGroupArchitecture::~OptionGroupArchitecture() {}
 
-static OptionDefinition g_option_table[] = {
+static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "arch", 'a', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeArchitecture,
+     nullptr, {}, 0, eArgTypeArchitecture,
      "Specify the architecture for the target."},
 };
 

--- a/source/Interpreter/OptionGroupBoolean.cpp
+++ b/source/Interpreter/OptionGroupBoolean.cpp
@@ -32,7 +32,7 @@ OptionGroupBoolean::OptionGroupBoolean(uint32_t usage_mask, bool required,
   m_option_definition.option_has_arg = no_argument_toggle_default
                                            ? OptionParser::eNoArgument
                                            : OptionParser::eRequiredArgument;
-  m_option_definition.enum_values = nullptr;
+  m_option_definition.enum_values = {};
   m_option_definition.completion_type = 0;
   m_option_definition.argument_type = eArgTypeBoolean;
   m_option_definition.usage_text = usage_text;

--- a/source/Interpreter/OptionGroupFile.cpp
+++ b/source/Interpreter/OptionGroupFile.cpp
@@ -30,7 +30,7 @@ OptionGroupFile::OptionGroupFile(uint32_t usage_mask, bool required,
   m_option_definition.short_option = short_option;
   m_option_definition.validator = nullptr;
   m_option_definition.option_has_arg = OptionParser::eRequiredArgument;
-  m_option_definition.enum_values = nullptr;
+  m_option_definition.enum_values = {};
   m_option_definition.completion_type = completion_type;
   m_option_definition.argument_type = argument_type;
   m_option_definition.usage_text = usage_text;
@@ -61,7 +61,7 @@ OptionGroupFileList::OptionGroupFileList(
   m_option_definition.short_option = short_option;
   m_option_definition.validator = nullptr;
   m_option_definition.option_has_arg = OptionParser::eRequiredArgument;
-  m_option_definition.enum_values = nullptr;
+  m_option_definition.enum_values = {};
   m_option_definition.completion_type = completion_type;
   m_option_definition.argument_type = argument_type;
   m_option_definition.usage_text = usage_text;

--- a/source/Interpreter/OptionGroupFormat.cpp
+++ b/source/Interpreter/OptionGroupFormat.cpp
@@ -27,18 +27,18 @@ OptionGroupFormat::OptionGroupFormat(lldb::Format default_format,
 
 OptionGroupFormat::~OptionGroupFormat() {}
 
-static OptionDefinition g_option_table[] = {
+static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "format", 'f', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFormat,
+     nullptr, {}, 0, eArgTypeFormat,
      "Specify a format to be used for display."},
     {LLDB_OPT_SET_2, false, "gdb-format", 'G', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeGDBFormat,
+     nullptr, {}, 0, eArgTypeGDBFormat,
      "Specify a format using a GDB format specifier string."},
     {LLDB_OPT_SET_3, false, "size", 's', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeByteSize,
+     nullptr, {}, 0, eArgTypeByteSize,
      "The size in bytes to use when displaying with the selected format."},
     {LLDB_OPT_SET_4, false, "count", 'c', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeCount,
+     nullptr, {}, 0, eArgTypeCount,
      "The number of total items to display."},
 };
 

--- a/source/Interpreter/OptionGroupOutputFile.cpp
+++ b/source/Interpreter/OptionGroupOutputFile.cpp
@@ -25,12 +25,12 @@ OptionGroupOutputFile::~OptionGroupOutputFile() {}
 
 static const uint32_t SHORT_OPTION_APND = 0x61706e64; // 'apnd'
 
-static OptionDefinition g_option_table[] = {
+static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "outfile", 'o', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFilename,
+     nullptr, {}, 0, eArgTypeFilename,
      "Specify a path for capturing command output."},
     {LLDB_OPT_SET_1, false, "append-outfile", SHORT_OPTION_APND,
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Append to the file specified with '--outfile <path>'."},
 };
 

--- a/source/Interpreter/OptionGroupPlatform.cpp
+++ b/source/Interpreter/OptionGroupPlatform.cpp
@@ -65,21 +65,21 @@ void OptionGroupPlatform::OptionParsingStarting(
   m_os_version = llvm::VersionTuple();
 }
 
-static OptionDefinition g_option_table[] = {
+static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_ALL, false, "platform", 'p', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypePlatform, "Specify name of the platform to "
-                                            "use for this target, creating the "
-                                            "platform if necessary."},
+     nullptr, {}, 0, eArgTypePlatform, "Specify name of the platform to "
+                                       "use for this target, creating the "
+                                       "platform if necessary."},
     {LLDB_OPT_SET_ALL, false, "version", 'v', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Specify the initial SDK version to use prior to connecting."},
     {LLDB_OPT_SET_ALL, false, "build", 'b', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Specify the initial SDK build number."},
     {LLDB_OPT_SET_ALL, false, "sysroot", 'S', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFilename, "Specify the SDK root directory "
-                                            "that contains a root of all "
-                                            "remote system files."}};
+     nullptr, {}, 0, eArgTypeFilename, "Specify the SDK root directory "
+                                       "that contains a root of all "
+                                       "remote system files."}};
 
 llvm::ArrayRef<OptionDefinition> OptionGroupPlatform::GetDefinitions() {
   llvm::ArrayRef<OptionDefinition> result(g_option_table);

--- a/source/Interpreter/OptionGroupString.cpp
+++ b/source/Interpreter/OptionGroupString.cpp
@@ -31,7 +31,7 @@ OptionGroupString::OptionGroupString(uint32_t usage_mask, bool required,
   m_option_definition.short_option = short_option;
   m_option_definition.validator = nullptr;
   m_option_definition.option_has_arg = OptionParser::eRequiredArgument;
-  m_option_definition.enum_values = nullptr;
+  m_option_definition.enum_values = {};
   m_option_definition.completion_type = completion_type;
   m_option_definition.argument_type = argument_type;
   m_option_definition.usage_text = usage_text;

--- a/source/Interpreter/OptionGroupUInt64.cpp
+++ b/source/Interpreter/OptionGroupUInt64.cpp
@@ -31,7 +31,7 @@ OptionGroupUInt64::OptionGroupUInt64(uint32_t usage_mask, bool required,
   m_option_definition.short_option = short_option;
   m_option_definition.validator = nullptr;
   m_option_definition.option_has_arg = OptionParser::eRequiredArgument;
-  m_option_definition.enum_values = nullptr;
+  m_option_definition.enum_values = {};
   m_option_definition.completion_type = completion_type;
   m_option_definition.argument_type = argument_type;
   m_option_definition.usage_text = usage_text;

--- a/source/Interpreter/OptionGroupUUID.cpp
+++ b/source/Interpreter/OptionGroupUUID.cpp
@@ -22,9 +22,9 @@ OptionGroupUUID::OptionGroupUUID() : m_uuid() {}
 
 OptionGroupUUID::~OptionGroupUUID() {}
 
-static OptionDefinition g_option_table[] = {
+static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "uuid", 'u', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeNone, "A module UUID value."},
+     nullptr, {}, 0, eArgTypeNone, "A module UUID value."},
 };
 
 llvm::ArrayRef<OptionDefinition> OptionGroupUUID::GetDefinitions() {

--- a/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -28,46 +28,45 @@ OptionGroupValueObjectDisplay::OptionGroupValueObjectDisplay() {}
 
 OptionGroupValueObjectDisplay::~OptionGroupValueObjectDisplay() {}
 
-static OptionDefinition g_option_table[] = {
+static const OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "dynamic-type", 'd',
-     OptionParser::eRequiredArgument, nullptr, g_dynamic_value_types, 0,
+     OptionParser::eRequiredArgument, nullptr, GetDynamicValueTypes(), 0,
      eArgTypeNone, "Show the object as its full dynamic type, not its static "
                    "type, if available."},
     {LLDB_OPT_SET_1, false, "synthetic-type", 'S',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Show the object obeying its synthetic provider, if available."},
     {LLDB_OPT_SET_1, false, "depth", 'D', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeCount, "Set the max recurse depth when "
-                                         "dumping aggregate types (default is "
-                                         "infinity)."},
+     nullptr, {}, 0, eArgTypeCount, "Set the max recurse depth when dumping "
+                                    "aggregate types (default is infinity)."},
     {LLDB_OPT_SET_1, false, "flat", 'F', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone, "Display results in a flat format that uses "
-                               "expression paths for each variable or member."},
+     {}, 0, eArgTypeNone, "Display results in a flat format that uses "
+                          "expression paths for each variable or member."},
     {LLDB_OPT_SET_1, false, "location", 'L', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone, "Show variable location information."},
+     {}, 0, eArgTypeNone, "Show variable location information."},
     {LLDB_OPT_SET_1, false, "object-description", 'O',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
+     // Difference to llvm.org is intended for this description
      "Display using a language-specific description API, if possible."},
     {LLDB_OPT_SET_1, false, "ptr-depth", 'P', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeCount, "The number of pointers to be "
-                                         "traversed when dumping values "
-                                         "(default is zero)."},
+     nullptr, {}, 0, eArgTypeCount, "The number of pointers to be traversed "
+                                    "when dumping values (default is zero)."},
     {LLDB_OPT_SET_1, false, "show-types", 'T', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Show variable types when dumping values."},
     {LLDB_OPT_SET_1, false, "no-summary-depth", 'Y',
-     OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeCount,
+     OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeCount,
      "Set the depth at which omitting summary information stops (default is "
      "1)."},
     {LLDB_OPT_SET_1, false, "raw-output", 'R', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone, "Don't use formatting options."},
+     nullptr, {}, 0, eArgTypeNone, "Don't use formatting options."},
     {LLDB_OPT_SET_1, false, "show-all-children", 'A', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Ignore the upper bound on the number of children to show."},
     {LLDB_OPT_SET_1, false, "validate", 'V', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeBoolean, "Show results of type validators."},
+     nullptr, {}, 0, eArgTypeBoolean, "Show results of type validators."},
     {LLDB_OPT_SET_1, false, "element-count", 'Z',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCount,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCount,
      "Treat the result of the expression as if its type is an array of this "
      "many values."}};
 
@@ -86,8 +85,8 @@ Status OptionGroupValueObjectDisplay::SetOptionValue(
   switch (short_option) {
   case 'd': {
     int32_t result;
-    result = OptionArgParser::ToOptionEnum(option_arg, g_dynamic_value_types, 2,
-                                           error);
+    result = OptionArgParser::ToOptionEnum(option_arg, GetDynamicValueTypes(),
+                                           2, error);
     if (error.Success())
       use_dynamic = (lldb::DynamicValueType)result;
   } break;

--- a/source/Interpreter/OptionGroupVariable.cpp
+++ b/source/Interpreter/OptionGroupVariable.cpp
@@ -24,31 +24,31 @@ using namespace lldb_private;
 
 // if you add any options here, remember to update the counters in
 // OptionGroupVariable::GetNumDefinitions()
-static OptionDefinition g_variable_options[] = {
+static constexpr OptionDefinition g_variable_options[] = {
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "no-args", 'a',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Omit function arguments."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "no-locals", 'l',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Omit local variables."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "show-globals", 'g',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Show the current frame source file global and static variables."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "show-declaration", 'c',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Show variable declaration information (source file and line where the "
      "variable was declared)."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "regex", 'r',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeRegularExpression,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeRegularExpression,
      "The <variable-name> argument for name lookups are regular expressions."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2, false, "scope", 's',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Show variable scope (argument, local, global, static)."},
     {LLDB_OPT_SET_1, false, "summary", 'y', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeName,
+     nullptr, {}, 0, eArgTypeName,
      "Specify the summary that the variable output should use."},
     {LLDB_OPT_SET_2, false, "summary-string", 'z',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeName,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,
      "Specify a summary string to use to format the variable output."},
 };
 

--- a/source/Interpreter/OptionGroupWatchpoint.cpp
+++ b/source/Interpreter/OptionGroupWatchpoint.cpp
@@ -20,33 +20,31 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static OptionEnumValueElement g_watch_type[] = {
+static constexpr OptionEnumValueElement g_watch_type[] = {
     {OptionGroupWatchpoint::eWatchRead, "read", "Watch for read"},
     {OptionGroupWatchpoint::eWatchWrite, "write", "Watch for write"},
     {OptionGroupWatchpoint::eWatchReadWrite, "read_write",
-     "Watch for read/write"},
-    {0, nullptr, nullptr}};
+     "Watch for read/write"} };
 
-static OptionEnumValueElement g_watch_size[] = {
+static constexpr OptionEnumValueElement g_watch_size[] = {
     {1, "1", "Watch for byte size of 1"},
     {2, "2", "Watch for byte size of 2"},
     {4, "4", "Watch for byte size of 4"},
-    {8, "8", "Watch for byte size of 8"},
-    {0, nullptr, nullptr}};
+    {8, "8", "Watch for byte size of 8"} };
 
-static OptionDefinition g_option_table[] = {
+static constexpr OptionDefinition g_option_table[] = {
     {LLDB_OPT_SET_1, false, "watch", 'w', OptionParser::eRequiredArgument,
-     nullptr, g_watch_type, 0, eArgTypeWatchType,
+     nullptr, OptionEnumValues(g_watch_type), 0, eArgTypeWatchType,
      "Specify the type of watching to perform."},
     {LLDB_OPT_SET_1, false, "size", 's', OptionParser::eRequiredArgument,
-     nullptr, g_watch_size, 0, eArgTypeByteSize,
+     nullptr, OptionEnumValues(g_watch_size), 0, eArgTypeByteSize,
      "Number of bytes to use to watch a region."}};
 
 bool OptionGroupWatchpoint::IsWatchSizeSupported(uint32_t watch_size) {
-  for (uint32_t i = 0; i < llvm::array_lengthof(g_watch_size); ++i) {
-    if (g_watch_size[i].value == 0)
+  for (const auto& size : g_watch_size) {
+    if (0  == size.value)
       break;
-    if (watch_size == g_watch_size[i].value)
+    if (watch_size == size.value)
       return true;
   }
   return false;

--- a/source/Interpreter/OptionValueEnumeration.cpp
+++ b/source/Interpreter/OptionValueEnumeration.cpp
@@ -19,7 +19,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 OptionValueEnumeration::OptionValueEnumeration(
-    const OptionEnumValueElement *enumerators, enum_type value)
+    const OptionEnumValues &enumerators, enum_type value)
     : OptionValue(), m_current_value(value), m_default_value(value),
       m_enumerations() {
   SetEnumerations(enumerators);
@@ -91,18 +91,16 @@ Status OptionValueEnumeration::SetValueFromString(llvm::StringRef value,
 }
 
 void OptionValueEnumeration::SetEnumerations(
-    const OptionEnumValueElement *enumerators) {
+    const OptionEnumValues &enumerators) {
   m_enumerations.Clear();
-  if (enumerators) {
-    for (size_t i = 0; enumerators[i].string_value != nullptr; ++i) {
-      ConstString const_enumerator_name(enumerators[i].string_value);
-      EnumeratorInfo enumerator_info = {enumerators[i].value,
-                                        enumerators[i].usage};
-      m_enumerations.Append(const_enumerator_name,
-                            enumerator_info);
-    }
-    m_enumerations.Sort();
+
+  for (const auto &enumerator : enumerators) {
+    ConstString const_enumerator_name(enumerator.string_value);
+    EnumeratorInfo enumerator_info = {enumerator.value, enumerator.usage};
+    m_enumerations.Append(const_enumerator_name, enumerator_info);
   }
+
+  m_enumerations.Sort();
 }
 
 lldb::OptionValueSP OptionValueEnumeration::DeepCopy() const {

--- a/source/Interpreter/OptionValueProperties.cpp
+++ b/source/Interpreter/OptionValueProperties.cpp
@@ -53,9 +53,9 @@ size_t OptionValueProperties::GetNumProperties() const {
   return m_properties.size();
 }
 
-void OptionValueProperties::Initialize(const PropertyDefinition *defs) {
-  for (size_t i = 0; defs[i].name; ++i) {
-    Property property(defs[i]);
+void OptionValueProperties::Initialize(const PropertyDefinitions &defs) {
+  for (const auto &definition : defs) {
+    Property property(definition);
     assert(property.IsValid());
     m_name_to_index.Append(ConstString(property.GetName()), m_properties.size());
     property.GetValue()->SetParent(shared_from_this());

--- a/source/Interpreter/Options.cpp
+++ b/source/Interpreter/Options.cpp
@@ -601,15 +601,17 @@ void Options::GenerateOptionUsage(Stream &strm, CommandObject *cmd,
 
       if (opt_defs[i].usage_text)
         OutputFormattedUsageText(strm, opt_defs[i], screen_width);
-      if (opt_defs[i].enum_values != nullptr) {
+      if (!opt_defs[i].enum_values.empty()) {
         strm.Indent();
         strm.Printf("Values: ");
-        for (int k = 0; opt_defs[i].enum_values[k].string_value != nullptr;
-             k++) {
-          if (k == 0)
-            strm.Printf("%s", opt_defs[i].enum_values[k].string_value);
+        bool is_first = true;
+        for (const auto &enum_value : opt_defs[i].enum_values) {
+          if (is_first) {
+            strm.Printf("%s", enum_value.string_value);
+            is_first = false;
+          }
           else
-            strm.Printf(" | %s", opt_defs[i].enum_values[k].string_value);
+            strm.Printf(" | %s", enum_value.string_value);
         }
         strm.EOL();
       }
@@ -770,17 +772,18 @@ bool Options::HandleOptionArgumentCompletion(
 
   // See if this is an enumeration type option, and if so complete it here:
 
-  OptionEnumValueElement *enum_values = opt_defs[opt_defs_index].enum_values;
-  if (enum_values != nullptr) {
+  const auto &enum_values = opt_defs[opt_defs_index].enum_values;
+  if (!enum_values.empty()) {
     bool return_value = false;
     std::string match_string(
         request.GetParsedLine().GetArgumentAtIndex(opt_arg_pos),
         request.GetParsedLine().GetArgumentAtIndex(opt_arg_pos) +
             request.GetCursorCharPosition());
-    for (int i = 0; enum_values[i].string_value != nullptr; i++) {
-      if (strstr(enum_values[i].string_value, match_string.c_str()) ==
-          enum_values[i].string_value) {
-        request.AddCompletion(enum_values[i].string_value);
+
+    for (const auto &enum_value : enum_values) {
+      if (strstr(enum_value.string_value, match_string.c_str()) ==
+          enum_value.string_value) {
+        request.AddCompletion(enum_value.string_value);
         return_value = true;
       }
     }

--- a/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -76,8 +76,7 @@ static constexpr PropertyDefinition g_properties[] = {
     {"scan-type", OptionValue::eTypeEnum, true, eKASLRScanNearPC, NULL,
      OptionEnumValues(g_kaslr_kernel_scan_enum_values),
      "Control how many reads lldb will make while searching for a Darwin "
-     "kernel on attach."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL} };
+     "kernel on attach."}};
 
 enum { ePropertyLoadKexts, ePropertyScanType };
 

--- a/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -58,7 +58,7 @@ enum KASLRScanType {
                            // range looking for a kernel
 };
 
-OptionEnumValueElement g_kaslr_kernel_scan_enum_values[] = {
+static constexpr OptionEnumValueElement g_kaslr_kernel_scan_enum_values[] = {
     {eKASLRScanNone, "none",
      "Do not read memory looking for a Darwin kernel when attaching."},
     {eKASLRScanLowgloAddresses, "basic", "Check for the Darwin kernel's load "
@@ -68,17 +68,16 @@ OptionEnumValueElement g_kaslr_kernel_scan_enum_values[] = {
                                     "the Darwin kernel's load address."},
     {eKASLRScanExhaustiveScan, "exhaustive-scan",
      "Scan through the entire potential address range of Darwin kernel (only "
-     "on 32-bit targets)."},
-    {0, NULL, NULL}};
+     "on 32-bit targets)."}};
 
-static PropertyDefinition g_properties[] = {
-    {"load-kexts", OptionValue::eTypeBoolean, true, true, NULL, NULL,
+static constexpr PropertyDefinition g_properties[] = {
+    {"load-kexts", OptionValue::eTypeBoolean, true, true, NULL, {},
      "Automatically loads kext images when attaching to a kernel."},
     {"scan-type", OptionValue::eTypeEnum, true, eKASLRScanNearPC, NULL,
-     g_kaslr_kernel_scan_enum_values, "Control how many reads lldb will make "
-                                      "while searching for a Darwin kernel on "
-                                      "attach."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, NULL, NULL}};
+     OptionEnumValues(g_kaslr_kernel_scan_enum_values),
+     "Control how many reads lldb will make while searching for a Darwin "
+     "kernel on attach."},
+    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL} };
 
 enum { ePropertyLoadKexts, ePropertyScanType };
 

--- a/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
+++ b/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
@@ -61,8 +61,7 @@ namespace {
 
 static constexpr PropertyDefinition g_properties[] = {
     {"enable-jit-breakpoint", OptionValue::eTypeBoolean, true, true, nullptr,
-     {}, "Enable breakpoint on __jit_debug_register_code."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+     {}, "Enable breakpoint on __jit_debug_register_code."}};
 
 enum { ePropertyEnableJITBreakpoint };
 

--- a/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
+++ b/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
@@ -59,10 +59,10 @@ template <typename ptr_t> struct jit_descriptor {
 
 namespace {
 
-PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"enable-jit-breakpoint", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr, "Enable breakpoint on __jit_debug_register_code."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+     {}, "Enable breakpoint on __jit_debug_register_code."},
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum { ePropertyEnableJITBreakpoint };
 

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -484,9 +484,9 @@ LanguageRuntime *AppleObjCRuntimeV2::CreateInstance(Process *process,
     return NULL;
 }
 
-static OptionDefinition g_objc_classtable_dump_options[] = {
+static constexpr OptionDefinition g_objc_classtable_dump_options[] = {
     {LLDB_OPT_SET_ALL, false, "verbose", 'v', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Print ivar and method information in detail"}};
 
 class CommandObjectObjC_ClassTable_Dump : public CommandObjectParsed {

--- a/source/Plugins/LanguageRuntime/RenderScript/RenderScriptRuntime/RenderScriptRuntime.cpp
+++ b/source/Plugins/LanguageRuntime/RenderScript/RenderScriptRuntime/RenderScriptRuntime.cpp
@@ -4171,13 +4171,13 @@ public:
   }
 };
 
-static OptionDefinition g_renderscript_reduction_bp_set_options[] = {
+static constexpr OptionDefinition g_renderscript_reduction_bp_set_options[] = {
     {LLDB_OPT_SET_1, false, "function-role", 't',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeOneLiner,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeOneLiner,
      "Break on a comma separated set of reduction kernel types "
      "(accumulator,outcoverter,combiner,initializer"},
     {LLDB_OPT_SET_1, false, "coordinate", 'c', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeValue,
+     nullptr, {}, 0, eArgTypeValue,
      "Set a breakpoint on a single invocation of the kernel with specified "
      "coordinate.\n"
      "Coordinate takes the form 'x[,y][,z] where x,y,z are positive "
@@ -4330,9 +4330,9 @@ private:
   CommandOptions m_options;
 };
 
-static OptionDefinition g_renderscript_kernel_bp_set_options[] = {
+static constexpr OptionDefinition g_renderscript_kernel_bp_set_options[] = {
     {LLDB_OPT_SET_1, false, "coordinate", 'c', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeValue,
+     nullptr, {}, 0, eArgTypeValue,
      "Set a breakpoint on a single invocation of the kernel with specified "
      "coordinate.\n"
      "Coordinate takes the form 'x[,y][,z] where x,y,z are positive "
@@ -4602,9 +4602,9 @@ public:
   }
 };
 
-static OptionDefinition g_renderscript_runtime_alloc_dump_options[] = {
+static constexpr OptionDefinition g_renderscript_runtime_alloc_dump_options[] = {
     {LLDB_OPT_SET_1, false, "file", 'f', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFilename,
+     nullptr, {}, 0, eArgTypeFilename,
      "Print results to specified file instead of command line."}};
 
 class CommandObjectRenderScriptRuntimeContext : public CommandObjectMultiword {
@@ -4738,9 +4738,9 @@ private:
   CommandOptions m_options;
 };
 
-static OptionDefinition g_renderscript_runtime_alloc_list_options[] = {
+static constexpr OptionDefinition g_renderscript_runtime_alloc_list_options[] = {
     {LLDB_OPT_SET_1, false, "id", 'i', OptionParser::eRequiredArgument, nullptr,
-     nullptr, 0, eArgTypeIndex,
+     {}, 0, eArgTypeIndex,
      "Only show details of a single allocation with specified id."}};
 
 class CommandObjectRenderScriptRuntimeAllocationList

--- a/source/Plugins/OperatingSystem/Go/OperatingSystemGo.cpp
+++ b/source/Plugins/OperatingSystem/Go/OperatingSystemGo.cpp
@@ -46,10 +46,9 @@ using namespace lldb_private;
 
 namespace {
 
-static PropertyDefinition g_properties[] = {
-    {"enable", OptionValue::eTypeBoolean, true, false, nullptr, nullptr,
-     "Specify whether goroutines should be treated as threads."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, NULL, NULL}};
+static constexpr PropertyDefinition g_properties[] = {
+    {"enable", OptionValue::eTypeBoolean, true, false, nullptr, {},
+     "Specify whether goroutines should be treated as threads."}};
 
 enum {
   ePropertyEnableGoroutines,

--- a/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -186,14 +186,13 @@ const char *PlatformDarwinKernel::GetDescriptionStatic() {
 /// Code to handle the PlatformDarwinKernel settings
 //------------------------------------------------------------------
 
-static PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"search-locally-for-kexts", OptionValue::eTypeBoolean, true, true, NULL,
      {}, "Automatically search for kexts on the local system when doing "
            "kernel debugging."},
     {"kext-directories", OptionValue::eTypeFileSpecList, false, 0, NULL, {},
      "Directories/KDKs to search for kexts in when starting a kernel debug "
-     "session."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL}};
+     "session."}};
 
 enum { ePropertySearchForKexts = 0, ePropertyKextDirectories };
 

--- a/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -188,12 +188,12 @@ const char *PlatformDarwinKernel::GetDescriptionStatic() {
 
 static PropertyDefinition g_properties[] = {
     {"search-locally-for-kexts", OptionValue::eTypeBoolean, true, true, NULL,
-     NULL, "Automatically search for kexts on the local system when doing "
+     {}, "Automatically search for kexts on the local system when doing "
            "kernel debugging."},
-    {"kext-directories", OptionValue::eTypeFileSpecList, false, 0, NULL, NULL,
+    {"kext-directories", OptionValue::eTypeFileSpecList, false, 0, NULL, {},
      "Directories/KDKs to search for kexts in when starting a kernel debug "
      "session."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, NULL, NULL}};
+    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL}};
 
 enum { ePropertySearchForKexts = 0, ePropertyKextDirectories };
 

--- a/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
+++ b/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
@@ -55,10 +55,9 @@ using namespace lldb_private;
 
 namespace {
 
-static PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"packet-timeout", OptionValue::eTypeUInt64, true, 5, NULL, {},
-     "Specify the default packet timeout in seconds."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL}};
+     "Specify the default packet timeout in seconds."}};
 
 enum { ePropertyPacketTimeout };
 

--- a/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
+++ b/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
@@ -56,9 +56,9 @@ using namespace lldb_private;
 namespace {
 
 static PropertyDefinition g_properties[] = {
-    {"packet-timeout", OptionValue::eTypeUInt64, true, 5, NULL, NULL,
+    {"packet-timeout", OptionValue::eTypeUInt64, true, 5, NULL, {},
      "Specify the default packet timeout in seconds."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, NULL, NULL}};
+    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL}};
 
 enum { ePropertyPacketTimeout };
 

--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -110,12 +110,12 @@ void DumpProcessGDBRemotePacketHistory(void *p, const char *path) {
 
 namespace {
 
-static PropertyDefinition g_properties[] = {
-    {"packet-timeout", OptionValue::eTypeUInt64, true, 1, NULL, NULL,
+static constexpr PropertyDefinition g_properties[] = {
+    {"packet-timeout", OptionValue::eTypeUInt64, true, 1, NULL, {},
      "Specify the default packet timeout in seconds."},
-    {"target-definition-file", OptionValue::eTypeFileSpec, true, 0, NULL, NULL,
+    {"target-definition-file", OptionValue::eTypeFileSpec, true, 0, NULL, {},
      "The file that provides the description for remote target registers."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, NULL, NULL}};
+    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL}};
 
 enum { ePropertyPacketTimeout, ePropertyTargetDefinitionFile };
 

--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -114,8 +114,7 @@ static constexpr PropertyDefinition g_properties[] = {
     {"packet-timeout", OptionValue::eTypeUInt64, true, 1, NULL, {},
      "Specify the default packet timeout in seconds."},
     {"target-definition-file", OptionValue::eTypeFileSpec, true, 0, NULL, {},
-     "The file that provides the description for remote target registers."},
-    {NULL, OptionValue::eTypeInvalid, false, 0, NULL, {}, NULL}};
+     "The file that provides the description for remote target registers."}};
 
 enum { ePropertyPacketTimeout, ePropertyTargetDefinitionFile };
 

--- a/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
+++ b/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
@@ -133,9 +133,7 @@ static constexpr PropertyDefinition g_properties[] = {
         "Specify the options to 'plugin structured-data darwin-log enable' "
         "that should be applied when automatically enabling logging on "
         "startup/attach." // description
-    },
-    // Last entry sentinel.
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+    }};
 
 enum { ePropertyEnableOnStartup = 0, ePropertyAutoEnableOptions = 1 };
 

--- a/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
+++ b/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
@@ -112,14 +112,14 @@ void SetGlobalEnableOptions(const DebuggerSP &debugger_sp,
 /// Code to handle the StructuredDataDarwinLog settings
 //------------------------------------------------------------------
 
-static PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {
         "enable-on-startup",       // name
         OptionValue::eTypeBoolean, // type
         true,                      // global
         false,                     // default uint value
         nullptr,                   // default cstring value
-        nullptr,                   // enum values
+        {},                        // enum values
         "Enable Darwin os_log collection when debugged process is launched "
         "or attached." // description
     },
@@ -129,13 +129,13 @@ static PropertyDefinition g_properties[] = {
         true,                     // global
         0,                        // default uint value
         "",                       // default cstring value
-        nullptr,                  // enum values
+        {},                       // enum values
         "Specify the options to 'plugin structured-data darwin-log enable' "
         "that should be applied when automatically enabling logging on "
         "startup/attach." // description
     },
     // Last entry sentinel.
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum { ePropertyEnableOnStartup = 0, ePropertyAutoEnableOptions = 1 };
 
@@ -402,23 +402,23 @@ static void RegisterFilterOperations() {
 /// This resets the logging with whatever settings are currently set.
 // -------------------------------------------------------------------------
 
-static OptionDefinition g_enable_option_table[] = {
+static constexpr OptionDefinition g_enable_option_table[] = {
     // Source stream include/exclude options (the first-level filter). This one
     // should be made as small as possible as everything that goes through here
     // must be processed by the process monitor.
     {LLDB_OPT_SET_ALL, false, "any-process", 'a', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Specifies log messages from other related processes should be "
      "included."},
     {LLDB_OPT_SET_ALL, false, "debug", 'd', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone,
+     {}, 0, eArgTypeNone,
      "Specifies debug-level log messages should be included.  Specifying"
      " --debug implies --info."},
     {LLDB_OPT_SET_ALL, false, "info", 'i', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone,
+     {}, 0, eArgTypeNone,
      "Specifies info-level log messages should be included."},
     {LLDB_OPT_SET_ALL, false, "filter", 'f', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgRawInput,
+     nullptr, {}, 0, eArgRawInput,
      // There doesn't appear to be a great way for me to have these multi-line,
      // formatted tables in help.  This looks mostly right but there are extra
      // linefeeds added at seemingly random spots, and indentation isn't
@@ -452,52 +452,52 @@ static OptionDefinition g_enable_option_table[] = {
      "Prefer character classes like [[:digit:]] to \\d and the like, as "
      "getting the backslashes escaped through properly is error-prone."},
     {LLDB_OPT_SET_ALL, false, "live-stream", 'l',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Specify whether logging events are live-streamed or buffered.  "
      "True indicates live streaming, false indicates buffered.  The "
      "default is true (live streaming).  Live streaming will deliver "
      "log messages with less delay, but buffered capture mode has less "
      "of an observer effect."},
     {LLDB_OPT_SET_ALL, false, "no-match-accepts", 'n',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Specify whether a log message that doesn't match any filter rule "
      "is accepted or rejected, where true indicates accept.  The "
      "default is true."},
     {LLDB_OPT_SET_ALL, false, "echo-to-stderr", 'e',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Specify whether os_log()/NSLog() messages are echoed to the "
      "target program's stderr.  When DarwinLog is enabled, we shut off "
      "the mirroring of os_log()/NSLog() to the program's stderr.  "
      "Setting this flag to true will restore the stderr mirroring."
      "The default is false."},
     {LLDB_OPT_SET_ALL, false, "broadcast-events", 'b',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Specify if the plugin should broadcast events.  Broadcasting "
      "log events is a requirement for displaying the log entries in "
      "LLDB command-line.  It is also required if LLDB clients want to "
      "process log events.  The default is true."},
     // Message formatting options
     {LLDB_OPT_SET_ALL, false, "timestamp-relative", 'r',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Include timestamp in the message header when printing a log "
      "message.  The timestamp is relative to the first displayed "
      "message."},
     {LLDB_OPT_SET_ALL, false, "subsystem", 's', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Include the subsystem in the the message header when displaying "
      "a log message."},
     {LLDB_OPT_SET_ALL, false, "category", 'c', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
-     "Include the category in the message header when displaying "
+     nullptr, {}, 0, eArgTypeNone,
+     "Include the category in the the message header when displaying "
      "a log message."},
     {LLDB_OPT_SET_ALL, false, "activity-chain", 'C', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Include the activity parent-child chain in the message header "
      "when displaying a log message.  The activity hierarchy is "
      "displayed as {grandparent-activity}:"
      "{parent-activity}:{activity}[:...]."},
     {LLDB_OPT_SET_ALL, false, "all-fields", 'A', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Shortcut to specify that all header fields should be displayed."}};
 
 class EnableOptions : public Options {

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -118,9 +118,7 @@ static constexpr PropertyDefinition g_properties[] = {
      "links will be resolved at DWARF parse time."},
     {"ignore-file-indexes", OptionValue::eTypeBoolean, true, 0, nullptr, {},
      "Ignore indexes present in the object files and always index DWARF "
-     "manually."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr},
-};
+     "manually."}};
 
 enum {
   ePropertySymLinkPaths,

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -111,16 +111,15 @@ using namespace lldb_private;
 
 namespace {
 
-PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"comp-dir-symlink-paths", OptionValue::eTypeFileSpecList, true, 0, nullptr,
-     nullptr,
+     {},
      "If the DW_AT_comp_dir matches any of these paths the symbolic "
      "links will be resolved at DWARF parse time."},
-    {"ignore-file-indexes", OptionValue::eTypeBoolean, true, 0, nullptr,
-     nullptr,
+    {"ignore-file-indexes", OptionValue::eTypeBoolean, true, 0, nullptr, {},
      "Ignore indexes present in the object files and always index DWARF "
      "manually."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr},
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr},
 };
 
 enum {

--- a/source/Target/Platform.cpp
+++ b/source/Target/Platform.cpp
@@ -71,8 +71,7 @@ static constexpr PropertyDefinition g_properties[] = {
     {"use-module-cache", OptionValue::eTypeBoolean, true, true, nullptr,
      {}, "Use module cache."},
     {"module-cache-directory", OptionValue::eTypeFileSpec, true, 0, nullptr,
-     {}, "Root directory for cached modules."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+     {}, "Root directory for cached modules."}};
 
 enum { ePropertyUseModuleCache, ePropertyModuleCacheDirectory };
 

--- a/source/Target/Platform.cpp
+++ b/source/Target/Platform.cpp
@@ -67,12 +67,12 @@ const char *Platform::GetHostPlatformName() { return "host"; }
 
 namespace {
 
-PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"use-module-cache", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr, "Use module cache."},
+     {}, "Use module cache."},
     {"module-cache-directory", OptionValue::eTypeFileSpec, true, 0, nullptr,
-     nullptr, "Root directory for cached modules."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+     {}, "Root directory for cached modules."},
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum { ePropertyUseModuleCache, ePropertyModuleCacheDirectory };
 
@@ -1378,32 +1378,32 @@ const char *Platform::GetLocalCacheDirectory() {
   return m_local_cache_directory.c_str();
 }
 
-static OptionDefinition g_rsync_option_table[] = {
+static constexpr OptionDefinition g_rsync_option_table[] = {
     {LLDB_OPT_SET_ALL, false, "rsync", 'r', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone, "Enable rsync."},
+     {}, 0, eArgTypeNone, "Enable rsync."},
     {LLDB_OPT_SET_ALL, false, "rsync-opts", 'R',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCommandName,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCommandName,
      "Platform-specific options required for rsync to work."},
     {LLDB_OPT_SET_ALL, false, "rsync-prefix", 'P',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeCommandName,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeCommandName,
      "Platform-specific rsync prefix put before the remote path."},
     {LLDB_OPT_SET_ALL, false, "ignore-remote-hostname", 'i',
-     OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone,
      "Do not automatically fill in the remote hostname when composing the "
      "rsync command."},
 };
 
-static OptionDefinition g_ssh_option_table[] = {
+static constexpr OptionDefinition g_ssh_option_table[] = {
     {LLDB_OPT_SET_ALL, false, "ssh", 's', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone, "Enable SSH."},
+     {}, 0, eArgTypeNone, "Enable SSH."},
     {LLDB_OPT_SET_ALL, false, "ssh-opts", 'S', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeCommandName,
+     nullptr, {}, 0, eArgTypeCommandName,
      "Platform-specific options required for SSH to work."},
 };
 
-static OptionDefinition g_caching_option_table[] = {
+static constexpr OptionDefinition g_caching_option_table[] = {
     {LLDB_OPT_SET_ALL, false, "local-cache-dir", 'c',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypePath,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypePath,
      "Path in which to store local copies of files."},
 };
 

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -148,8 +148,7 @@ static constexpr PropertyDefinition g_properties[] = {
          "stepping and variable availability may not behave as expected."},
     {"stop-on-exec", OptionValue::eTypeBoolean, true, true,
      nullptr, {},
-     "If true, stop when a shared library is loaded or unloaded."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+     "If true, stop when a shared library is loaded or unloaded."}};
 
 enum {
   ePropertyDisableMemCache,

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -117,39 +117,39 @@ public:
   }
 };
 
-static PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"disable-memory-cache", OptionValue::eTypeBoolean, false,
-     DISABLE_MEM_CACHE_DEFAULT, nullptr, nullptr,
+     DISABLE_MEM_CACHE_DEFAULT, nullptr, {},
      "Disable reading and caching of memory in fixed-size units."},
     {"extra-startup-command", OptionValue::eTypeArray, false,
-     OptionValue::eTypeString, nullptr, nullptr,
+     OptionValue::eTypeString, nullptr, {},
      "A list containing extra commands understood by the particular process "
      "plugin used.  "
      "For instance, to turn on debugserver logging set this to "
      "\"QSetLogging:bitmask=LOG_DEFAULT;\""},
     {"ignore-breakpoints-in-expressions", OptionValue::eTypeBoolean, true, true,
-     nullptr, nullptr,
+     nullptr, {},
      "If true, breakpoints will be ignored during expression evaluation."},
     {"unwind-on-error-in-expressions", OptionValue::eTypeBoolean, true, true,
-     nullptr, nullptr, "If true, errors in expression evaluation will unwind "
-                       "the stack back to the state before the call."},
+     nullptr, {}, "If true, errors in expression evaluation will unwind "
+                  "the stack back to the state before the call."},
     {"python-os-plugin-path", OptionValue::eTypeFileSpec, false, true, nullptr,
-     nullptr, "A path to a python OS plug-in module file that contains a "
-              "OperatingSystemPlugIn class."},
+     {}, "A path to a python OS plug-in module file that contains a "
+         "OperatingSystemPlugIn class."},
     {"stop-on-sharedlibrary-events", OptionValue::eTypeBoolean, true, false,
-     nullptr, nullptr,
+     nullptr, {},
      "If true, stop when a shared library is loaded or unloaded."},
     {"detach-keeps-stopped", OptionValue::eTypeBoolean, true, false, nullptr,
-     nullptr, "If true, detach will attempt to keep the process stopped."},
+     {}, "If true, detach will attempt to keep the process stopped."},
     {"memory-cache-line-size", OptionValue::eTypeUInt64, false, 512, nullptr,
-     nullptr, "The memory cache line size"},
+     {}, "The memory cache line size"},
     {"optimization-warnings", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "If true, warn when stopped in code that is optimized where "
-              "stepping and variable availability may not behave as expected."},
+     {}, "If true, warn when stopped in code that is optimized where "
+         "stepping and variable availability may not behave as expected."},
     {"stop-on-exec", OptionValue::eTypeBoolean, true, true,
-     nullptr, nullptr,
+     nullptr, {},
      "If true, stop when a shared library is loaded or unloaded."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum {
   ePropertyDisableMemCache,
@@ -534,52 +534,52 @@ Status ProcessLaunchCommandOptions::SetOptionValue(
   return error;
 }
 
-static OptionDefinition g_process_launch_options[] = {
+static constexpr OptionDefinition g_process_launch_options[] = {
     {LLDB_OPT_SET_ALL, false, "stop-at-entry", 's', OptionParser::eNoArgument,
-     nullptr, nullptr, 0, eArgTypeNone,
+     nullptr, {}, 0, eArgTypeNone,
      "Stop at the entry point of the program when launching a process."},
     {LLDB_OPT_SET_ALL, false, "disable-aslr", 'A',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Set whether to disable address space layout randomization when launching "
      "a process."},
     {LLDB_OPT_SET_ALL, false, "plugin", 'p', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypePlugin,
+     nullptr, {}, 0, eArgTypePlugin,
      "Name of the process plugin you want to use."},
     {LLDB_OPT_SET_ALL, false, "working-dir", 'w',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0,
+     OptionParser::eRequiredArgument, nullptr, {}, 0,
      eArgTypeDirectoryName,
      "Set the current working directory to <path> when running the inferior."},
     {LLDB_OPT_SET_ALL, false, "arch", 'a', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeArchitecture,
+     nullptr, {}, 0, eArgTypeArchitecture,
      "Set the architecture for the process to launch when ambiguous."},
     {LLDB_OPT_SET_ALL, false, "environment", 'v',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeNone,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeNone,
      "Specify an environment variable name/value string (--environment "
      "NAME=VALUE). Can be specified multiple times for subsequent environment "
      "entries."},
     {LLDB_OPT_SET_1 | LLDB_OPT_SET_2 | LLDB_OPT_SET_3, false, "shell", 'c',
-     OptionParser::eOptionalArgument, nullptr, nullptr, 0, eArgTypeFilename,
+     OptionParser::eOptionalArgument, nullptr, {}, 0, eArgTypeFilename,
      "Run the process in a shell (not supported on all platforms)."},
 
     {LLDB_OPT_SET_1, false, "stdin", 'i', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFilename,
+     nullptr, {}, 0, eArgTypeFilename,
      "Redirect stdin for the process to <filename>."},
     {LLDB_OPT_SET_1, false, "stdout", 'o', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFilename,
+     nullptr, {}, 0, eArgTypeFilename,
      "Redirect stdout for the process to <filename>."},
     {LLDB_OPT_SET_1, false, "stderr", 'e', OptionParser::eRequiredArgument,
-     nullptr, nullptr, 0, eArgTypeFilename,
+     nullptr, {}, 0, eArgTypeFilename,
      "Redirect stderr for the process to <filename>."},
 
     {LLDB_OPT_SET_2, false, "tty", 't', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone,
+     {}, 0, eArgTypeNone,
      "Start the process in a terminal (not supported on all platforms)."},
 
     {LLDB_OPT_SET_3, false, "no-stdio", 'n', OptionParser::eNoArgument, nullptr,
-     nullptr, 0, eArgTypeNone,
+     {}, 0, eArgTypeNone,
      "Do not set up for terminal I/O to go to running process."},
     {LLDB_OPT_SET_4, false, "shell-expand-args", 'X',
-     OptionParser::eRequiredArgument, nullptr, nullptr, 0, eArgTypeBoolean,
+     OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeBoolean,
      "Set whether to shell expand arguments to the process when launching."},
 };
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -4049,7 +4049,7 @@ SwiftDemangleNodeKindToCString(const swift::Demangle::Node::Kind node_kind) {
 
 static OptionDefinition g_swift_demangle_options[] = {
   // clang-format off
-  {LLDB_OPT_SET_1, false, "expand", 'e', OptionParser::eNoArgument, nullptr, nullptr, 0, eArgTypeNone, "Whether LLDB should print the demangled tree"},
+  {LLDB_OPT_SET_1, false, "expand", 'e', OptionParser::eNoArgument, nullptr, {}, 0, eArgTypeNone, "Whether LLDB should print the demangled tree"},
   // clang-format on
 };
 

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3590,16 +3590,19 @@ void Target::StopHook::GetDescription(Stream *s,
 // class TargetProperties
 //--------------------------------------------------------------
 
-OptionEnumValueElement lldb_private::g_dynamic_value_types[] = {
+static constexpr OptionEnumValueElement g_dynamic_value_types[] = {
     {eNoDynamicValues, "no-dynamic-values",
      "Don't calculate the dynamic type of values"},
     {eDynamicCanRunTarget, "run-target", "Calculate the dynamic type of values "
                                          "even if you have to run the target."},
     {eDynamicDontRunTarget, "no-run-target",
-     "Calculate the dynamic type of values, but don't run the target."},
-    {0, nullptr, nullptr}};
+     "Calculate the dynamic type of values, but don't run the target."} };
 
-static OptionEnumValueElement g_inline_breakpoint_enums[] = {
+OptionEnumValues lldb_private::GetDynamicValueTypes() {
+  return OptionEnumValues(g_dynamic_value_types);
+}
+
+static constexpr OptionEnumValueElement g_inline_breakpoint_enums[] = {
     {eInlineBreakpointsNever, "never", "Never look for inline breakpoint "
                                        "locations (fastest). This setting "
                                        "should only be used if you know that "
@@ -3610,8 +3613,7 @@ static OptionEnumValueElement g_inline_breakpoint_enums[] = {
      "files (default)."},
     {eInlineBreakpointsAlways, "always",
      "Always look for inline breakpoint locations when setting file and line "
-     "breakpoints (slower but most accurate)."},
-    {0, nullptr, nullptr}};
+     "breakpoints (slower but most accurate)."} };
 
 typedef enum x86DisassemblyFlavor {
   eX86DisFlavorDefault,
@@ -3619,36 +3621,33 @@ typedef enum x86DisassemblyFlavor {
   eX86DisFlavorATT
 } x86DisassemblyFlavor;
 
-static OptionEnumValueElement g_x86_dis_flavor_value_types[] = {
+static constexpr OptionEnumValueElement g_x86_dis_flavor_value_types[] = {
     {eX86DisFlavorDefault, "default", "Disassembler default (currently att)."},
     {eX86DisFlavorIntel, "intel", "Intel disassembler flavor."},
-    {eX86DisFlavorATT, "att", "AT&T disassembler flavor."},
-    {0, nullptr, nullptr}};
+    {eX86DisFlavorATT, "att", "AT&T disassembler flavor."} };
 
-static OptionEnumValueElement g_hex_immediate_style_values[] = {
+static constexpr OptionEnumValueElement g_hex_immediate_style_values[] = {
     {Disassembler::eHexStyleC, "c", "C-style (0xffff)."},
-    {Disassembler::eHexStyleAsm, "asm", "Asm-style (0ffffh)."},
-    {0, nullptr, nullptr}};
+    {Disassembler::eHexStyleAsm, "asm", "Asm-style (0ffffh)."} };
 
-static OptionEnumValueElement g_load_script_from_sym_file_values[] = {
+static constexpr OptionEnumValueElement g_load_script_from_sym_file_values[] = {
     {eLoadScriptFromSymFileTrue, "true",
      "Load debug scripts inside symbol files"},
     {eLoadScriptFromSymFileFalse, "false",
      "Do not load debug scripts inside symbol files."},
     {eLoadScriptFromSymFileWarn, "warn",
-     "Warn about debug scripts inside symbol files but do not load them."},
-    {0, nullptr, nullptr}};
+     "Warn about debug scripts inside symbol files but do not load them."} };
 
-static OptionEnumValueElement g_load_current_working_dir_lldbinit_values[] = {
+static constexpr
+OptionEnumValueElement g_load_current_working_dir_lldbinit_values[] = {
     {eLoadCWDlldbinitTrue, "true",
      "Load .lldbinit files from current directory"},
     {eLoadCWDlldbinitFalse, "false",
      "Do not load .lldbinit files from current directory"},
     {eLoadCWDlldbinitWarn, "warn",
-     "Warn about loading .lldbinit files from current directory"},
-    {0, nullptr, nullptr}};
+     "Warn about loading .lldbinit files from current directory"} };
 
-static OptionEnumValueElement g_memory_module_load_level_values[] = {
+static constexpr OptionEnumValueElement g_memory_module_load_level_values[] = {
     {eMemoryModuleLoadLevelMinimal, "minimal",
      "Load minimal information when loading modules from memory. Currently "
      "this setting loads sections only."},
@@ -3657,28 +3656,27 @@ static OptionEnumValueElement g_memory_module_load_level_values[] = {
      "this setting loads sections and function bounds."},
     {eMemoryModuleLoadLevelComplete, "complete",
      "Load complete information when loading modules from memory. Currently "
-     "this setting loads sections and all symbols."},
-    {0, nullptr, nullptr}};
+     "this setting loads sections and all symbols."} };
 
-static PropertyDefinition g_properties[] = {
-    {"default-arch", OptionValue::eTypeArch, true, 0, nullptr, nullptr,
+static constexpr PropertyDefinition g_properties[] = {
+    {"default-arch", OptionValue::eTypeArch, true, 0, nullptr, {},
      "Default architecture to choose, when there's a choice."},
     {"move-to-nearest-code", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Move breakpoints to nearest code."},
+     {}, "Move breakpoints to nearest code."},
     {"language", OptionValue::eTypeLanguage, false, eLanguageTypeUnknown,
-     nullptr, nullptr,
+     nullptr, {},
      "The language to use when interpreting expressions entered in commands."},
-    {"expr-prefix", OptionValue::eTypeFileSpec, false, 0, nullptr, nullptr,
+    {"expr-prefix", OptionValue::eTypeFileSpec, false, 0, nullptr, {},
      "Path to a file containing expressions to be prepended to all "
      "expressions."},
     {"prefer-dynamic-value", OptionValue::eTypeEnum, false,
-     eDynamicDontRunTarget, nullptr, g_dynamic_value_types,
+     eDynamicDontRunTarget, nullptr, OptionEnumValues(g_dynamic_value_types),
      "Should printed values be shown as their dynamic value."},
     {"enable-synthetic-value", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Should synthetic values be used by default whenever available."},
-    {"skip-prologue", OptionValue::eTypeBoolean, false, true, nullptr, nullptr,
+     {}, "Should synthetic values be used by default whenever available."},
+    {"skip-prologue", OptionValue::eTypeBoolean, false, true, nullptr, {},
      "Skip function prologues when setting breakpoints by name."},
-    {"source-map", OptionValue::eTypePathMap, false, 0, nullptr, nullptr,
+    {"source-map", OptionValue::eTypePathMap, false, 0, nullptr, {},
      "Source path remappings are used to track the change of location between "
      "a source file when built, and "
      "where it exists on the current system.  It consists of an array of "
@@ -3690,13 +3688,13 @@ static PropertyDefinition g_properties[] = {
      "Each element of the array is checked in order and the first one that "
      "results in a match wins."},
     {"exec-search-paths", OptionValue::eTypeFileSpecList, false, 0, nullptr,
-     nullptr, "Executable search paths to use when locating executable files "
-              "whose paths don't match the local file system."},
+     {}, "Executable search paths to use when locating executable files "
+         "whose paths don't match the local file system."},
     {"debug-file-search-paths", OptionValue::eTypeFileSpecList, false, 0,
-     nullptr, nullptr,
+     nullptr, {},
      "List of directories to be searched when locating debug symbol files."},
     {"clang-module-search-paths", OptionValue::eTypeFileSpecList, false, 0,
-     nullptr, nullptr,
+     nullptr, {},
      "List of directories to be searched when locating modules for Clang."},
     {"swift-framework-search-paths", OptionValue::eTypeFileSpecList, false, 0,
      nullptr, nullptr,
@@ -3705,60 +3703,61 @@ static PropertyDefinition g_properties[] = {
      nullptr, nullptr,
      "List of directories to be searched when locating modules for Swift."},
     {"auto-import-clang-modules", OptionValue::eTypeBoolean, false, true,
-     nullptr, nullptr,
+     nullptr, {},
      "Automatically load Clang modules referred to by the program."},
     {"use-all-compiler-flags", OptionValue::eTypeBoolean, false, true, nullptr,
      nullptr, "Try to use compiler flags for all modules when setting up the "
               "Swift expression parser, not just the main executable."},
     {"auto-apply-fixits", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Automatically apply fix-it hints to expressions."},
+     {}, "Automatically apply fix-it hints to expressions."},
     {"notify-about-fixits", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Print the fixed expression text."},
+     {}, "Print the fixed expression text."},
     {"save-jit-objects", OptionValue::eTypeBoolean, false, false, nullptr,
-     nullptr, "Save intermediate object files generated by the LLVM JIT"},
+     {}, "Save intermediate object files generated by the LLVM JIT"},
     {"max-children-count", OptionValue::eTypeSInt64, false, 256, nullptr,
-     nullptr, "Maximum number of children to expand in any level of depth."},
+     {}, "Maximum number of children to expand in any level of depth."},
     {"max-string-summary-length", OptionValue::eTypeSInt64, false, 1024,
-     nullptr, nullptr,
+     nullptr, {},
      "Maximum number of characters to show when using %s in summary strings."},
     {"max-memory-read-size", OptionValue::eTypeSInt64, false, 1024, nullptr,
-     nullptr, "Maximum number of bytes that 'memory read' will fetch before "
-              "--force must be specified."},
+     {}, "Maximum number of bytes that 'memory read' will fetch before "
+         "--force must be specified."},
     {"breakpoints-use-platform-avoid-list", OptionValue::eTypeBoolean, false,
-     true, nullptr, nullptr, "Consult the platform module avoid list when "
-                             "setting non-module specific breakpoints."},
-    {"arg0", OptionValue::eTypeString, false, 0, nullptr, nullptr,
+     true, nullptr, {}, "Consult the platform module avoid list when "
+                        "setting non-module specific breakpoints."},
+    {"arg0", OptionValue::eTypeString, false, 0, nullptr, {},
      "The first argument passed to the program in the argument array which can "
      "be different from the executable itself."},
-    {"run-args", OptionValue::eTypeArgs, false, 0, nullptr, nullptr,
+    {"run-args", OptionValue::eTypeArgs, false, 0, nullptr, {},
      "A list containing all the arguments to be passed to the executable when "
      "it is run. Note that this does NOT include the argv[0] which is in "
      "target.arg0."},
     {"env-vars", OptionValue::eTypeDictionary, false, OptionValue::eTypeString,
-     nullptr, nullptr, "A list of all the environment variables to be passed "
-                       "to the executable's environment, and their values."},
-    {"inherit-env", OptionValue::eTypeBoolean, false, true, nullptr, nullptr,
+     nullptr, {}, "A list of all the environment variables to be passed "
+                  "to the executable's environment, and their values."},
+    {"inherit-env", OptionValue::eTypeBoolean, false, true, nullptr, {},
      "Inherit the environment from the process that is running LLDB."},
-    {"input-path", OptionValue::eTypeFileSpec, false, 0, nullptr, nullptr,
+    {"input-path", OptionValue::eTypeFileSpec, false, 0, nullptr, {},
      "The file/path to be used by the executable program for reading its "
      "standard input."},
-    {"output-path", OptionValue::eTypeFileSpec, false, 0, nullptr, nullptr,
+    {"output-path", OptionValue::eTypeFileSpec, false, 0, nullptr, {},
      "The file/path to be used by the executable program for writing its "
      "standard output."},
-    {"error-path", OptionValue::eTypeFileSpec, false, 0, nullptr, nullptr,
+    {"error-path", OptionValue::eTypeFileSpec, false, 0, nullptr, {},
      "The file/path to be used by the executable program for writing its "
      "standard error."},
     {"detach-on-error", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "debugserver will detach (rather than killing) a process if it "
+     {}, "debugserver will detach (rather than killing) a process if it "
               "loses connection with lldb."},
-    {"preload-symbols", OptionValue::eTypeBoolean, false, true, nullptr, nullptr,
+    {"preload-symbols", OptionValue::eTypeBoolean, false, true, nullptr, {},
      "Enable loading of symbol tables before they are needed."},
-    {"disable-aslr", OptionValue::eTypeBoolean, false, true, nullptr, nullptr,
+    {"disable-aslr", OptionValue::eTypeBoolean, false, true, nullptr, {},
      "Disable Address Space Layout Randomization (ASLR)"},
-    {"disable-stdio", OptionValue::eTypeBoolean, false, false, nullptr, nullptr,
+    {"disable-stdio", OptionValue::eTypeBoolean, false, false, nullptr, {},
      "Disable stdin/stdout for process (e.g. for a GUI application)"},
     {"inline-breakpoint-strategy", OptionValue::eTypeEnum, false,
-     eInlineBreakpointsAlways, nullptr, g_inline_breakpoint_enums,
+     eInlineBreakpointsAlways, nullptr,
+     OptionEnumValues(g_inline_breakpoint_enums),
      "The strategy to use when settings breakpoints by file and line. "
      "Breakpoint locations can end up being inlined by the compiler, so that a "
      "compile unit 'a.c' might contain an inlined function from another source "
@@ -3778,25 +3777,29 @@ static PropertyDefinition g_properties[] = {
     // FIXME: This is the wrong way to do per-architecture settings, but we
     // don't have a general per architecture settings system in place yet.
     {"x86-disassembly-flavor", OptionValue::eTypeEnum, false,
-     eX86DisFlavorDefault, nullptr, g_x86_dis_flavor_value_types,
+     eX86DisFlavorDefault, nullptr,
+     OptionEnumValues(g_x86_dis_flavor_value_types),
      "The default disassembly flavor to use for x86 or x86-64 targets."},
     {"use-hex-immediates", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Show immediates in disassembly as hexadecimal."},
+     {}, "Show immediates in disassembly as hexadecimal."},
     {"hex-immediate-style", OptionValue::eTypeEnum, false,
-     Disassembler::eHexStyleC, nullptr, g_hex_immediate_style_values,
+     Disassembler::eHexStyleC, nullptr,
+     OptionEnumValues(g_hex_immediate_style_values),
      "Which style to use for printing hexadecimal disassembly values."},
     {"use-fast-stepping", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Use a fast stepping algorithm based on running from branch to "
-              "branch rather than instruction single-stepping."},
+     {}, "Use a fast stepping algorithm based on running from branch to "
+         "branch rather than instruction single-stepping."},
     {"load-script-from-symbol-file", OptionValue::eTypeEnum, false,
-     eLoadScriptFromSymFileWarn, nullptr, g_load_script_from_sym_file_values,
+     eLoadScriptFromSymFileWarn, nullptr,
+     OptionEnumValues(g_load_script_from_sym_file_values),
      "Allow LLDB to load scripting resources embedded in symbol files when "
      "available."},
     {"load-cwd-lldbinit", OptionValue::eTypeEnum, false, eLoadCWDlldbinitWarn,
-     nullptr, g_load_current_working_dir_lldbinit_values,
+     nullptr, OptionEnumValues(g_load_current_working_dir_lldbinit_values),
      "Allow LLDB to .lldbinit files from the current directory automatically."},
     {"memory-module-load-level", OptionValue::eTypeEnum, false,
-     eMemoryModuleLoadLevelComplete, nullptr, g_memory_module_load_level_values,
+     eMemoryModuleLoadLevelComplete, nullptr,
+     OptionEnumValues(g_memory_module_load_level_values),
      "Loading modules from memory can be slow as reading the symbol tables and "
      "other data can take a long time depending on your connection to the "
      "debug target. "
@@ -3812,22 +3815,21 @@ static PropertyDefinition g_properties[] = {
      "symbols, but should rarely be used as stack frames in these memory "
      "regions will be inaccurate and not provide any context (fastest). "},
     {"display-expression-in-crashlogs", OptionValue::eTypeBoolean, false, false,
-     nullptr, nullptr, "Expressions that crash will show up in crash logs if "
-                       "the host system supports executable specific crash log "
-                       "strings and this setting is set to true."},
+     nullptr, {}, "Expressions that crash will show up in crash logs if "
+                  "the host system supports executable specific crash log "
+                  "strings and this setting is set to true."},
     {"trap-handler-names", OptionValue::eTypeArray, true,
-     OptionValue::eTypeString, nullptr, nullptr,
+     OptionValue::eTypeString, nullptr, {},
      "A list of trap handler function names, e.g. a common Unix user process "
      "one is _sigtramp."},
     {"sdk-path", OptionValue::eTypeFileSpec, false, 0, nullptr, nullptr,
      "The path to the SDK used to build the current target."},
     {"display-runtime-support-values", OptionValue::eTypeBoolean, false, false,
-     nullptr, nullptr, "If true, LLDB will show variables that are meant to "
-                       "support the operation of a language's runtime "
-                       "support."},
-    {"non-stop-mode", OptionValue::eTypeBoolean, false, 0, nullptr, nullptr,
+     nullptr, {}, "If true, LLDB will show variables that are meant to "
+                  "support the operation of a language's runtime support."},
+    {"non-stop-mode", OptionValue::eTypeBoolean, false, 0, nullptr, {},
      "Disable lock-step debugging, instead control threads independently."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum {
   ePropertyDefaultArch,
@@ -3953,18 +3955,18 @@ protected:
 //----------------------------------------------------------------------
 // TargetProperties
 //----------------------------------------------------------------------
-static PropertyDefinition g_experimental_properties[]{
+static constexpr PropertyDefinition g_experimental_properties[]{
     {"inject-local-vars", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr,
+     {},
      "If true, inject local variables explicitly into the expression text.  "
      "This will fix symbol resolution when there are name collisions between "
      "ivars and local variables.  "
      "But it can make expressions run much more slowly."},
     {"use-modern-type-lookup", OptionValue::eTypeBoolean, true, false, nullptr,
-     nullptr, "If true, use Clang's modern type lookup infrastructure."},
-    {"swift-create-module-contexts-in-parallel", OptionValue::eTypeBoolean, false, true,
-     nullptr, nullptr, "Create the per-module Swift AST contexts in parallel."},
-    {nullptr, OptionValue::eTypeInvalid, true, 0, nullptr, nullptr, nullptr}};
+     {}, "If true, use Clang's modern type lookup infrastructure."},
+    {"swift-create-module-contexts-in-parallel", OptionValue::eTypeBoolean,
+     false, true, nullptr, {},
+     "Create the per-module Swift AST contexts in parallel."}};
 
 enum {
   ePropertyInjectLocalVars = 0,

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3697,17 +3697,17 @@ static constexpr PropertyDefinition g_properties[] = {
      nullptr, {},
      "List of directories to be searched when locating modules for Clang."},
     {"swift-framework-search-paths", OptionValue::eTypeFileSpecList, false, 0,
-     nullptr, nullptr,
+     nullptr, {},
      "List of directories to be searched when locating frameworks for Swift."},
     {"swift-module-search-paths", OptionValue::eTypeFileSpecList, false, 0,
-     nullptr, nullptr,
+     nullptr, {},
      "List of directories to be searched when locating modules for Swift."},
     {"auto-import-clang-modules", OptionValue::eTypeBoolean, false, true,
      nullptr, {},
      "Automatically load Clang modules referred to by the program."},
     {"use-all-compiler-flags", OptionValue::eTypeBoolean, false, true, nullptr,
-     nullptr, "Try to use compiler flags for all modules when setting up the "
-              "Swift expression parser, not just the main executable."},
+     {}, "Try to use compiler flags for all modules when setting up the "
+         "Swift expression parser, not just the main executable."},
     {"auto-apply-fixits", OptionValue::eTypeBoolean, false, true, nullptr,
      {}, "Automatically apply fix-it hints to expressions."},
     {"notify-about-fixits", OptionValue::eTypeBoolean, false, true, nullptr,
@@ -3822,7 +3822,7 @@ static constexpr PropertyDefinition g_properties[] = {
      OptionValue::eTypeString, nullptr, {},
      "A list of trap handler function names, e.g. a common Unix user process "
      "one is _sigtramp."},
-    {"sdk-path", OptionValue::eTypeFileSpec, false, 0, nullptr, nullptr,
+    {"sdk-path", OptionValue::eTypeFileSpec, false, 0, nullptr, {},
      "The path to the SDK used to build the current target."},
     {"display-runtime-support-values", OptionValue::eTypeBoolean, false, false,
      nullptr, {}, "If true, LLDB will show variables that are meant to "

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3828,8 +3828,7 @@ static constexpr PropertyDefinition g_properties[] = {
      nullptr, {}, "If true, LLDB will show variables that are meant to "
                   "support the operation of a language's runtime support."},
     {"non-stop-mode", OptionValue::eTypeBoolean, false, 0, nullptr, {},
-     "Disable lock-step debugging, instead control threads independently."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+     "Disable lock-step debugging, instead control threads independently."}};
 
 enum {
   ePropertyDefaultArch,

--- a/source/Target/Thread.cpp
+++ b/source/Target/Thread.cpp
@@ -64,25 +64,24 @@ const ThreadPropertiesSP &Thread::GetGlobalProperties() {
   return *g_settings_sp_ptr;
 }
 
-static PropertyDefinition g_properties[] = {
+static constexpr PropertyDefinition g_properties[] = {
     {"step-in-avoid-nodebug", OptionValue::eTypeBoolean, true, true, nullptr,
-     nullptr,
+     {},
      "If true, step-in will not stop in functions with no debug information."},
     {"step-out-avoid-nodebug", OptionValue::eTypeBoolean, true, false, nullptr,
-     nullptr, "If true, when step-in/step-out/step-over leave the current "
-              "frame, they will continue to step out till they come to a "
-              "function with "
-              "debug information.  Passing a frame argument to step-out will "
-              "override this option."},
-    {"step-avoid-regexp", OptionValue::eTypeRegex, true, 0, "^std::", nullptr,
+     {}, "If true, when step-in/step-out/step-over leave the current frame, "
+         "they will continue to step out till they come to a function with "
+         "debug information. Passing a frame argument to step-out will "
+         "override this option."},
+    {"step-avoid-regexp", OptionValue::eTypeRegex, true, 0, "^std::", {},
      "A regular expression defining functions step-in won't stop in."},
     {"step-avoid-libraries", OptionValue::eTypeFileSpecList, true, 0, nullptr,
-     nullptr, "A list of libraries that source stepping won't stop in."},
-    {"trace-thread", OptionValue::eTypeBoolean, false, false, nullptr, nullptr,
+     {}, "A list of libraries that source stepping won't stop in."},
+    {"trace-thread", OptionValue::eTypeBoolean, false, false, nullptr, {},
      "If true, this thread will single-step and log execution."},
     {"max-backtrace-depth", OptionValue::eTypeUInt64, false, 300000, nullptr,
-     nullptr, "Maximum number of frames to backtrace."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, nullptr, nullptr}};
+     {}, "Maximum number of frames to backtrace."},
+    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
 
 enum {
   ePropertyStepInAvoidsNoDebug,

--- a/source/Target/Thread.cpp
+++ b/source/Target/Thread.cpp
@@ -80,8 +80,7 @@ static constexpr PropertyDefinition g_properties[] = {
     {"trace-thread", OptionValue::eTypeBoolean, false, false, nullptr, {},
      "If true, this thread will single-step and log execution."},
     {"max-backtrace-depth", OptionValue::eTypeUInt64, false, 300000, nullptr,
-     {}, "Maximum number of frames to backtrace."},
-    {nullptr, OptionValue::eTypeInvalid, false, 0, nullptr, {}, nullptr}};
+     {}, "Maximum number of frames to backtrace."}};
 
 enum {
   ePropertyStepInAvoidsNoDebug,

--- a/tools/driver/Driver.cpp
+++ b/tools/driver/Driver.cpp
@@ -9,6 +9,7 @@
 
 #include "Driver.h"
 
+#include <algorithm>
 #include <atomic>
 #include <csignal>
 #include <fcntl.h>
@@ -46,6 +47,7 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Signals.h"
 #include <thread>
+#include <utility>
 
 #if !defined(__APPLE__)
 #include "llvm/Support/DataTypes.h"
@@ -87,7 +89,7 @@ typedef struct {
 #define LLDB_3_TO_5 LLDB_OPT_SET_3 | LLDB_OPT_SET_4 | LLDB_OPT_SET_5
 #define LLDB_4_TO_5 LLDB_OPT_SET_4 | LLDB_OPT_SET_5
 
-static OptionDefinition g_options[] = {
+static constexpr OptionDefinition g_options[] = {
     {LLDB_OPT_SET_1, true, "help", 'h', no_argument, 0, eArgTypeNone,
      "Prints out the usage information for the LLDB debugger."},
     {LLDB_OPT_SET_2, true, "version", 'v', no_argument, 0, eArgTypeNone,
@@ -159,8 +161,9 @@ static OptionDefinition g_options[] = {
     {LLDB_OPT_SET_7, true, "repl", 'r', optional_argument, 0, eArgTypeNone,
      "Runs lldb in REPL mode with a stub process."},
     {LLDB_OPT_SET_7, true, "repl-language", 'R', required_argument, 0,
-     eArgTypeNone, "Chooses the language for the REPL."},
-    {0, false, NULL, 0, 0, 0, eArgTypeNone, NULL}};
+     eArgTypeNone, "Chooses the language for the REPL."}};
+
+static constexpr auto g_num_options = sizeof(g_options)/sizeof(OptionDefinition);
 
 static const uint32_t last_option_set_with_args = 2;
 
@@ -229,8 +232,7 @@ void OutputFormattedUsageText(FILE *out, int indent, const char *text,
   }
 }
 
-void ShowUsage(FILE *out, OptionDefinition *option_table,
-               Driver::OptionData data) {
+static void ShowUsage(FILE *out, Driver::OptionData data) {
   uint32_t screen_width = 80;
   uint32_t indent_level = 0;
   const char *name = "lldb";
@@ -245,12 +247,10 @@ void ShowUsage(FILE *out, OptionDefinition *option_table,
   //                                                   [options-for-level-1]
   //                                                   etc.
 
-  uint32_t num_options;
   uint32_t num_option_sets = 0;
 
-  for (num_options = 0; option_table[num_options].long_option != NULL;
-       ++num_options) {
-    uint32_t this_usage_mask = option_table[num_options].usage_mask;
+  for (const auto &opt : g_options) {
+    uint32_t this_usage_mask = opt.usage_mask;
     if (this_usage_mask == LLDB_OPT_SET_ALL) {
       if (num_option_sets == 0)
         num_option_sets = 1;
@@ -274,32 +274,32 @@ void ShowUsage(FILE *out, OptionDefinition *option_table,
     fprintf(out, "%*s%s", indent_level, "", name);
     bool is_help_line = false;
 
-    for (uint32_t i = 0; i < num_options; ++i) {
-      if (option_table[i].usage_mask & opt_set_mask) {
-        CommandArgumentType arg_type = option_table[i].argument_type;
+    for (const auto &opt : g_options) {
+      if (opt.usage_mask & opt_set_mask) {
+        CommandArgumentType arg_type = opt.argument_type;
         const char *arg_name =
             SBCommandInterpreter::GetArgumentTypeAsCString(arg_type);
         // This is a bit of a hack, but there's no way to say certain options
         // don't have arguments yet...
         // so we do it by hand here.
-        if (option_table[i].short_option == 'h')
+        if (opt.short_option == 'h')
           is_help_line = true;
 
-        if (option_table[i].required) {
-          if (option_table[i].option_has_arg == required_argument)
-            fprintf(out, " -%c <%s>", option_table[i].short_option, arg_name);
-          else if (option_table[i].option_has_arg == optional_argument)
-            fprintf(out, " -%c [<%s>]", option_table[i].short_option, arg_name);
+        if (opt.required) {
+          if (opt.option_has_arg == required_argument)
+            fprintf(out, " -%c <%s>", opt.short_option, arg_name);
+          else if (opt.option_has_arg == optional_argument)
+            fprintf(out, " -%c [<%s>]", opt.short_option, arg_name);
           else
-            fprintf(out, " -%c", option_table[i].short_option);
+            fprintf(out, " -%c", opt.short_option);
         } else {
-          if (option_table[i].option_has_arg == required_argument)
-            fprintf(out, " [-%c <%s>]", option_table[i].short_option, arg_name);
-          else if (option_table[i].option_has_arg == optional_argument)
-            fprintf(out, " [-%c [<%s>]]", option_table[i].short_option,
+          if (opt.option_has_arg == required_argument)
+            fprintf(out, " [-%c <%s>]", opt.short_option, arg_name);
+          else if (opt.option_has_arg == optional_argument)
+            fprintf(out, " [-%c [<%s>]]", opt.short_option,
                     arg_name);
           else
-            fprintf(out, " [-%c]", option_table[i].short_option);
+            fprintf(out, " [-%c]", opt.short_option);
         }
       }
     }
@@ -325,25 +325,25 @@ void ShowUsage(FILE *out, OptionDefinition *option_table,
 
   indent_level += 5;
 
-  for (uint32_t i = 0; i < num_options; ++i) {
+  for (const auto &opt : g_options) {
     // Only print this option if we haven't already seen it.
-    pos = options_seen.find(option_table[i].short_option);
+    pos = options_seen.find(opt.short_option);
     if (pos == options_seen.end()) {
-      CommandArgumentType arg_type = option_table[i].argument_type;
+      CommandArgumentType arg_type = opt.argument_type;
       const char *arg_name =
           SBCommandInterpreter::GetArgumentTypeAsCString(arg_type);
 
-      options_seen.insert(option_table[i].short_option);
-      fprintf(out, "%*s-%c ", indent_level, "", option_table[i].short_option);
+      options_seen.insert(opt.short_option);
+      fprintf(out, "%*s-%c ", indent_level, "", opt.short_option);
       if (arg_type != eArgTypeNone)
         fprintf(out, "<%s>", arg_name);
       fprintf(out, "\n");
-      fprintf(out, "%*s--%s ", indent_level, "", option_table[i].long_option);
+      fprintf(out, "%*s--%s ", indent_level, "", opt.long_option);
       if (arg_type != eArgTypeNone)
         fprintf(out, "<%s>", arg_name);
       fprintf(out, "\n");
       indent_level += 5;
-      OutputFormattedUsageText(out, indent_level, option_table[i].usage_text,
+      OutputFormattedUsageText(out, indent_level, opt.usage_text,
                                screen_width);
       indent_level -= 5;
       fprintf(out, "\n");
@@ -380,26 +380,19 @@ void ShowUsage(FILE *out, OptionDefinition *option_table,
       "");
 }
 
-void BuildGetOptTable(OptionDefinition *expanded_option_table,
-                      std::vector<struct option> &getopt_table,
-                      uint32_t num_options) {
-  if (num_options == 0)
-    return;
+ static void BuildGetOptTable(std::vector<option> &getopt_table) {
+  getopt_table.resize(g_num_options + 1);
 
-  uint32_t i;
-  uint32_t j;
   std::bitset<256> option_seen;
-
-  getopt_table.resize(num_options + 1);
-
-  for (i = 0, j = 0; i < num_options; ++i) {
-    char short_opt = expanded_option_table[i].short_option;
+  uint32_t j = 0;
+  for (const auto &opt : g_options) {
+    char short_opt = opt.short_option;
 
     if (option_seen.test(short_opt) == false) {
-      getopt_table[j].name = expanded_option_table[i].long_option;
-      getopt_table[j].has_arg = expanded_option_table[i].option_has_arg;
+      getopt_table[j].name = opt.long_option;
+      getopt_table[j].has_arg = opt.option_has_arg;
       getopt_table[j].flag = NULL;
-      getopt_table[j].val = expanded_option_table[i].short_option;
+      getopt_table[j].val = opt.short_option;
       option_seen.set(short_opt);
       ++j;
     }
@@ -582,44 +575,30 @@ bool Driver::GetDebugMode() const { return m_option_data.m_debug_mode; }
 
 SBError Driver::ParseArgs(int argc, const char *argv[], FILE *out_fh,
                           bool &exiting) {
+  static_assert(g_num_options > 0, "cannot handle arguments");
+
   ResetOptionValues();
 
-  SBCommandReturnObject result;
+  // No arguments or just program name, nothing to parse.
+  if (argc <= 1)
+    return SBError();
 
   SBError error;
-  std::string option_string;
-  struct option *long_options = NULL;
-  std::vector<struct option> long_options_vector;
-  uint32_t num_options;
-
-  for (num_options = 0; g_options[num_options].long_option != NULL;
-       ++num_options)
-    /* Do Nothing. */;
-
-  if (num_options == 0) {
-    if (argc > 1)
-      error.SetErrorStringWithFormat("invalid number of options");
-    return error;
-  }
-
-  BuildGetOptTable(g_options, long_options_vector, num_options);
-
-  if (long_options_vector.empty())
-    long_options = NULL;
-  else
-    long_options = &long_options_vector.front();
-
-  if (long_options == NULL) {
+  std::vector<option> long_options_vector;
+  BuildGetOptTable(long_options_vector);
+  if (long_options_vector.empty()) {
     error.SetErrorStringWithFormat("invalid long options");
     return error;
   }
 
   // Build the option_string argument for call to getopt_long_only.
-
-  for (int i = 0; long_options[i].name != NULL; ++i) {
-    if (long_options[i].flag == NULL) {
-      option_string.push_back((char)long_options[i].val);
-      switch (long_options[i].has_arg) {
+  std::string option_string;
+  auto sentinel_it = std::prev(std::end(long_options_vector));
+  for (auto long_opt_it = std::begin(long_options_vector);
+            long_opt_it != sentinel_it; ++long_opt_it) {
+    if (long_opt_it->flag == nullptr) {
+      option_string.push_back(static_cast<char>(long_opt_it->val));
+      switch (long_opt_it->has_arg) {
       default:
       case no_argument:
         break;
@@ -657,7 +636,7 @@ SBError Driver::ParseArgs(int argc, const char *argv[], FILE *out_fh,
   while (1) {
     int long_options_index = -1;
     val = ::getopt_long_only(argc, const_cast<char **>(argv),
-                             option_string.c_str(), long_options,
+                             option_string.c_str(), long_options_vector.data(),
                              &long_options_index);
 
     if (val == -1)
@@ -671,14 +650,11 @@ SBError Driver::ParseArgs(int argc, const char *argv[], FILE *out_fh,
     else {
       m_option_data.m_seen_options.insert((char)val);
       if (long_options_index == -1) {
-        for (int i = 0; long_options[i].name || long_options[i].has_arg ||
-                        long_options[i].flag || long_options[i].val;
-             ++i) {
-          if (long_options[i].val == val) {
-            long_options_index = i;
-            break;
-          }
-        }
+        auto long_opt_it = std::find_if(std::begin(long_options_vector), sentinel_it,
+            [val](const option &long_option) { return long_option.val == val; });
+        if (std::end(long_options_vector) != long_opt_it)
+          long_options_index =
+              std::distance(std::begin(long_options_vector), long_opt_it);
       }
 
       if (long_options_index >= 0) {
@@ -831,7 +807,7 @@ SBError Driver::ParseArgs(int argc, const char *argv[], FILE *out_fh,
   }
 
   if (error.Fail() || m_option_data.m_print_help) {
-    ShowUsage(out_fh, g_options, m_option_data);
+    ShowUsage(out_fh, m_option_data);
     exiting = true;
   } else if (m_option_data.m_print_version) {
     ::fprintf(out_fh, "%s\n", m_debugger.GetVersionString());

--- a/tools/driver/Driver.h
+++ b/tools/driver/Driver.h
@@ -68,8 +68,6 @@ public:
     void AddInitialCommand(const char *command, CommandPlacement placement,
                            bool is_file, lldb::SBError &error);
 
-    // static OptionDefinition m_cmd_option_table[];
-
     struct InitialCmdEntry {
       InitialCmdEntry(const char *in_contents, bool in_is_file,
                       bool is_cwd_lldbinit_file_read, bool in_quiet = false)


### PR DESCRIPTION
Cherry-picking this to `stable` in preparation for my changes from https://reviews.llvm.org/D52788 (Add EchoCommentCommands) and https://reviews.llvm.org/D52270 (TestMultilineExpr).

Double-checked conflict resolutions with `upstream-with-swift`. Should be fine.