### PR TITLE
build: add dependency on generated target

### DIFF
--- a/source/Commands/CMakeLists.txt
+++ b/source/Commands/CMakeLists.txt
@@ -47,3 +47,6 @@ add_lldb_library(lldbCommands
   LINK_COMPONENTS
     Support
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbCommands swift-syntax-generated-headers)
+endif()

--- a/source/Core/CMakeLists.txt
+++ b/source/Core/CMakeLists.txt
@@ -82,6 +82,9 @@ add_lldb_library(lldbCore
     Support
     Demangle
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbCore swift-syntax-generated-headers)
+endif()
 
 # Needed to properly resolve references in a debug build.
 # TODO: Remove once we have better layering

--- a/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -41,3 +41,6 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
     Support
     Core
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbPluginExpressionParserSwift swift-syntax-generated-headers)
+endif()

--- a/source/Plugins/InstrumentationRuntime/MainThreadChecker/CMakeLists.txt
+++ b/source/Plugins/InstrumentationRuntime/MainThreadChecker/CMakeLists.txt
@@ -11,3 +11,7 @@ add_lldb_library(lldbPluginInstrumentationRuntimeMainThreadChecker PLUGIN
   LINK_COMPONENTS
     Support
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbPluginInstrumentationRuntimeMainThreadChecker
+    swift-syntax-generated-headers)
+endif()

--- a/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/CMakeLists.txt
+++ b/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/CMakeLists.txt
@@ -11,3 +11,7 @@ add_lldb_library(lldbPluginInstrumentationRuntimeSwiftRuntimeReporting PLUGIN
   LINK_COMPONENTS
     Support
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbPluginInstrumentationRuntimeSwiftRuntimeReporting
+    swift-syntax-generated-headers)
+endif()

--- a/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/source/Plugins/Language/Swift/CMakeLists.txt
@@ -28,4 +28,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   LINK_COMPONENTS
     Support
 )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbPluginSwiftLanguage swift-syntax-generated-headers)
+endif()
 

--- a/source/Symbol/CMakeLists.txt
+++ b/source/Symbol/CMakeLists.txt
@@ -68,3 +68,6 @@ add_lldb_library(lldbSymbol
   LINK_COMPONENTS
     Support
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbSymbol swift-syntax-generated-headers)
+endif()

--- a/source/Target/CMakeLists.txt
+++ b/source/Target/CMakeLists.txt
@@ -129,3 +129,6 @@ add_lldb_library(lldbTarget
   LINK_COMPONENTS
     Support
   )
+if(NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldbTarget swift-syntax-generated-headers)
+endif()


### PR DESCRIPTION
This repairs the build for the unified layout.  The lldb target depends
on generated headers.  When building in non-standalone mode, ensure that
we have a dependency present to ensure the ordering.