### PR TITLE
Un-conditionalize use of libcompression.  debugserver only builds

### DIFF
--- a/tools/debugserver/debugserver.xcodeproj/project.pbxproj
+++ b/tools/debugserver/debugserver.xcodeproj/project.pbxproj
@@ -711,12 +711,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 0;
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -750,13 +747,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 0;
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
 				STRIPFLAGS = "-x";
@@ -987,12 +981,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 1;
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = "";
 				STRIPFLAGS = "-x";
 				STRIP_STYLE = debugging;
@@ -1025,20 +1016,15 @@
 				HEADER_SEARCH_PATHS = /System/Library/Frameworks/System.framework/PrivateHeaders;
 				INSTALL_PATH = /usr/bin;
 				"INSTALL_PATH[sdk=iphoneos*]" = /Developer/usr/bin/;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"$(LLDB_ENERGY_CFLAGS)",
 					"-DDT_VARIANT_$(DT_VARIANT)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*]" = (
@@ -1048,8 +1034,6 @@
 					"-DWITH_BKS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -1068,7 +1052,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -1077,7 +1060,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = debugserver;
@@ -1113,20 +1095,15 @@
 				GCC_PREPROCESSOR_DEFINITIONS = LLDB_DEBUGSERVER_DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/bin;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -1136,8 +1113,6 @@
 					"-DWITH_FBS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -1156,7 +1131,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -1164,7 +1138,6 @@
 					__info_plist,
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
@@ -1200,20 +1173,15 @@
 				GCC_PREPROCESSOR_DEFINITIONS = LLDB_DEBUGSERVER_RELEASE;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/bin;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*.internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -1223,8 +1191,6 @@
 					"-DWITH_BKS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -1243,7 +1209,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -1252,7 +1217,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = debugserver;
@@ -1304,21 +1268,16 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INSTALL_PATH = /usr/local/bin;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*.internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -1327,7 +1286,6 @@
 					"-DDEBUGSERVER_PROGRAM_SYMBOL=debugserver_nonui",
 					"$(LLDB_ENERGY_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
 				);
 				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*][arch=*]" = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = "";
@@ -1388,8 +1346,6 @@
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
 				OTHER_CFLAGS = (
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
 					"-Wparentheses",
@@ -1412,7 +1368,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = "debugserver-nonui";
@@ -1448,7 +1403,6 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = /System/Library/Frameworks/System.framework/PrivateHeaders;
 				INSTALL_PATH = /usr/local/bin;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
@@ -1456,8 +1410,6 @@
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
 				OTHER_CFLAGS = (
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"-DDEBUGSERVER_PROGRAM_SYMBOL=debugserver_nonui",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
@@ -1466,7 +1418,6 @@
 					"-DOS_OBJECT_USE_OBJC=0",
 					"-DDEBUGSERVER_PROGRAM_SYMBOL=debugserver_nonui",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*][arch=*]" = "$(OTHER_CFLAGS)";
@@ -1476,7 +1427,6 @@
 					Foundation,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -1485,7 +1435,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = "debugserver-nonui";
@@ -1588,7 +1537,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 0;
@@ -1623,20 +1571,15 @@
 				GCC_PREPROCESSOR_DEFINITIONS = LLDB_DEBUGSERVER_DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/bin;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*.internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -1646,8 +1589,6 @@
 					"-DWITH_BKS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -1665,7 +1606,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -1674,7 +1614,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = debugserver;
@@ -1713,7 +1652,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 0;
@@ -1748,19 +1686,14 @@
 				GCC_PREPROCESSOR_DEFINITIONS = LLDB_DEBUGSERVER_DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/bin;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*.internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -1770,8 +1703,6 @@
 					"-DWITH_BKS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -1789,7 +1720,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -1798,7 +1728,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = debugserver;
@@ -1913,7 +1842,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 0;
@@ -1948,20 +1876,15 @@
 				GCC_PREPROCESSOR_DEFINITIONS = LLDB_DEBUGSERVER_DEBUG;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/bin;
-				LLDB_COMPRESSION_CFLAGS = "";
-				LLDB_COMPRESSION_LDFLAGS = "";
+				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*.internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -1971,8 +1894,6 @@
 					"-DWITH_FBS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -1991,7 +1912,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -2000,7 +1920,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = debugserver;
@@ -2038,7 +1957,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LLDB_COMPRESSION_CFLAGS = "-DHAVE_LIBCOMPRESSION=1";
 				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_OS_LOG_CFLAGS = "-DLLDB_USE_OS_LOG=$(LLDB_USE_OS_LOG)";
 				LLDB_USE_OS_LOG = 0;
@@ -2075,20 +1993,15 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = /System/Library/Frameworks/System.framework/PrivateHeaders;
 				INSTALL_PATH = /usr/bin;
-				LLDB_COMPRESSION_CFLAGS = "";
-				LLDB_COMPRESSION_LDFLAGS = "";
+				LLDB_COMPRESSION_LDFLAGS = "-lcompression";
 				LLDB_DEBUGSERVER = 1;
 				LLDB_ENERGY_CFLAGS = "";
 				"LLDB_ENERGY_CFLAGS[sdk=*.internal]" = "-DLLDB_ENERGY";
 				LLDB_ENERGY_LDFLAGS = "-lpmenergy -lpmsample";
-				LLDB_ZLIB_CFLAGS = "-DHAVE_LIBZ=1";
-				LLDB_ZLIB_LDFLAGS = "-lz";
 				OTHER_CFLAGS = (
 					"-Wparentheses",
 					"-DDT_VARIANT_$(DT_VARIANT)",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 				);
 				"OTHER_CFLAGS[sdk=iphoneos*][arch=*]" = (
@@ -2098,8 +2011,6 @@
 					"-DWITH_BKS",
 					"-DOS_OBJECT_USE_OBJC=0",
 					"$(LLDB_ENERGY_CFLAGS)",
-					"$(LLDB_COMPRESSION_CFLAGS)",
-					"$(LLDB_ZLIB_CFLAGS)",
 					"$(LLDB_OS_LOG_CFLAGS)",
 					"-isystem",
 					"$(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders",
@@ -2117,7 +2028,6 @@
 					MobileCoreServices,
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-sectcreate",
@@ -2126,7 +2036,6 @@
 					"$(PROJECT_DIR)/resources/lldb-debugserver-Info.plist",
 					"$(LLDB_ENERGY_LDFLAGS)",
 					"$(LLDB_COMPRESSION_LDFLAGS)",
-					"$(LLDB_ZLIB_LDFLAGS)",
 				);
 				OTHER_MIGFLAGS = "-I$(DERIVED_FILE_DIR)";
 				PRODUCT_NAME = debugserver;

--- a/tools/debugserver/source/RNBRemote.cpp
+++ b/tools/debugserver/source/RNBRemote.cpp
@@ -42,13 +42,7 @@
 #include "RNBSocket.h"
 #include "StdStringExtractor.h"
 
-#if defined(HAVE_LIBCOMPRESSION)
 #include <compression.h>
-#endif
-
-#if defined(HAVE_LIBZ)
-#include <zlib.h>
-#endif
 
 #include <TargetConditionals.h> // for endianness predefines
 #include <iomanip>
@@ -709,53 +703,73 @@ std::string RNBRemote::CompressString(const std::string &orig) {
       std::vector<uint8_t> encoded_data(encoded_data_buf_size);
       size_t compressed_size = 0;
 
-#if defined(HAVE_LIBCOMPRESSION)
+      // Allocate a scratch buffer for libcompression the first
+      // time we see a different compression type; reuse it in 
+      // all compression_encode_buffer calls so it doesn't need
+      // to allocate / free its own scratch buffer each time.
+      // This buffer will only be freed when compression type
+      // changes; otherwise it will persist until debugserver
+      // exit.
+
+      static compression_types g_libcompress_scratchbuf_type = compression_types::none;
+      static void *g_libcompress_scratchbuf = nullptr;
+
+      if (g_libcompress_scratchbuf_type != compression_type) {
+        if (g_libcompress_scratchbuf) {
+          free (g_libcompress_scratchbuf);
+          g_libcompress_scratchbuf = nullptr;
+        }
+        size_t scratchbuf_size = 0;
+        switch (compression_type) {
+          case compression_types::lz4: 
+            scratchbuf_size = compression_encode_scratch_buffer_size (COMPRESSION_LZ4_RAW);
+            break;
+          case compression_types::zlib_deflate: 
+            scratchbuf_size = compression_encode_scratch_buffer_size (COMPRESSION_ZLIB);
+            break;
+          case compression_types::lzma: 
+            scratchbuf_size = compression_encode_scratch_buffer_size (COMPRESSION_LZMA);
+            break;
+          case compression_types::lzfse: 
+            scratchbuf_size = compression_encode_scratch_buffer_size (COMPRESSION_LZFSE);
+            break;
+          default:
+            break;
+        }
+        if (scratchbuf_size > 0) {
+          g_libcompress_scratchbuf = (void*) malloc (scratchbuf_size);
+          g_libcompress_scratchbuf_type = compression_type;
+        }
+      }
+
       if (compression_type == compression_types::lz4) {
         compressed_size = compression_encode_buffer(
             encoded_data.data(), encoded_data_buf_size,
-            (const uint8_t *)orig.c_str(), orig.size(), nullptr,
+            (const uint8_t *)orig.c_str(), orig.size(), 
+            g_libcompress_scratchbuf,
             COMPRESSION_LZ4_RAW);
       }
       if (compression_type == compression_types::zlib_deflate) {
         compressed_size = compression_encode_buffer(
             encoded_data.data(), encoded_data_buf_size,
-            (const uint8_t *)orig.c_str(), orig.size(), nullptr,
+            (const uint8_t *)orig.c_str(), orig.size(), 
+            g_libcompress_scratchbuf,
             COMPRESSION_ZLIB);
       }
       if (compression_type == compression_types::lzma) {
         compressed_size = compression_encode_buffer(
             encoded_data.data(), encoded_data_buf_size,
-            (const uint8_t *)orig.c_str(), orig.size(), nullptr,
+            (const uint8_t *)orig.c_str(), orig.size(), 
+            g_libcompress_scratchbuf,
             COMPRESSION_LZMA);
       }
       if (compression_type == compression_types::lzfse) {
         compressed_size = compression_encode_buffer(
             encoded_data.data(), encoded_data_buf_size,
-            (const uint8_t *)orig.c_str(), orig.size(), nullptr,
+            (const uint8_t *)orig.c_str(), orig.size(), 
+            g_libcompress_scratchbuf,
             COMPRESSION_LZFSE);
       }
-#endif
-
-#if defined(HAVE_LIBZ)
-      if (compressed_size == 0 &&
-          compression_type == compression_types::zlib_deflate) {
-        z_stream stream;
-        memset(&stream, 0, sizeof(z_stream));
-        stream.next_in = (Bytef *)orig.c_str();
-        stream.avail_in = (uInt)orig.size();
-        stream.next_out = (Bytef *)encoded_data.data();
-        stream.avail_out = (uInt)encoded_data_buf_size;
-        stream.zalloc = Z_NULL;
-        stream.zfree = Z_NULL;
-        stream.opaque = Z_NULL;
-        deflateInit2(&stream, 5, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
-        int compress_status = deflate(&stream, Z_FINISH);
-        deflateEnd(&stream);
-        if (compress_status == Z_STREAM_END && stream.total_out > 0) {
-          compressed_size = stream.total_out;
-        }
-      }
-#endif
 
       if (compressed_size > 0) {
         compressed.clear();
@@ -3614,13 +3628,13 @@ rnb_err_t RNBRemote::HandlePacket_qSupported(const char *p) {
   bool enable_compression = false;
   (void)enable_compression;
 
-#if (defined (TARGET_OS_WATCH) && TARGET_OS_WATCH == 1) || (defined (TARGET_OS_IOS) && TARGET_OS_IOS == 1) || (defined (TARGET_OS_TV) && TARGET_OS_TV == 1)
+#if (defined (TARGET_OS_WATCH) && TARGET_OS_WATCH == 1) \
+    || (defined (TARGET_OS_IOS) && TARGET_OS_IOS == 1) \
+    || (defined (TARGET_OS_TV) && TARGET_OS_TV == 1) \
+    || (defined (TARGET_OS_BRIDGE) && TARGET_OS_BRIDGE == 1)
   enable_compression = true;
 #endif
 
-#if defined(HAVE_LIBCOMPRESSION)
-  // libcompression is weak linked so test if compression_decode_buffer() is
-  // available
   if (enable_compression) {
     strcat(buf, ";SupportedCompressions=lzfse,zlib-deflate,lz4,lzma;"
                 "DefaultCompressionMinSize=");
@@ -3628,17 +3642,7 @@ rnb_err_t RNBRemote::HandlePacket_qSupported(const char *p) {
     snprintf(numbuf, sizeof(numbuf), "%zu", m_compression_minsize);
     numbuf[sizeof(numbuf) - 1] = '\0';
     strcat(buf, numbuf);
-  }
-#elif defined(HAVE_LIBZ)
-  if (enable_compression) {
-    strcat(buf,
-           ";SupportedCompressions=zlib-deflate;DefaultCompressionMinSize=");
-    char numbuf[16];
-    snprintf(numbuf, sizeof(numbuf), "%zu", m_compression_minsize);
-    numbuf[sizeof(numbuf) - 1] = '\0';
-    strcat(buf, numbuf);
-  }
-#endif
+  } 
 
   return SendPacket(buf);
 }
@@ -4306,7 +4310,6 @@ rnb_err_t RNBRemote::HandlePacket_QEnableCompression(const char *p) {
     }
   }
 
-#if defined(HAVE_LIBCOMPRESSION)
   if (strstr(p, "type:zlib-deflate;") != nullptr) {
     EnableCompressionNextSendPacket(compression_types::zlib_deflate);
     m_compression_minsize = new_compression_minsize;
@@ -4324,15 +4327,6 @@ rnb_err_t RNBRemote::HandlePacket_QEnableCompression(const char *p) {
     m_compression_minsize = new_compression_minsize;
     return SendPacket("OK");
   }
-#endif
-
-#if defined(HAVE_LIBZ)
-  if (strstr(p, "type:zlib-deflate;") != nullptr) {
-    EnableCompressionNextSendPacket(compression_types::zlib_deflate);
-    m_compression_minsize = new_compression_minsize;
-    return SendPacket("OK");
-  }
-#endif
 
   return SendPacket("E88");
 }


### PR DESCRIPTION
Un-conditionalize use of libcompression.  debugserver only builds
on Darwin systems and libcompression has been in the OS for over
three years. 

Remove use of / linking to zlib.  We'll always have libcompression
available now.

Create a scratch buffer via compression_encode_scratch_buffer_size()
and use it in calls to compression_encode_buffer() to avoid 
compression_encode_buffer having to malloc & free a scratch buffer
on each call.  

Tested by forcing compression to be enabled on macos native (normally
only enabled on iOS et al devices), running the testsuite.

<rdar://problem/41601084>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@349553 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d04d395a740ed6fa00292de75c1ba7c4f59ee478)