### PR TITLE
"help finish" tells you it is an alias.  "help fin" doesn't.

### DIFF
--- a/packages/Python/lldbsuite/test/help/TestHelp.py
+++ b/packages/Python/lldbsuite/test/help/TestHelp.py
@@ -232,6 +232,17 @@ class HelpCommandTestCase(TestBase):
         self.expect("help averyfriendlyalias", matching=True,
                     substrs=['I am a very friendly alias'])
     @no_debug_info_test
+    def test_alias_prints_origin(self):
+        """Test that 'help <unique_match_to_alias>' prints the alias origin."""
+        def cleanup():
+            self.runCmd('command unalias alongaliasname', check=False)
+
+        self.addTearDownHook(cleanup)
+        self.runCmd('command alias alongaliasname help')
+        self.expect("help alongaliasna", matching=True,
+                    substrs=["'alongaliasna' is an abbreviation for 'help'"])
+
+    @no_debug_info_test
     def test_help_format_output(self):
         """Test that help output reaches TerminalWidth."""
         self.runCmd(

--- a/source/Commands/CommandObjectHelp.cpp
+++ b/source/Commands/CommandObjectHelp.cpp
@@ -171,10 +171,13 @@ bool CommandObjectHelp::DoExecute(Args &command, CommandReturnObject &result) {
       }
 
       sub_cmd_obj->GenerateHelpText(result);
-
-      if (m_interpreter.AliasExists(command_name)) {
+      std::string alias_full_name;
+      // Don't use AliasExists here, that only checks exact name matches.  If
+      // the user typed a shorter unique alias name, we should still tell them
+      // it was an alias.
+      if (m_interpreter.GetAliasFullName(command_name, alias_full_name)) {
         StreamString sstr;
-        m_interpreter.GetAlias(command_name)->GetAliasExpansion(sstr);
+        m_interpreter.GetAlias(alias_full_name)->GetAliasExpansion(sstr);
         result.GetOutputStream().Printf("\n'%s' is an abbreviation for %s\n",
                                         command[0].c_str(), sstr.GetData());
       }


### PR DESCRIPTION
They both run the same command, and people get used to typing the shortest
string they can, so we should support alias info on shortened strings as well.

<rdar://problem/46859207>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@349874 91177308-0d34-0410-b5e6-96231b3b80d8