### PR TITLE
Don't run TestBreakpointIt.py on arm64 devices;

### DIFF
--- a/packages/Python/lldbsuite/test/arm/breakpoint-it/TestBreakpointIt.py
+++ b/packages/Python/lldbsuite/test/arm/breakpoint-it/TestBreakpointIt.py
@@ -19,6 +19,7 @@ class TestBreakpointIt(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIf(archs=no_match(["arm"]))
+    @skipIf(archs=["arm64", "arm64e"])
     def test_false(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
@@ -32,6 +33,7 @@ class TestBreakpointIt(TestBase):
                 "Breakpoint does not get hit")
 
     @skipIf(archs=no_match(["arm"]))
+    @skipIf(archs=["arm64", "arm64e"])
     def test_true(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
Don't run TestBreakpointIt.py on arm64 devices;
it is armv7 specific.


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@344633 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit bcf3f50886c68b8085962af61aee1e997e12140a)