### PR TITLE
[Swift] Fix several bugs in existential dynamic type resolution.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_error/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error/TestGenericError.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error/TestGenericError.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error/TestGenericError.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error/main.swift
@@ -1,0 +1,11 @@
+enum MyErr : Error {
+  case Patatino
+  case Mio
+}
+
+func f<T>(_ Pat : T) -> T {
+  return Pat //%self.expect("frame var -d run-target -- Pat", substrs=['(a.MyErr) Pat = Patatino'])
+}
+
+let patatino = f(MyErr.Patatino as Error)
+print(patatino)

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
@@ -1,0 +1,29 @@
+class MyErr : Error {
+  var x : Int
+
+  init(_ x : Int) {
+    self.x = x
+  }
+}
+
+class MyOtherErr : MyErr {}
+
+func h<U, V>(_ tuple : (U, V)) -> (U, V) {
+  return tuple //%self.expect("frame var -d run-target -- tuple", 
+               //%             substrs=['(a.MyErr, a.MyErr) tuple',
+               //%                      '0 =', '(x = 23)',
+               //%                      'a.MyErr = {', 'x = 42'])
+               //%self.expect("expr -d run-target -- tuple",
+               //%             substrs=['(a.MyErr, a.MyErr) $R',
+               //%                      '0 =', '(x = 23)',
+               //%                      'a.MyErr = {', 'x = 42'])
+}
+
+func main() -> Int {
+  let foo : MyErr = MyErr(23)
+  let goo : MyErr = MyOtherErr(42)
+  h((foo, goo))
+  return 0
+}
+
+let _ = main()

--- a/packages/Python/lldbsuite/test/lang/swift/generic_existentials/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_existentials/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/generic_existentials/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_existentials/main.swift
@@ -1,0 +1,14 @@
+class Pat : Error {
+  var x : Int
+  init(_ x : Int) {
+    self.x = x
+  }
+}
+
+func f<T>(_ x : T) -> T {
+  return x //%self.expect("frame var -d run-target -- x", substrs=['(a.Pat) x', '(x = 23)'])
+           //%self.expect("expr -d run-target -- x", substrs=['(a.Pat) $R', '(x = 23)'])
+}
+
+let patatino = Pat(23) as AnyObject
+f(patatino)

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2001,57 +2001,28 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
   } break;
   case swift::MetadataKind::Existential: {
     CompilerType protocol_type(promise_sp->FulfillTypePromise());
-    // Error has a special, NSError-compatible layout.
     SwiftASTContext *swift_ast_ctx =
         llvm::dyn_cast_or_null<SwiftASTContext>(protocol_type.GetTypeSystem());
-    if (swift_ast_ctx && swift_ast_ctx->IsErrorType(protocol_type)) {
-      Status error;
-      lldb::addr_t archetype_ptr_value = in_value.GetValueAsUnsigned(0);
-      lldb::addr_t metadata_ptr =
-          m_process->ReadPointerFromMemory(archetype_ptr_value, error);
-      MetadataPromiseSP promise_sp(GetMetadataPromise(metadata_ptr, in_value));
-      if (!promise_sp)
-        return false;
-      CompilerType dynamic_type(promise_sp->FulfillTypePromise());
-      if (dynamic_type.IsValid()) {
-        class_type_or_name.SetCompilerType(dynamic_type);
-        address.SetLoadAddress(archetype_ptr_value, &m_process->GetTarget());
-        return true;
-      }
-    } else {
-      Status error;
-      lldb::addr_t ptr_to_instance_type = in_value.GetValueAsUnsigned(0) +
-                                          (3 * m_process->GetAddressByteSize());
-      lldb::addr_t metadata_of_impl_addr =
-          m_process->ReadPointerFromMemory(ptr_to_instance_type, error);
-      if (error.Fail() || metadata_of_impl_addr == 0 ||
-          metadata_of_impl_addr == LLDB_INVALID_ADDRESS)
-        return false;
-      MetadataPromiseSP promise_of_impl_sp(
-          GetMetadataPromise(metadata_of_impl_addr, in_value));
-      if (GetDynamicTypeAndAddress_Promise(in_value, promise_of_impl_sp,
-                                           use_dynamic, class_type_or_name,
-                                           address)) {
-        lldb::addr_t load_addr = in_value.GetValueAsUnsigned(0);
-        if (promise_of_impl_sp->FulfillKindPromise() &&
-            promise_of_impl_sp->FulfillKindPromise().getValue() ==
-                swift::MetadataKind::Class) {
-          load_addr = m_process->ReadPointerFromMemory(load_addr, error);
-          if (error.Fail() || load_addr == 0 ||
-              load_addr == LLDB_INVALID_ADDRESS)
-            return false;
-        } else if (promise_of_impl_sp->FulfillKindPromise() &&
-                   (promise_of_impl_sp->FulfillKindPromise().getValue() ==
-                        swift::MetadataKind::Enum ||
-                    promise_of_impl_sp->FulfillKindPromise().getValue() ==
-                        swift::MetadataKind::Struct)) {
-        } else
-          lldbassert(false && "class, enum and struct are the only protocol "
-                              "implementor types I know about");
-        address.SetLoadAddress(load_addr, &m_process->GetTarget());
-        return true;
-      }
-    }
+    lldb::addr_t existential_address = in_value.GetPointerValue();
+    if (!existential_address || existential_address == LLDB_INVALID_ADDRESS)
+      return false;
+    auto &target = m_process->GetTarget();
+    assert(IsScratchContextLocked(target) &&
+           "Swift scratch context not locked ahead");
+    auto scratch_ctx = in_value.GetSwiftASTContext();
+    auto &remote_ast = GetRemoteASTContext(*scratch_ctx);
+    swift::remote::RemoteAddress remote_existential(existential_address);
+    auto result = remote_ast.getDynamicTypeAndAddressForExistential(
+        remote_existential, GetSwiftType(protocol_type));
+    if (!result.isSuccess())
+      return false;
+    auto type_and_address = result.getValue();
+    CompilerType dynamic_type(scratch_ctx->GetASTContext(),
+                              type_and_address.first);
+    class_type_or_name.SetCompilerType(dynamic_type);
+    address.SetLoadAddress(type_and_address.second.getAddressData(),
+                           &m_process->GetTarget());
+    return true;
   } break;
   default:
     break;


### PR DESCRIPTION
lldb was performing their own dynamic type resolution and payload
projection. At lesat the following cases were broken (and fixed
with my patch), in a generic context:

-> Error as AnyObject (class-backed existentials)
-> enums conforming to the Error protocol (and, probably, Error
   existentials in general)
-> Tuples of Errors.

The patch switches this codepath to RemoteAST, removing a bit
of code, and fixing several corner cases of existential resolution.
There are maybe other cases that are still broken, but this is
a decent enough improvement that I figure I could just go ahead
and commit.

Fixes:
<rdar://problem/41228727>
<rdar://problem/37479968>
<rdar://problem/41229005>

Adding several testcases, while here, to make sure this doesn't
regress in future.