### PR TITLE
 Fix the layout calculation of generic tuple types.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_error/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error/main.swift
@@ -7,5 +7,4 @@ func f<T>(_ Pat : T) -> T {
   return Pat //%self.expect("frame var -d run-target -- Pat", substrs=['(a.MyErr) Pat = Patatino'])
 }
 
-let patatino = f(MyErr.Patatino as Error)
-print(patatino)
+f(MyErr.Patatino as Error)

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
@@ -1,4 +1,4 @@
-class MyErr : Error {
+class PayloadErr : Error {
   var x : Int
 
   init(_ x : Int) {
@@ -6,24 +6,28 @@ class MyErr : Error {
   }
 }
 
-class MyOtherErr : MyErr {}
+class MyOtherErr : PayloadErr {}
+
+enum CErr : Error {
+  case Topolino
+  case Paperino
+}
+
+func g<T, U>(_ tuple : (T, U)) -> T {
+  return tuple.0 //%self.expect("frame var -d run-target -- tuple",
+                 //%            substrs=['(a.CErr, Int)', 'Topolino', '42'])
+}
 
 func h<U, V>(_ tuple : (U, V)) -> (U, V) {
   return tuple //%self.expect("frame var -d run-target -- tuple", 
-               //%             substrs=['(a.MyErr, a.MyErr) tuple',
+               //%             substrs=['(a.PayloadErr, a.MyOtherErr) tuple',
                //%                      '0 =', '(x = 23)',
-               //%                      'a.MyErr = {', 'x = 42'])
+               //%                      'a.PayloadErr = {', 'x = 42'])
                //%self.expect("expr -d run-target -- tuple",
-               //%             substrs=['(a.MyErr, a.MyErr) $R',
+               //%             substrs=['(a.PayloadErr, a.PayloadErr) $R',
                //%                      '0 =', '(x = 23)',
-               //%                      'a.MyErr = {', 'x = 42'])
+               //%                      'a.PayloadErr = {', 'x = 42'])
 }
 
-func main() -> Int {
-  let foo : MyErr = MyErr(23)
-  let goo : MyErr = MyOtherErr(42)
-  h((foo, goo))
-  return 0
-}
-
-let _ = main()
+g((CErr.Topolino as Error, 42))
+h((PayloadErr(23), MyOtherErr(42) as PayloadErr))

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -79,6 +79,12 @@ using namespace lldb_utility;
 
 static user_id_t g_value_obj_uid = 0;
 
+static const ExecutionContextRef *GetSwiftExeCtx(ValueObject &valobj) {
+  return (valobj.GetPreferredDisplayLanguage() == eLanguageTypeSwift)
+             ? &valobj.GetExecutionContextRef()
+             : nullptr;
+}
+
 //----------------------------------------------------------------------
 // ValueObject constructor
 //----------------------------------------------------------------------
@@ -2837,12 +2843,6 @@ void ValueObject::LogValueObject(Log *log,
     if (s.GetSize())
       log->PutCString(s.GetData());
   }
-}
-
-static const ExecutionContextRef *GetSwiftExeCtx(ValueObject &valobj) {
-  return (valobj.GetPreferredDisplayLanguage() == eLanguageTypeSwift)
-             ? &valobj.GetExecutionContextRef()
-             : nullptr;
 }
 
 void ValueObject::Dump(Stream &s) { Dump(s, DumpValueObjectOptions(*this)); }

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6905,6 +6905,25 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   } break;
 
   case swift::TypeKind::Tuple: {
+    // Dynamic type resolution may actually change(!) the layout of a tuple, so
+    // we need to get the offset from the static (but archetype-bound) version.
+    auto static_value = valobj->GetStaticValue();
+    auto static_type = static_value->GetCompilerType();
+    auto static_swift_type = GetCanonicalSwiftType(static_type);
+    if (swift::isa<swift::TupleType>(static_swift_type))
+      swift_can_type = static_swift_type;
+    if (swift_can_type->hasTypeParameter()) {
+      if (!exe_ctx)
+        return {};
+      auto *exe_scope = exe_ctx->GetBestExecutionContextScope();
+      auto *frame = exe_scope->CalculateStackFrame().get();
+      auto *runtime = exe_scope->CalculateProcess()->GetSwiftLanguageRuntime();
+      if (!frame || !runtime)
+        return {};
+      auto bound = runtime->DoArchetypeBindingForType(*frame, static_type);
+      swift_can_type = GetCanonicalSwiftType(bound);
+    }
+
     auto tuple_type = cast<swift::TupleType>(swift_can_type);
     if (idx >= tuple_type->getNumElements()) break;
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1443,6 +1443,8 @@ SwiftLanguageRuntime::GetMemberVariableOffset(CompilerType instance_type,
 
   // Check whether we've already cached this offset.
   auto *swift_type = GetCanonicalSwiftType(instance_type).getPointer();
+
+  // Perform the cache lookup.
   auto key = std::make_tuple(swift_type, member_name.GetCString());
   auto it = m_member_offsets.find(key);
   if (it != m_member_offsets.end())
@@ -2048,7 +2050,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     if (!dyn_type.IsValid())
       return false;
     class_type_or_name.SetCompilerType(dyn_type);
-    lldb::addr_t val_ptr_addr = in_value.GetPointerValue();
+    lldb::addr_t val_ptr_addr = in_value.GetAddressOf();
     val_ptr_addr = GetProcess()->ReadPointerFromMemory(val_ptr_addr, error);
     address.SetLoadAddress(val_ptr_addr, &m_process->GetTarget());
     return true;
@@ -2060,7 +2062,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     if (!dyn_type.IsValid())
       return false;
     class_type_or_name.SetCompilerType(dyn_type);
-    lldb::addr_t val_ptr_addr = in_value.GetPointerValue();
+    lldb::addr_t val_ptr_addr = in_value.GetAddressOf();
     address.SetLoadAddress(val_ptr_addr, &m_process->GetTarget());
     return true;
   } break;
@@ -2069,7 +2071,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     if (!dyn_type.IsValid())
       return false;
     class_type_or_name.SetCompilerType(dyn_type);
-    lldb::addr_t val_ptr_addr = in_value.GetPointerValue();
+    lldb::addr_t val_ptr_addr = in_value.GetAddressOf();
     {
       auto swift_type = GetSwiftType(dyn_type);
       if (swift_type->getOptionalObjectType())
@@ -2082,7 +2084,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     CompilerType protocol_type(promise_sp->FulfillTypePromise());
     SwiftASTContext *swift_ast_ctx =
         llvm::dyn_cast_or_null<SwiftASTContext>(protocol_type.GetTypeSystem());
-    lldb::addr_t existential_address = in_value.GetPointerValue();
+    lldb::addr_t existential_address = in_value.GetAddressOf();
     if (!existential_address || existential_address == LLDB_INVALID_ADDRESS)
       return false;
     auto &target = m_process->GetTarget();
@@ -2261,8 +2263,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Tuple(
     Address address;
     Value::ValueType value_type;
     CompilerType child_type;
-    if (!GetDynamicTypeAndAddress(*child_sp.get(), use_dynamic, type_and_or_name,
-                                 address, value_type))
+    if (!GetDynamicTypeAndAddress(*child_sp.get(), use_dynamic,
+                                  type_and_or_name, address, value_type))
       child_type = child_sp->GetCompilerType();
     else
       child_type = type_and_or_name.GetCompilerType();
@@ -2369,7 +2371,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_IndirectEnumCase(
 
     Value::ValueType value_type;
     if (!GetDynamicTypeAndAddress(*valobj_sp, use_dynamic, class_type_or_name,
-                                 address, value_type))
+                                  address, value_type))
       return false;
 
     address.SetRawAddress(old_box_value);
@@ -2397,7 +2399,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_IndirectEnumCase(
 
     Value::ValueType value_type;
     if (!GetDynamicTypeAndAddress(*valobj_sp, use_dynamic, class_type_or_name,
-                                   address, value_type))
+                                  address, value_type))
       return false;
 
     address.SetRawAddress(box_value);


### PR DESCRIPTION
Performing dynamic type resolution on a tuple type can actually change
the tuple's layout, so when computing the offsets of a tuple's
elements, we need to use the static (but archetype-bound) type instead
of the dynamic type.
    
This patch requires a matching commit in Swift compiler.
    
rdar://problem/45462765