### PR TITLE
[CMake] Add missing dep for unified builds

### DIFF
--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -168,7 +168,7 @@ set(lib_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX}")
 set(CLANG_RESOURCE_PATH "${LLDB_PATH_TO_SWIFT_BUILD}/lib${LLVM_LIBDIR_SUFFIX}/swift/clang")
 set(clang_headers_target ${CLANG_RESOURCE_PATH}/include)
 if(NOT LLDB_BUILT_STANDALONE)
-  set(clang_headers_target symlink_clang_headers)
+  set(clang_headers_target clang-headers symlink_clang_headers)
 endif()
 
 # Copy the clang resource directory.


### PR DESCRIPTION
The target of the symlink needs to exist too.