### PR TITLE
[DWARF] Use a function-local offset for AT_call_return_pc (lldb)

### DIFF
--- a/include/lldb/Symbol/Function.h
+++ b/include/lldb/Symbol/Function.h
@@ -324,7 +324,8 @@ public:
   /// made the call.
   lldb::addr_t GetReturnPCAddress(Function &caller, Target &target) const;
 
-  /// Like \ref GetReturnPCAddress, but returns an unresolved file address.
+  /// Like \ref GetReturnPCAddress, but returns an unslid function-local PC
+  /// offset.
   lldb::addr_t GetUnresolvedReturnPCAddress() const { return return_pc; }
 
 private:
@@ -337,8 +338,9 @@ private:
     Function *def;
   } lazy_callee;
 
-  /// An invalid address if this is a tail call. Otherwise, the return PC for
-  /// the call. Note that this is a file address which must be resolved.
+  /// An invalid address if this is a tail call. Otherwise, the function-local
+  /// PC offset. Adding this PC offset to the function's base load address
+  /// gives the return PC for the call.
   lldb::addr_t return_pc;
 
   /// Whether or not an attempt was made to find the callee's definition.

--- a/source/Symbol/Function.cpp
+++ b/source/Symbol/Function.cpp
@@ -180,8 +180,7 @@ Function *CallEdge::GetCallee(ModuleList &images) {
 lldb::addr_t CallEdge::GetReturnPCAddress(Function &caller,
                                           Target &target) const {
   const Address &base = caller.GetAddressRange().GetBaseAddress();
-  Address return_pc_addr{base.GetSection(), return_pc};
-  return return_pc_addr.GetLoadAddress(&target);
+  return base.GetLoadAddress(&target) + return_pc;
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Logs provided by @stella.stamenova indicate that on Linux, lldb adds a
spurious slide offset to the return PC it loads from AT_call_return_pc
attributes (see the list thread: "[PATCH] D50478: Add support for
artificial tail call frames").

This patch side-steps the issue by getting rid of the load address
calculation in lldb's CallEdge::GetReturnPCAddress.

The idea is to have the DWARF writer emit function-local offsets to the
instruction after a call. I.e. return-pc = label-after-call-insn -
function-entry. LLDB can simply add this offset to the base address of a
function to get the return PC.

Differential Revision: https://reviews.llvm.org/D53469

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@344960 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 9b4fd67ab9fabf596aa3c47ff3fc10a6a1051fd4)