### PR TITLE
[MemoryReader] Only dump a reasonable number of bytes.

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1162,7 +1162,7 @@ SwiftLanguageRuntime::GetMemoryReader() {
         return false;
       }
 
-      if (log) {
+      if (log && log->GetVerbose()) {
         StreamString stream;
         for (uint64_t i = 0; i < size; i++) {
           stream.PutHex8(dest[i]);


### PR DESCRIPTION
Otherwise the log gets too verbose, not really readable.
Discussed with (and proposed by) Adrian.

<rdar://problem/45592295>