### PR TITLE
Fix a use-after-free of the ABI plugin.

### DIFF
--- a/source/Symbol/Variable.cpp
+++ b/source/Symbol/Variable.cpp
@@ -156,14 +156,14 @@ void Variable::Dump(Stream *s, bool show_context) const {
                                 .GetBaseAddress()
                                 .GetFileAddress();
     }
-    ABI *abi = nullptr;
+    ABISP abi;
     if (m_owner_scope) {
       ModuleSP module_sp(m_owner_scope->CalculateSymbolContextModule());
       if (module_sp)
-        abi = ABI::FindPlugin(ProcessSP(), module_sp->GetArchitecture()).get();
+        abi = ABI::FindPlugin(ProcessSP(), module_sp->GetArchitecture());
     }
     m_location.GetDescription(s, lldb::eDescriptionLevelBrief,
-                              loclist_base_addr, abi);
+                              loclist_base_addr, abi.get());
   }
 
   if (m_external)
@@ -458,11 +458,11 @@ bool Variable::DumpLocationForAddress(Stream *s, const Address &address) {
     SymbolContext sc;
     CalculateSymbolContext(&sc);
     if (sc.module_sp == address.GetModule()) {
-      ABI *abi = nullptr;
+      ABISP abi;
       if (m_owner_scope) {
         ModuleSP module_sp(m_owner_scope->CalculateSymbolContextModule());
         if (module_sp)
-          abi = ABI::FindPlugin(ProcessSP(), module_sp->GetArchitecture()).get();
+          abi = ABI::FindPlugin(ProcessSP(), module_sp->GetArchitecture());
       }
 
       const addr_t file_addr = address.GetFileAddress();
@@ -474,11 +474,12 @@ bool Variable::DumpLocationForAddress(Stream *s, const Address &address) {
             return false;
           return m_location.DumpLocationForAddress(s, eDescriptionLevelBrief,
                                                    loclist_base_file_addr,
-                                                   file_addr, abi);
+                                                   file_addr, abi.get());
         }
       }
-      return m_location.DumpLocationForAddress(
-          s, eDescriptionLevelBrief, LLDB_INVALID_ADDRESS, file_addr, abi);
+      return m_location.DumpLocationForAddress(s, eDescriptionLevelBrief,
+                                               LLDB_INVALID_ADDRESS, file_addr,
+                                               abi.get());
     }
   }
   return false;


### PR DESCRIPTION
This was introduced in r346775.  Previously the ABI shared_ptr
was declared as a function local static meaning it would live
forever.  After the change, someone has to create a strong
reference to it or it will go away.  In this code, we were
calling ABI::FindPlugin(...).get(), so it was being immediately
destroyed and we were holding onto a dangling pointer.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@346932 91177308-0d34-0410-b5e6-96231b3b80d8