### PR TITLE
Since ABI's now hold a process WP, they should be handed

### DIFF
--- a/source/Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.cpp
+++ b/source/Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.cpp
@@ -1327,16 +1327,13 @@ size_t ABIMacOSX_arm::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABIMacOSX_arm::CreateInstance(ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   const llvm::Triple::ArchType arch_type = arch.GetTriple().getArch();
   const llvm::Triple::VendorType vendor_type = arch.GetTriple().getVendor();
 
   if (vendor_type == llvm::Triple::Apple) {
     if ((arch_type == llvm::Triple::arm) ||
         (arch_type == llvm::Triple::thumb)) {
-      if (!g_abi_sp)
-        g_abi_sp.reset(new ABIMacOSX_arm(process_sp));
-      return g_abi_sp;
+      return ABISP(new ABIMacOSX_arm(process_sp));
     }
   }
 

--- a/source/Plugins/ABI/MacOSX-arm64/ABIMacOSX_arm64.cpp
+++ b/source/Plugins/ABI/MacOSX-arm64/ABIMacOSX_arm64.cpp
@@ -1667,15 +1667,12 @@ size_t ABIMacOSX_arm64::GetRedZoneSize() const { return 128; }
 
 ABISP
 ABIMacOSX_arm64::CreateInstance(ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   const llvm::Triple::ArchType arch_type = arch.GetTriple().getArch();
   const llvm::Triple::VendorType vendor_type = arch.GetTriple().getVendor();
 
   if (vendor_type == llvm::Triple::Apple) {
     if (arch_type == llvm::Triple::aarch64) {
-      if (!g_abi_sp)
-        g_abi_sp.reset(new ABIMacOSX_arm64(process_sp));
-      return g_abi_sp;
+      return ABISP(new ABIMacOSX_arm64(process_sp));
     }
   }
 

--- a/source/Plugins/ABI/MacOSX-i386/ABIMacOSX_i386.cpp
+++ b/source/Plugins/ABI/MacOSX-i386/ABIMacOSX_i386.cpp
@@ -714,13 +714,10 @@ size_t ABIMacOSX_i386::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABIMacOSX_i386::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   if ((arch.GetTriple().getArch() == llvm::Triple::x86) &&
       (arch.GetTriple().isMacOSX() || arch.GetTriple().isiOS() ||
        arch.GetTriple().isWatchOS())) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABIMacOSX_i386(process_sp));
-    return g_abi_sp;
+    return ABISP(new ABIMacOSX_i386(process_sp));
   }
   return ABISP();
 }

--- a/source/Plugins/ABI/SysV-arm/ABISysV_arm.cpp
+++ b/source/Plugins/ABI/SysV-arm/ABISysV_arm.cpp
@@ -1328,16 +1328,13 @@ size_t ABISysV_arm::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABISysV_arm::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   const llvm::Triple::ArchType arch_type = arch.GetTriple().getArch();
   const llvm::Triple::VendorType vendor_type = arch.GetTriple().getVendor();
 
   if (vendor_type != llvm::Triple::Apple) {
     if ((arch_type == llvm::Triple::arm) ||
         (arch_type == llvm::Triple::thumb)) {
-      if (!g_abi_sp)
-        g_abi_sp.reset(new ABISysV_arm(process_sp));
-      return g_abi_sp;
+      return ABISP(new ABISysV_arm(process_sp));
     }
   }
 

--- a/source/Plugins/ABI/SysV-arm64/ABISysV_arm64.cpp
+++ b/source/Plugins/ABI/SysV-arm64/ABISysV_arm64.cpp
@@ -1671,15 +1671,12 @@ size_t ABISysV_arm64::GetRedZoneSize() const { return 128; }
 
 ABISP
 ABISysV_arm64::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   const llvm::Triple::ArchType arch_type = arch.GetTriple().getArch();
   const llvm::Triple::VendorType vendor_type = arch.GetTriple().getVendor();
 
   if (vendor_type != llvm::Triple::Apple) {
     if (arch_type == llvm::Triple::aarch64) {
-      if (!g_abi_sp)
-        g_abi_sp.reset(new ABISysV_arm64(process_sp));
-      return g_abi_sp;
+      return ABISP(new ABISysV_arm64(process_sp));
     }
   }
 

--- a/source/Plugins/ABI/SysV-hexagon/ABISysV_hexagon.cpp
+++ b/source/Plugins/ABI/SysV-hexagon/ABISysV_hexagon.cpp
@@ -1020,11 +1020,8 @@ size_t ABISysV_hexagon::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABISysV_hexagon::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   if (arch.GetTriple().getArch() == llvm::Triple::hexagon) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABISysV_hexagon(process_sp));
-    return g_abi_sp;
+    return ABISP(new ABISysV_hexagon(process_sp));
   }
   return ABISP();
 }

--- a/source/Plugins/ABI/SysV-i386/ABISysV_i386.cpp
+++ b/source/Plugins/ABI/SysV-i386/ABISysV_i386.cpp
@@ -203,12 +203,9 @@ ABISysV_i386::GetRegisterInfoArray(uint32_t &count) {
 
 ABISP
 ABISysV_i386::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   if (arch.GetTriple().getVendor() != llvm::Triple::Apple) {
     if (arch.GetTriple().getArch() == llvm::Triple::x86) {
-      if (!g_abi_sp)
-        g_abi_sp.reset(new ABISysV_i386(process_sp));
-      return g_abi_sp;
+      return ABISP(new ABISysV_i386(process_sp));
     }
   }
   return ABISP();

--- a/source/Plugins/ABI/SysV-mips/ABISysV_mips.cpp
+++ b/source/Plugins/ABI/SysV-mips/ABISysV_mips.cpp
@@ -560,13 +560,10 @@ size_t ABISysV_mips::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABISysV_mips::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   const llvm::Triple::ArchType arch_type = arch.GetTriple().getArch();
   if ((arch_type == llvm::Triple::mips) ||
       (arch_type == llvm::Triple::mipsel)) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABISysV_mips(process_sp));
-    return g_abi_sp;
+    return ABISP(new ABISysV_mips(process_sp));
   }
   return ABISP();
 }

--- a/source/Plugins/ABI/SysV-mips64/ABISysV_mips64.cpp
+++ b/source/Plugins/ABI/SysV-mips64/ABISysV_mips64.cpp
@@ -560,13 +560,10 @@ size_t ABISysV_mips64::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABISysV_mips64::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   const llvm::Triple::ArchType arch_type = arch.GetTriple().getArch();
   if ((arch_type == llvm::Triple::mips64) ||
       (arch_type == llvm::Triple::mips64el)) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABISysV_mips64(process_sp));
-    return g_abi_sp;
+    return ABISP(new ABISysV_mips64(process_sp));
   }
   return ABISP();
 }

--- a/source/Plugins/ABI/SysV-ppc/ABISysV_ppc.cpp
+++ b/source/Plugins/ABI/SysV-ppc/ABISysV_ppc.cpp
@@ -224,11 +224,8 @@ size_t ABISysV_ppc::GetRedZoneSize() const { return 224; }
 
 ABISP
 ABISysV_ppc::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   if (arch.GetTriple().getArch() == llvm::Triple::ppc) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABISysV_ppc(process_sp));
-    return g_abi_sp;
+     return ABISP(new ABISysV_ppc(process_sp));
   }
   return ABISP();
 }

--- a/source/Plugins/ABI/SysV-s390x/ABISysV_s390x.cpp
+++ b/source/Plugins/ABI/SysV-s390x/ABISysV_s390x.cpp
@@ -206,11 +206,8 @@ size_t ABISysV_s390x::GetRedZoneSize() const { return 0; }
 
 ABISP
 ABISysV_s390x::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   if (arch.GetTriple().getArch() == llvm::Triple::systemz) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABISysV_s390x(process_sp));
-    return g_abi_sp;
+    return ABISP(new ABISysV_s390x(process_sp));
   }
   return ABISP();
 }

--- a/source/Plugins/ABI/SysV-x86_64/ABISysV_x86_64.cpp
+++ b/source/Plugins/ABI/SysV-x86_64/ABISysV_x86_64.cpp
@@ -1095,11 +1095,8 @@ size_t ABISysV_x86_64::GetRedZoneSize() const { return 128; }
 
 ABISP
 ABISysV_x86_64::CreateInstance(lldb::ProcessSP process_sp, const ArchSpec &arch) {
-  static ABISP g_abi_sp;
   if (arch.GetTriple().getArch() == llvm::Triple::x86_64) {
-    if (!g_abi_sp)
-      g_abi_sp.reset(new ABISysV_x86_64(process_sp));
-    return g_abi_sp;
+    return ABISP(new ABISysV_x86_64(process_sp));
   }
   return ABISP();
 }


### PR DESCRIPTION
out one per process rather than keeping a single global instance.

Differential Revision: https://reviews.llvm.org/D54460


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@346775 91177308-0d34-0410-b5e6-96231b3b80d8