### PR TITLE
Tiny testsuite tweaks.  Don't run the apple simulator

### DIFF
--- a/packages/Python/lldbsuite/test/macosx/safe-to-func-call/main.c
+++ b/packages/Python/lldbsuite/test/macosx/safe-to-func-call/main.c
@@ -1,3 +1,4 @@
+#include <sys/time.h>  // work around module map issue with iOS sdk, <rdar://problem/35159346> 
 #include <sys/select.h>
 #include <stdio.h>
 #include <pthread.h>

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -193,6 +193,7 @@ ifeq "$(OS)" "Darwin"
 	DSYM = $(EXE).dSYM
 	AR := $(CROSS_COMPILE)libtool
 	ARFLAGS := -static -o
+	CODESIGN = codesign
 else
 	AR := $(CROSS_COMPILE)ar
 	# On non-Apple platforms, -arch becomes -m
@@ -658,6 +659,9 @@ endif
 else
 $(EXE) : $(OBJECTS) $(ARCHIVE_NAME)
 	$(LD) $(OBJECTS) $(LDFLAGS) $(ARCHIVE_NAME) -o "$(EXE)"
+ifneq "$(CODESIGN)" ""
+	$(CODESIGN) -s - "$(EXE)"
+endif
 endif
 endif
 #----------------------------------------------------------------------
@@ -709,6 +713,9 @@ endif
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS)
 ifeq "$(OS)" "Darwin"
 	$(LD) $(DYLIB_OBJECTS) $(LDFLAGS) -install_name "$(DYLIB_EXECUTABLE_PATH)/$(DYLIB_FILENAME)" -dynamiclib -o "$(DYLIB_FILENAME)"
+ifneq "$(CODESIGN)" ""
+	$(CODESIGN) -s - "$(DYLIB_FILENAME)"
+endif
 ifneq "$(MAKE_DSYM)" "NO"
 ifneq "$(DS)" ""
 	"$(DS)" $(DSFLAGS) "$(DYLIB_FILENAME)"

--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -96,18 +96,21 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
 
     @apple_simulator_test('iphone')
     @debugserver_test
+    @skipIfDarwinEmbedded
     def test_simulator_ostype_ios(self):
         self.check_simulator_ostype(sdk='iphonesimulator',
                                     platform='ios')
 
     @apple_simulator_test('appletv')
     @debugserver_test
+    @skipIfDarwinEmbedded
     def test_simulator_ostype_tvos(self):
         self.check_simulator_ostype(sdk='appletvsimulator',
                                     platform='tvos')
 
     @apple_simulator_test('watch')
     @debugserver_test
+    @skipIfDarwinEmbedded
     def test_simulator_ostype_watchos(self):
         self.check_simulator_ostype(sdk='watchsimulator',
                                     platform='watchos', arch='i386')


### PR DESCRIPTION
Tiny testsuite tweaks.  Don't run the apple simulator
tests when targetting a device.  Add an include to 
safe-to-call-func to work around a modules issue with
a certain combination of header files.  Add rules for
Darwin systems to ad-hoc codesign binaries that the
testsuite builds.


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@344635 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit b7c75b7f5a297c8f0bd56ea3c390c58bd66a3a40)