### PR TITLE
Adjust for SVN r346707

### DIFF
--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1490,8 +1490,8 @@ SymbolFileDWARFDebugMap::GetASTData(lldb::LanguageType language) {
       if (FileSystem::Instance().Exists(file_spec)) {
         // We found the source data for the AST data blob.
         // Read it in and add it to our return vector.
-        std::shared_ptr<DataBufferLLVM> data_buf_sp 
-                = DataBufferLLVM::CreateFromPath(file_spec.GetPath());
+        std::shared_ptr<DataBufferLLVM> data_buf_sp =
+            FileSystem::Instance().CreateDataBuffer(file_spec);
         if (data_buf_sp) {
           ast_datas.push_back(data_buf_sp);
           if (log)


### PR DESCRIPTION
Looks like r346707 removed `DataBufferLLVM::CreateFromPath`

cc @JDevlieghere @jimingham 