### PR TITLE
[CMake] Premerged upstream changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,6 @@ else()
   add_definitions( -DLLDB_CONFIGURATION_RELEASE )
 endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Windows|Android")
-  set(LLDB_DEFAULT_DISABLE_LIBEDIT 1)
-else()
-  set(LLDB_DEFAULT_DISABLE_LIBEDIT 0)
-endif ()
-
-# We need libedit support to go down both the source and
-# the scripts directories.
-set(LLDB_DISABLE_LIBEDIT ${LLDB_DEFAULT_DISABLE_LIBEDIT} CACHE BOOL "Disables the use of editline.")
 if (LLDB_DISABLE_LIBEDIT)
   add_definitions( -DLLDB_DISABLE_LIBEDIT )
 else()
@@ -50,16 +41,9 @@ endif()
 add_custom_target(lldb-suite)
 set(LLDB_SUITE_TARGET lldb-suite)
 
-option(LLDB_BUILD_FRAMEWORK "Build the Darwin LLDB.framework" Off)
 if(LLDB_BUILD_FRAMEWORK)
-  if (CMAKE_VERSION VERSION_LESS 3.7)
-    message(FATAL_ERROR "LLDB_BUILD_FRAMEWORK is not supported on CMake < 3.7")
-  endif()
-  if (NOT APPLE)
-    message(FATAL_ERROR "LLDB.framework can only be generated when targeting Apple platforms")
-  endif()
-
   add_custom_target(lldb-framework)
+
   # These are used to fill out LLDB-Info.plist. These are relevant when building
   # the framework, and must be defined before building liblldb.
   set(PRODUCT_NAME "LLDB")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,7 @@ if(LLDB_INCLUDE_TESTS)
   endif()
 
   if(TARGET debugserver)
-    if(NOT CMAKE_HOST_APPLE OR LLDB_CODESIGN_IDENTITY)
-      list(APPEND LLDB_TEST_DEPS debugserver)
-    endif()
+    list(APPEND LLDB_TEST_DEPS debugserver)
   endif()
 
   if(TARGET lldb-mi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,46 +36,18 @@ if(APPLE)
   add_definitions(-DLLDB_USE_OS_LOG)
 endif()
 
-# lldb-suite is a dummy target that encompasses all the necessary tools and
-# libraries for building a fully-functioning liblldb.
-add_custom_target(lldb-suite)
-set(LLDB_SUITE_TARGET lldb-suite)
-
-if(LLDB_BUILD_FRAMEWORK)
-  add_custom_target(lldb-framework)
-
-  # These are used to fill out LLDB-Info.plist. These are relevant when building
-  # the framework, and must be defined before building liblldb.
-  set(PRODUCT_NAME "LLDB")
-  set(EXECUTABLE_NAME "LLDB")
-  set(CURRENT_PROJECT_VERSION "360.99.0")
-  set(LLDB_SUITE_TARGET lldb-framework)
-
-  set(LLDB_FRAMEWORK_DIR
-    ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LLDB_FRAMEWORK_INSTALL_DIR})
-  include(LLDBFramework)
-endif()
-
 add_subdirectory(docs)
 if (NOT LLDB_DISABLE_PYTHON)
-  if(LLDB_USE_SYSTEM_SIX)
-    set(SIX_EXTRA_ARGS "--useSystemSix")
-  endif()
-
   set(LLDB_PYTHON_TARGET_DIR ${LLDB_BINARY_DIR}/scripts)
   set(LLDB_WRAP_PYTHON ${LLDB_BINARY_DIR}/scripts/LLDBWrapPython.cpp)
   if(LLDB_BUILD_FRAMEWORK)
-    set(LLDB_PYTHON_TARGET_DIR ${LLDB_FRAMEWORK_DIR})
+    set(LLDB_PYTHON_TARGET_DIR ${LLDB_FRAMEWORK_BUILD_DIR})
     set(LLDB_WRAP_PYTHON ${LLDB_PYTHON_TARGET_DIR}/LLDBWrapPython.cpp)
-  else()
-    # Don't set -m when building the framework.
-    set(FINISH_EXTRA_ARGS "-m")
   endif()
 
 
   add_subdirectory(scripts)
 endif ()
-
 add_subdirectory(source)
 add_subdirectory(tools)
 
@@ -149,8 +121,14 @@ if(LLDB_INCLUDE_TESTS)
   add_subdirectory(utils/lldb-dotest)
 endif()
 
-
 if (NOT LLDB_DISABLE_PYTHON)
+    if(NOT LLDB_BUILD_FRAMEWORK)
+      set(use_python_wrapper_from_src_dir -m)
+    endif()
+    if(LLDB_USE_SYSTEM_SIX)
+      set(use_six_py_from_system --useSystemSix)
+    endif()
+
     # Add a Post-Build Event to copy over Python files and create the symlink
     # to liblldb.so for the Python API(hardlink on Windows)
     if (APPLE)
@@ -178,30 +156,25 @@ if (NOT LLDB_DISABLE_PYTHON)
                --prefix=${CMAKE_BINARY_DIR}
                --cmakeBuildConfiguration=${CMAKE_CFG_INTDIR}
                --lldbLibDir=lib${LLVM_LIBDIR_SUFFIX}
-               ${SIX_EXTRA_ARGS}
-               ${FINISH_EXTRA_ARGS}
+               ${use_python_wrapper_from_src_dir}
+               ${use_six_py_from_system}
         VERBATIM
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/finishSwigWrapperClasses.py
         DEPENDS ${LLDB_PYTHON_TARGET_DIR}/lldb.py
         COMMENT "Python script sym-linking LLDB Python API")
     endif()
 
-    # We depend on liblldb and lldb-argdumper being built before we can do this step.
-    add_dependencies(finish_swig ${LLDB_SUITE_TARGET})
 
-    # If we build the readline module, we depend on that happening
-    # first.
     if (TARGET readline)
-        add_dependencies(finish_swig readline)
+      set(readline_dep readline)
     endif()
+    add_dependencies(finish_swig swig_wrapper liblldb lldb-argdumper ${readline_dep})
 
     # Ensure we do the python post-build step when building lldb.
     add_dependencies(lldb finish_swig)
 
-    if (LLDB_BUILD_FRAMEWORK)
-      # The target to install libLLDB needs to depend on finish_swig so that the
-      # framework build properly copies over the Python files.
-      add_dependencies(install-liblldb finish_swig)
+    if(LLDB_BUILD_FRAMEWORK)
+      add_dependencies(lldb-framework finish_swig)
     endif()
 
     # Add a Post-Build Event to copy the custom Python DLL to the lldb binaries dir so that Windows can find it when launching

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,6 @@ endif()
 
 add_subdirectory(docs)
 if (NOT LLDB_DISABLE_PYTHON)
-  set(LLDB_PYTHON_TARGET_DIR ${LLDB_BINARY_DIR}/scripts)
-  set(LLDB_WRAP_PYTHON ${LLDB_BINARY_DIR}/scripts/LLDBWrapPython.cpp)
-  if(LLDB_BUILD_FRAMEWORK)
-    set(LLDB_PYTHON_TARGET_DIR ${LLDB_FRAMEWORK_BUILD_DIR})
-    set(LLDB_WRAP_PYTHON ${LLDB_PYTHON_TARGET_DIR}/LLDBWrapPython.cpp)
-  endif()
-
-
   add_subdirectory(scripts)
 endif ()
 add_subdirectory(source)
@@ -128,6 +120,8 @@ if (NOT LLDB_DISABLE_PYTHON)
     if(LLDB_USE_SYSTEM_SIX)
       set(use_six_py_from_system --useSystemSix)
     endif()
+    get_target_property(lldb_scripts_dir swig_wrapper BINARY_DIR)
+    get_target_property(liblldb_build_dir liblldb LIBRARY_OUTPUT_DIRECTORY)
 
     # Add a Post-Build Event to copy over Python files and create the symlink
     # to liblldb.so for the Python API(hardlink on Windows)
@@ -149,21 +143,20 @@ if (NOT LLDB_DISABLE_PYTHON)
     else()
     add_custom_target(finish_swig ALL
         COMMAND
-           ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/finishSwigWrapperClasses.py
+           ${PYTHON_EXECUTABLE} ${LLDB_SOURCE_DIR}/scripts/finishSwigWrapperClasses.py
                --srcRoot=${LLDB_SOURCE_DIR}
-               --targetDir=${LLDB_PYTHON_TARGET_DIR}
-               --cfgBldDir=${LLDB_PYTHON_TARGET_DIR}
+               --targetDir=${liblldb_build_dir}
+               --cfgBldDir=${lldb_scripts_dir}
                --prefix=${CMAKE_BINARY_DIR}
                --cmakeBuildConfiguration=${CMAKE_CFG_INTDIR}
                --lldbLibDir=lib${LLVM_LIBDIR_SUFFIX}
                ${use_python_wrapper_from_src_dir}
                ${use_six_py_from_system}
         VERBATIM
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/finishSwigWrapperClasses.py
-        DEPENDS ${LLDB_PYTHON_TARGET_DIR}/lldb.py
+        DEPENDS ${LLDB_SOURCE_DIR}/scripts/finishSwigWrapperClasses.py
+        DEPENDS ${lldb_scripts_dir}/lldb.py
         COMMENT "Python script sym-linking LLDB Python API")
     endif()
-
 
     if (TARGET readline)
       set(readline_dep readline)

--- a/cmake/modules/AddLLDB.cmake
+++ b/cmake/modules/AddLLDB.cmake
@@ -100,13 +100,13 @@ endfunction(add_lldb_library)
 function(add_lldb_executable name)
   cmake_parse_arguments(ARG
     "INCLUDE_IN_SUITE;GENERATE_INSTALL"
-    ""
+    "ENTITLEMENTS"
     "LINK_LIBS;LINK_COMPONENTS"
     ${ARGN}
     )
 
   list(APPEND LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS})
-  add_llvm_executable(${name} ${ARG_UNPARSED_ARGUMENTS})
+  add_llvm_executable(${name} ${ARG_UNPARSED_ARGUMENTS} ENTITLEMENTS ${ARG_ENTITLEMENTS})
 
   target_link_libraries(${name} PRIVATE ${ARG_LINK_LIBS})
   set_target_properties(${name} PROPERTIES

--- a/cmake/modules/AddLLDB.cmake
+++ b/cmake/modules/AddLLDB.cmake
@@ -44,9 +44,15 @@ function(add_lldb_library name)
   if (PARAM_OBJECT)
     add_library(${name} ${libkind} ${srcs})
   else()
-    llvm_add_library(${name} ${libkind} ${srcs} LINK_LIBS
-                                ${PARAM_LINK_LIBS}
-                                DEPENDS ${PARAM_DEPENDS})
+    if(LLDB_NO_INSTALL_DEFAULT_RPATH)
+      set(pass_NO_INSTALL_RPATH NO_INSTALL_RPATH)
+    endif()
+
+    llvm_add_library(${name} ${libkind} ${srcs}
+      LINK_LIBS ${PARAM_LINK_LIBS}
+      DEPENDS ${PARAM_DEPENDS}
+      ${pass_NO_INSTALL_RPATH}
+    )
 
     if (${name} STREQUAL "liblldb")
       if (PARAM_SHARED)
@@ -98,8 +104,15 @@ function(add_lldb_executable name)
     ${ARGN}
     )
 
+  if(LLDB_NO_INSTALL_DEFAULT_RPATH)
+    set(pass_NO_INSTALL_RPATH NO_INSTALL_RPATH)
+  endif()
+
   list(APPEND LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS})
-  add_llvm_executable(${name} ${ARG_UNPARSED_ARGUMENTS} ENTITLEMENTS ${ARG_ENTITLEMENTS})
+  add_llvm_executable(${name} ${ARG_UNPARSED_ARGUMENTS}
+    ENTITLEMENTS ${ARG_ENTITLEMENTS}
+    ${pass_NO_INSTALL_RPATH}
+  )
 
   target_link_libraries(${name} PRIVATE ${ARG_LINK_LIBS})
   set_target_properties(${name} PROPERTIES FOLDER "lldb executables")
@@ -134,4 +147,41 @@ function(lldb_append_link_flags target_name new_link_flags)
 
   # Now set them onto the target.
   set_target_properties(${target_name} PROPERTIES LINK_FLAGS ${new_link_flags})
+endfunction()
+
+# For tools that depend on liblldb, account for varying directory structures in
+# which LLDB.framework can be used and distributed: In the build-tree we find it
+# by its absolute target path. This is only relevant for running the test suite.
+# In the install step CMake will remove this entry and insert the final RPATHs.
+# These are relative to the file path from where the tool will be loaded on the
+# enduser system.
+#
+# Note that the LLVM install-tree doesn't match the enduser system structure
+# for LLDB.framework, so by default dependent tools will not be functional in
+# their install location. The LLDB_FRAMEWORK_INSTALL_DIR variable allows to fix
+# this. If specified, it causes the install-tree location of the framework to be
+# added as an extra RPATH below.
+#
+function(lldb_setup_framework_rpaths_in_tool name)
+  # In the build-tree, we know the exact path to the binary in the framework.
+  set(rpath_build_tree "$<TARGET_FILE:liblldb>")
+
+  # The installed framework is relocatable and can be in different locations.
+  set(rpaths_install_tree "@loader_path/../../../SharedFrameworks")
+  list(APPEND rpaths_install_tree "@loader_path/../../System/Library/PrivateFrameworks")
+  list(APPEND rpaths_install_tree "@loader_path/../../Library/PrivateFrameworks")
+
+  if(LLDB_FRAMEWORK_INSTALL_DIR)
+    set(rpaths_install_tree "@loader_path/../${LLDB_FRAMEWORK_INSTALL_DIR}")
+  endif()
+
+  # If LLDB_NO_INSTALL_DEFAULT_RPATH was NOT enabled (default), this overwrites
+  # the default settings from llvm_setup_rpath().
+  set_target_properties(${name} PROPERTIES
+    BUILD_WITH_INSTALL_RPATH OFF
+    BUILD_RPATH "${rpath_build_tree}"
+    INSTALL_RPATH "${rpaths_install_tree}"
+  )
+
+  add_dependencies(${name} lldb-framework)
 endfunction()

--- a/cmake/modules/AddLLDB.cmake
+++ b/cmake/modules/AddLLDB.cmake
@@ -50,20 +50,20 @@ function(add_lldb_library name)
 
     if (${name} STREQUAL "liblldb")
       if (PARAM_SHARED)
-        set(out_dir lib${LLVM_LIBDIR_SUFFIX})
         if(${name} STREQUAL "liblldb" AND LLDB_BUILD_FRAMEWORK)
-          set(out_dir ${LLDB_FRAMEWORK_INSTALL_DIR})
-          # The framework that is generated will install with install-liblldb
-          # because we enable CMake's framework support. CMake will copy all the
-          # headers and resources for us.
-          add_dependencies(install-lldb-framework install-${name})
-          add_dependencies(install-lldb-framework-stripped install-${name}-stripped)
+          if(LLDB_FRAMEWORK_INSTALL_DIR)
+            set(install_dir ${LLDB_FRAMEWORK_INSTALL_DIR})
+          else()
+            set(install_dir ".")
+          endif()
+        else()
+          set(install_dir lib${LLVM_LIBDIR_SUFFIX})
         endif()
         install(TARGETS ${name}
           COMPONENT ${name}
           RUNTIME DESTINATION bin
-          LIBRARY DESTINATION ${out_dir}
-          ARCHIVE DESTINATION ${out_dir})
+          LIBRARY DESTINATION ${install_dir}
+          ARCHIVE DESTINATION ${install_dir})
       else()
         install(TARGETS ${name}
           COMPONENT ${name}
@@ -74,13 +74,6 @@ function(add_lldb_library name)
         add_llvm_install_targets(install-${name}
                                  DEPENDS $<TARGET_FILE:${name}>
                                  COMPONENT ${name})
-
-        # install-liblldb{,-stripped} is the actual target that will install the
-        # framework, so it must rely on the framework being fully built first.
-        if (LLDB_BUILD_FRAMEWORK AND ${name} STREQUAL "liblldb")
-          add_dependencies(install-${name} lldb-framework)
-          add_dependencies(install-lldb-framework-stripped lldb-framework)
-        endif()
       endif()
     endif()
   endif()
@@ -99,7 +92,7 @@ endfunction(add_lldb_library)
 
 function(add_lldb_executable name)
   cmake_parse_arguments(ARG
-    "INCLUDE_IN_SUITE;GENERATE_INSTALL"
+    "GENERATE_INSTALL"
     "ENTITLEMENTS"
     "LINK_LIBS;LINK_COMPONENTS"
     ${ARGN}
@@ -109,52 +102,17 @@ function(add_lldb_executable name)
   add_llvm_executable(${name} ${ARG_UNPARSED_ARGUMENTS} ENTITLEMENTS ${ARG_ENTITLEMENTS})
 
   target_link_libraries(${name} PRIVATE ${ARG_LINK_LIBS})
-  set_target_properties(${name} PROPERTIES
-    FOLDER "lldb executables")
-
-  if(ARG_INCLUDE_IN_SUITE)
-    add_dependencies(lldb-suite ${name})
-    if(LLDB_BUILD_FRAMEWORK)
-      if(NOT IOS)
-        set(resource_dir "/Resources")
-        set(resource_dots "../")
-      endif()
-      string(REGEX REPLACE "[^/]+" ".." _dots ${LLDB_FRAMEWORK_INSTALL_DIR})
-      set_target_properties(${name} PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:liblldb>${resource_dir}
-            BUILD_WITH_INSTALL_RPATH On
-            INSTALL_RPATH "@loader_path/../../../${resource_dots}${_dots}/${LLDB_FRAMEWORK_INSTALL_DIR}")
-    endif()
-  endif()
-
-  if(LLDB_BUILD_FRAMEWORK AND NOT ARG_INCLUDE_IN_SUITE)
-    set_target_properties(${name} PROPERTIES
-          BUILD_WITH_INSTALL_RPATH On
-          INSTALL_RPATH "@loader_path/../${LLDB_FRAMEWORK_INSTALL_DIR}")
-  endif()
+  set_target_properties(${name} PROPERTIES FOLDER "lldb executables")
 
   if(ARG_GENERATE_INSTALL)
-    set(out_dir "bin")
-    if (LLDB_BUILD_FRAMEWORK AND ARG_INCLUDE_IN_SUITE)
-      set(out_dir ${LLDB_FRAMEWORK_INSTALL_DIR}/${LLDB_FRAMEWORK_RESOURCE_DIR})
-      # While install-liblldb-stripped will handle copying the tools, it will
-      # not strip them. We depend on this target to guarantee a stripped version
-      # will get installed in the framework.
-      add_dependencies(install-lldb-framework-stripped install-${name}-stripped)
-    endif()
     install(TARGETS ${name}
-          COMPONENT ${name}
-          RUNTIME DESTINATION ${out_dir})
+            COMPONENT ${name}
+            RUNTIME DESTINATION bin)
     if (NOT CMAKE_CONFIGURATION_TYPES)
       add_llvm_install_targets(install-${name}
                                DEPENDS ${name}
                                COMPONENT ${name})
     endif()
-  endif()
-
-  if(ARG_INCLUDE_IN_SUITE AND LLDB_BUILD_FRAMEWORK)
-    add_llvm_tool_symlink(${name} ${name} ALWAYS_GENERATE SKIP_INSTALL
-                            OUTPUT_DIR ${LLVM_RUNTIME_OUTPUT_INTDIR})
   endif()
 endfunction(add_lldb_executable)
 

--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -52,6 +52,8 @@ if (LLDB_DISABLE_CURSES)
   add_definitions( -DLLDB_DISABLE_CURSES )
 endif()
 
+option(LLDB_USE_ENTITLEMENTS "When code signing, use entitlements if available" ON)
+
 # On Windows, we can't use the normal FindPythonLibs module that comes with CMake,
 # for a number of reasons.
 # 1) Prior to MSVC 2015, it is only possible to embed Python if python itself was

--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -10,30 +10,44 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Darw
   set(LLDB_LINKER_SUPPORTS_GROUPS ON)
 endif()
 
-set(LLDB_DEFAULT_DISABLE_PYTHON 0)
-set(LLDB_DEFAULT_DISABLE_CURSES 0)
+set(default_disable_python OFF)
+set(default_disable_curses OFF)
+set(default_disable_libedit OFF)
 
-if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
-  set(LLDB_DEFAULT_DISABLE_CURSES 1)
-elseif (CMAKE_SYSTEM_NAME MATCHES "Android" )
-  set(LLDB_DEFAULT_DISABLE_PYTHON 1)
-  set(LLDB_DEFAULT_DISABLE_CURSES 1)
-elseif(IOS)
-  set(LLDB_DEFAULT_DISABLE_PYTHON 1)
+if(DEFINED LLVM_ENABLE_LIBEDIT AND NOT LLVM_ENABLE_LIBEDIT)
+  set(default_disable_libedit ON)
 endif()
 
-set(LLDB_DISABLE_PYTHON ${LLDB_DEFAULT_DISABLE_PYTHON} CACHE BOOL
-  "Disables the Python scripting integration.")
-set(LLDB_ALLOW_STATIC_BINDINGS FALSE CACHE BOOL
-  "Enable using static/baked language bindings if swig is not present.")
-set(LLDB_DISABLE_CURSES ${LLDB_DEFAULT_DISABLE_CURSES} CACHE BOOL
-  "Disables the Curses integration.")
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  set(default_disable_curses ON)
+  set(default_disable_libedit ON)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Android")
+  set(default_disable_python ON)
+  set(default_disable_curses ON)
+  set(default_disable_libedit ON)
+elseif(IOS)
+  set(default_disable_python ON)
+endif()
 
-set(LLDB_RELOCATABLE_PYTHON 0 CACHE BOOL
-  "Causes LLDB to use the PYTHONHOME environment variable to locate Python.")
+option(LLDB_DISABLE_PYTHON "Disable Python scripting integration." ${default_disable_python})
+option(LLDB_DISABLE_CURSES "Disable Curses integration." ${default_disable_curses})
+option(LLDB_DISABLE_LIBEDIT "Disable the use of editline." ${default_disable_libedit})
+option(LLDB_RELOCATABLE_PYTHON "Use the PYTHONHOME environment variable to locate Python." OFF)
+option(LLDB_USE_SYSTEM_SIX "Use six.py shipped with system and do not install a copy of it" OFF)
+option(LLDB_USE_ENTITLEMENTS "When codesigning, use entitlements if available" ON)
+option(LLDB_BUILD_FRAMEWORK "Build LLDB.framework (Darwin only)" OFF)
 
-set(LLDB_USE_SYSTEM_SIX 0 CACHE BOOL
-  "Use six.py shipped with system and do not install a copy of it")
+option(LLDB_ALLOW_STATIC_BINDINGS "Enable using static/baked language bindings if swig is not present." OFF)
+
+if(LLDB_BUILD_FRAMEWORK)
+  if(NOT APPLE)
+    message(FATAL_ERROR "LLDB.framework can only be generated when targeting Apple platforms")
+  endif()
+  # CMake 3.6 did not correctly emit POST_BUILD commands for Apple Framework targets
+  if(CMAKE_VERSION VERSION_LESS 3.7)
+    message(FATAL_ERROR "LLDB_BUILD_FRAMEWORK is not supported on CMake < 3.7")
+  endif()
+endif()
 
 if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
   set(LLDB_EXPORT_ALL_SYMBOLS 0 CACHE BOOL
@@ -51,8 +65,6 @@ endif()
 if (LLDB_DISABLE_CURSES)
   add_definitions( -DLLDB_DISABLE_CURSES )
 endif()
-
-option(LLDB_USE_ENTITLEMENTS "When code signing, use entitlements if available" ON)
 
 # On Windows, we can't use the normal FindPythonLibs module that comes with CMake,
 # for a number of reasons.

--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -48,6 +48,7 @@ option(LLDB_RELOCATABLE_PYTHON "Use the PYTHONHOME environment variable to locat
 option(LLDB_USE_SYSTEM_SIX "Use six.py shipped with system and do not install a copy of it" OFF)
 option(LLDB_USE_ENTITLEMENTS "When codesigning, use entitlements if available" ON)
 option(LLDB_BUILD_FRAMEWORK "Build LLDB.framework (Darwin only)" OFF)
+option(LLDB_NO_INSTALL_DEFAULT_RPATH "Disable default RPATH settings in binaries" OFF)
 
 option(LLDB_ALLOW_STATIC_BINDINGS "Enable using static/baked language bindings if swig is not present." OFF)
 

--- a/cmake/modules/LLDBFramework.cmake
+++ b/cmake/modules/LLDBFramework.cmake
@@ -1,29 +1,103 @@
+# Path relative to the root binary directory
+get_filename_component(
+  framework_target_dir ${LLDB_FRAMEWORK_BUILD_DIR} ABSOLUTE
+  BASE_DIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}
+)
+
+message(STATUS "LLDB.framework: build path is '${framework_target_dir}'")
+message(STATUS "LLDB.framework: install path is '${LLDB_FRAMEWORK_INSTALL_DIR}'")
+message(STATUS "LLDB.framework: resources subdirectory is 'Versions/${LLDB_FRAMEWORK_VERSION}/Resources'")
+
+# Configure liblldb as a framework bundle
+set_target_properties(liblldb PROPERTIES
+  FRAMEWORK ON
+  FRAMEWORK_VERSION ${LLDB_FRAMEWORK_VERSION}
+
+  OUTPUT_NAME LLDB
+  VERSION ${LLDB_VERSION}
+  LIBRARY_OUTPUT_DIRECTORY ${framework_target_dir}
+
+  # Compatibility version
+  SOVERSION "1.0.0"
+
+  MACOSX_FRAMEWORK_IDENTIFIER com.apple.LLDB.framework
+  MACOSX_FRAMEWORK_BUNDLE_VERSION ${LLDB_VERSION}
+  MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${LLDB_VERSION}
+  MACOSX_FRAMEWORK_INFO_PLIST ${LLDB_SOURCE_DIR}/resources/LLDB-Info.plist.in
+)
+
+# Affects the layout of the framework bundle (default is macOS layout).
+if(IOS)
+  set_target_properties(liblldb PROPERTIES
+    XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "${IPHONEOS_DEPLOYMENT_TARGET}")
+else()
+  set_target_properties(liblldb PROPERTIES
+    XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "${MACOSX_DEPLOYMENT_TARGET}")
+endif()
+
+# Target to capture extra steps for a fully functional framework bundle.
+add_custom_target(lldb-framework)
+add_dependencies(lldb-framework liblldb)
+
+# Dependencies are defined once tools are added (see AddLLDB.cmake)
+if(LLDB_FRAMEWORK_TOOLS)
+  foreach(tool ${LLDB_FRAMEWORK_TOOLS})
+    add_custom_command(TARGET lldb-framework POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${tool}> $<TARGET_FILE_DIR:liblldb>/Resources
+      COMMENT "LLDB.framework: copy additional tool ${tool}"
+    )
+  endforeach()
+else()
+  message(WARNING "LLDB.framework: no additional tools configured (set via LLDB_FRAMEWORK_TOOLS)")
+endif()
+
+# Apart from this one, CMake creates all required symlinks in the framework bundle.
+add_custom_command(TARGET lldb-framework POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E create_symlink
+          $<TARGET_FILE_DIR:liblldb>/Headers
+          ${framework_target_dir}/LLDB.framework/Headers
+  COMMENT "LLDB.framework: create Headers symlink"
+)
+
+# At configuration time, collect headers for the framework bundle and copy them
+# into a staging directory. Later we can copy over the entire folder.
 file(GLOB public_headers ${LLDB_SOURCE_DIR}/include/lldb/API/*.h)
 file(GLOB root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-*.h)
 file(GLOB root_private_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-private*.h)
 list(REMOVE_ITEM root_public_headers ${root_private_headers})
+
+set(lldb_header_staging ${CMAKE_CURRENT_BINARY_DIR}/FrameworkHeaders)
 foreach(header
     ${public_headers}
     ${root_public_headers}
     ${LLDB_SOURCE_DIR}/include/lldb/Utility/SharingPtr.h)
+
   get_filename_component(basename ${header} NAME)
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/FrameworkHeaders/${basename}
-                     DEPENDS ${header}
-                     COMMAND ${CMAKE_COMMAND} -E copy ${header} ${CMAKE_CURRENT_BINARY_DIR}/FrameworkHeaders/${basename})
-  list(APPEND framework_headers ${CMAKE_CURRENT_BINARY_DIR}/FrameworkHeaders/${basename})
+  set(staged_header ${lldb_header_staging}/${basename})
+
+  add_custom_command(
+    DEPENDS ${header} OUTPUT ${staged_header}
+    COMMAND ${CMAKE_COMMAND} -E copy ${header} ${staged_header}
+    COMMENT "LLDB.framework: collect framework header")
+
+  list(APPEND lldb_staged_headers ${staged_header})
 endforeach()
 
-add_custom_target(lldb-framework-headers DEPENDS ${framework_headers})
+# Wrap output in a target, so lldb-framework can depend on it.
+add_custom_target(lldb-framework-headers DEPENDS ${lldb_staged_headers})
+add_dependencies(lldb-framework lldb-framework-headers)
 
-add_custom_command(TARGET lldb-framework POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/FrameworkHeaders $<TARGET_FILE_DIR:liblldb>/Headers
+# At build time, copy the staged headers into the framework bundle (and do
+# some post-processing in-place).
+add_custom_command(TARGET lldb-framework-headers POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${lldb_header_staging} $<TARGET_FILE_DIR:liblldb>/Headers
   COMMAND ${LLDB_SOURCE_DIR}/scripts/framework-header-fix.sh $<TARGET_FILE_DIR:liblldb>/Headers ${LLDB_VERSION}
+  COMMENT "LLDB.framework: copy framework headers"
 )
 
-if (NOT IOS)
-  if (NOT LLDB_BUILT_STANDALONE)
-    add_dependencies(lldb-framework clang-headers)
-  endif()
+# Copy vendor-specific headers from clang (without staging).
+if(NOT IOS AND NOT LLDB_BUILT_STANDALONE)
+  add_dependencies(lldb-framework clang-headers)
   add_custom_command(TARGET lldb-framework POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink Versions/Current/Headers ${LLDB_FRAMEWORK_DIR}/LLDB.framework/Headers
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${LLDB_FRAMEWORK_VERSION} ${LLDB_FRAMEWORK_DIR}/LLDB.framework/Versions/Current
@@ -31,10 +105,3 @@ if (NOT IOS)
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${LLDB_PATH_TO_SWIFT_BUILD}/lib/swift $<TARGET_FILE_DIR:liblldb>/Resources/Swift
   )
 endif()
-
-add_dependencies(lldb-framework
-  lldb-framework-headers
-  lldb-suite)
-
-add_custom_target(install-lldb-framework)
-add_custom_target(install-lldb-framework-stripped)

--- a/cmake/modules/debugserverConfig.cmake
+++ b/cmake/modules/debugserverConfig.cmake
@@ -1,0 +1,3 @@
+# Duplicate options from LLDBConfig that are relevant for debugserver Standalone builds.
+
+option(LLDB_USE_ENTITLEMENTS "When code signing, use entitlements if available" ON)

--- a/resources/LLDB-Info.plist.in
+++ b/resources/LLDB-Info.plist.in
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>LLDB</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_FRAMEWORK_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_FRAMEWORK_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_FRAMEWORK_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>LLDB</string>
+</dict>
+</plist>

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -11,42 +11,25 @@ set(SWIG_HEADERS
 
 include(FindPythonInterp)
 
-if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
-  set(SWIG_PYTHON_DIR
-    ${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-else()
-  set(SWIG_PYTHON_DIR ${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/site-packages)
-endif()
-
-set(SWIG_INSTALL_DIR lib${LLVM_LIBDIR_SUFFIX})
-
-# Generating the LLDB framework correctly is a bit complicated because the
-# framework depends on the swig output.
 if(LLDB_BUILD_FRAMEWORK)
   set(framework_arg --framework --target-platform Darwin)
-  set(SWIG_PYTHON_DIR
-    ${LLDB_PYTHON_TARGET_DIR}/${LLDB_FRAMEWORK_RESOURCE_DIR}/Python)
-  set(SWIG_INSTALL_DIR
-    ${LLDB_FRAMEWORK_INSTALL_DIR}/${LLDB_FRAMEWORK_RESOURCE_DIR})
 endif()
 
-get_filename_component(CFGBLDDIR ${LLDB_WRAP_PYTHON} DIRECTORY)
-
 find_package(SWIG)
-if( ${SWIG_FOUND} )
+if(${SWIG_FOUND})
   set(PREPARE_BINDINGS_ARGS
     "--swig-executable=${SWIG_EXECUTABLE}")
-elseif( ${LLDB_ALLOW_STATIC_BINDINGS} )
+elseif(${LLDB_ALLOW_STATIC_BINDINGS})
   set(PREPARE_BINDINGS_ARGS
     --find-swig
     --allow-static-binding)
 else()
-    message( FATAL_ERROR "swig not found and static bindings not permitted - install swig or specify -DLLDB_ALLOW_STATIC_BINDINGS=1")
+  message(FATAL_ERROR "swig not found and static bindings not permitted - install swig or specify -DLLDB_ALLOW_STATIC_BINDINGS=1")
 endif()
 
 add_custom_command(
-  OUTPUT ${LLDB_WRAP_PYTHON}
-  OUTPUT ${LLDB_PYTHON_TARGET_DIR}/lldb.py
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/LLDBWrapPython.cpp
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lldb.py
   DEPENDS ${SWIG_SOURCES}
   DEPENDS ${SWIG_INTERFACES}
   DEPENDS ${SWIG_HEADERS}
@@ -55,19 +38,31 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/prepare_bindings.py
       ${framework_arg}
       --srcRoot=${LLDB_SOURCE_DIR}
-      --targetDir=${LLDB_PYTHON_TARGET_DIR}
-      --cfgBldDir=${CFGBLDDIR}
+      --targetDir=${CMAKE_CURRENT_BINARY_DIR}
+      --cfgBldDir=${CMAKE_CURRENT_BINARY_DIR}
       --prefix=${CMAKE_BINARY_DIR}
       ${PREPARE_BINDINGS_ARGS}
   VERBATIM
   COMMENT "Python script building LLDB Python wrapper")
-add_custom_target(swig_wrapper ALL DEPENDS ${LLDB_WRAP_PYTHON})
 
-set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/lldb.py PROPERTIES GENERATED 1)
+add_custom_target(swig_wrapper ALL DEPENDS
+  ${CMAKE_CURRENT_BINARY_DIR}/LLDBWrapPython.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/lldb.py
+)
 
+if(NOT LLDB_BUILD_FRAMEWORK)
+  if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(swig_python_subdir site-packages)
+  else()
+    set(swig_python_subdir python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+  endif()
 
-# Install the LLDB python module
-install(DIRECTORY ${SWIG_PYTHON_DIR} DESTINATION ${SWIG_INSTALL_DIR})
+  set(SWIG_PYTHON_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR}/${swig_python_subdir})
+  set(SWIG_INSTALL_DIR lib${LLVM_LIBDIR_SUFFIX})
+
+  # Install the LLDB python module
+  install(DIRECTORY ${SWIG_PYTHON_DIR} DESTINATION ${SWIG_INSTALL_DIR})
+endif()
 
 # build Python modules
 add_subdirectory(Python/modules)

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -9,6 +9,11 @@ endif()
 
 get_property(LLDB_ALL_PLUGINS GLOBAL PROPERTY LLDB_PLUGINS)
 
+if(NOT LLDB_DISABLE_PYTHON)
+  get_target_property(lldb_scripts_dir swig_wrapper BINARY_DIR)
+  set(lldb_python_wrapper ${lldb_scripts_dir}/LLDBWrapPython.cpp)
+endif()
+
 add_lldb_library(liblldb SHARED
   SBAddress.cpp
   SBAttachInfo.cpp
@@ -77,7 +82,7 @@ add_lldb_library(liblldb SHARED
   SBWatchpoint.cpp
   SBUnixSignals.cpp
   SystemInitializerFull.cpp
-  ${LLDB_WRAP_PYTHON}
+  ${lldb_python_wrapper}
 
   LINK_LIBS
     lldbBase
@@ -97,23 +102,23 @@ add_lldb_library(liblldb SHARED
     Support
   )
 
-if(LLDB_WRAP_PYTHON)
+if(lldb_python_wrapper)
   add_dependencies(liblldb swig_wrapper)
 
   if (MSVC)
-    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING PROPERTY COMPILE_FLAGS " /W0")
+    set_property(SOURCE ${lldb_python_wrapper} APPEND_STRING PROPERTY COMPILE_FLAGS " /W0")
   else()
-    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
+    set_property(SOURCE ${lldb_python_wrapper} APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
   endif()
 
-  set_source_files_properties(${LLDB_WRAP_PYTHON} PROPERTIES GENERATED 1)
+  set_source_files_properties(${lldb_python_wrapper} PROPERTIES GENERATED ON)
   if (CLANG_CL)
-    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING
+    set_property(SOURCE ${lldb_python_wrapper} APPEND_STRING
       PROPERTY COMPILE_FLAGS " -Wno-unused-function")
   endif()
   if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND
       NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
-    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING
+    set_property(SOURCE ${lldb_python_wrapper} APPEND_STRING
       PROPERTY COMPILE_FLAGS " -Wno-sequence-point -Wno-cast-qual")
   endif ()
 endif()

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -97,24 +97,26 @@ add_lldb_library(liblldb SHARED
     Support
   )
 
-add_dependencies(lldb-suite liblldb)
+if(LLDB_WRAP_PYTHON)
+  add_dependencies(liblldb swig_wrapper)
 
-if (MSVC)
-  set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING PROPERTY COMPILE_FLAGS " /W0")
-else()
-  set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
-endif()
+  if (MSVC)
+    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING PROPERTY COMPILE_FLAGS " /W0")
+  else()
+    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
+  endif()
 
-set_source_files_properties(${LLDB_WRAP_PYTHON} PROPERTIES GENERATED 1)
-if (CLANG_CL)
-  set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-unused-function")
+  set_source_files_properties(${LLDB_WRAP_PYTHON} PROPERTIES GENERATED 1)
+  if (CLANG_CL)
+    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING
+      PROPERTY COMPILE_FLAGS " -Wno-unused-function")
+  endif()
+  if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND
+      NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+    set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING
+      PROPERTY COMPILE_FLAGS " -Wno-sequence-point -Wno-cast-qual")
+  endif ()
 endif()
-if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND
-    NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
-  set_property(SOURCE ${LLDB_WRAP_PYTHON} APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-sequence-point -Wno-cast-qual")
-endif ()
 
 set_target_properties(liblldb
   PROPERTIES
@@ -149,19 +151,8 @@ else()
   )
 endif()
 
-if (LLDB_BUILD_FRAMEWORK)
-  set_target_properties(liblldb
-    PROPERTIES
-    OUTPUT_NAME LLDB
-    FRAMEWORK On
-    FRAMEWORK_VERSION ${LLDB_FRAMEWORK_VERSION}
-    MACOSX_FRAMEWORK_INFO_PLIST ${LLDB_SOURCE_DIR}/resources/LLDB-Info.plist
-    LIBRARY_OUTPUT_DIRECTORY ${LLDB_FRAMEWORK_DIR}
-  )
-endif()
-
-if (LLDB_WRAP_PYTHON)
-  add_dependencies(liblldb swig_wrapper)
+if(LLDB_BUILD_FRAMEWORK)
+  include(LLDBFramework)
 endif()
 
 set(lib_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,8 +85,8 @@ if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
   endif()
 endif()
 
-if(LLDB_CODESIGN_IDENTITY)
-  list(APPEND LLDB_TEST_COMMON_ARGS --codesign-identity "${LLDB_CODESIGN_IDENTITY}")
+if(LLDB_CODESIGN_IDENTITY_USED)
+  list(APPEND LLDB_TEST_COMMON_ARGS --codesign-identity "${LLDB_CODESIGN_IDENTITY_USED}")
 endif()
 
 if(LLDB_BUILD_FRAMEWORK)
@@ -98,11 +98,17 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows|Darwin")
     --env ARCHIVER=${CMAKE_AR} --env OBJCOPY=${CMAKE_OBJCOPY})
 endif()
 
-if(CMAKE_HOST_APPLE)
+if (NOT "${LLDB_LIT_TOOLS_DIR}" STREQUAL "")
+  if (NOT EXISTS "${LLDB_LIT_TOOLS_DIR}")
+    message(WARNING "LLDB_LIT_TOOLS_DIR ${LLDB_LIT_TOOLS_DIR} does not exist.")
+  endif()
+endif()
+
+if(CMAKE_HOST_APPLE AND DEBUGSERVER_PATH)
   list(APPEND LLDB_TEST_COMMON_ARGS --server ${DEBUGSERVER_PATH})
 endif()
 
-if(SKIP_DEBUGSERVER)
+if(SKIP_TEST_DEBUGSERVER)
   list(APPEND LLDB_TEST_COMMON_ARGS --out-of-tree-debugserver)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,7 +90,8 @@ if(LLDB_CODESIGN_IDENTITY_USED)
 endif()
 
 if(LLDB_BUILD_FRAMEWORK)
-  list(APPEND LLDB_TEST_COMMON_ARGS --framework ${LLDB_FRAMEWORK_DIR}/LLDB.framework)
+  get_target_property(framework_target_dir liblldb LIBRARY_OUTPUT_DIRECTORY)
+  list(APPEND LLDB_TEST_COMMON_ARGS --framework ${framework_target_dir}/LLDB.framework)
 endif()
 
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows|Darwin")

--- a/tools/argdumper/CMakeLists.txt
+++ b/tools/argdumper/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_lldb_tool(lldb-argdumper INCLUDE_IN_SUITE
+add_lldb_tool(lldb-argdumper
   argdumper.cpp
 
   LINK_LIBS

--- a/tools/darwin-debug/CMakeLists.txt
+++ b/tools/darwin-debug/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_lldb_tool(darwin-debug INCLUDE_IN_SUITE
+add_lldb_tool(darwin-debug
   darwin-debug.cpp
   )

--- a/tools/debugserver/CMakeLists.txt
+++ b/tools/debugserver/CMakeLists.txt
@@ -15,11 +15,6 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
   set(LLDB_SOURCE_DIR "${CMAKE_SOURCE_DIR}/../../")
   include_directories(${LLDB_SOURCE_DIR}/include)
-
-  # lldb-suite is a dummy target that encompasses all the necessary tools and
-  # libraries for building a fully-functioning liblldb.
-  add_custom_target(lldb-suite)
-  set(LLDB_SUITE_TARGET lldb-suite)
 endif()
 
 add_subdirectory(source)

--- a/tools/debugserver/CMakeLists.txt
+++ b/tools/debugserver/CMakeLists.txt
@@ -10,12 +10,11 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     )
   
   include(LLDBStandalone)
+  include(debugserverConfig)
   include(AddLLDB)
 
   set(LLDB_SOURCE_DIR "${CMAKE_SOURCE_DIR}/../../")
   include_directories(${LLDB_SOURCE_DIR}/include)
-
-  option(LLDB_USE_ENTITLEMENTS "When code signing, use entitlements if available" ON)
 
   # lldb-suite is a dummy target that encompasses all the necessary tools and
   # libraries for building a fully-functioning liblldb.

--- a/tools/debugserver/CMakeLists.txt
+++ b/tools/debugserver/CMakeLists.txt
@@ -14,6 +14,13 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
   set(LLDB_SOURCE_DIR "${CMAKE_SOURCE_DIR}/../../")
   include_directories(${LLDB_SOURCE_DIR}/include)
+
+  option(LLDB_USE_ENTITLEMENTS "When code signing, use entitlements if available" ON)
+
+  # lldb-suite is a dummy target that encompasses all the necessary tools and
+  # libraries for building a fully-functioning liblldb.
+  add_custom_target(lldb-suite)
+  set(LLDB_SUITE_TARGET lldb-suite)
 endif()
 
 add_subdirectory(source)

--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -257,7 +257,7 @@ if(build_and_sign_debugserver)
                  COMPILE_DEFINITIONS HAVE_LIBCOMPRESSION)
   endif()
   set(LLVM_OPTIONAL_SOURCES ${lldbDebugserverCommonSources})
-  add_lldb_tool(debugserver INCLUDE_IN_SUITE
+  add_lldb_tool(debugserver
     debugserver.cpp
 
     LINK_LIBS

--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -94,32 +94,119 @@ set(lldbDebugserverCommonSources
 
 add_library(lldbDebugserverCommon ${lldbDebugserverCommonSources})
 
+# LLDB-specific identity, currently used for code signing debugserver.
+set(LLDB_CODESIGN_IDENTITY "" CACHE STRING
+    "Override code sign identity for debugserver and for use in tests; falls back to LLVM_CODESIGNING_IDENTITY if set or lldb_codesign otherwise (Darwin only)")
 
-set(LLDB_CODESIGN_IDENTITY "lldb_codesign"
-  CACHE STRING "Identity used for code signing. Set to empty string to skip the signing step.")
-
-if(NOT LLDB_CODESIGN_IDENTITY STREQUAL "")
-  set(DEBUGSERVER_PATH ${LLVM_RUNTIME_OUTPUT_INTDIR}/debugserver${CMAKE_EXECUTABLE_SUFFIX} CACHE PATH "Path to debugserver.")
-  set(SKIP_DEBUGSERVER OFF CACHE BOOL "Skip building the in-tree debug server")
+# Determine which identity to use and store it in the separate cache entry.
+# We will query it later for LLDB_TEST_COMMON_ARGS.
+if(LLDB_CODESIGN_IDENTITY)
+  set(LLDB_CODESIGN_IDENTITY_USED ${LLDB_CODESIGN_IDENTITY} CACHE INTERNAL "" FORCE)
+elseif(LLVM_CODESIGNING_IDENTITY)
+  set(LLDB_CODESIGN_IDENTITY_USED ${LLVM_CODESIGNING_IDENTITY} CACHE INTERNAL "" FORCE)
 else()
+  set(LLDB_CODESIGN_IDENTITY_USED lldb_codesign CACHE INTERNAL "" FORCE)
+endif()
+
+# Override locally, so the identity is used for targets created in this scope.
+set(LLVM_CODESIGNING_IDENTITY ${LLDB_CODESIGN_IDENTITY_USED})
+
+option(LLDB_NO_DEBUGSERVER "Disable the debugserver target" OFF)
+option(LLDB_USE_SYSTEM_DEBUGSERVER "Use the system's debugserver instead of building it from source (Darwin only)." OFF)
+
+# Incompatible options
+if(LLDB_NO_DEBUGSERVER AND LLDB_USE_SYSTEM_DEBUGSERVER)
+  message(FATAL_ERROR "Inconsistent options: LLDB_NO_DEBUGSERVER and LLDB_USE_SYSTEM_DEBUGSERVER")
+endif()
+
+# Try to locate the system debugserver.
+# Subsequent feasibility checks depend on it.
+if(APPLE AND CMAKE_HOST_APPLE)
   execute_process(
     COMMAND xcode-select -p
-    OUTPUT_VARIABLE XCODE_DEV_DIR)
-  string(STRIP ${XCODE_DEV_DIR} XCODE_DEV_DIR)
-  if(EXISTS "${XCODE_DEV_DIR}/../SharedFrameworks/LLDB.framework/")
-    set(DEBUGSERVER_PATH
-      "${XCODE_DEV_DIR}/../SharedFrameworks/LLDB.framework/Resources/debugserver" CACHE PATH "Path to debugserver.")
-  elseif(EXISTS "${XCODE_DEV_DIR}/Library/PrivateFrameworks/LLDB.framework/")
-    set(DEBUGSERVER_PATH
-      "${XCODE_DEV_DIR}/Library/PrivateFrameworks/LLDB.framework/Resources/debugserver" CACHE PATH "Path to debugserver.")
-  else()
-    message(SEND_ERROR "Cannot find debugserver on system.")
-  endif()
-  set(SKIP_DEBUGSERVER ON CACHE BOOL "Skip building the in-tree debug server")
-endif()
-message(STATUS "Path to the lldb debugserver: ${DEBUGSERVER_PATH}")
+    OUTPUT_VARIABLE xcode_dev_dir)
+  string(STRIP ${xcode_dev_dir} xcode_dev_dir)
 
-if (APPLE)
+  set(debugserver_rel_path "LLDB.framework/Resources/debugserver")
+  set(debugserver_shared "${xcode_dev_dir}/../SharedFrameworks/${debugserver_rel_path}")
+  set(debugserver_private "${xcode_dev_dir}/Library/PrivateFrameworks/${debugserver_rel_path}")
+
+  if(EXISTS ${debugserver_shared})
+    set(system_debugserver ${debugserver_shared})
+  elseif(EXISTS ${debugserver_private})
+    set(system_debugserver ${debugserver_private})
+  endif()
+endif()
+
+# Handle unavailability
+if(LLDB_USE_SYSTEM_DEBUGSERVER)
+  if(system_debugserver)
+    set(use_system_debugserver ON)
+  elseif(APPLE AND CMAKE_HOST_APPLE)
+    # Binary not found on system. Keep cached variable, to try again on reconfigure.
+    message(SEND_ERROR
+      "LLDB_USE_SYSTEM_DEBUGSERVER option set, but no debugserver found in:\
+        ${debugserver_shared}\
+        ${debugserver_private}")
+  else()
+    # Non-Apple target platform or non-Darwin host. Reset invalid cached variable.
+    message(WARNING "Reverting invalid option LLDB_USE_SYSTEM_DEBUGSERVER (Darwin only)")
+    set(LLDB_USE_SYSTEM_DEBUGSERVER OFF CACHE BOOL "" FORCE)
+  endif()
+elseif(NOT LLDB_NO_DEBUGSERVER)
+  # Default case: on Darwin we need the right code signing ID.
+  # See lldb/docs/code-signing.txt for details.
+  if(CMAKE_HOST_APPLE AND NOT LLVM_CODESIGNING_IDENTITY STREQUAL "lldb_codesign")
+    set(msg "Cannot code sign debugserver with identity '${LLVM_CODESIGNING_IDENTITY}'.")
+    if(system_debugserver)
+      message(WARNING "${msg} Will fall back to system's debugserver.")
+      set(use_system_debugserver ON)
+    else()
+      message(WARNING "${msg} debugserver will not be available.")
+    endif()
+  else()
+    set(build_and_sign_debugserver ON)
+  endif()
+endif()
+
+# TODO: We don't use the $<TARGET_FILE:debugserver> generator expression here,
+# because the value of DEBUGSERVER_PATH is used to build LLDB_DOTEST_ARGS,
+# which is used for configuring lldb-dotest.in, which does not have a generator
+# step at the moment.
+set(default_debugserver_path "${LLVM_RUNTIME_OUTPUT_INTDIR}/debugserver${CMAKE_EXECUTABLE_SUFFIX}")
+
+# Remember where debugserver binary goes and whether or not we have to test it.
+set(DEBUGSERVER_PATH "" CACHE FILEPATH "Path to debugserver")
+set(SKIP_TEST_DEBUGSERVER OFF CACHE BOOL "Building the in-tree debugserver was skipped")
+
+# Reset values in all cases in order to correctly support reconfigurations.
+if(use_system_debugserver)
+  add_custom_target(debugserver
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${system_debugserver} ${LLVM_RUNTIME_OUTPUT_INTDIR}
+    COMMENT "Copying the system debugserver to LLDB's binaries directory.")
+
+  # Don't test debugserver itself.
+  # Tests that require debugserver will use the copy.
+  set(DEBUGSERVER_PATH ${default_debugserver_path} CACHE FILEPATH "" FORCE)
+  set(SKIP_TEST_DEBUGSERVER ON CACHE BOOL "" FORCE)
+
+  message(STATUS "Copy system debugserver from: ${system_debugserver}")
+elseif(build_and_sign_debugserver)
+  # Build, sign and test debugserver (below)
+  set(DEBUGSERVER_PATH ${default_debugserver_path} CACHE FILEPATH "" FORCE)
+  set(SKIP_TEST_DEBUGSERVER OFF CACHE BOOL "" FORCE)
+
+  message(STATUS "lldb debugserver: ${DEBUGSERVER_PATH}")
+else()
+  # No tests for debugserver, no tests that require it.
+  set(DEBUGSERVER_PATH "" CACHE FILEPATH "" FORCE)
+  set(SKIP_TEST_DEBUGSERVER ON CACHE BOOL "" FORCE)
+
+  message(STATUS "lldb debugserver will not be available.")
+endif()
+
+if(APPLE)
   if(IOS)
     find_library(BACKBOARD_LIBRARY BackBoardServices
       PATHS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
@@ -132,7 +219,7 @@ if (APPLE)
     find_library(LOCKDOWN_LIBRARY lockdown)
 
     if(NOT BACKBOARD_LIBRARY)
-      set(SKIP_DEBUGSERVER ON CACHE BOOL "Skip building the in-tree debug server" FORCE)
+      set(SKIP_TEST_DEBUGSERVER ON CACHE BOOL "" FORCE)
     endif()
   else()
     find_library(COCOA_LIBRARY Cocoa)
@@ -143,7 +230,16 @@ if(HAVE_LIBCOMPRESSION)
   set(LIBCOMPRESSION compression)
 endif()
 
-if(NOT SKIP_DEBUGSERVER)
+if(LLDB_USE_ENTITLEMENTS)
+  if(IOS)
+    set(entitlements ${CMAKE_CURRENT_SOURCE_DIR}/debugserver-entitlements.plist)
+  else()
+    # Same entitlements file as used for lldb-server
+    set(entitlements ${LLDB_SOURCE_DIR}/resources/debugserver-macosx-entitlements.plist)
+  endif()
+endif()
+
+if(build_and_sign_debugserver)
   target_link_libraries(lldbDebugserverCommon
                         INTERFACE ${COCOA_LIBRARY}
                         ${CORE_FOUNDATION_LIBRARY}
@@ -166,6 +262,9 @@ if(NOT SKIP_DEBUGSERVER)
 
     LINK_LIBS
       lldbDebugserverCommon
+
+    ENTITLEMENTS
+      ${entitlements}
     )
   if(IOS)
     set_property(TARGET lldbDebugserverCommon APPEND PROPERTY COMPILE_DEFINITIONS
@@ -203,56 +302,8 @@ if(IOS)
 
     LINK_LIBS
       lldbDebugserverCommon_NonUI
+
+    ENTITLEMENTS
+      ${entitlements}
     )
 endif()
-
-set(entitlements_xml ${CMAKE_CURRENT_SOURCE_DIR}/debugserver-macosx-entitlements.plist)
-if(IOS)
-  set(entitlements_xml ${CMAKE_CURRENT_SOURCE_DIR}/debugserver-entitlements.plist)
-else()
-  set(entitlements_xml ${CMAKE_CURRENT_SOURCE_DIR}/../../../resources/debugserver-macosx-entitlements.plist)
-endif()
-
-set(LLDB_USE_ENTITLEMENTS_Default On)
-option(LLDB_USE_ENTITLEMENTS "Use entitlements when codesigning (Defaults Off when using lldb_codesign identity, otherwise On)" ${LLDB_USE_ENTITLEMENTS_Default})
-
-if (SKIP_DEBUGSERVER)
-  if (CMAKE_HOST_APPLE)
-    # If we haven't built a signed debugserver, copy the one from the system.
-    add_custom_target(debugserver
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEBUGSERVER_PATH} ${CMAKE_BINARY_DIR}/bin
-      VERBATIM
-      COMMENT "Copying the system debugserver to LLDB's binaries directory.")
-  endif()
-else()
-  if(LLDB_USE_ENTITLEMENTS)
-    set(entitlements_flags --entitlements ${entitlements_xml})
-  endif()
-  execute_process(
-    COMMAND xcrun -f codesign_allocate
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE CODESIGN_ALLOCATE
-    )
-  add_custom_command(TARGET debugserver
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E env CODESIGN_ALLOCATE=${CODESIGN_ALLOCATE}
-            codesign --force --sign ${LLDB_CODESIGN_IDENTITY}
-            ${entitlements_flags}
-            $<TARGET_FILE:debugserver>
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  if(IOS)
-    add_custom_command(TARGET debugserver-nonui
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E env CODESIGN_ALLOCATE=${CODESIGN_ALLOCATE}
-              codesign --force --sign ${LLDB_CODESIGN_IDENTITY}
-              ${entitlements_flags}
-              $<TARGET_FILE:debugserver>
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    )
-  endif()
-endif()
-
-
-
-

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -24,4 +24,7 @@ if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
   add_definitions( -DIMPORT_LIBLLDB )
 endif()
 
-add_dependencies(lldb ${LLDB_SUITE_TARGET})
+add_dependencies(lldb
+  LLDBOptionsTableGen
+  ${tablegen_deps}
+)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -28,3 +28,7 @@ add_dependencies(lldb
   LLDBOptionsTableGen
   ${tablegen_deps}
 )
+
+if(LLDB_BUILD_FRAMEWORK)
+  lldb_setup_framework_rpaths_in_tool(lldb)
+endif()

--- a/tools/lldb-mi/CMakeLists.txt
+++ b/tools/lldb-mi/CMakeLists.txt
@@ -93,3 +93,7 @@ add_lldb_tool(lldb-mi
   LINK_COMPONENTS
     Support
   )
+
+if(LLDB_BUILD_FRAMEWORK)
+  lldb_setup_framework_rpaths_in_tool(lldb-mi)
+endif()

--- a/tools/lldb-server/CMakeLists.txt
+++ b/tools/lldb-server/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   list(APPEND LLDB_PLUGINS lldbPluginObjectFileELF)
 endif()
 
-add_lldb_tool(lldb-server INCLUDE_IN_SUITE
+add_lldb_tool(lldb-server
     Acceptor.cpp
     lldb-gdbserver.cpp
     lldb-platform.cpp

--- a/tools/lldb-vscode/CMakeLists.txt
+++ b/tools/lldb-vscode/CMakeLists.txt
@@ -1,0 +1,34 @@
+if ( CMAKE_SYSTEM_NAME MATCHES "Windows" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD" )
+  add_definitions( -DIMPORT_LIBLLDB )
+  list(APPEND extra_libs lldbHost)
+endif ()
+
+if (HAVE_LIBPTHREAD)
+  list(APPEND extra_libs pthread)
+endif ()
+
+# We need to include the llvm components we depend on manually, as liblldb does
+# not re-export those.
+set(LLVM_LINK_COMPONENTS Support)
+add_lldb_tool(lldb-vscode
+  lldb-vscode.cpp
+  BreakpointBase.cpp
+  ExceptionBreakpoint.cpp
+  FunctionBreakpoint.cpp
+  JSONUtils.cpp
+  LLDBUtils.cpp
+  SourceBreakpoint.cpp
+  VSCode.cpp
+
+  LINK_LIBS
+    liblldb
+    ${host_lib}
+    ${extra_libs}
+
+  LINK_COMPONENTS
+    Support
+  )
+
+if(LLDB_BUILD_FRAMEWORK)
+  lldb_setup_framework_rpaths_in_tool(lldb-vscode)
+endif()

--- a/unittests/tools/CMakeLists.txt
+++ b/unittests/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|Linux|NetBSD")
-  if (CMAKE_SYSTEM_NAME MATCHES "Darwin" AND SKIP_DEBUGSERVER)
+  if (CMAKE_SYSTEM_NAME MATCHES "Darwin" AND SKIP_TEST_DEBUGSERVER)
     # These tests are meant to test lldb-server/debugserver in isolation, and
     # don't provide any value if run against a server copied from somewhere.
   else()

--- a/unittests/tools/lldb-server/CMakeLists.txt
+++ b/unittests/tools/lldb-server/CMakeLists.txt
@@ -12,7 +12,7 @@ endfunction()
 add_lldb_test_executable(thread_inferior inferior/thread_inferior.cpp)
 add_lldb_test_executable(environment_check inferior/environment_check.cpp)
 
-if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+if(DEBUGSERVER_PATH)
   add_definitions(-DLLDB_SERVER="${DEBUGSERVER_PATH}" -DLLDB_SERVER_IS_DEBUGSERVER=1)
 else()
   add_definitions(-DLLDB_SERVER="$<TARGET_FILE:lldb-server>" -DLLDB_SERVER_IS_DEBUGSERVER=0)


### PR DESCRIPTION
Committing pre-merged upstream changes (in history order):
[CMake] Python bindings generation polishing https://reviews.llvm.org/D55332
[CMake] Revised RPATH handling https://reviews.llvm.org/D55330
[CMake] Revised LLDB.framework builds https://reviews.llvm.org/D55328
[CMake] Move debugserver options to separate debugserverConfig.cmake https://reviews.llvm.org/D55320
[CMake] Aggregate options for LLDB in LLDBConfig.cmake https://reviews.llvm.org/D55317
[CMake] Streamline code signing for debugserver #2 https://reviews.llvm.org/D55013