### PR TITLE
Enabled REPLMode and PlaygroundTransform at the same time for Playground REPL mode

### DIFF
--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -410,6 +410,10 @@ public:
 
   void SetIsForUtilityExpr(bool b) { m_running_utility_expression = b; }
 
+  void SetPreparePlaygroundStubFunctions(bool b) { m_prepare_playground_stub_functions = b; }
+
+  bool GetPreparePlaygroundStubFunctions() const { return m_prepare_playground_stub_functions; }
+
 private:
   ExecutionPolicy m_execution_policy = default_execution_policy;
   lldb::LanguageType m_language = lldb::eLanguageTypeUnknown;
@@ -445,6 +449,7 @@ private:
   // originates
   mutable std::string m_pound_line_file;
   mutable uint32_t m_pound_line_line;
+  bool m_prepare_playground_stub_functions = true;
 };
 
 //----------------------------------------------------------------------

--- a/source/Expression/ExpressionSourceCode.cpp
+++ b/source/Expression/ExpressionSourceCode.cpp
@@ -501,8 +501,22 @@ bool ExpressionSourceCode::GetText(
           }
         }
       }
+      const bool playground = options.GetPlaygroundTransformEnabled();
+      SwiftPersistentExpressionState *persistent_state =
+        llvm::cast<SwiftPersistentExpressionState>(target->GetPersistentExpressionStateForLanguage(lldb::eLanguageTypeSwift));
+      std::vector<swift::ValueDecl *> persistent_results;
+      // Check if we have already declared the playground stub debug functions
+      persistent_state->GetSwiftPersistentDecls(ConstString("__builtin_log_with_id"), {},
+                                                persistent_results);
+
+      size_t num_persistent_results = persistent_results.size();
+      bool need_to_declare_log_functions = num_persistent_results == 0;
+      EvaluateExpressionOptions localOptions(options);
+
+      localOptions.SetPreparePlaygroundStubFunctions(need_to_declare_log_functions);
+
       SwiftASTManipulator::WrapExpression(wrap_stream, m_body.c_str(),
-                                          language_flags, options, generic_info,
+                                          language_flags, localOptions, generic_info,
                                           os_vers.str(),
                                           first_body_line);
     }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1566,7 +1566,10 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
   if (repl || !playground) {
     code_manipulator =
         llvm::make_unique<SwiftASTManipulator>(*source_file, repl);
-    code_manipulator->RewriteResult();
+
+    if (!playground) {
+      code_manipulator->RewriteResult();
+    }
   }
 
   Status auto_import_error;


### PR DESCRIPTION
Suppress redeclaration of sil log functions in subseqeuent calls to evaluate expressions.

Fix cases where playground transform and REPL interfere

<rdar://problem/43763715>

@swift-ci please test and merge