### PR TITLE
[Swift] Support evaluating of `$0`/`$1` etc.. inside a closure.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -1,0 +1,16 @@
+# TestAccelerateSIMD.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(),
+                          decorators=[swiftTest,skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -1,4 +1,4 @@
-# TestAccelerateSIMD.py
+# TestClosureShortcuts.py
 #
 # This source file is part of the Swift.org open source project
 #
@@ -13,4 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin])
+                          decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/closure_shortcuts/main.swift
@@ -1,0 +1,14 @@
+func main() -> Int {
+  let names = ["foo", "patatino"]
+
+  var reversedNames = names.sorted(by: {
+    $0 > $1 } //%self.expect('p $0', substrs=['patatino'])
+              //%self.expect('p $1', substrs=['foo'])
+              //%self.expect('frame var $0', substrs=['patatino'])
+              //%self.expect('frame var $1', substrs=['foo'])
+  )
+
+  return 0
+}
+
+_ = main()

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1184,13 +1184,8 @@ static swift::ASTContext *SetupASTContext(
   if (disable_objc_runtime())
     swift_ast_context->GetLanguageOptions().EnableObjCInterop = false;
 
-  if (repl || playground) {
-    swift_ast_context->GetLanguageOptions().Playground = true;
-    swift_ast_context->GetIRGenOptions().Playground = true;
-  } else {
-    swift_ast_context->GetLanguageOptions().Playground = true;
-    swift_ast_context->GetIRGenOptions().Playground = false;
-  }
+  swift_ast_context->GetLanguageOptions().Playground = repl || playground;
+  swift_ast_context->GetIRGenOptions().Playground = repl || playground;
 
   // For the expression parser and REPL we want to relax the
   // requirement that you put "try" in front of every expression that


### PR DESCRIPTION
<rdar://problem/20719448>