### PR TITLE
Disable simd tests 5.0

### DIFF
--- a/lit/SwiftREPL/SIMD.test
+++ b/lit/SwiftREPL/SIMD.test
@@ -1,5 +1,6 @@
 // Test formatters for Accelerate/simd.
 // REQUIRES: darwin
+// REQUIRES: rdar46330565
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/TestAccelerateSIMD.py
+++ b/packages/Python/lldbsuite/test/lang/swift/accelerate_simd/TestAccelerateSIMD.py
@@ -13,4 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin])
+                          decorators=[swiftTest,skipUnlessDarwin,
+                                      skipIf(bugnumber=46330565)])


### PR DESCRIPTION
Disable simd tests so we can land simd changes in Swift for 5.0