### PR TITLE
 Fix stack-buffer-overflow in lldb_private::Host::FindProcesses

### DIFF
--- a/source/Host/macosx/objcxx/Host.mm
+++ b/source/Host/macosx/objcxx/Host.mm
@@ -629,7 +629,7 @@ uint32_t Host::FindProcesses(const ProcessInstanceInfoMatch &match_info,
   int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
 
   size_t pid_data_size = 0;
-  if (::sysctl(mib, 3, NULL, &pid_data_size, NULL, 0) != 0)
+  if (::sysctl(mib, 3, nullptr, &pid_data_size, nullptr, 0) != 0)
     return 0;
 
   // Add a few extra in case a few more show up
@@ -639,7 +639,7 @@ uint32_t Host::FindProcesses(const ProcessInstanceInfoMatch &match_info,
   kinfos.resize(estimated_pid_count);
   pid_data_size = kinfos.size() * sizeof(struct kinfo_proc);
 
-  if (::sysctl(mib, 4, &kinfos[0], &pid_data_size, NULL, 0) != 0)
+  if (::sysctl(mib, 3, &kinfos[0], &pid_data_size, nullptr, 0) != 0)
     return 0;
 
   const size_t actual_pid_count = (pid_data_size / sizeof(struct kinfo_proc));

--- a/source/Host/macosx/objcxx/Host.mm
+++ b/source/Host/macosx/objcxx/Host.mm
@@ -629,7 +629,7 @@ uint32_t Host::FindProcesses(const ProcessInstanceInfoMatch &match_info,
   int mib[3] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL};
 
   size_t pid_data_size = 0;
-  if (::sysctl(mib, 4, NULL, &pid_data_size, NULL, 0) != 0)
+  if (::sysctl(mib, 3, NULL, &pid_data_size, NULL, 0) != 0)
     return 0;
 
   // Add a few extra in case a few more show up


### PR DESCRIPTION
This fixes two stack-buffer-overflows detected by our GreenDragon bot.