### PR TITLE
[ValueObject] Stop assuming types are non-zero sized.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/array_enum/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/array_enum/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/array_enum/TestArrayEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/array_enum/TestArrayEnum.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/array_enum/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/array_enum/main.swift
@@ -1,0 +1,19 @@
+enum x : String {
+  case patatino
+}
+
+struct y {
+  var z: x?
+}
+
+func main() -> Int {
+  var a = y()
+  a.z = x.patatino
+  var j = [a]
+  return 0 //%self.expect('frame var -d run-target a', substrs=['(a.y) a = (z = patatino)'])
+           //%self.expect('expr -d run-target -- a', substrs=['(a.y) $R0 = (z = patatino)'])
+           //%self.expect('frame var -d run-target j', substrs=['[0] = (z = patatino)'])
+           //%self.expect('expr -d run-target -- j', substrs=['[0] = (z = patatino)'])
+}
+
+let _ = main()

--- a/source/Core/ValueObjectConstResultImpl.cpp
+++ b/source/Core/ValueObjectConstResultImpl.cpp
@@ -77,7 +77,13 @@ ValueObject *ValueObjectConstResultImpl::CreateChildAtIndex(
       ignore_array_bounds, child_name_str, child_byte_size, child_byte_offset,
       child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
       child_is_deref_of_parent, m_impl_backend, language_flags);
-  if (child_compiler_type && child_byte_size) {
+
+  // One might think we should check that the size of the children
+  // is always strictly positive, hence we could avoid creating a
+  // ValueObject if that's not the case, but it turns out there
+  // are languages out there which allow zero-size types with
+  // children (e.g. Swift).
+  if (child_compiler_type) {
     if (synthetic_index)
       child_byte_offset += child_byte_size * synthetic_index;
 


### PR DESCRIPTION
Some backends might violate this assumption, e.g. swift.

<rdar://problem/40962410>
