### PR TITLE
Refactor ClangASTContext::AddEnumerationValueToEnumerationType() to fix expression parser scoped enum issue

### DIFF
--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -907,7 +907,6 @@ public:
   // Modifying Enumeration types
   //----------------------------------------------------------------------
   bool AddEnumerationValueToEnumerationType(
-      lldb::opaque_compiler_type_t type,
       const CompilerType &enumerator_qual_type, const Declaration &decl,
       const char *name, int64_t enum_value, uint32_t enum_value_bit_size);
 

--- a/packages/Python/lldbsuite/test/expression_command/radar_43822994/Makefile
+++ b/packages/Python/lldbsuite/test/expression_command/radar_43822994/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../make
+
+CXX_SOURCES := main.cpp
+CXXFLAGS += -std=c++11
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/expression_command/radar_43822994/TestScopedEnumType.py
+++ b/packages/Python/lldbsuite/test/expression_command/radar_43822994/TestScopedEnumType.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class ExprXValuePrintingTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test(self):
+        self.build()
+
+        self.main_source = "main.cpp"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                                          '// Set break point at this line.', self.main_source_spec)
+        frame = thread.GetFrameAtIndex(0)
+
+        self.expect("expr f == Foo::FooBar",
+                substrs=['(bool) $0 = true'])
+
+        value = frame.EvaluateExpression("f == Foo::FooBar")
+        self.assertTrue(value.IsValid())
+        self.assertTrue(value.GetError().Success())
+        self.assertEqual(value.GetValueAsUnsigned(), 1)

--- a/packages/Python/lldbsuite/test/expression_command/radar_43822994/main.cpp
+++ b/packages/Python/lldbsuite/test/expression_command/radar_43822994/main.cpp
@@ -1,0 +1,9 @@
+enum class Foo {
+  FooBar = 42
+};
+
+int main(int argc, const char **argv) {
+  Foo f = Foo::FooBar;
+  bool b1 = f == Foo::FooBar;
+  return 0; // Set break point at this line.
+}

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2608,9 +2608,7 @@ size_t DWARFASTParserClang::ParseChildEnumerators(
 
         if (name && name[0] && got_value) {
           m_ast.AddEnumerationValueToEnumerationType(
-              clang_type.GetOpaqueQualType(),
-              m_ast.GetEnumerationIntegerType(clang_type.GetOpaqueQualType()),
-              decl, name, enum_value, enumerator_byte_size * 8);
+              clang_type, decl, name, enum_value, enumerator_byte_size * 8);
           ++enumerators_added;
         }
       }

--- a/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
+++ b/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
@@ -510,6 +510,5 @@ bool PDBASTParser::AddEnumValue(CompilerType enum_type,
   uint32_t byte_size = m_ast.getASTContext()->getTypeSize(
       ClangUtil::GetQualType(underlying_type));
   return m_ast.AddEnumerationValueToEnumerationType(
-      enum_type.GetOpaqueQualType(), underlying_type, decl, name.c_str(),
-      raw_value, byte_size * 8);
+      enum_type, decl, name.c_str(), raw_value, byte_size * 8);
 }

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -8851,43 +8851,55 @@ bool ClangASTContext::CompleteTagDeclarationDefinition(
 }
 
 bool ClangASTContext::AddEnumerationValueToEnumerationType(
-    lldb::opaque_compiler_type_t type,
-    const CompilerType &enumerator_clang_type, const Declaration &decl,
-    const char *name, int64_t enum_value, uint32_t enum_value_bit_size) {
-  if (type && enumerator_clang_type.IsValid() && name && name[0]) {
-    clang::QualType enum_qual_type(GetCanonicalQualType(type));
+    const CompilerType &enum_type, const Declaration &decl, const char *name,
+    int64_t enum_value, uint32_t enum_value_bit_size) {
 
-    bool is_signed = false;
-    enumerator_clang_type.IsIntegerType(is_signed);
-    const clang::Type *clang_type = enum_qual_type.getTypePtr();
-    if (clang_type) {
-      const clang::EnumType *enutype =
-          llvm::dyn_cast<clang::EnumType>(clang_type);
+  if (!enum_type || ConstString(name).IsEmpty())
+    return nullptr;
 
-      if (enutype) {
-        llvm::APSInt enum_llvm_apsint(enum_value_bit_size, is_signed);
-        enum_llvm_apsint = enum_value;
-        clang::EnumConstantDecl *enumerator_decl =
-            clang::EnumConstantDecl::Create(
-                *getASTContext(), enutype->getDecl(), clang::SourceLocation(),
-                name ? &getASTContext()->Idents.get(name)
-                     : nullptr, // Identifier
-                ClangUtil::GetQualType(enumerator_clang_type),
-                nullptr, enum_llvm_apsint);
+  lldbassert(enum_type.GetTypeSystem() == static_cast<TypeSystem *>(this));
 
-        if (enumerator_decl) {
-          enutype->getDecl()->addDecl(enumerator_decl);
+  lldb::opaque_compiler_type_t enum_opaque_compiler_type =
+      enum_type.GetOpaqueQualType();
+
+  if (!enum_opaque_compiler_type)
+    return nullptr;
+
+  CompilerType underlying_type =
+      GetEnumerationIntegerType(enum_type.GetOpaqueQualType());
+
+  clang::QualType enum_qual_type(
+      GetCanonicalQualType(enum_opaque_compiler_type));
+
+  bool is_signed = false;
+  underlying_type.IsIntegerType(is_signed);
+  const clang::Type *clang_type = enum_qual_type.getTypePtr();
+
+  if (!clang_type)
+    return false;
+
+  const clang::EnumType *enutype = llvm::dyn_cast<clang::EnumType>(clang_type);
+
+  if (!enutype)
+    return false;
+
+  llvm::APSInt enum_llvm_apsint(enum_value_bit_size, is_signed);
+  enum_llvm_apsint = enum_value;
+  clang::EnumConstantDecl *enumerator_decl = clang::EnumConstantDecl::Create(
+      *getASTContext(), enutype->getDecl(), clang::SourceLocation(),
+      name ? &getASTContext()->Idents.get(name) : nullptr, // Identifier
+      clang::QualType(enutype, 0), nullptr, enum_llvm_apsint);
+
+  if (!enumerator_decl)
+    return false;
+
+  enutype->getDecl()->addDecl(enumerator_decl);
 
 #ifdef LLDB_CONFIGURATION_DEBUG
-          VerifyDecl(enumerator_decl);
+  VerifyDecl(enumerator_decl);
 #endif
 
-          return true;
-        }
-      }
-    }
-  }
-  return false;
+  return true;
 }
 
 CompilerType


### PR DESCRIPTION
Refactor ClangASTContext::AddEnumerationValueToEnumerationType() to remove redundant parameter which can be calculated from other parameter. This fixes an underlying issue with expression parser and scoped enums.

rdar://problem/43822994