### PR TITLE
[SwiftExpressionParser] Remove unneeded call to getImportedModules.

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -210,12 +210,8 @@ static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
   if (compile_unit && compile_unit->GetLanguage() == lldb::eLanguageTypeSwift)
     cu_modules = &compile_unit->GetImportedModules();
 
-  llvm::SmallVector<swift::ModuleDecl::ImportedModule, 2> imported_modules;
   llvm::SmallVector<swift::SourceFile::ImportedModuleDesc, 2>
       additional_imports;
-
-  source_file.getImportedModules(imported_modules,
-                                 swift::ModuleDecl::ImportFilter::All);
 
   std::set<ConstString> loaded_modules;
 
@@ -271,9 +267,6 @@ static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
     additional_imports.push_back(swift::SourceFile::ImportedModuleDesc(
         std::make_pair(swift::ModuleDecl::AccessPathTy(), swift_module),
         swift::SourceFile::ImportOptions()));
-    imported_modules.push_back(
-        std::make_pair(swift::ModuleDecl::AccessPathTy(), swift_module));
-
     return true;
   };
 


### PR DESCRIPTION
Everything getModulesDoes() is pushing_back into a vector, and
the results of this operation is actually unused. In preparation
for moving this function to be used somewhere else.

<rdar://problem/30398933>