### PR TITLE
[Swift] Rewrite IsSwiftThunk so that it doesn't need runtime instanti…

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -128,8 +128,6 @@ public:
   static lldb::LanguageType
   GuessLanguageForSymbolByName(Target &target, const char *symbol_name);
 
-  virtual bool IsSymbolARuntimeThunk(const Symbol &symbol) { return false; }
-
   Target &GetTargetRef() { return m_process->GetTarget(); }
 
   virtual lldb::BreakpointResolverSP
@@ -159,9 +157,8 @@ public:
   virtual bool GetIRPasses(LLVMUserExpression::IRPasses &custom_passes) {
     return false;
   }
-  
-  static bool
-  IsSymbolAnyRuntimeThunk(lldb::ProcessSP process, Symbol &symbol);
+
+  static bool IsSymbolAnyRuntimeThunk(Symbol &symbol);
 
 protected:
   //------------------------------------------------------------------

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -209,7 +209,9 @@ public:
   static bool IsSwiftMangledName(const char *name);
   
   static bool IsSwiftClassName(const char *name);
-  
+
+  static bool IsSymbolARuntimeThunk(const Symbol &symbol);
+
   static const std::string GetCurrentMangledName(const char *mangled_name);
 
   struct SwiftErrorDescriptor {
@@ -293,8 +295,6 @@ public:
 
   virtual lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
                                                           bool stop_others);
-
-  bool IsSymbolARuntimeThunk(const Symbol &symbol) override;
 
   // this call should return true if it could set the name and/or the type
   virtual bool GetDynamicTypeAndAddress(ValueObject &in_value,

--- a/source/Target/LanguageRuntime.cpp
+++ b/source/Target/LanguageRuntime.cpp
@@ -344,24 +344,8 @@ LanguageRuntime::GuessLanguageForSymbolByName(Target &target,
     return eLanguageTypeUnknown;
 }
 
-bool
-LanguageRuntime::IsSymbolAnyRuntimeThunk(ProcessSP process_sp, Symbol &symbol)
-{
-  if (!process_sp)
-    return false;
-    
-  enum LanguageType languages_to_try[] = {
-      eLanguageTypeSwift, eLanguageTypeObjC, eLanguageTypeC_plus_plus};
-
-  LanguageRuntime *language_runtime;
-  for (enum LanguageType language : languages_to_try) {
-    language_runtime = process_sp->GetLanguageRuntime(language);
-    if (language_runtime) {
-        if (language_runtime->IsSymbolARuntimeThunk(symbol))
-          return true;
-    }
-  }
-  return false;
+bool LanguageRuntime::IsSymbolAnyRuntimeThunk(Symbol &symbol) {
+  return SwiftLanguageRuntime::IsSymbolARuntimeThunk(symbol);
 }
 
 

--- a/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/source/Target/ThreadPlanShouldStopHere.cpp
@@ -91,8 +91,8 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
     Symbol *symbol = frame->GetSymbolContext(eSymbolContextSymbol).symbol;
     if (symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
-      if (LanguageRuntime::IsSymbolAnyRuntimeThunk(process_sp, *symbol)) {
-          should_stop_here = false;
+      if (LanguageRuntime::IsSymbolAnyRuntimeThunk(*symbol)) {
+        should_stop_here = false;
       }
     }
   }
@@ -138,10 +138,10 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
     if (sc.symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
 
-      if (LanguageRuntime::IsSymbolAnyRuntimeThunk(process_sp, *sc.symbol)) {
-          if (log)
-            log->Printf("In runtime thunk %s - stepping out.",
-              sc.symbol->GetName().GetCString());
+      if (LanguageRuntime::IsSymbolAnyRuntimeThunk(*sc.symbol)) {
+        if (log)
+          log->Printf("In runtime thunk %s - stepping out.",
+                      sc.symbol->GetName().GetCString());
         just_step_out = true;
       }
       // If the whole function is marked line 0 just step out, that's easier &


### PR DESCRIPTION
…ation.

It's a property of a mangled name, so there's no need to do the
heavy lifting. Makes this call much much cheaper, as it showed
up in several profile runs.