### PR TITLE
[Swift][DataFormatters] Add formatters for GLKit types.

### DIFF
--- a/lit/SwiftREPL/GLKIT.test
+++ b/lit/SwiftREPL/GLKIT.test
@@ -1,0 +1,46 @@
+// Test formatters for Accelerate/simd.
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s
+
+import GLKit
+
+GLKVector3(v: (1, 2, 3))
+// CHECK: $R{{.*}}: GLKVector3 = (1.000000e+00, 2.000000e+00, 3.000000e+00)
+
+GLKVector4(v: (1, 2, 3, 4))
+// CHECK: $R{{.*}}: GLKVector4 = (1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)
+
+GLKVector2(v: (4, 5))
+// CHECK: $R{{.*}}: GLKVector2 = (4.000000e+00, 5.000000e+00)
+
+GLKQuaternion(q: (4, 3, 2, 1))
+// CHECK: $R{{.*}}: GLKQuaternion = (4.000000e+00, 3.000000e+00, 2.000000e+00, 1.000000e+00)
+
+GLKMatrix3Identity
+// CHECK: $R{{.*}}: GLKMatrix3 =
+// CHECK: [ [1.000000e+00, 0.000000e+00, 0.000000e+00],
+// CHECK:   [0.000000e+00, 1.000000e+00, 0.000000e+00],
+// CHECK:   [0.000000e+00, 0.000000e+00, 1.000000e+00] ]
+
+GLKMatrix4Identity
+// CHECK: $R{{.*}}: GLKMatrix4 =
+// CHECK: [ [1.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00],
+// CHECK:   [0.000000e+00, 1.000000e+00, 0.000000e+00, 0.000000e+00],
+// CHECK:   [0.000000e+00, 0.000000e+00, 1.000000e+00, 0.000000e+00],
+// CHECK:   [0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00] ]
+
+let mat = GLKMatrix3Make(10, 20, 30, 40, 50, 60, 70, 80, 90)
+// CHECK: {{mat}}: GLKMatrix3 =
+// CHECK: [ [1.000000e+01, 4.000000e+01, 7.000000e+01],
+// CHECK:   [2.000000e+01, 5.000000e+01, 8.000000e+01],
+// CHECK:   [3.000000e+01, 6.000000e+01, 9.000000e+01] ]
+
+GLKMatrix3GetMatrix2(mat)
+// CHECK: $R{{.*}}: GLKMatrix2 =
+// CHECK: [ [1.000000e+01, 4.000000e+01],
+// CHECK:   [2.000000e+01, 5.000000e+01] ]
+
+
+
+

--- a/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -87,6 +87,9 @@ bool StridedRangeGenerator_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool AccelerateSIMD_SummaryProvider(ValueObject &valobj, Stream &stream,
                                     const TypeSummaryOptions &options);
 
+bool GLKit_SummaryProvider(ValueObject &valobj, Stream &stream,
+                           const TypeSummaryOptions &options);
+
 // TODO: this is a transient workaround for the fact that
 // ObjC types are totally opaque in Swift for LLDB
 bool BuiltinObjC_SummaryProvider(ValueObject &valobj, Stream &stream,

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -559,7 +559,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       .SetDontShowChildren(true)
       .SetHideItemNames(true)
       .SetShowMembersOneLiner(false);
-  const char *accelSIMDTypes = "^(simd\.)?(simd_)?("
+  const char *accelSIMDTypes = "^(simd\\.)?(simd_)?("
                                "(int|uint|float|double)[234]|"
                                "(float|double)[234]x[234]|"
                                "quat(f|d)"
@@ -567,6 +567,12 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::AccelerateSIMD_SummaryProvider,
                 "Accelerate/SIMD summary provider", ConstString(accelSIMDTypes),
+                simd_summary_flags, true);
+
+  const char *GLKitTypes = "^(GLKMatrix[234]|GLKVector[234]|GLKQuaternion)$";
+  AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::GLKit_SummaryProvider,
+                "GLKit summary provider", ConstString(GLKitTypes),
                 simd_summary_flags, true);
 
   TypeSummaryImpl::Flags nil_summary_flags;


### PR DESCRIPTION
GLKit types are completely opaque, but reusing the support we have for
Accelearate types, it was easy to add a summary formatters for them.

rdar://44685031