### PR TITLE
Warning Cleanups

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -46,7 +46,7 @@ class TypeInfo;
 }
 namespace serialization {
 struct ValidationInfo;
-struct ExtendedValidationInfo;
+class ExtendedValidationInfo;
 }
 }
 

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -34,8 +34,8 @@ class MemoryReader;
 class RemoteAddress;
 }
 
-template <typename T> class External;
-template <unsigned PointerSize> class RuntimeTarget;
+template <typename T> struct External;
+template <unsigned PointerSize> struct RuntimeTarget;
 
 namespace reflection {
 template <typename T> class ReflectionContext;

--- a/source/API/SBHostOS.cpp
+++ b/source/API/SBHostOS.cpp
@@ -74,6 +74,10 @@ SBFileSpec SBHostOS::GetLLDBPath(lldb::PathType path_type) {
   case ePathTypeClangDir:
     fspec = GetClangResourceDir();
     break;
+
+  case ePathTypeSupportFileDir:
+  case ePathTypeSwiftDir:
+    break;
   }
 
   SBFileSpec sb_fspec;

--- a/source/Commands/CommandObjectType.cpp
+++ b/source/Commands/CommandObjectType.cpp
@@ -1014,13 +1014,6 @@ public:
 };
 
 
-static constexpr OptionDefinition g_type_formatter_list_options[] = {
-  // clang-format off
-  {LLDB_OPT_SET_1, false, "category-regex", 'w', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeName,     "Only show categories matching this filter."},
-  {LLDB_OPT_SET_2, false, "language",       'l', OptionParser::eRequiredArgument, nullptr, {}, 0, eArgTypeLanguage, "Only show the category for a specific language."}
-  // clang-format on
-};
-
 template <typename FormatterType>
 class CommandObjectTypeFormatterList : public CommandObjectParsed {
   typedef typename FormatterType::SharedPointer FormatterSharedPointer;

--- a/source/Core/Section.cpp
+++ b/source/Core/Section.cpp
@@ -131,6 +131,10 @@ const char *Section::GetTypeAsCString() const {
     return "dwarf-gnu-debugaltlink";
   case eSectionTypeOther:
     return "regular";
+
+  case eSectionTypeSwiftModules:
+  case eSectionTypeDWARFAppleExternalTypes:
+    break;
   }
   return "unknown";
 }

--- a/source/Expression/ExpressionSourceCode.cpp
+++ b/source/Expression/ExpressionSourceCode.cpp
@@ -186,7 +186,7 @@ static void AddMacros(const DebugMacros *dm, CompileUnit *comp_unit,
 }
 
 static bool ExprBodyContainsVar(llvm::StringRef var, llvm::StringRef body) {
-  int from = 0;
+  size_t from = 0;
   while ((from = body.find(var, from)) != llvm::StringRef::npos) {
     if ((from != 0 && clang::isIdentifierBody(body[from-1])) ||
         (from + var.size() != body.size() &&
@@ -486,7 +486,6 @@ bool ExpressionSourceCode::GetText(
       if (triple.isOSDarwin()) {
         if (auto process_sp = exe_ctx.GetProcessSP()) {
           os_vers << getAvailabilityName(triple.getOS()) << " ";
-          uint32_t major, minor, patch;
           auto platform = target->GetPlatform();
           bool is_simulator =
               platform->GetPluginName().GetStringRef().endswith("-simulator");

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -1113,7 +1113,6 @@ private:
   CompilerType m_type;
   bool m_is_program_reference;
   bool m_keep_in_memory;
-  bool m_is_error_result;
 
   lldb::addr_t m_temporary_allocation;
   size_t m_temporary_allocation_size;

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -689,6 +689,9 @@ addr_t ClangExpressionDeclMap::GetSymbolAddress(Target &target,
     case eSymbolTypeASTFile:
       symbol_load_addr = sym_address.GetLoadAddress(&target);
       break;
+
+    case eSymbolTypeIVarOffset:
+      break;
     }
   }
 

--- a/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -145,11 +145,6 @@ void StoringDiagnosticConsumer::DumpDiagnostics(Stream &error_stream) {
   }
 }
 
-static FileSpec GetResourceDir() {
-  static FileSpec g_cached_resource_dir = GetClangResourceDir();
-  return g_cached_resource_dir;
-}
-
 ClangModulesDeclVendor::ClangModulesDeclVendor() {}
 
 ClangModulesDeclVendor::~ClangModulesDeclVendor() {}

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -39,58 +39,6 @@
 
 using namespace lldb_private;
 
-static void DumpGenericNames(
-    lldb_private::Stream &wrapped_stream,
-    llvm::ArrayRef<Expression::SwiftGenericInfo::Binding> generic_bindings) {
-  if (generic_bindings.empty())
-    return;
-
-  wrapped_stream.PutChar('<');
-
-  bool comma = false;
-
-  for (const Expression::SwiftGenericInfo::Binding &binding :
-       generic_bindings) {
-    if (comma)
-      wrapped_stream.PutCString(", ");
-    comma = true;
-
-    wrapped_stream.PutCString(binding.name);
-  }
-
-  wrapped_stream.PutChar('>');
-}
-
-static void DumpPlaceholderArguments(
-    lldb_private::Stream &wrapped_stream,
-    llvm::ArrayRef<Expression::SwiftGenericInfo::Binding> generic_bindings) {
-  if (generic_bindings.empty())
-    return;
-
-  for (const Expression::SwiftGenericInfo::Binding &binding :
-       generic_bindings) {
-    const char *name = binding.name;
-
-    wrapped_stream.Printf(", _ __lldb_placeholder_%s : UnsafePointer<%s>!",
-                          name, name);
-  }
-}
-
-static void DumpPlaceholdersIntoCall(
-    lldb_private::Stream &wrapped_stream,
-    llvm::ArrayRef<Expression::SwiftGenericInfo::Binding> generic_bindings) {
-  if (generic_bindings.empty())
-    return;
-
-  for (const Expression::SwiftGenericInfo::Binding &binding :
-       generic_bindings) {
-    wrapped_stream.Printf(
-        ",\n"
-        "      (nil as UnsafePointer<$__lldb_typeof_generic_%s>?)",
-        binding.name);
-  }
-}
-
 swift::VarDecl::Specifier
 SwiftASTManipulator::VariableInfo::GetVarSpecifier() const {
   if (m_decl)
@@ -1453,7 +1401,6 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  llvm::MutableArrayRef<swift::TypeLoc> inherited;
   swift::TypeAliasDecl *type_alias_decl = new (ast_context)
       swift::TypeAliasDecl(source_loc, swift::SourceLoc(), name, source_loc,
                            nullptr, &m_source_file);
@@ -1471,8 +1418,8 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
     ss.flush();
 
     log->Printf("Made global type alias for %s (%p) in context (%p):\n%s",
-                name.get(), GetSwiftType(type).getPointer(), &ast_context,
-                s.c_str());
+                name.get(), static_cast<void *>(GetSwiftType(type).getPointer()),
+                static_cast<void *>(&ast_context), s.c_str());
   }
 
   if (type_alias_decl) {

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -69,7 +69,7 @@ public:
   /// Currently unimplemented for Swift.
   //------------------------------------------------------------------
   bool Complete(CompletionRequest &request, unsigned line, unsigned pos,
-                unsigned typed_pos);
+                unsigned typed_pos) override;
 
   //------------------------------------------------------------------
   /// Parse a single expression and convert it to IR using Swift.  Don't

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -347,7 +347,7 @@ lldb::offset_t SwiftREPL::GetDesiredIndentation(const StringList &lines,
   if (cursor_position == 0 || last_line[cursor_position - 1] == '}') {
 
     // The brace must be the first non-space character
-    const int actual_indent = REPL::CalculateActualIndentation(lines);
+    const size_t actual_indent = REPL::CalculateActualIndentation(lines);
 
     if (last_line.length() > actual_indent && last_line[actual_indent] == '}') {
       // Stop searching once a reason to unindent was found
@@ -419,7 +419,7 @@ bool isThrownError(ValueObjectSP valobj_sp) {
     return false;
   if (name_cstr[1] != 'E')
     return false;
-  for (int index = 2; index < length; index++) {
+  for (size_t index = 2; index < length; index++) {
 
     char digit = name_cstr[index];
     if (digit < '0' || digit > '9')

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -295,9 +295,9 @@ public:
   EntityREPLPersistentVariable(
       lldb::ExpressionVariableSP &persistent_variable_sp,
       SwiftREPLMaterializer *parent,
-      Materializer::PersistentVariableDelegate *delegate)
+      Materializer::PersistentVariableDelegate *)
       : Entity(), m_persistent_variable_sp(persistent_variable_sp),
-        m_parent(parent), m_delegate(delegate) {
+        m_parent(parent) {
     // Hard-coding to maximum size of a pointer since persistent variables are
     // materialized by reference
     m_size = 8;
@@ -450,7 +450,6 @@ public:
 private:
   lldb::ExpressionVariableSP m_persistent_variable_sp;
   SwiftREPLMaterializer *m_parent;
-  Materializer::PersistentVariableDelegate *m_delegate;
 };
 
 uint32_t SwiftREPLMaterializer::AddPersistentVariable(

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -631,9 +631,8 @@ lldb::ExpressionVariableSP SwiftUserExpression::GetResultAfterDematerialization(
 }
 
 SwiftUserExpression::ResultDelegate::ResultDelegate(
-    lldb::TargetSP target, SwiftUserExpression &user_expression, bool is_error)
-    : m_target_sp(target), m_user_expression(user_expression),
-      m_is_error(is_error) {}
+    lldb::TargetSP target, SwiftUserExpression &, bool is_error)
+    : m_target_sp(target), m_is_error(is_error) {}
 
 ConstString SwiftUserExpression::ResultDelegate::GetName() {
   auto prefix = m_persistent_state->GetPersistentVariablePrefix(m_is_error);
@@ -656,8 +655,7 @@ lldb::ExpressionVariableSP &SwiftUserExpression::ResultDelegate::GetVariable() {
 }
 
 SwiftUserExpression::PersistentVariableDelegate::PersistentVariableDelegate(
-    SwiftUserExpression &user_expression)
-    : m_user_expression(user_expression) {}
+    SwiftUserExpression &) {}
 
 ConstString SwiftUserExpression::PersistentVariableDelegate::GetName() {
   return ConstString();

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -51,13 +51,10 @@ public:
 
   class SwiftUserExpressionHelper : public ExpressionTypeSystemHelper {
   public:
-    SwiftUserExpressionHelper(Target &target)
-        : ExpressionTypeSystemHelper(eKindSwiftHelper), m_target(target) {}
+    SwiftUserExpressionHelper(Target &)
+        : ExpressionTypeSystemHelper(eKindSwiftHelper) {}
 
     ~SwiftUserExpressionHelper() {}
-
-  private:
-    Target &m_target;
   };
 
   //------------------------------------------------------------------
@@ -166,7 +163,6 @@ private:
 
   private:
     lldb::TargetSP m_target_sp;
-    SwiftUserExpression &m_user_expression;
     PersistentExpressionState *m_persistent_state;
     lldb::ExpressionVariableSP m_variable;
     bool m_is_error;
@@ -181,9 +177,6 @@ private:
     PersistentVariableDelegate(SwiftUserExpression &);
     ConstString GetName() override;
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
-
-  private:
-    SwiftUserExpression &m_user_expression;
   };
 
   PersistentVariableDelegate m_persistent_variable_delegate;

--- a/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.cpp
+++ b/source/Plugins/InstrumentationRuntime/SwiftRuntimeReporting/SwiftRuntimeReporting.cpp
@@ -86,7 +86,7 @@ static StructuredData::ArraySP ReadThreads(ProcessSP process_sp, addr_t addr) {
   uint64_t num_extra_threads = process_sp->ReadUnsignedIntegerFromMemory(addr, ptr_size, 0, read_error);
   if (num_extra_threads > 16) num_extra_threads = 16;
   addr_t threads_ptr = process_sp->ReadUnsignedIntegerFromMemory(addr + ptr_size, ptr_size, 0, read_error);
-  for (int i = 0; i < num_extra_threads; i++) {
+  for (size_t i = 0; i < num_extra_threads; i++) {
     StructuredData::ArraySP trace(new StructuredData::Array());
     int thread_struct_stride = 3 * ptr_size + 8;
     addr_t thread_ptr = threads_ptr + i * thread_struct_stride;
@@ -105,7 +105,7 @@ static StructuredData::ArraySP ReadThreads(ProcessSP process_sp, addr_t addr) {
     if (num_frames > 256) num_frames = 256;
     addr_t frames_ptr = process_sp->ReadUnsignedIntegerFromMemory(
         thread_ptr + 8 + 2 * ptr_size, ptr_size, 0, read_error);
-    for (int j = 0; j < num_frames; j++) {
+    for (size_t j = 0; j < num_frames; j++) {
       addr_t frame = process_sp->ReadUnsignedIntegerFromMemory(
           frames_ptr + j * ptr_size, ptr_size, 0, read_error);
       trace->AddItem(
@@ -131,7 +131,7 @@ static StructuredData::ArraySP ReadFixits(ProcessSP process_sp, addr_t addr) {
   uint64_t num_fixits = process_sp->ReadUnsignedIntegerFromMemory(addr, ptr_size, 0, read_error);
   if (num_fixits > 16) num_fixits = 16;
   addr_t fixits_ptr = process_sp->ReadUnsignedIntegerFromMemory(addr + ptr_size, ptr_size, 0, read_error);
-  for (int i = 0; i < num_fixits; i++) {
+  for (size_t i = 0; i < num_fixits; i++) {
     int fixit_struct_stride = 6 * ptr_size;
     addr_t fixit_ptr = fixits_ptr + i * fixit_struct_stride;
 
@@ -181,7 +181,7 @@ static StructuredData::ArraySP ReadNotes(ProcessSP process_sp, addr_t addr) {
   uint64_t num_notes = process_sp->ReadUnsignedIntegerFromMemory(addr, ptr_size, 0, read_error);
   if (num_notes > 16) num_notes = 16;
   addr_t fixits_ptr = process_sp->ReadUnsignedIntegerFromMemory(addr + ptr_size, ptr_size, 0, read_error);
-  for (int i = 0; i < num_notes; i++) {
+  for (size_t i = 0; i < num_notes; i++) {
     int note_struct_stride = 3 * ptr_size;
     addr_t note_ptr = fixits_ptr + i * note_struct_stride;
 
@@ -299,7 +299,7 @@ SwiftRuntimeReporting::RetrieveReportData(ExecutionContextRef exe_ctx_ref) {
   thread->AddStringItem("description", current_stack_description);
   thread->AddIntegerItem("tid", thread_sp->GetIndexID());
   threads->AddItem(thread);
-  for (int i = 0; i < extra_threads->GetSize(); i++) {
+  for (size_t i = 0; i < extra_threads->GetSize(); i++) {
     threads->AddItem(extra_threads->GetItemAtIndex(i));
   }
 

--- a/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/source/Plugins/Language/Swift/CMakeLists.txt
@@ -28,4 +28,8 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   LINK_COMPONENTS
     Support
 )
+if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_MSVC_LIKE)
+  target_compile_options(lldbPluginSwiftLanguage PRIVATE
+    -Wno-dollar-in-identifier-extension)
+endif()
 

--- a/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -271,7 +271,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
   bool success = false;
   uint64_t len = value_sp->GetValueAsUnsigned(0, &success);
   if (success) {
-    stream.Printf("%llu bytes", len);
+    stream.Printf("%" PRIu64 " bytes", len);
     return true;
   }
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -521,7 +521,7 @@ bool NativeHashedStorageHandler::IsValid() {
 
 uint64_t
 NativeHashedStorageHandler::GetMetadataWord(int index, Status &error) {
-  if (index >= GetWordCount()) {
+  if (static_cast<size_t>(index) >= GetWordCount()) {
     error.SetErrorToGenericError();
     return 0;
   }

--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1305,6 +1305,9 @@ AddressClass ObjectFileMachO::GetAddressClass(lldb::addr_t file_addr) {
         return AddressClass::eRuntime;
       case eSymbolTypeASTFile:
         return AddressClass::eDebug;
+
+      case eSymbolTypeIVarOffset:
+        break;
       }
     }
   }

--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -3857,6 +3857,9 @@ void GDBRemoteCommunicationClient::ServeSymbolLookups(
                         symbol_load_addr =
                             sc.symbol->GetLoadAddress(&process->GetTarget());
                         break;
+
+                      case eSymbolTypeIVarOffset:
+                        break;
                       }
                     }
                   }

--- a/source/Symbol/CMakeLists.txt
+++ b/source/Symbol/CMakeLists.txt
@@ -68,3 +68,6 @@ add_lldb_library(lldbSymbol
   LINK_COMPONENTS
     Support
   )
+if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+  target_compile_options(lldbSymbol PRIVATE -Wno-dollar-in-identifier-extension)
+endif()

--- a/source/Symbol/ObjectFile.cpp
+++ b/source/Symbol/ObjectFile.cpp
@@ -454,6 +454,9 @@ AddressClass ObjectFile::GetAddressClass(addr_t file_addr) {
         return AddressClass::eRuntime;
       case eSymbolTypeASTFile:
         return AddressClass::eDebug;
+
+      case eSymbolTypeIVarOffset:
+        break;
       }
     }
   }

--- a/source/Symbol/SymbolContext.cpp
+++ b/source/Symbol/SymbolContext.cpp
@@ -894,6 +894,12 @@ SymbolContext::FindBestGlobalDataSymbol(const ConstString &name, Status &error) 
             case eSymbolTypeUndefined:
             case eSymbolTypeResolver:
               break;
+
+            case eSymbolTypeASTFile:
+              break;
+
+            case eSymbolTypeIVarOffset:
+              break;
           }
         }
       }

--- a/source/Target/CMakeLists.txt
+++ b/source/Target/CMakeLists.txt
@@ -129,3 +129,6 @@ add_lldb_library(lldbTarget
   LINK_COMPONENTS
     Support
   )
+if(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+  target_compile_options(lldbTarget PRIVATE -Wno-dollar-in-identifier-extension)
+endif()

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -1500,8 +1500,6 @@ bool Process::IsAlive() {
   case eStateCrashed:
   case eStateSuspended:
     return true;
-  default:
-    return false;
   }
 }
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -179,7 +179,7 @@ void SwiftLanguageRuntime::SetupExclusivity() {
   Log *log(GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
   if (log)
-    log->Printf("SwiftLanguageRuntime: _swift_disableExclusivityChecking = %llu",
+    log->Printf("SwiftLanguageRuntime: _swift_disableExclusivityChecking = %lu",
                 m_dynamic_exclusivity_flag_addr ?
                 *m_dynamic_exclusivity_flag_addr : 0);
 }
@@ -1478,16 +1478,6 @@ SwiftLanguageRuntime::GetMemberVariableOffset(CompilerType instance_type,
   return llvm::None;
 }
 
-static size_t BaseClassDepth(ValueObject &in_value) {
-  ValueObject *ptr = &in_value;
-  size_t depth = 0;
-  while (ptr->IsBaseClass()) {
-    depth++;
-    ptr = ptr->GetParent();
-  }
-  return depth;
-}
-
 /// Determine whether the scratch SwiftASTContext has been locked.
 static bool IsScratchContextLocked(Target &target) {
   if (target.GetSwiftScratchContextLock().try_lock()) {
@@ -1526,7 +1516,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
   auto metadata_address = remote_ast.getHeapMetadataForObject(instance_address);
   if (!metadata_address) {
     if (log) {
-      log->Printf("could not read heap metadata for object at %llu: %s\n",
+      log->Printf("could not read heap metadata for object at %lu: %s\n",
                   class_metadata_ptr,
                   metadata_address.getFailure().render().c_str());
     }
@@ -1539,8 +1529,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
                                               /*skipArtificial=*/true);
   if (!instance_type) {
     if (log) {
-      log->Printf("could not get type metadata from address %llu: %s\n",
-                  metadata_address.getValue(),
+      log->Printf("could not get type metadata from address %" PRIu64 " : %s\n",
+                  metadata_address.getValue().getAddressData(),
                   instance_type.getFailure().render().c_str());
     }
     return false;
@@ -2001,8 +1991,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
   } break;
   case swift::MetadataKind::Existential: {
     CompilerType protocol_type(promise_sp->FulfillTypePromise());
-    SwiftASTContext *swift_ast_ctx =
-        llvm::dyn_cast_or_null<SwiftASTContext>(protocol_type.GetTypeSystem());
     lldb::addr_t existential_address = in_value.GetPointerValue();
     if (!existential_address || existential_address == LLDB_INVALID_ADDRESS)
       return false;
@@ -2113,7 +2101,7 @@ bool SwiftLanguageRuntime::GetAbstractTypeName(StreamString &name,
   swift::TypeBase *base = swift_type.getPointer();
   while (dependent_member) {
     base = dependent_member->getBase().getPointer();
-    assoc.Printf(".%s", dependent_member->getName());
+    assoc.Printf(".%s", dependent_member->getName().get());
     dependent_member = llvm::dyn_cast<swift::DependentMemberType>(base);
   }
 
@@ -2122,7 +2110,7 @@ bool SwiftLanguageRuntime::GetAbstractTypeName(StreamString &name,
     return false;
 
   name.Printf(u8"\u03C4_%d_%d%s", generic_type_param->getDepth(),
-              generic_type_param->getIndex(), assoc.GetString());
+              generic_type_param->getIndex(), assoc.GetString().data());
   return true;
 }
 
@@ -3837,7 +3825,6 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression() {
 llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
     lldb::StackFrameSP frame_sp)
 {
-  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
   llvm::Optional<Value> error_val;
 
   llvm::StringRef error_reg_name;
@@ -3889,7 +3876,6 @@ llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
 
 llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationBeforeReturn(
     lldb::StackFrameSP frame_sp, bool &need_to_check_after_return) {
-  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_STEP));
   llvm::Optional<Value> error_val;
   
   if (!frame_sp)
@@ -3913,8 +3899,6 @@ llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationBeforeReturn(
     if (error_loc_val_sp && error_loc_val_sp->GetError().Success())
       error_val = error_loc_val_sp->GetValue();
 
-//    if (log)
-//      log->Printf("Found return address: 0x%" PRIu64 " from error variable.", return_addr);
     return error_val;
   }
   
@@ -4114,8 +4098,6 @@ private:
     case ReferenceCountType::eReferenceWeak:
       Kind = "Weak";
       break;
-    default:
-      llvm_unreachable("Unhandled refcount type in switch!");
     }
 
     EvaluateExpressionOptions eval_options;


### PR DESCRIPTION
This is intended to cleanup most of the warnings from the LLDB build.  The ones in particular that are left are related to C11 and four character codes.