### PR TITLE
Ensure Consistent Typing in GetWordCount()

### DIFF
--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -84,7 +84,7 @@ protected:
 
   size_t GetBucketCount() { return 1 << m_scale; }
   size_t GetWordWidth() { return m_ptr_size * 8; }
-  size_t GetWordCount() { return std::max(1ul, GetBucketCount() / GetWordWidth()); }
+  size_t GetWordCount() { return std::max(static_cast<size_t>(1), GetBucketCount() / GetWordWidth()); }
 
   uint64_t GetMetadataWord(int index, Status &error);
 


### PR DESCRIPTION
Inside SwiftHashedContainer::GetWordCount, it uses std::max with potentially confliciting types. The literal constant should be coerced into the correct type that will work on both 32-bit and 64-bit.