### PR TITLE
Change the default handling for SIGPIPE to pass/,no-stop/no-notify.

### DIFF
--- a/source/Target/UnixSignals.cpp
+++ b/source/Target/UnixSignals.cpp
@@ -88,7 +88,7 @@ void UnixSignals::Reset() {
   AddSignal(10, "SIGBUS", false, true, true, "bus error");
   AddSignal(11, "SIGSEGV", false, true, true, "segmentation violation");
   AddSignal(12, "SIGSYS", false, true, true, "bad argument to system call");
-  AddSignal(13, "SIGPIPE", false, true, true,
+  AddSignal(13, "SIGPIPE", false, false, false,
             "write on a pipe with no one to read it");
   AddSignal(14, "SIGALRM", false, false, false, "alarm clock");
   AddSignal(15, "SIGTERM", false, true, true,


### PR DESCRIPTION
Most of the time SIGPIPE is just annoying, and so we should
pass it on silently it by default.

<rdar://problem/39359145>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@344418 91177308-0d34-0410-b5e6-96231b3b80d8