### PR TITLE
V for frame var

### DIFF
--- a/source/Commands/CommandObjectFrame.cpp
+++ b/source/Commands/CommandObjectFrame.cpp
@@ -427,7 +427,17 @@ public:
             "arguments and local variables in scope. Names of argument, "
             "local, file static and file global variables can be specified. "
             "Children of aggregate variables can be specified such as "
-            "'var->child.x'.",
+            "'var->child.x'.  The -> and [] operators in 'frame variable' do "
+            "not invoke operator overloads if they exist, but directly access "
+            "the specified element.  If you want to trigger operator overloads "
+            "use the expression command to print the variable instead."
+            "\nIt is worth noting that except for overloaded "
+            "operators, when printing local variables 'expr local_var' and "
+            "'frame var local_var' produce the same "
+            "results.  However, 'frame variable' is more efficient, since it "
+            "uses debug information and memory reads directly, rather than "
+            "parsing and evaluating an expression, which may even involve "
+            "JITing and running code in the target program.",
             nullptr, eCommandRequiresFrame | eCommandTryTargetAPILock |
                          eCommandProcessMustBeLaunched |
                          eCommandProcessMustBePaused | eCommandRequiresProcess),

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -427,6 +427,13 @@ void CommandInterpreter::Initialize() {
   if (cmd_obj_sp) {
     AddAlias("rbreak", cmd_obj_sp, "--func-regex %1");
   }
+
+  cmd_obj_sp = GetCommandSPExact("frame variable", false);
+  if (cmd_obj_sp) {
+    AddAlias("var", cmd_obj_sp);
+    AddAlias("vo", cmd_obj_sp, "--object-description");
+  }
+  
 }
 
 void CommandInterpreter::Clear() {

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -430,6 +430,7 @@ void CommandInterpreter::Initialize() {
 
   cmd_obj_sp = GetCommandSPExact("frame variable", false);
   if (cmd_obj_sp) {
+    AddAlias("v", cmd_obj_sp);
     AddAlias("var", cmd_obj_sp);
     AddAlias("vo", cmd_obj_sp, "--object-description");
   }


### PR DESCRIPTION
This adds "var" and "v" as short-hand aliases for "frame var" and "vo" as a short-hand alias for "frame var -O".