### PR TITLE
[5.0] Account for the Swift renames of various Dictionary, Set, and String classes.

### DIFF
--- a/lit/SwiftREPL/DictBridging.test
+++ b/lit/SwiftREPL/DictBridging.test
@@ -11,7 +11,7 @@ let d0: Dictionary<Int, Int> = [:]
 
 // All empty dictionaries use the same type-punned storage class.
 let d0b = d0 as NSDictionary
-// DICT-LABEL: d0b: {{(__RawNativeDictionaryStorage|_EmptyDictionarySingleton)}} = 0 key/value pairs
+// DICT-LABEL: d0b: {{(__RawNativeDictionaryStorage|__EmptyDictionarySingleton)}} = 0 key/value pairs
 
 // Baseline case: native Dictionary of non-verbatim bridged elements
 let d1: Dictionary<Int,Int> = [1:2]

--- a/lit/SwiftREPL/SetBridging.test
+++ b/lit/SwiftREPL/SetBridging.test
@@ -11,7 +11,7 @@ let s0: Set<Int> = []
 
 // All empty sets use the same type-punned storage class.
 let s0b = s0 as NSSet
-// DICT-LABEL: s0b: {{(__RawNativeSetStorage|_EmptySetSingleton)}} = 0 values
+// DICT-LABEL: s0b: {{(__RawNativeSetStorage|__EmptySetSingleton)}} = 0 values
 
 // Baseline case: native Set of non-verbatim bridged elements
 let s1: Set<Int> = [1]

--- a/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -339,7 +339,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
     //
     //   struct InlineSlice {
     //       var slice: Range<HalfInt>
-    //       var storage: _DataStorage
+    //       var storage: __DataStorage
     //   }
     static ConstString g_slice("slice");
     ValueObjectSP slice_storage_sp = slice_data_sp->GetChildAtNamePath(g_slice);
@@ -400,7 +400,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
     //
     //   struct LargeSlice {
     //       var slice: RangeReference
-    //       var storage: _DataStorage
+    //       var storage: __DataStorage
     //   }
     static ConstString g_slice("slice");
     ValueObjectSP slice_ref_sp = large_data_sp->GetChildAtNamePath(g_slice);

--- a/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -45,9 +45,9 @@ DictionaryConfig::DictionaryConfig()
   // still used to name classes in the ObjC runtime.
 
   m_nativeStorageRoot_mangled =
-    ConstString("_TtCs21_RawDictionaryStorage");
+    ConstString("_TtCs22__RawDictionaryStorage");
   m_nativeStorageRoot_demangled =
-    ConstString("Swift._RawDictionaryStorage");
+    ConstString("Swift.__RawDictionaryStorage");
 
   // Native storage class
   m_nativeStorage_mangledRegex_ObjC =
@@ -59,9 +59,9 @@ DictionaryConfig::DictionaryConfig()
 
   // Type-punned empty dictionary
   m_emptyStorage_mangled_ObjC =
-    ConstString("_TtCs25_EmptyDictionarySingleton");
+    ConstString("_TtCs26__EmptyDictionarySingleton");
   m_emptyStorage_demangled
-    = ConstString("Swift._EmptyDictionarySingleton");
+    = ConstString("Swift.__EmptyDictionarySingleton");
 
   // Deferred non-verbatim bridged dictionary
   m_deferredBridgedStorage_mangledRegex_ObjC

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -320,7 +320,7 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
   }
 
   if ((discriminator & 0xF0) == 0x00) { // Shared string
-    // FIXME: Verify that there is a _SharedStringStorage instance at `address`.
+    // FIXME: Verify that there is a __SharedStringStorage instance at `address`.
     lldbassert((flags & 0x3000) == 0);
     uint64_t startOffset = (ptrSize == 8 ? 24 : 12);
     auto address = objectAddress + startOffset;

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -58,9 +58,9 @@ using lldb_private::formatters::swift::DictionaryConfig;
 using lldb_private::formatters::swift::SetConfig;
 
 void SwiftLanguage::Initialize() {
-  static ConstString g_SwiftSharedStringClass(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs20_SharedStringStorage"));
+  static ConstString g_SwiftSharedStringClass(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21__SharedStringStorage"));
   static ConstString g_SwiftStringStorageClass(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs14_StringStorage"));
+      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs15__StringStorage"));
   static ConstString g_NSArrayClass1Old("_TtCs22__SwiftDeferredNSArray");
   static ConstString g_NSArrayClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray"));
   PluginManager::RegisterPlugin(GetPluginNameStatic(), "Swift Language",
@@ -87,9 +87,9 @@ void SwiftLanguage::Initialize() {
 
 void SwiftLanguage::Terminate() {
   // FIXME: Duplicating this list from Initialize seems error-prone.
-  static ConstString g_SwiftSharedStringClass(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs20_SharedStringStorage"));
+  static ConstString g_SwiftSharedStringClass(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21__SharedStringStorage"));
   static ConstString g_SwiftStringStorageClass(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs14_StringStorage"));
+      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs15__StringStorage"));
   static ConstString g_NSArrayClass1Old("_TtCs22__SwiftDeferredNSArray");
   static ConstString g_NSArrayClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray"));
 
@@ -429,7 +429,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::SwiftSharedString_SummaryProvider,
       "SharedStringStorage summary provider",
-      ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs20_SharedStringStorage")), summary_flags);
+      ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21__SharedStringStorage")), summary_flags);
   summary_flags.SetSkipPointers(true);
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::BuiltinObjC_SummaryProvider,

--- a/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -46,9 +46,9 @@ SetConfig::SetConfig()
   // still used to name classes in the ObjC runtime.
 
   m_nativeStorageRoot_mangled =
-    ConstString("_TtCs14_RawSetStorage");
+    ConstString("_TtCs15__RawSetStorage");
   m_nativeStorageRoot_demangled =
-    ConstString("Swift._RawSetStorage");
+    ConstString("Swift.__RawSetStorage");
 
     // Native storage class
   m_nativeStorage_mangledRegex_ObjC =
@@ -59,8 +59,8 @@ SetConfig::SetConfig()
     ConstString("^Swift\\._SetStorage<.+>$");
 
   // Type-punned empty set
-  m_emptyStorage_mangled_ObjC = ConstString("_TtCs18_EmptySetSingleton");
-  m_emptyStorage_demangled = ConstString("Swift._EmptySetSingleton");
+  m_emptyStorage_mangled_ObjC = ConstString("_TtCs19__EmptySetSingleton");
+  m_emptyStorage_demangled = ConstString("Swift.__EmptySetSingleton");
 
   // Deferred non-verbatim bridged set
   m_deferredBridgedStorage_mangledRegex_ObjC


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-lldb/pull/1154 for `swift-5.0-branch`.

rdar://problem/46646438