### PR TITLE
Support unknown references to Objective-C classes.

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -105,6 +105,10 @@ public:
   virtual TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                          ValueObject &static_value) = 0;
 
+  /// This allows a language runtime to adjust references depending on the type.
+  /// \return true on success.
+  virtual bool FixupReference(lldb::addr_t &addr, CompilerType type) {}
+
   virtual void SetExceptionBreakpoints() {}
 
   virtual void ClearExceptionBreakpoints() {}

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -306,6 +306,8 @@ public:
   virtual TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                          ValueObject &static_value) override;
 
+  virtual bool FixupReference(lldb::addr_t &addr, CompilerType type) override;
+
   bool IsRuntimeSupportValue(ValueObject &valobj) override;
 
   virtual CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,

--- a/packages/Python/lldbsuite/test/lang/swift/unknown_reference/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/unknown_reference/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/packages/Python/lldbsuite/test/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -1,0 +1,51 @@
+# TestSwiftUnknownReference.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftUnknownReference(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    def check_class(self, var_self):
+        lldbutil.check_variable(self, var_self, num_children=2)
+        m_base_string = var_self.GetChildMemberWithName("base_string")
+        m_string = var_self.GetChildMemberWithName("string")
+        lldbutil.check_variable(self, m_base_string, summary='"hello"')
+        lldbutil.check_variable(self, m_string, summary='"world"')
+
+    
+    @swiftTest
+    def test_unknown_objc_ref(self):
+        """Test unknown references to Objective-C objects."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        frame = thread.frames[0]
+        var_self = frame.FindVariable("self")
+        m_pure_ref = var_self.GetChildMemberWithName("pure_ref")
+        self.check_class(m_pure_ref)
+        m_objc_ref = var_self.GetChildMemberWithName("objc_ref")
+        self.check_class(m_objc_ref)
+
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/unknown_reference/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/unknown_reference/main.swift
@@ -1,0 +1,51 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Foundation
+
+// Auxiliary functions.
+func use(_ c : ObjCClass) {}
+func use(_ c : PureClass) {}
+func doCall(_ fn : () -> ()) { fn() }
+
+// Pure Swift objects.
+class PureBase {
+  let base_string = "hello"
+}
+
+class PureClass : PureBase {
+  let string = "world"
+}
+
+// Objective-C objects.
+class Base : NSObject {
+  let base_string = "hello"
+}
+
+class ObjCClass : Base {
+  let string = "world"
+}
+
+struct S {
+  let string = "offset"
+  unowned var pure_ref : PureClass
+  unowned var objc_ref : ObjCClass
+
+  func f() {
+    use(self.pure_ref) // break here
+  }
+}
+
+let pure = PureClass()
+let objc = ObjCClass()
+
+S(pure_ref: pure, objc_ref: objc).f()
+

--- a/packages/Python/lldbsuite/test/lang/swift/unknown_self/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/unknown_self/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/packages/Python/lldbsuite/test/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -1,0 +1,61 @@
+# TestSwiftUnknownSelf.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftUnknownSelf(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    def check_class(self, var_self, broken):
+        lldbutil.check_variable(self, var_self, num_children=2)
+        m_base_string = var_self.GetChildMemberWithName("base_string")
+        m_string = var_self.GetChildMemberWithName("string")
+        if not broken:
+            lldbutil.check_variable(self, m_base_string, summary='"hello"')
+        lldbutil.check_variable(self, m_string, summary='"world"')
+
+    
+    @swiftTest
+    def test_unknown_self_objc_ref(self):
+        """Test unknown references to Objective-C objects."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        for i in range(2):
+            self.assertTrue(thread.GetStopReason() == lldb.eStopReasonBreakpoint)
+            frame = thread.frames[0]
+            var_self = frame.FindVariable("self")
+            self.check_class(var_self, broken=False)
+            process.Continue()
+
+            # weak
+            self.assertTrue(thread.GetStopReason() == lldb.eStopReasonBreakpoint)
+            frame = thread.frames[0]
+            var_self = frame.FindVariable("self")
+            self.check_class(var_self, broken=True)
+            process.Continue()
+
+        self.assertTrue(thread.GetStopReason() != lldb.eStopReasonBreakpoint)
+
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/unknown_self/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/unknown_self/main.swift
@@ -1,0 +1,56 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+import Foundation
+
+// Auxiliary functions.
+func use(_ c : ObjCClass) {}
+func use(_ c : PureClass) {}
+func doCall(_ fn : () -> ()) { fn() }
+
+// Pure Swift objects.
+class PureBase {
+  let base_string = "hello"
+}
+
+class PureClass : PureBase {
+  let string = "world"
+
+  func f() {
+    doCall() { [unowned self] in
+      use(self) // break here
+    }
+    doCall() { [weak self] in
+      use(self!) // break here
+    }
+  }
+}
+
+// Objective-C objects.
+class Base : NSObject {
+  let base_string = "hello"
+}
+
+class ObjCClass : Base {
+  let string = "world"
+
+  func f() {
+    doCall() { [unowned self] in
+      use(self) // break here
+    }
+    doCall() { [weak self] in
+      use(self!) // break here
+    }
+  }
+}
+
+PureClass().f()
+ObjCClass().f()

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2630,6 +2630,48 @@ SwiftLanguageRuntime::FixUpDynamicType(const TypeAndOrName &type_and_or_name,
   return ret;
 }
 
+bool SwiftLanguageRuntime::FixupReference(lldb::addr_t &addr,
+                                          CompilerType type) {
+  swift::CanType swift_can_type = GetCanonicalSwiftType(type);
+  switch (swift_can_type->getKind()) {
+  case swift::TypeKind::UnownedStorage: {
+    Target &target = m_process->GetTarget();
+    llvm::Triple triple = target.GetArchitecture().GetTriple();
+    // On Darwin the Swift runtime stores unowned references to
+    // Objective-C objects as a pointer to a struct that has the
+    // actual object pointer at offset zero. The least significant bit
+    // of the reference pointer indicates whether the reference refers
+    // to an Objective-C or Swift object.
+    //
+    // This is a property of the Swift runtime(!). In the future it
+    // may be necessary to check for the version of the Swift runtime
+    // (or indirectly by looking at the version of the remote
+    // operating system) to determine how to interpret references.
+    if (triple.isOSDarwin()) {
+      // Check whether this is a reference to an Objective-C object.
+      if ((addr & 1) == 0) {
+        // This is a Swift object, no further processing necessary.
+        return true;
+      }
+
+      Status error;
+      if (!m_process)
+        return false;
+
+      // Clear the discriminator bit to get at the pointer to the struct.
+      addr &= ~1ULL;
+      size_t ptr_size = m_process->GetAddressByteSize();
+
+      // Read the pointer to the Objective-C object.
+      target.ReadMemory(addr & ~1ULL, false, &addr, ptr_size, error);
+    }
+  }
+  default:
+    break;
+  }
+  return true;
+}
+
 bool SwiftLanguageRuntime::IsRuntimeSupportValue(ValueObject &valobj) {
   llvm::StringRef g_dollar_tau(u8"$\u03C4_");
   auto valobj_name = valobj.GetName().GetStringRef();


### PR DESCRIPTION
On Darwin the Swift runtime stores references to Objective-C
objects as a pointer to a struct that has the actual object
pointer at offset zero. The least significant bit of the
reference pointer indicates whether the reference refers to an
Objective-C or Swift object.

This is a property of the Swift runtime(!). In the future it
may be necessary to check for the version of the Swift runtime
(or indirectly by looking at the version of the remote
operating system) to determine how to interpret references.

This patch teaches the SwiftLanguageRuntime about this and handles
unwoned references accordingly whengetting the data of any
ValueObjectChildren (which classes always are).

<rdar://problem/42300829>