### PR TITLE
[ExpressionParser] Perform archetype binding in the materializer.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
+++ b/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
@@ -1,0 +1,15 @@
+# TestSwiftMaterializerArchetypeBinding.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/materializer_archetype_binding/main.swift
@@ -1,0 +1,71 @@
+protocol Generic {
+    associatedtype Associated: Decodable
+    var test: String { get }
+}
+
+struct DecStruct: Decodable {
+    let test: String
+}
+
+struct GenericImpl: Generic {
+    typealias Associated = DecStruct
+    let test: String = "test test"
+}
+
+protocol Problematic {
+    func problemMethod<G: Generic>(param: G, anotherParam: String)
+}
+
+extension Problematic {
+    func problemMethod<G>(param: G, anotherParam: String) where G : Generic {
+        print("patatino")   //%self.expect('frame var -d run-target -- param',
+                            //% substrs=['(a.GenericImpl) param = (test = "test test")'])
+                            //%self.expect('expr -d run-target -- param',
+                            //% substrs=['(a.GenericImpl)', '= (test = "test test")'])
+                            //%self.expect('frame var -d run-target -- anotherParam',
+                            //% substrs=['(String) anotherParam = "just a string"'])
+                            //%self.expect('expr -d run-target -- anotherParam',
+                            //% substrs=['(String)', '= "just a string"'])
+        getAStringAsync { string in
+            print("breakpoint")
+        }
+    }
+}
+
+class ProblematicImpl: Problematic {}
+
+protocol NotProblematic {
+    func problemMethod<G: Generic>(param: G, anotherParam: String)
+}
+
+extension NotProblematic {
+    func problemMethod<G>(param: G, anotherParam: String) where G : Generic {}
+}
+
+class NotProblematicImpl: NotProblematic {
+    func problemMethod<G>(param: G, anotherParam: String) where G : Generic {
+        print("patatino")   //%self.expect('frame var -d run-target -- param',
+                            //% substrs=['(a.GenericImpl) param = (test = "test test")'])
+                            //%self.expect('expr -d run-target -- param',
+                            //% substrs=['(a.GenericImpl)', '= (test = "test test")'])
+                            //%self.expect('frame var -d run-target -- anotherParam',
+                            //% substrs=['(String) anotherParam = "just a string"'])
+                            //%self.expect('expr -d run-target -- anotherParam',
+                            //% substrs=['(String)', '= "just a string"'])
+        getAStringAsync { string in
+            print("breakpoint")
+        }
+    }
+}
+
+func getAStringAsync(completion: @escaping (String) -> ()) {
+    completion("asd")
+}
+
+let useCase = ProblematicImpl()
+let data = GenericImpl()
+useCase.problemMethod(param: data, anotherParam: "just a string")
+
+let useCase2 = NotProblematicImpl()
+let data2 = GenericImpl()
+useCase2.problemMethod(param: data2, anotherParam: "just a string")


### PR DESCRIPTION
(if needed). We immediately after IRGen the type and ask its size.
IRGen needs a fully realized type, otherwise it asserts.

Fixes (part of) SR-8938.

<rdar://problem/45216847>