### PR TITLE
chery-pick Adding support to step into the callable wrapped by libc++ std::function

### DIFF
--- a/include/lldb/Target/CPPLanguageRuntime.h
+++ b/include/lldb/Target/CPPLanguageRuntime.h
@@ -24,6 +24,25 @@ namespace lldb_private {
 
 class CPPLanguageRuntime : public LanguageRuntime {
 public:
+  enum class LibCppStdFunctionCallableCase {
+    Lambda = 0,
+    CallableObject,
+    FreeOrMemberFunction,
+    Invalid
+  };
+
+  struct LibCppStdFunctionCallableInfo {
+    Symbol callable_symbol;
+    Address callable_address;
+    LineEntry callable_line_entry;
+    lldb::addr_t member__f_pointer_value = 0u;
+    LibCppStdFunctionCallableCase callable_case =
+        LibCppStdFunctionCallableCase::Invalid;
+  };
+
+  LibCppStdFunctionCallableInfo
+  FindLibCppStdFunctionCallableInfo(lldb::ValueObjectSP &valobj_sp);
+
   ~CPPLanguageRuntime() override;
 
   lldb::LanguageType GetLanguageType() const override {

--- a/include/lldb/Target/CPPLanguageRuntime.h
+++ b/include/lldb/Target/CPPLanguageRuntime.h
@@ -56,6 +56,19 @@ public:
   bool GetObjectDescription(Stream &str, Value &value,
                             ExecutionContextScope *exe_scope) override;
 
+  /// Obtain a ThreadPlan to get us into C++ constructs such as std::function.
+  ///
+  /// @param[in] thread
+  ///     Curent thrad of execution.
+  ///
+  /// @param[in] stop_others
+  ///     True if other threads should pause during execution.
+  ///
+  /// @return
+  ///      A ThreadPlan Shared pointer
+  lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
+                                                  bool stop_others);
+
 protected:
   //------------------------------------------------------------------
   // Classes that inherit from CPPLanguageRuntime can see and modify these

--- a/include/lldb/Target/StackFrame.h
+++ b/include/lldb/Target/StackFrame.h
@@ -517,6 +517,21 @@ public:
                                                      int64_t offset);
 
   //------------------------------------------------------------------
+  /// Attempt to reconstruct the ValueObject for a variable with a given \a name
+  /// from within the current StackFrame, within the current block. The search
+  /// for the variable starts in the deepest block corresponding to the current
+  /// PC in the stack frame and traverse through all parent blocks stopping at
+  /// inlined function boundaries.
+  ///
+  /// @params [in] name
+  ///   The name of the variable.
+  ///
+  /// @return
+  ///   The ValueObject if found.
+  //------------------------------------------------------------------
+  lldb::ValueObjectSP FindVariable(ConstString name);
+
+  //------------------------------------------------------------------
   // lldb::ExecutionContextScope pure virtual functions
   //------------------------------------------------------------------
   lldb::TargetSP CalculateTarget() override;

--- a/packages/Python/lldbsuite/test/lang/cpp/std-function-step-into-callable/Makefile
+++ b/packages/Python/lldbsuite/test/lang/cpp/std-function-step-into-callable/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../make
+
+CXX_SOURCES := main.cpp
+CXXFLAGS += -std=c++11
+USE_LIBCPP := 1
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/cpp/std-function-step-into-callable/TestStdFunctionStepIntoCallable.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/std-function-step-into-callable/TestStdFunctionStepIntoCallable.py
@@ -1,0 +1,71 @@
+"""
+Test stepping into std::function
+"""
+
+from __future__ import print_function
+
+
+import lldb
+import sys
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class LibCxxFunctionTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @add_test_categories(["libc++"])
+    def test(self):
+        """Test that std::function as defined by libc++ is correctly printed by LLDB"""
+        self.build()
+
+        self.main_source = "main.cpp"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        self.source_foo_line = line_number(
+            self.main_source, '// Source foo start line')
+        self.source_lambda_f2_line = line_number(
+            self.main_source, '// Source lambda used by f2 start line')
+        self.source_lambda_f3_line = line_number(
+            self.main_source, '// Source lambda used by f3 start line')
+        self.source_bar_operator_line = line_number(
+            self.main_source, '// Source Bar::operator()() start line')
+        self.source_bar_add_num_line = line_number(
+            self.main_source, '// Source Bar::add_num start line')
+        self.source_main_invoking_f1 = line_number(
+            self.main_source, '// Source main invoking f1')
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "// Set break point at this line.", self.main_source_spec)
+
+        thread.StepInto()
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.source_main_invoking_f1 ) ;
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec().GetFilename(), self.main_source) ;
+
+        thread.StepInto()
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.source_foo_line ) ;
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec().GetFilename(), self.main_source) ;
+        process.Continue()
+
+        thread.StepInto()
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.source_lambda_f2_line ) ;
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec().GetFilename(), self.main_source) ;
+        process.Continue()
+
+        thread.StepInto()
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.source_lambda_f3_line ) ;
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec().GetFilename(), self.main_source) ;
+        process.Continue()
+
+        thread.StepInto()
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.source_bar_operator_line ) ;
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec().GetFilename(), self.main_source) ;
+        process.Continue()
+
+        thread.StepInto()
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetLine(), self.source_bar_add_num_line ) ;
+        self.assertEqual( thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec().GetFilename(), self.main_source) ;
+        process.Continue()

--- a/packages/Python/lldbsuite/test/lang/cpp/std-function-step-into-callable/main.cpp
+++ b/packages/Python/lldbsuite/test/lang/cpp/std-function-step-into-callable/main.cpp
@@ -1,0 +1,38 @@
+#include <functional>
+
+int foo(int x, int y) {
+  return x + y - 1; // Source foo start line
+}
+
+struct Bar {
+   int operator()() {
+       return 66 ; // Source Bar::operator()() start line
+   }
+   int add_num(int i) const { return i + 3 ; } // Source Bar::add_num start line
+   int num_ = 0 ;
+} ;
+
+int main (int argc, char *argv[])
+{
+  int acc = 42;
+  std::function<int (int,int)> f1 = foo;
+  std::function<int (int)> f2 = [acc,f1] (int x) -> int {
+    return x+f1(acc,x); // Source lambda used by f2 start line
+  };
+
+  auto f = [](int x, int y) { return x + y; }; // Source lambda used by f3 start line
+  auto g = [](int x, int y) { return x * y; } ;
+  std::function<int (int,int)> f3 =  argc %2 ? f : g ;
+
+  Bar bar1 ;
+  std::function<int ()> f4( bar1 ) ;
+  std::function<int (const Bar&, int)> f5 = &Bar::add_num;
+  std::function<int(Bar const&)> f_mem = &Bar::num_;
+
+  return f_mem(bar1) +     // Set break point at this line.
+         f1(acc,acc) +     // Source main invoking f1
+         f2(acc) +         // Set break point at this line.
+         f3(acc+1,acc+2) + // Set break point at this line. 
+         f4() +            // Set break point at this line. 
+         f5(bar1, 10);     // Set break point at this line.
+}

--- a/source/API/SBFrame.cpp
+++ b/source/API/SBFrame.cpp
@@ -667,28 +667,10 @@ SBValue SBFrame::FindVariable(const char *name,
     if (stop_locker.TryLock(&process->GetRunLock())) {
       frame = exe_ctx.GetFramePtr();
       if (frame) {
-        VariableList variable_list;
-        SymbolContext sc(frame->GetSymbolContext(eSymbolContextBlock));
+        value_sp = frame->FindVariable(ConstString(name));
 
-        if (sc.block) {
-          const bool can_create = true;
-          const bool get_parent_variables = true;
-          const bool stop_if_block_is_inlined_function = true;
-
-          if (sc.block->AppendVariables(
-                  can_create, get_parent_variables,
-                  stop_if_block_is_inlined_function,
-                  [frame](Variable *v) { return v->IsInScope(frame); },
-                  &variable_list)) {
-            var_sp = variable_list.FindVariable(ConstString(name));
-          }
-        }
-
-        if (var_sp) {
-          value_sp =
-              frame->GetValueObjectForFrameVariable(var_sp, eNoDynamicValues);
+        if (value_sp)
           sb_value.SetSP(value_sp, use_dynamic);
-        }
       } else {
         if (log)
           log->Printf("SBFrame::FindVariable () => error: could not "

--- a/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -23,6 +23,7 @@
 #include "lldb/DataFormatters/TypeSummary.h"
 #include "lldb/DataFormatters/VectorIterator.h"
 #include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Target/CPPLanguageRuntime.h"
 #include "lldb/Target/ProcessStructReader.h"
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/Target.h"
@@ -65,216 +66,44 @@ bool lldb_private::formatters::LibcxxFunctionSummaryProvider(
   if (!valobj_sp)
     return false;
 
-  // Member __f_ has type __base*, the contents of which will hold:
-  // 1) a vtable entry which may hold type information needed to discover the
-  //    lambda being called
-  // 2) possibly hold a pointer to the callable object
-  // e.g.
-  //
-  // (lldb) frame var -R  f_display
-  // (std::__1::function<void (int)>) f_display = {
-  //  __buf_ = {
-  //  …
-  // }
-  //  __f_ = 0x00007ffeefbffa00
-  // }
-  // (lldb) memory read -fA 0x00007ffeefbffa00
-  // 0x7ffeefbffa00: ... `vtable for std::__1::__function::__func<void (*) ...
-  // 0x7ffeefbffa08: ... `print_num(int) at std_function_cppreference_exam ...
-  //
-  // We will be handling five cases below, std::function is wrapping:
-  //
-  // 1) a lambda we know at compile time. We will obtain the name of the lambda
-  //    from the first template pameter from __func's vtable. We will look up
-  //    the lambda's operator()() and obtain the line table entry.
-  // 2) a lambda we know at runtime. A pointer to the lambdas __invoke method
-  //    will be stored after the vtable. We will obtain the lambdas name from
-  //    this entry and lookup operator()() and obtain the line table entry.
-  // 3) a callable object via operator()(). We will obtain the name of the
-  //    object from the first template parameter from __func's vtable. We will
-  //    look up the objectc operator()() and obtain the line table entry.
-  // 4) a member function. A pointer to the function will stored after the
-  //    we will obtain the name from this pointer.
-  // 5) a free function. A pointer to the function will stored after the vtable
-  //    we will obtain the name from this pointer.
-  ValueObjectSP member__f_(
-      valobj_sp->GetChildMemberWithName(ConstString("__f_"), true));
-  lldb::addr_t member__f_pointer_value = member__f_->GetValueAsUnsigned(0);
-
   ExecutionContext exe_ctx(valobj_sp->GetExecutionContextRef());
   Process *process = exe_ctx.GetProcessPtr();
 
   if (process == nullptr)
     return false;
 
-  uint32_t address_size = process->GetAddressByteSize();
-  Status status;
+  CPPLanguageRuntime *cpp_runtime = process->GetCPPLanguageRuntime();
 
-  // First item pointed to by __f_ should be the pointer to the vtable for
-  // a __base object.
-  lldb::addr_t vtable_address =
-      process->ReadPointerFromMemory(member__f_pointer_value, status);
-
-  if (status.Fail())
+  if (!cpp_runtime)
     return false;
 
-  bool found_wrapped_function = false;
+  CPPLanguageRuntime::LibCppStdFunctionCallableInfo callable_info =
+      cpp_runtime->FindLibCppStdFunctionCallableInfo(valobj_sp);
 
-  // Using scoped exit so we can use early return and still execute the default
-  // action in case we don't find the wrapper function. Otherwise we can't use
-  // early exit without duplicating code.
-  auto default_print_on_exit = llvm::make_scope_exit(
-      [&found_wrapped_function, &stream, &member__f_pointer_value]() {
-        if (!found_wrapped_function)
-          stream.Printf(" __f_ = %llu", member__f_pointer_value);
-      });
-
-  lldb::addr_t address_after_vtable = member__f_pointer_value + address_size;
-  // As commened above we may not have a function pointer but if we do we will
-  // need it.
-  lldb::addr_t possible_function_address =
-      process->ReadPointerFromMemory(address_after_vtable, status);
-
-  if (status.Fail())
+  switch (callable_info.callable_case) {
+  case CPPLanguageRuntime::LibCppStdFunctionCallableCase::Invalid:
+    stream.Printf(" __f_ = %" PRIu64, callable_info.member__f_pointer_value);
     return false;
-
-  Target &target = process->GetTarget();
-
-  if (target.GetSectionLoadList().IsEmpty())
-    return false;
-
-  Address vtable_addr_resolved;
-  SymbolContext sc;
-  Symbol *symbol;
-
-  if (!target.GetSectionLoadList().ResolveLoadAddress(vtable_address,
-                                                      vtable_addr_resolved))
-    return false;
-
-  target.GetImages().ResolveSymbolContextForAddress(
-      vtable_addr_resolved, eSymbolContextEverything, sc);
-  symbol = sc.symbol;
-
-  if (symbol == NULL)
-    return false;
-
-  llvm::StringRef vtable_name(symbol->GetName().GetCString());
-  bool found_expected_start_string =
-      vtable_name.startswith("vtable for std::__1::__function::__func<");
-
-  if (!found_expected_start_string)
-    return false;
-
-  // Given case 1 or 3 we have a vtable name, we are want to extract the first
-  // template parameter
-  //
-  //  ... __func<main::$_0, std::__1::allocator<main::$_0> ...
-  //             ^^^^^^^^^
-  //
-  // We do this by find the first < and , and extracting in between.
-  //
-  // This covers the case of the lambda known at compile time.
-  //
-  size_t first_open_angle_bracket = vtable_name.find('<') + 1;
-  size_t first_comma = vtable_name.find_first_of(',');
-
-  llvm::StringRef first_template_parameter =
-      vtable_name.slice(first_open_angle_bracket, first_comma);
-
-  Address function_address_resolved;
-
-  // Setup for cases 2, 4 and 5 we have a pointer to a function after the
-  // vtable. We will use a process of elimination to drop through each case
-  // and obtain the data we need.
-  if (target.GetSectionLoadList().ResolveLoadAddress(
-          possible_function_address, function_address_resolved)) {
-    target.GetImages().ResolveSymbolContextForAddress(
-        function_address_resolved, eSymbolContextEverything, sc);
-    symbol = sc.symbol;
+    break;
+  case CPPLanguageRuntime::LibCppStdFunctionCallableCase::Lambda:
+    stream.Printf(
+        " Lambda in File %s at Line %u",
+        callable_info.callable_line_entry.file.GetFilename().GetCString(),
+        callable_info.callable_line_entry.line);
+    break;
+  case CPPLanguageRuntime::LibCppStdFunctionCallableCase::CallableObject:
+    stream.Printf(
+        " Function in File %s at Line %u",
+        callable_info.callable_line_entry.file.GetFilename().GetCString(),
+        callable_info.callable_line_entry.line);
+    break;
+  case CPPLanguageRuntime::LibCppStdFunctionCallableCase::FreeOrMemberFunction:
+    stream.Printf(" Function = %s ",
+                  callable_info.callable_symbol.GetName().GetCString());
+    break;
   }
 
-  auto get_name = [&first_template_parameter, &symbol]() {
-    // Given case 1:
-    //
-    //    main::$_0
-    //
-    // we want to append ::operator()()
-    if (first_template_parameter.contains("$_"))
-      return llvm::Regex::escape(first_template_parameter.str()) +
-             R"(::operator\(\)\(.*\))";
-
-    if (symbol != NULL &&
-        symbol->GetName().GetStringRef().contains("__invoke")) {
-
-      llvm::StringRef symbol_name = symbol->GetName().GetStringRef();
-      size_t pos2 = symbol_name.find_last_of(':');
-
-      // Given case 2:
-      //
-      //    main::$_1::__invoke(...)
-      //
-      // We want to slice off __invoke(...) and append operator()()
-      std::string lambda_operator =
-          llvm::Regex::escape(symbol_name.slice(0, pos2 + 1).str()) +
-          R"(operator\(\)\(.*\))";
-
-      return lambda_operator;
-    }
-
-    // Case 3
-    return first_template_parameter.str() + R"(::operator\(\)\(.*\))";
-    ;
-  };
-
-  std::string func_to_match = get_name();
-
-  SymbolContextList scl;
-
-  target.GetImages().FindFunctions(RegularExpression{func_to_match}, true, true,
-                                   true, scl);
-
-  // Case 1,2 or 3
-  if (scl.GetSize() >= 1) {
-    SymbolContext sc2 = scl[0];
-
-    AddressRange range;
-    sc2.GetAddressRange(eSymbolContextEverything, 0, false, range);
-
-    Address address = range.GetBaseAddress();
-
-    Address addr;
-    if (target.ResolveLoadAddress(address.GetCallableLoadAddress(&target),
-                                  addr)) {
-      LineEntry line_entry;
-      addr.CalculateSymbolContextLineEntry(line_entry);
-
-      found_wrapped_function = true;
-      if (first_template_parameter.contains("$_") ||
-          (symbol != NULL &&
-           symbol->GetName().GetStringRef().contains("__invoke"))) {
-        // Case 1 and 2
-        stream.Printf(" Lambda in File %s at Line %u",
-                      line_entry.file.GetFilename().GetCString(),
-                      line_entry.line);
-      } else {
-        // Case 3
-        stream.Printf(" Function in File %s at Line %u",
-                      line_entry.file.GetFilename().GetCString(),
-                      line_entry.line);
-      }
-
-      return true;
-    }
-  }
-
-  // Case 4 or 5
-  if (!symbol->GetName().GetStringRef().startswith("vtable for")) {
-    found_wrapped_function = true;
-    stream.Printf(" Function = %s ", symbol->GetName().GetCString());
-    return true;
-  }
-
-  return false;
+  return true;
 }
 
 bool lldb_private::formatters::LibcxxSmartPointerSummaryProvider(

--- a/source/Target/CPPLanguageRuntime.cpp
+++ b/source/Target/CPPLanguageRuntime.cpp
@@ -14,9 +14,20 @@
 
 #include "llvm/ADT/StringRef.h"
 
+#include "lldb/API/SBValue.h"
+#include "lldb/Symbol/Block.h"
+#include "lldb/Symbol/VariableList.h"
+
+#include "lldb/API/SBFrame.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/UniqueCStringMap.h"
+#include "lldb/Symbol/ClangASTContext.h"
+#include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/SectionLoadList.h"
+#include "lldb/Target/StackFrame.h"
+#include "lldb/Target/ThreadPlanRunToAddress.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -39,4 +50,217 @@ bool CPPLanguageRuntime::GetObjectDescription(
     Stream &str, Value &value, ExecutionContextScope *exe_scope) {
   // C++ has no generic way to do this.
   return false;
+}
+
+CPPLanguageRuntime::LibCppStdFunctionCallableInfo
+CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
+    lldb::ValueObjectSP &valobj_sp) {
+  LibCppStdFunctionCallableInfo optional_info;
+
+  if (!valobj_sp)
+    return optional_info;
+
+  // Member __f_ has type __base*, the contents of which will hold:
+  // 1) a vtable entry which may hold type information needed to discover the
+  //    lambda being called
+  // 2) possibly hold a pointer to the callable object
+  // e.g.
+  //
+  // (lldb) frame var -R  f_display
+  // (std::__1::function<void (int)>) f_display = {
+  //  __buf_ = {
+  //  …
+  // }
+  //  __f_ = 0x00007ffeefbffa00
+  // }
+  // (lldb) memory read -fA 0x00007ffeefbffa00
+  // 0x7ffeefbffa00: ... `vtable for std::__1::__function::__func<void (*) ...
+  // 0x7ffeefbffa08: ... `print_num(int) at std_function_cppreference_exam ...
+  //
+  // We will be handling five cases below, std::function is wrapping:
+  //
+  // 1) a lambda we know at compile time. We will obtain the name of the lambda
+  //    from the first template pameter from __func's vtable. We will look up
+  //    the lambda's operator()() and obtain the line table entry.
+  // 2) a lambda we know at runtime. A pointer to the lambdas __invoke method
+  //    will be stored after the vtable. We will obtain the lambdas name from
+  //    this entry and lookup operator()() and obtain the line table entry.
+  // 3) a callable object via operator()(). We will obtain the name of the
+  //    object from the first template parameter from __func's vtable. We will
+  //    look up the objectc operator()() and obtain the line table entry.
+  // 4) a member function. A pointer to the function will stored after the
+  //    we will obtain the name from this pointer.
+  // 5) a free function. A pointer to the function will stored after the vtable
+  //    we will obtain the name from this pointer.
+  ValueObjectSP member__f_(
+      valobj_sp->GetChildMemberWithName(ConstString("__f_"), true));
+  lldb::addr_t member__f_pointer_value = member__f_->GetValueAsUnsigned(0);
+
+  optional_info.member__f_pointer_value = member__f_pointer_value;
+
+  ExecutionContext exe_ctx(valobj_sp->GetExecutionContextRef());
+  Process *process = exe_ctx.GetProcessPtr();
+
+  if (process == nullptr)
+    return optional_info;
+
+  uint32_t address_size = process->GetAddressByteSize();
+  Status status;
+
+  // First item pointed to by __f_ should be the pointer to the vtable for
+  // a __base object.
+  lldb::addr_t vtable_address =
+      process->ReadPointerFromMemory(member__f_pointer_value, status);
+
+  if (status.Fail())
+    return optional_info;
+
+  lldb::addr_t address_after_vtable = member__f_pointer_value + address_size;
+  // As commened above we may not have a function pointer but if we do we will
+  // need it.
+  lldb::addr_t possible_function_address =
+      process->ReadPointerFromMemory(address_after_vtable, status);
+
+  if (status.Fail())
+    return optional_info;
+
+  Target &target = process->GetTarget();
+
+  if (target.GetSectionLoadList().IsEmpty())
+    return optional_info;
+
+  Address vtable_addr_resolved;
+  SymbolContext sc;
+  Symbol *symbol;
+
+  if (!target.GetSectionLoadList().ResolveLoadAddress(vtable_address,
+                                                      vtable_addr_resolved))
+    return optional_info;
+
+  target.GetImages().ResolveSymbolContextForAddress(
+      vtable_addr_resolved, eSymbolContextEverything, sc);
+  symbol = sc.symbol;
+
+  if (symbol == nullptr)
+    return optional_info;
+
+  llvm::StringRef vtable_name(symbol->GetName().GetCString());
+  bool found_expected_start_string =
+      vtable_name.startswith("vtable for std::__1::__function::__func<");
+
+  if (!found_expected_start_string)
+    return optional_info;
+
+  // Given case 1 or 3 we have a vtable name, we are want to extract the first
+  // template parameter
+  //
+  //  ... __func<main::$_0, std::__1::allocator<main::$_0> ...
+  //             ^^^^^^^^^
+  //
+  // We do this by find the first < and , and extracting in between.
+  //
+  // This covers the case of the lambda known at compile time.
+  //
+  size_t first_open_angle_bracket = vtable_name.find('<') + 1;
+  size_t first_comma = vtable_name.find_first_of(',');
+
+  llvm::StringRef first_template_parameter =
+      vtable_name.slice(first_open_angle_bracket, first_comma);
+
+  Address function_address_resolved;
+
+  // Setup for cases 2, 4 and 5 we have a pointer to a function after the
+  // vtable. We will use a process of elimination to drop through each case
+  // and obtain the data we need.
+  if (target.GetSectionLoadList().ResolveLoadAddress(
+          possible_function_address, function_address_resolved)) {
+    target.GetImages().ResolveSymbolContextForAddress(
+        function_address_resolved, eSymbolContextEverything, sc);
+    symbol = sc.symbol;
+  }
+
+  auto get_name = [&first_template_parameter, &symbol]() {
+    // Given case 1:
+    //
+    //    main::$_0
+    //
+    // we want to append ::operator()()
+    if (first_template_parameter.contains("$_"))
+      return llvm::Regex::escape(first_template_parameter.str()) +
+             R"(::operator\(\)\(.*\))";
+
+    if (symbol != NULL &&
+        symbol->GetName().GetStringRef().contains("__invoke")) {
+
+      llvm::StringRef symbol_name = symbol->GetName().GetStringRef();
+      size_t pos2 = symbol_name.find_last_of(':');
+
+      // Given case 2:
+      //
+      //    main::$_1::__invoke(...)
+      //
+      // We want to slice off __invoke(...) and append operator()()
+      std::string lambda_operator =
+          llvm::Regex::escape(symbol_name.slice(0, pos2 + 1).str()) +
+          R"(operator\(\)\(.*\))";
+
+      return lambda_operator;
+    }
+
+    // Case 3
+    return first_template_parameter.str() + R"(::operator\(\)\(.*\))";
+    ;
+  };
+
+  std::string func_to_match = get_name();
+
+  SymbolContextList scl;
+
+  target.GetImages().FindFunctions(RegularExpression{func_to_match}, true, true,
+                                   true, scl);
+
+  // Case 1,2 or 3
+  if (scl.GetSize() >= 1) {
+    SymbolContext sc2 = scl[0];
+
+    AddressRange range;
+    sc2.GetAddressRange(eSymbolContextEverything, 0, false, range);
+
+    Address address = range.GetBaseAddress();
+
+    Address addr;
+    if (target.ResolveLoadAddress(address.GetCallableLoadAddress(&target),
+                                  addr)) {
+      LineEntry line_entry;
+      addr.CalculateSymbolContextLineEntry(line_entry);
+
+      if (first_template_parameter.contains("$_") ||
+          (symbol != nullptr &&
+           symbol->GetName().GetStringRef().contains("__invoke"))) {
+        // Case 1 and 2
+        optional_info.callable_case = LibCppStdFunctionCallableCase::Lambda;
+      } else {
+        // Case 3
+        optional_info.callable_case =
+            LibCppStdFunctionCallableCase::CallableObject;
+      }
+
+      optional_info.callable_symbol = *symbol;
+      optional_info.callable_line_entry = line_entry;
+      optional_info.callable_address = addr;
+      return optional_info;
+    }
+  }
+
+  // Case 4 or 5
+  if (!symbol->GetName().GetStringRef().startswith("vtable for")) {
+    optional_info.callable_case =
+        LibCppStdFunctionCallableCase::FreeOrMemberFunction;
+    optional_info.callable_address = function_address_resolved;
+    optional_info.callable_symbol = *symbol;
+
+    return optional_info;
+  }
+
+  return optional_info;
 }

--- a/source/Target/CPPLanguageRuntime.cpp
+++ b/source/Target/CPPLanguageRuntime.cpp
@@ -28,6 +28,7 @@
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Target/ThreadPlanRunToAddress.h"
+#include "lldb/Target/ThreadPlanStepInRange.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -160,7 +161,6 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
   // We do this by find the first < and , and extracting in between.
   //
   // This covers the case of the lambda known at compile time.
-  //
   size_t first_open_angle_bracket = vtable_name.find('<') + 1;
   size_t first_comma = vtable_name.find_first_of(',');
 
@@ -263,4 +263,77 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
   }
 
   return optional_info;
+}
+
+lldb::ThreadPlanSP
+CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
+                                                 bool stop_others) {
+  ThreadPlanSP ret_plan_sp;
+
+  lldb::addr_t curr_pc = thread.GetRegisterContext()->GetPC();
+
+  TargetSP target_sp(thread.CalculateTarget());
+
+  if (target_sp->GetSectionLoadList().IsEmpty())
+    return ret_plan_sp;
+
+  Address pc_addr_resolved;
+  SymbolContext sc;
+  Symbol *symbol;
+
+  if (!target_sp->GetSectionLoadList().ResolveLoadAddress(curr_pc,
+                                                          pc_addr_resolved))
+    return ret_plan_sp;
+
+  target_sp->GetImages().ResolveSymbolContextForAddress(
+      pc_addr_resolved, eSymbolContextEverything, sc);
+  symbol = sc.symbol;
+
+  if (symbol == nullptr)
+    return ret_plan_sp;
+
+  llvm::StringRef function_name(symbol->GetName().GetCString());
+
+  // Handling the case where we are attempting to step into std::function.
+  // The behavior will be that we will attempt to obtain the wrapped
+  // callable via FindLibCppStdFunctionCallableInfo() and if we find it we
+  // will return a ThreadPlanRunToAddress to the callable. Therefore we will
+  // step into the wrapped callable.
+  //
+  bool found_expected_start_string =
+      function_name.startswith("std::__1::function<");
+
+  if (!found_expected_start_string)
+    return ret_plan_sp;
+
+  AddressRange range_of_curr_func;
+  sc.GetAddressRange(eSymbolContextEverything, 0, false, range_of_curr_func);
+
+  StackFrameSP frame = thread.GetStackFrameAtIndex(0);
+
+  if (frame) {
+    ValueObjectSP value_sp = frame->FindVariable(ConstString("this"));
+
+    CPPLanguageRuntime::LibCppStdFunctionCallableInfo callable_info =
+        FindLibCppStdFunctionCallableInfo(value_sp);
+
+    if (callable_info.callable_case != LibCppStdFunctionCallableCase::Invalid &&
+        value_sp->GetValueIsValid()) {
+      // We found the std::function wrapped callable and we have its address.
+      // We now create a ThreadPlan to run to the callable.
+      ret_plan_sp.reset(new ThreadPlanRunToAddress(
+          thread, callable_info.callable_address, stop_others));
+      return ret_plan_sp;
+    } else {
+      // We are in std::function but we could not obtain the callable.
+      // We create a ThreadPlan to keep stepping through using the address range
+      // of the current function.
+      ret_plan_sp.reset(new ThreadPlanStepInRange(thread, range_of_curr_func,
+                                                  sc, eOnlyThisThread,
+                                                  eLazyBoolYes, eLazyBoolYes));
+      return ret_plan_sp;
+    }
+  }
+
+  return ret_plan_sp;
 }

--- a/source/Target/StackFrame.cpp
+++ b/source/Target/StackFrame.cpp
@@ -1713,6 +1713,41 @@ lldb::ValueObjectSP StackFrame::GuessValueForRegisterAndOffset(ConstString reg,
                         GetFrameCodeAddress());
 }
 
+lldb::ValueObjectSP StackFrame::FindVariable(ConstString name) {
+  ValueObjectSP value_sp;
+
+  if (!name)
+    return value_sp;
+
+  TargetSP target_sp = CalculateTarget();
+  ProcessSP process_sp = CalculateProcess();
+
+  if (!target_sp && !process_sp)
+    return value_sp;
+
+  VariableList variable_list;
+  VariableSP var_sp;
+  SymbolContext sc(GetSymbolContext(eSymbolContextBlock));
+
+  if (sc.block) {
+    const bool can_create = true;
+    const bool get_parent_variables = true;
+    const bool stop_if_block_is_inlined_function = true;
+
+    if (sc.block->AppendVariables(
+            can_create, get_parent_variables, stop_if_block_is_inlined_function,
+            [this](Variable *v) { return v->IsInScope(this); },
+            &variable_list)) {
+      var_sp = variable_list.FindVariable(name);
+    }
+
+    if (var_sp)
+      value_sp = GetValueObjectForFrameVariable(var_sp, eNoDynamicValues);
+  }
+
+  return value_sp;
+}
+
 TargetSP StackFrame::CalculateTarget() {
   TargetSP target_sp;
   ThreadSP thread_sp(GetThread());

--- a/source/Target/ThreadPlanStepThrough.cpp
+++ b/source/Target/ThreadPlanStepThrough.cpp
@@ -13,6 +13,7 @@
 // Project includes
 #include "lldb/Target/ThreadPlanStepThrough.h"
 #include "lldb/Breakpoint/Breakpoint.h"
+#include "lldb/Target/CPPLanguageRuntime.h"
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/Target/ObjCLanguageRuntime.h"
 #include "lldb/Target/Process.h"
@@ -95,6 +96,15 @@ void ThreadPlanStepThrough::LookForPlanToStepThroughFromCurrentPC() {
     if (objc_runtime)
       m_sub_plan_sp =
           objc_runtime->GetStepThroughTrampolinePlan(m_thread, m_stop_others);
+
+    CPPLanguageRuntime *cpp_runtime =
+        m_thread.GetProcess()->GetCPPLanguageRuntime();
+
+    // If the ObjC runtime did not provide us with a step though plan then if we
+    // have it check the C++ runtime for a step though plan.
+    if (!m_sub_plan_sp.get() && cpp_runtime)
+      m_sub_plan_sp =
+          cpp_runtime->GetStepThroughTrampolinePlan(m_thread, m_stop_others);
   }
   if (!m_sub_plan_sp.get()) {
     SwiftLanguageRuntime *swift_runtime =


### PR DESCRIPTION
- Refactoring std::function formatter to move core functionality into CPPLanguageRuntime
- Refactor FindVariable() core functionality into StackFrame out of SBFrame
- Adding support to step into the callable wrapped by libc++ std::function

Differential Revision: https://reviews.llvm.org/D51896
  git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@341991 91177308-0d34-0410-b5e6-96231b3b80d8
    (cherry picked from commit d892db7b51d504bc5bf024539bbc9b746911f1df)

Differential Revision: https://reviews.llvm.org/D52247
    git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342663 91177308-0d34-0410-b5e6-96231b3b80d8
    (cherry picked from commit d930bed03141d1b5c032579e4afff72bef8d6228)

Differential Revision: https://reviews.llvm.org/D52851
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@344371 91177308-0d34-0410-b5e6-96231b3b80d8
    (cherry picked from commit 00c11c4cf7741b4829fdae2549f1e3768a607a05)
