### PR TITLE
 Fix the layout calculation of generic tuple types.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_error/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error/main.swift
@@ -7,5 +7,4 @@ func f<T>(_ Pat : T) -> T {
   return Pat //%self.expect("frame var -d run-target -- Pat", substrs=['(a.MyErr) Pat = Patatino'])
 }
 
-let patatino = f(MyErr.Patatino as Error)
-print(patatino)
+f(MyErr.Patatino as Error)

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
@@ -1,4 +1,4 @@
-class MyErr : Error {
+class PayloadErr : Error {
   var x : Int
 
   init(_ x : Int) {
@@ -6,24 +6,28 @@ class MyErr : Error {
   }
 }
 
-class MyOtherErr : MyErr {}
+class MyOtherErr : PayloadErr {}
+
+enum CErr : Error {
+  case Topolino
+  case Paperino
+}
+
+func g<T, U>(_ tuple : (T, U)) -> T {
+  return tuple.0 //%self.expect("frame var -d run-target -- tuple",
+                 //%            substrs=['(a.CErr, Int)', 'Topolino', '42'])
+}
 
 func h<U, V>(_ tuple : (U, V)) -> (U, V) {
   return tuple //%self.expect("frame var -d run-target -- tuple", 
-               //%             substrs=['(a.MyErr, a.MyErr) tuple',
+               //%             substrs=['(a.PayloadErr, a.MyOtherErr) tuple',
                //%                      '0 =', '(x = 23)',
-               //%                      'a.MyErr = {', 'x = 42'])
+               //%                      'a.PayloadErr = {', 'x = 42'])
                //%self.expect("expr -d run-target -- tuple",
-               //%             substrs=['(a.MyErr, a.MyErr) $R',
+               //%             substrs=['(a.PayloadErr, a.PayloadErr) $R',
                //%                      '0 =', '(x = 23)',
-               //%                      'a.MyErr = {', 'x = 42'])
+               //%                      'a.PayloadErr = {', 'x = 42'])
 }
 
-func main() -> Int {
-  let foo : MyErr = MyErr(23)
-  let goo : MyErr = MyOtherErr(42)
-  h((foo, goo))
-  return 0
-}
-
-let _ = main()
+g((CErr.Topolino as Error, 42))
+h((PayloadErr(23), MyOtherErr(42) as PayloadErr))

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -79,6 +79,12 @@ using namespace lldb_utility;
 
 static user_id_t g_value_obj_uid = 0;
 
+static const ExecutionContextRef *GetSwiftExeCtx(ValueObject &valobj) {
+  return (valobj.GetPreferredDisplayLanguage() == eLanguageTypeSwift)
+             ? &valobj.GetExecutionContextRef()
+             : nullptr;
+}
+
 //----------------------------------------------------------------------
 // ValueObject constructor
 //----------------------------------------------------------------------
@@ -2837,12 +2843,6 @@ void ValueObject::LogValueObject(Log *log,
     if (s.GetSize())
       log->PutCString(s.GetData());
   }
-}
-
-static const ExecutionContextRef *GetSwiftExeCtx(ValueObject &valobj) {
-  return (valobj.GetPreferredDisplayLanguage() == eLanguageTypeSwift)
-             ? &valobj.GetExecutionContextRef()
-             : nullptr;
 }
 
 void ValueObject::Dump(Stream &s) { Dump(s, DumpValueObjectOptions(*this)); }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1353,9 +1353,13 @@ bool SwiftLanguageRuntime::MetadataPromise::IsStaticallyDetermined() {
   llvm_unreachable("Unknown metadata kind");
 }
 
-static inline swift::Type GetSwiftType(const CompilerType &type) {
-  return swift::Type(
-      reinterpret_cast<swift::TypeBase *>(type.GetOpaqueQualType()));
+static swift::Type GetCanonicalSwiftType(const CompilerType &type) {
+  return reinterpret_cast<swift::TypeBase *>(
+      type.GetCanonicalType().GetOpaqueQualType());
+}
+
+static swift::Type GetSwiftType(const CompilerType &type) {
+  return reinterpret_cast<swift::TypeBase *>(type.GetOpaqueQualType());
 }
 
 SwiftLanguageRuntime::MetadataPromiseSP
@@ -1433,8 +1437,7 @@ SwiftLanguageRuntime::GetMemberVariableOffset(CompilerType instance_type,
         member_name.AsCString());
 
   // Check whether we've already cached this offset.
-  auto *swift_type = reinterpret_cast<swift::TypeBase *>(
-      instance_type.GetCanonicalType().GetOpaqueQualType());
+  auto *swift_type = GetCanonicalSwiftType(instance_type).getPointer();
   auto key = std::make_tuple(swift_type, member_name.GetCString());
   auto it = m_member_offsets.find(key);
   if (it != m_member_offsets.end())
@@ -1475,9 +1478,7 @@ SwiftLanguageRuntime::GetMemberVariableOffset(CompilerType instance_type,
                 "[MemberVariableOffsetResolver] resolved non-class type = %s",
                 bound.GetTypeName().AsCString());
 
-          swift_type = reinterpret_cast<swift::TypeBase *>(
-              bound.GetCanonicalType().GetOpaqueQualType());
-
+          swift_type = GetCanonicalSwiftType(bound).getPointer();
           auto key = std::make_tuple(swift_type, member_name.GetCString());
           auto it = m_member_offsets.find(key);
           if (it != m_member_offsets.end())


### PR DESCRIPTION
Performing dynamic type resolution on a tuple type can actually change
the tuple's layout, so when computing the offsets of a tuple's
elements, we need to use the static (but archetype-bound) type instead
of the dynamic type.

This patch requires a matching commit in the Swift compiler.

rdar://problem/45462765