### PR TITLE
Don't forget to free the libcompression scratch buffer in the dtor.

### DIFF
--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -153,6 +153,9 @@ GDBRemoteCommunication::~GDBRemoteCommunication() {
     Disconnect();
   }
 
+  if (m_decompression_scratch)
+    free (m_decompression_scratch);
+
   // Stop the communications read thread which is used to parse all incoming
   // packets.  This function will block until the read thread returns.
   if (m_read_thread_enabled)


### PR DESCRIPTION
Don't forget to free the libcompression scratch buffer in the dtor.
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@349580 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 83aa61216ced4f86e2ffa0a050a911ecdb9c410c)