### PR TITLE
ASAN: disable container overflow detection.

### DIFF
--- a/lit/Suite/lit.cfg
+++ b/lit/Suite/lit.cfg
@@ -30,6 +30,10 @@ if 'Address' in config.llvm_use_sanitizer and \
                          'libclang_rt.asan_osx_dynamic.dylib')
   config.environment['ASAN_OPTIONS'] = \
     'detect_stack_use_after_return=1:container_overflow=0'
+  # Swift's libReflection builds without ASAN, which causes a known
+  # false positive in std::vector.
+  config.environment['ASAN_OPTIONS'] += \
+    ':detect_container_overflow=0'
   config.environment['DYLD_INSERT_LIBRARIES'] = runtime
 
 # Build dotest command.


### PR DESCRIPTION
Swift's libReflection builds without ASAN because it inheriuts the
build settings of the stdlib. This causes a known false positive in
std::vector.

rdar://problem/46787949