### PR TITLE
[SymbolFile] Add the module lock where necessary and assert that we o…

### DIFF
--- a/include/lldb/Symbol/SymbolFile.h
+++ b/include/lldb/Symbol/SymbolFile.h
@@ -22,6 +22,14 @@
 
 #include "llvm/ADT/DenseSet.h"
 
+#include <mutex>
+
+#if defined(LLDB_CONFIGURATION_DEBUG)
+#define ASSERT_MODULE_LOCK(expr) (expr->AssertModuleLock();)
+#else
+#define ASSERT_MODULE_LOCK(expr) ((void)0)
+#endif
+
 namespace lldb_private {
 
 class SymbolFile : public PluginInterface {
@@ -94,6 +102,12 @@ public:
   }
 
   virtual uint32_t CalculateAbilities() = 0;
+
+  //------------------------------------------------------------------
+  /// Symbols file subclasses should override this to return the Module that
+  /// owns the TypeSystem that this symbol file modifies type information in.
+  //------------------------------------------------------------------
+  virtual std::recursive_mutex &GetModuleMutex() const;
 
   //------------------------------------------------------------------
   /// Initialize the SymbolFile object.
@@ -273,6 +287,8 @@ protected:
     uint32_t first_line;
     uint32_t last_line;
   };
+
+  void AssertModuleLock();
 
   ObjectFile *m_obj_file; // The object file that symbols can be extracted from.
   uint32_t m_abilities;

--- a/include/lldb/Symbol/SymbolFile.h
+++ b/include/lldb/Symbol/SymbolFile.h
@@ -25,7 +25,7 @@
 #include <mutex>
 
 #if defined(LLDB_CONFIGURATION_DEBUG)
-#define ASSERT_MODULE_LOCK(expr) (expr->AssertModuleLock();)
+#define ASSERT_MODULE_LOCK(expr) (expr->AssertModuleLock())
 #else
 #define ASSERT_MODULE_LOCK(expr) ((void)0)
 #endif

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -238,6 +238,8 @@ public:
 
   void PreloadSymbols() override;
 
+  std::recursive_mutex &GetModuleMutex() const override;
+
   //------------------------------------------------------------------
   // PluginInterface protocol
   //------------------------------------------------------------------

--- a/source/Symbol/SymbolFile.cpp
+++ b/source/Symbol/SymbolFile.cpp
@@ -21,10 +21,16 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/lldb-private.h"
 
+#include <future>
+
 using namespace lldb_private;
 
 void SymbolFile::PreloadSymbols() {
   // No-op for most implementations.
+}
+
+std::recursive_mutex &SymbolFile::GetModuleMutex() const {
+  return GetObjectFile()->GetModule()->GetMutex();
 }
 
 SymbolFile *SymbolFile::FindPlugin(ObjectFile *obj_file) {
@@ -198,4 +204,18 @@ size_t SymbolFile::FindTypes(const std::vector<CompilerContext> &context,
   if (!append)
     types.Clear();
   return 0;
+}
+
+void SymbolFile::AssertModuleLock() {
+  // The code below is too expensive to leave enabled in release builds. It's
+  // enabled in debug builds or when the correct macro is set.
+#if defined(LLDB_CONFIGURATION_DEBUG)
+  // We assert that we have to module lock by trying to acquire the lock from a
+  // different thread. Note that we must abort if the result is true to
+  // guarantee correctness.
+  assert(std::async(std::launch::async,
+                    [this] { return this->GetModuleMutex().try_lock(); })
+                 .get() == false &&
+         "Module is not locked");
+#endif
 }


### PR DESCRIPTION
…wn it.

As discussed with Greg at the dev meeting, we need to ensure we have the
module lock in the SymbolFile. Usually the symbol file is accessed
through the symbol vendor which ensures that the necessary locks are
taken. However, there are a few methods that are accessed by the
expression parser and were lacking the lock.

This patch adds the locking where necessary and everywhere else asserts
that we actually already own the lock.

Differential revision: https://reviews.llvm.org/D52543

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@344945 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit a3b913c723d2120f745dc681d2261c1a193adb65)