### PR TITLE
Replace boolean parameter with enum value according r342633 (Fix building with clang-cl on Windows)

### DIFF
--- a/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -837,7 +837,7 @@ void ProcessWindows::OnDebuggerConnected(lldb::addr_t image_base) {
       return;
     }
 
-    GetTarget().SetExecutableModule(module, false);
+    GetTarget().SetExecutableModule(module, eLoadDependentsNo);
   }
 
   bool load_addr_changed;


### PR DESCRIPTION
Building on Windows with Clang-cl fails without this patch from upstream. I filed this bug: https://bugs.swift.org/browse/SR-9107, but this might be an easier solution.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@342671 91177308-0d34-0410-b5e6-96231b3b80d8