### PR TITLE
Make TestAppleSimulatorOSType.py more flexible

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -20,7 +20,13 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
         sim_devices = json.loads(sim_devices_str)['devices']
         # Find an available simulator for the requested platform
         deviceUDID = None
-        for (runtime,devices) in sim_devices.items():
+        for simulator in sim_devices:
+            if isinstance(simulator,dict):
+                runtime = simulator['name']
+                devices = simulator['devices']
+            else:
+                runtime = simulator
+                devices = sim_devices[simulator]
             if not platform in runtime.lower():
                 continue
             for device in devices:


### PR DESCRIPTION
Different versions of Xcode have different outputs for the simctl command

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@347117 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 47916947abc087c447044448d8e6f3159af623d5)