### PR TITLE
Thread-safety: Lock the global LLVMContext before constructing an IRGenModule

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -801,6 +801,8 @@ protected:
 
   std::vector<lldb::DataBufferSP> &GetASTVectorForModule(const Module *module);
 
+  /// Data members.
+  /// @{
   std::unique_ptr<swift::CompilerInvocation> m_compiler_invocation_ap;
   std::unique_ptr<swift::SourceManager> m_source_manager_ap;
   std::unique_ptr<swift::DiagnosticEngine> m_diagnostic_engine_ap;
@@ -857,6 +859,7 @@ protected:
 
   typedef ThreadSafeDenseMap<const char *, lldb::TypeSP> SwiftTypeMap;
   SwiftTypeMap m_swift_type_map;
+  /// @}
 
   ExtraTypeInformation GetExtraTypeInformation(void *type);
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -105,9 +105,7 @@ public:
     return ts->getKind() == TypeSystem::eKindSwift;
   }
 
-  //------------------------------------------------------------------
-  // Provide a global LLVMContext
-  //------------------------------------------------------------------
+  /// Provide the global LLVMContext.
   static llvm::LLVMContext &GetGlobalLLVMContext();
 
   //------------------------------------------------------------------

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -90,6 +90,7 @@
 #include "lldb/Core/StreamFile.h"
 #include "lldb/Core/ThreadSafeDenseMap.h"
 #include "lldb/Expression/DiagnosticManager.h"
+#include "lldb/Expression/IRExecutionUnit.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/StringConvert.h"
@@ -192,8 +193,6 @@ namespace {
 }
 
 llvm::LLVMContext &SwiftASTContext::GetGlobalLLVMContext() {
-  // TODO check with Sean.  Do we really want this to be static across
-  // an LLDB managing multiple Swift processes?
   static llvm::LLVMContext s_global_context;
   return s_global_context;
 }
@@ -4433,6 +4432,9 @@ swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
             GetCompilerInvocation()
                 .getFrontendOptions()
                 .InputsAndOutputs.getPrimarySpecificPathsForAtMostOnePrimary();
+
+        std::lock_guard<std::recursive_mutex> global_context_locker(
+            IRExecutionUnit::GetLLVMGlobalContextMutex());
         m_ir_gen_module_ap.reset(new swift::irgen::IRGenModule(
             ir_generator, ir_generator.createTargetMachine(), nullptr,
             GetGlobalLLVMContext(), ir_gen_opts.ModuleName, PSPs.OutputFilename,


### PR DESCRIPTION
The DWARFParser may call into multiple SwiftASTContexts at the same
time but only once per SwiftASTContext.

<rdar://problem/43877611>