### PR TITLE
Fix deadlock rdar://45600292

### DIFF
--- a/lit/SwiftREPL/Deadlock.test
+++ b/lit/SwiftREPL/Deadlock.test
@@ -1,0 +1,15 @@
+// RUN: %lldb --repl < %s | FileCheck %s
+
+// From https://bugs.swift.org/browse/SR-7114
+// This sequence was deadlocking.
+
+let a = 9007199254740991.0
+// CHECK: a: Double = 9007199254740991
+(a * a - a * a).squareRoot() 
+// CHECK: (Double) = {
+// CHECK-NEXT:  _value = 0
+// CHECK-NEXT: }
+(a * a).addingProduct(-a, a).squareRoot()
+// CHECK: (Double) = {
+// CHECK-NEXT:  _value = NaN 
+// CHECK-NEXT: }

--- a/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -68,7 +68,11 @@ void ManualDWARFIndex::Index() {
   // to wait until all compile units have been indexed in case a DIE in one
   // compile unit refers to another and the indexes accesses those DIEs.
   //----------------------------------------------------------------------
-  TaskMapOverInt(0, units_to_index.size(), extract_fn);
+  for (int i=0; i<units_to_index.size(); ++i) {
+     extract_fn(i);
+  }
+  // This call can deadlock because we are sometimes holding the module lock.
+  //TaskMapOverInt(0, units_to_index.size(), extract_fn);
 
   // Now create a task runner that can index each DWARF compile unit in a
   // separate thread so we can index quickly.


### PR DESCRIPTION
This was already worked around in rdar://problem/38461035, but it was lost in
a follow-up merge resolution. This reinstates the workaround and adds a test
(from https://bugs.swift.org/browse/SR-7114) to make sure we don't regress this.