### PR TITLE
 Fix a bug PlatformDarwin::SDKSupportsModule.

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1402,14 +1402,11 @@ bool PlatformDarwin::SDKSupportsModules(SDKType desired_type,
   if (last_path_component) {
     const llvm::StringRef sdk_name = last_path_component.GetStringRef();
 
-    llvm::StringRef version_part;
-
-    if (sdk_name.startswith(sdk_strings[(int)desired_type])) {
-      version_part =
-          sdk_name.drop_front(strlen(sdk_strings[(int)desired_type]));
-    } else {
+    if (!sdk_name.startswith(sdk_strings[(int)desired_type]))
       return false;
-    }
+    auto version_part =
+        sdk_name.drop_front(strlen(sdk_strings[(int)desired_type]));
+    version_part.consume_back(".sdk");
 
     llvm::VersionTuple version;
     if (version.tryParse(version_part))

--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1402,10 +1402,10 @@ bool PlatformDarwin::SDKSupportsModules(SDKType desired_type,
   if (last_path_component) {
     const llvm::StringRef sdk_name = last_path_component.GetStringRef();
 
-    if (!sdk_name.startswith(sdk_strings[(int)desired_type]))
+    if (!sdk_name.startswith(sdk_strings[desired_type]))
       return false;
     auto version_part =
-        sdk_name.drop_front(strlen(sdk_strings[(int)desired_type]));
+        sdk_name.drop_front(strlen(sdk_strings[desired_type]));
     version_part.consume_back(".sdk");
 
     llvm::VersionTuple version;

--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -88,6 +88,12 @@ public:
   static std::tuple<llvm::VersionTuple, llvm::StringRef>
   ParseVersionBuildDir(llvm::StringRef str);
 
+  enum class SDKType {
+    MacOSX = 0,
+    iPhoneSimulator,
+    iPhoneOS,
+  };
+
 protected:
   void ReadLibdispatchOffsetsAddress(lldb_private::Process *process);
 
@@ -97,12 +103,6 @@ protected:
       const lldb_private::ModuleSpec &module_spec, lldb::ModuleSP &module_sp,
       const lldb_private::FileSpecList *module_search_paths_ptr,
       lldb::ModuleSP *old_module_sp_ptr, bool *did_create_ptr);
-
-  enum class SDKType {
-    MacOSX = 0,
-    iPhoneSimulator,
-    iPhoneOS,
-  };
 
   static bool SDKSupportsModules(SDKType sdk_type, llvm::VersionTuple version);
 

--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -88,7 +88,7 @@ public:
   static std::tuple<llvm::VersionTuple, llvm::StringRef>
   ParseVersionBuildDir(llvm::StringRef str);
 
-  enum class SDKType {
+  enum SDKType : unsigned {
     MacOSX = 0,
     iPhoneSimulator,
     iPhoneOS,

--- a/source/Utility/ArchSpec.cpp
+++ b/source/Utility/ArchSpec.cpp
@@ -1028,6 +1028,11 @@ static bool isCompatibleEnvironment(llvm::Triple::EnvironmentType lhs,
       rhs == llvm::Triple::UnknownEnvironment)
     return true;
 
+  // If any of the environment is unknown then they are compatible
+  if (lhs == llvm::Triple::UnknownEnvironment ||
+      rhs == llvm::Triple::UnknownEnvironment)
+    return true;
+
   // If one of the environment is Android and the other one is EABI then they
   // are considered to be compatible. This is required as a workaround for
   // shared libraries compiled for Android without the NOTE section indicating

--- a/source/Utility/ArchSpec.cpp
+++ b/source/Utility/ArchSpec.cpp
@@ -1028,11 +1028,6 @@ static bool isCompatibleEnvironment(llvm::Triple::EnvironmentType lhs,
       rhs == llvm::Triple::UnknownEnvironment)
     return true;
 
-  // If any of the environment is unknown then they are compatible
-  if (lhs == llvm::Triple::UnknownEnvironment ||
-      rhs == llvm::Triple::UnknownEnvironment)
-    return true;
-
   // If one of the environment is Android and the other one is EABI then they
   // are considered to be compatible. This is required as a workaround for
   // shared libraries compiled for Android without the NOTE section indicating

--- a/unittests/Platform/PlatformDarwinTest.cpp
+++ b/unittests/Platform/PlatformDarwinTest.cpp
@@ -18,6 +18,13 @@
 using namespace lldb;
 using namespace lldb_private;
 
+struct PlatformDarwinTester : public PlatformDarwin {
+  static bool SDKSupportsModules(SDKType desired_type,
+                                 const lldb_private::FileSpec &sdk_path) {
+    return PlatformDarwin::SDKSupportsModules(desired_type, sdk_path);
+  }
+};
+
 TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
   llvm::VersionTuple V;
   llvm::StringRef D;
@@ -44,4 +51,23 @@ TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
 
   std::tie(V, D) = PlatformDarwin::ParseVersionBuildDir("3.4.5");
   EXPECT_EQ(llvm::VersionTuple(3, 4, 5), V);
+
+  std::string base = "/Applications/Xcode.app/Contents/Developer/Platforms/";
+  EXPECT_TRUE(PlatformDarwinTester::SDKSupportsModules(
+      PlatformDarwin::SDKType::iPhoneSimulator,
+      FileSpec(base +
+          "iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator12.0.sdk",
+          false)));
+  EXPECT_FALSE(PlatformDarwinTester::SDKSupportsModules(
+      PlatformDarwin::SDKType::iPhoneSimulator,
+      FileSpec(base +
+          "iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator7.2.sdk",
+          false)));
+  EXPECT_TRUE(PlatformDarwinTester::SDKSupportsModules(
+      PlatformDarwin::SDKType::MacOSX,
+      FileSpec(base + "MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk",
+               false)));
+  EXPECT_FALSE(PlatformDarwinTester::SDKSupportsModules(
+      PlatformDarwin::SDKType::MacOSX,
+      FileSpec(base + "MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk", false)));
 }


### PR DESCRIPTION
This fixes a bug PlatformDarwin::SDKSupportsModule introduced by
https://reviews.llvm.org/D47889.  VersionTuple::tryParse() can deal
with an optional third (micro) component, but the parse will fail when
there are extra characters after the version number (e.g.: trying to
parse the substring "12.0.sdk" out of "iPhoneSimulator12.0.sdk" fails
after that patch).  Fixed here by stripping the ".sdk" suffix first.

(Part of) rdar://problem/45041492

Differential Revision https://reviews.llvm.org/D53677

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@345274 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e71f3170d0589b078592b8367b45abea1c5aa90a)