### PR TITLE
 Fix a bug in the parsing of the LC_BUILD_VERSION Mach-O load command.

### DIFF
--- a/lit/Modules/lc_build_version_notools.yaml
+++ b/lit/Modules/lc_build_version_notools.yaml
@@ -10,7 +10,7 @@ FileHeader:
   cpusubtype:      0x80000003
   filetype:        0x00000002
   ncmds:           14
-  sizeofcmds:      744
+  sizeofcmds:      738
   flags:           0x00200085
   reserved:        0x00000000
 LoadCommands:    
@@ -119,14 +119,11 @@ LoadCommands:
     cmdsize:         24
     uuid:            8F41E140-23B9-3720-AC28-4E7AF9D159BA
   - cmd:             LC_BUILD_VERSION
-    cmdsize:         32
+    cmdsize:         24
     platform:        1
     minos:           658944
     sdk:             658944
-    ntools:          1
-    Tools:           
-      - tool:            3
-        version:         26738944
+    ntools:          0
   - cmd:             LC_SOURCE_VERSION
     cmdsize:         16
     version:         0

--- a/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5224,24 +5224,28 @@ bool ObjectFileMachO::GetArchitecture(const llvm::MachO::mach_header &header,
         const lldb::offset_t cmd_offset = offset;
         if (data.GetU32(&offset, &load_cmd, 2) == NULL)
           break;
-
-        if (load_cmd.cmd == llvm::MachO::LC_BUILD_VERSION) {
-          struct build_version_command build_version;
-          if (load_cmd.cmdsize != sizeof(build_version))
+        do {
+          if (load_cmd.cmd == llvm::MachO::LC_BUILD_VERSION) {
+            struct build_version_command build_version;
+            if (load_cmd.cmdsize < sizeof(build_version)) {
+              // Malformed load command.
+              break;
+            }
             if (data.ExtractBytes(cmd_offset, sizeof(build_version),
                                   data.GetByteOrder(), &build_version) == 0)
-              continue;
-          MinOS min_os(build_version.minos);
-          OSEnv os_env(build_version.platform);
-          if (os_env.os_type.empty())
-            continue;
-          os << os_env.os_type << min_os.major_version << '.'
-             << min_os.minor_version << '.' << min_os.patch_version;
-          triple.setOSName(os.str());
-          if (!os_env.environment.empty())
-            triple.setEnvironmentName(os_env.environment);
-          return true;
-        }
+              break;
+            MinOS min_os(build_version.minos);
+            OSEnv os_env(build_version.platform);
+            if (os_env.os_type.empty())
+              break;
+            os << os_env.os_type << min_os.major_version << '.'
+               << min_os.minor_version << '.' << min_os.patch_version;
+            triple.setOSName(os.str());
+            if (!os_env.environment.empty())
+              triple.setEnvironmentName(os_env.environment);
+            return true;
+          }
+        } while (0);
         offset = cmd_offset + load_cmd.cmdsize;
       }
 


### PR DESCRIPTION
LC_BUILD_VERSION records are of variable length. The original code
would use uninitialized memory when the size of a record was exactly 24.

rdar://problem/46032185

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@346812 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 2e9aff681eee5e9ab5155e635b5c1bdc0cdd38cf)