### PR TITLE
Remove an early-return from Driver::ParseArgs that

### DIFF
--- a/tools/driver/Driver.cpp
+++ b/tools/driver/Driver.cpp
@@ -579,10 +579,6 @@ SBError Driver::ParseArgs(int argc, const char *argv[], FILE *out_fh,
 
   ResetOptionValues();
 
-  // No arguments or just program name, nothing to parse.
-  if (argc <= 1)
-    return SBError();
-
   SBError error;
   std::vector<option> long_options_vector;
   BuildGetOptTable(long_options_vector);


### PR DESCRIPTION
Remove an early-return from Driver::ParseArgs that
was added as a part of D52604 / r343348.  If the
lldb driver is run without any arguments, .lldbinit 
file reading was not enabled.

<rdar://problem/45570242> 


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@345422 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 7d702f9a46f030f829bacd1b2075714ff7ff4c4e)
(cherry picked from commit d5f3bd26e16ec4ada55c989abb7d638cfb6ee0cd)