### PR TITLE
[5.0] Fix PythonString::GetString for >=python-3.7

### DIFF
--- a/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -399,14 +399,16 @@ llvm::StringRef PythonString::GetString() const {
     return llvm::StringRef();
 
   Py_ssize_t size;
-  char *c;
+  const char *data;
 
 #if PY_MAJOR_VERSION >= 3
-  c = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
+  data = PyUnicode_AsUTF8AndSize(m_py_obj, &size);
 #else
+  char *c;
   PyString_AsStringAndSize(m_py_obj, &c, &size);
+  data = c;
 #endif
-  return llvm::StringRef(c, size);
+  return llvm::StringRef(data, size);
 }
 
 size_t PythonString::GetSize() const {


### PR DESCRIPTION
Cherry-pick of https://reviews.llvm.org/rLLDB337908 to swift-5.0-branch.

[SR-9180](https://bugs.swift.org/browse/SR-9180)