### PR TITLE
[Target] AutoImport modules when getting the scratch ASTContext.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -786,7 +786,7 @@ public:
   static bool PerformAutoImport(SwiftASTContext &swift_ast_context,
                                 SymbolContext &sc,
                                 lldb::StackFrameWP &stack_frame_wp,
-                                swift::SourceFile &source_file, Status &error);
+                                swift::SourceFile *source_file, Status &error);
 
 protected:
   // This map uses the string value of ConstStrings as the key, and the TypeBase

--- a/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/Makefile
@@ -1,0 +1,4 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/TestFirstExprModuleLoad.py
+++ b/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/TestFirstExprModuleLoad.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/first_expr_module_load/main.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+protocol MyProtocol {
+    func foo() -> String
+}
+
+extension MyProtocol {
+    func foo() -> String {
+        return "\(self)" //%self.expect('expr -d run -- self', substrs=['NSAttributedString'])
+    }
+}
+
+extension NSAttributedString: MyProtocol {}
+let attributed = NSAttributedString(string: "attributed", attributes: [:]).foo()

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1370,7 +1370,7 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
 
   Status auto_import_error;
   if (!SwiftASTContext::PerformAutoImport(*swift_ast_context, sc,
-                                          stack_frame_wp, *source_file,
+                                          stack_frame_wp, source_file,
                                           auto_import_error))
     return make_error<ModuleImportError>(llvm::Twine("in auto-import:\n") +
                                          auto_import_error.AsCString());

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -8224,7 +8224,7 @@ bool SwiftASTContext::PerformUserImport(SwiftASTContext &swift_ast_context,
 bool SwiftASTContext::PerformAutoImport(SwiftASTContext &swift_ast_context,
                                         SymbolContext &sc,
                                         lldb::StackFrameWP &stack_frame_wp,
-                                        swift::SourceFile &source_file,
+                                        swift::SourceFile *source_file,
                                         Status &error) {
   llvm::SmallVector<swift::SourceFile::ImportedModuleDesc, 2>
       additional_imports;
@@ -8243,6 +8243,9 @@ bool SwiftASTContext::PerformAutoImport(SwiftASTContext &swift_ast_context,
           return false;
       }
     }
-  source_file.addImports(additional_imports);
+  // source_file might be NULL outside of the expression parser, where
+  // we don't need to notify the source file of additional imports.
+  if (source_file)
+    source_file->addImports(additional_imports);
   return true;
 }

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -2494,6 +2494,15 @@ SwiftASTContextReader Target::GetScratchSwiftASTContext(
         llvm::cast_or_null<SwiftASTContext>(GetScratchTypeSystemForLanguage(
             &error, eLanguageTypeSwift, create_on_demand));
   }
+
+  StackFrameWP frame = exe_scope.CalculateStackFrame();
+  StackFrameSP frame_sp = StackFrameSP(frame.lock());
+  if (frame_sp && frame_sp.get() && swift_ast_ctx &&
+      !swift_ast_ctx->HasFatalErrors()) {
+    SymbolContext sc = exe_scope.CalculateStackFrame()->GetSymbolContext(true);
+    swift_ast_ctx->PerformAutoImport(*swift_ast_ctx, sc, frame, nullptr, error);
+  }
+
   return SwiftASTContextReader(GetSwiftScratchContextLock(), swift_ast_ctx);
 }
 


### PR DESCRIPTION
    This is easy, after a fair amount of yak shaving. The patch
    fixes the case where we need to print something from foundation,
    but we didn't import foundation already (i.e. this is the first `expr`).
    Don't imprort if the ASTContext was already poisoned, it would be
    a disaster.
    
    Finally fixes <rdar://problem/30398933>
