### PR TITLE
 Remap relative search paths into the appropriate working directory

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -209,9 +209,8 @@ public:
 
   const char *GetFrameworkSearchPathAtIndex(size_t idx) const;
 
-  size_t GetNumClangArguments();
-
-  const char *GetClangArgumentAtIndex(size_t idx);
+  /// \return the ExtraArgs of the ClangImporterOptions.
+  const std::vector<std::string> &GetClangArguments();
 
   swift::ModuleDecl *CreateModule(const ConstString &module_basename,
                                   Status &error);

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -180,9 +180,13 @@ public:
 
   bool AddFrameworkSearchPath(const char *path);
 
-  bool AddClangArgument(std::string arg, bool force = false);
+  bool AddClangArgument(std::string arg, bool unique = true);
 
   bool AddClangArgumentPair(const char *arg1, const char *arg2);
+
+  /// Add a list of Clang arguments to the ClangImporter options and
+  /// apply the working directory to any relative paths.
+  void AddExtraClangArgs(std::vector<std::string> ExtraArgs);
 
   const char *GetPlatformSDKPath() const {
     if (m_platform_sdk_path.empty())

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -23,7 +23,12 @@ libFoo.dylib: Foo.swift
             -module-name $(shell basename $< .swift) -emit-module \
             -Xlinker -install_name -Xlinker @executable_path/$@ \
             -Xcc -I$(BOTDIR)/Foo $(SWIFTFLAGS) -emit-objc-header-path Foo.h \
-            -sdk "$(SWIFTSDKROOT)" -import-objc-header $(BOTDIR)/Foo/bridge.h
+	    -Xcc -iquote -Xcc ./buildbot/iquote-path \
+	    -Xcc -I -Xcc ./buildbot/I-double \
+	    -Xcc -I./buildbot/I-single \
+	    -Xcc -F./buildbot/Frameworks \
+	    -Xcc -F -Xcc buildbot/Frameworks \
+	    -sdk "$(SWIFTSDKROOT)" -import-objc-header $(BOTDIR)/Foo/bridge.h
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -93,13 +93,34 @@ class TestSwiftRewriteClangPaths(TestBase):
             self.expect("fr var bar", comment, substrs=["y", "42"])
             self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
 
+        # Scan through the types log.
         errs = 0
+        found_iquote = 0
+        found_f = 0
+        found_i1 = 0
+        found_i2 = 0
+        found_rel = 0
         logfile = open(log, "r")
         for line in logfile:
+            if " remapped " in line: continue
             if "error: missing required module 'CFoo'" in line:
                 errs += 1
+                continue
+            if 'user/iquote-path' in line: found_iquote += 1; continue
+            if 'user/I-single'    in line: found_i1 += 1;     continue
+            if 'user/I-double'    in line: found_i2 += 1;     continue
+            if './iquote-path'    in line: found_rel += 1;    continue
+            if './I-'             in line: found_rel += 1;    continue
+            if '/user/Frameworks' in line: found_f += 1;      continue
+
         if remap:
-            self.assertTrue(errs == 0, "expected no module import error")
+            self.assertEqual(errs, 0, "expected no module import error")
+            # Module context + scratch context.
+            self.assertEqual(found_iquote, 2)
+            self.assertEqual(found_i1, 2)
+            self.assertEqual(found_i2, 2)
+            self.assertEqual(found_f, 4)
+            self.assertEqual(found_rel, 0)
         else:
             self.assertTrue(errs > 0, "expected module import error")
         

--- a/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/nonmodular-include/Makefile
@@ -6,8 +6,7 @@ SWIFT_SOURCES := main.swift
 all: module.modulemap conflict.h a.out
 
 include $(LEVEL)/Makefile.rules
-# $(PWD) is not what we want because VPATH changes it
-SWIFTFLAGS += -Xcc -F$(SRCDIR) -I$(SRCDIR) -I$(shell pwd)
+SWIFTFLAGS += -Xcc -F$(SRCDIR) -I$(SRCDIR) -I$(BUILDDIR)
 
 # Create a nonmodular include by removing the modulemap after building.
 all:

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1957,7 +1957,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                                   swift_ast_sp->GetDiagnosticEngine());
   }
 
-  // Apply source path remappings ofund in the target settings.
+  // Apply source path remappings found in the target settings.
   swift_ast_sp->RemapClangImporterOptions(target.GetSourcePathMap());
 
   // This needs to happen once all the import paths are set, or

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1373,6 +1373,63 @@ bool HasSwiftModules(Module &module) {
   return !ast_file_datas.empty();
 }
 
+namespace {
+/// Turn relative paths in clang options into absolute paths based on
+/// \c cur_working_dir.
+template <typename SmallString>
+void ApplyWorkingDir(SmallString &clang_argument,
+                     StringRef cur_working_dir) {
+  StringRef arg = clang_argument.str();
+  StringRef prefix;
+  // Ignore the option part of a double-arg include option.
+  if (arg == "-I" || arg == "-F")
+    return;
+  if (arg.consume_front("-I"))
+    prefix = "-I";
+  else if (arg.consume_front("-F"))
+    prefix = "-F";
+  else if (arg.startswith("-"))
+    // Assume this is a compiler arg and not a path starting with "-".
+    return;
+  // There is most probably a path in arg now.
+  if (!llvm::sys::path::is_relative(arg))
+    return;
+  SmallString rel_path = arg;
+  clang_argument = prefix;
+  llvm::sys::path::append(clang_argument, cur_working_dir, rel_path);
+  llvm::sys::path::remove_dots(clang_argument);
+}
+}
+
+void SwiftASTContext::AddExtraClangArgs(std::vector<std::string> ExtraArgs) {
+  llvm::SmallString<128> cur_working_dir;
+  llvm::SmallString<128> clang_argument;
+  for (const std::string &arg : ExtraArgs) {
+    // Join multi-arg -D and -U options for uniquing.
+    clang_argument += arg;
+    if (clang_argument == "-D" || clang_argument == "-U" ||
+        clang_argument == "-working-directory")
+      continue;
+
+    // Enable uniquing for -D and -U options.
+    bool is_macro = (clang_argument.size() >= 2 && clang_argument[0] == '-' &&
+                     (clang_argument[1] == 'D' || clang_argument[1] == 'U'));
+    bool unique = is_macro;
+
+    // Consume any -working-directory arguments.
+    StringRef cwd(clang_argument);
+    if (cwd.consume_front("-working-directory"))
+      cur_working_dir = cwd;
+    else {
+      // Otherwise add the argument to the list.
+      if (!is_macro)
+        ApplyWorkingDir(clang_argument, cur_working_dir);
+      AddClangArgument(clang_argument.str(), unique);
+    }
+    clang_argument.clear();
+  }
+}
+
 void SwiftASTContext::RemapClangImporterOptions(
     const PathMappingList &path_map) {
   Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
@@ -1389,6 +1446,8 @@ void SwiftASTContext::RemapClangImporterOptions(
     StringRef arg = arg_string;
     if (arg.consume_front("-I"))
       prefix = "-I";
+    else if (arg.consume_front("-F"))
+      prefix = "-F";
     if (path_map.RemapPath(arg, remapped)) {
       if (log)
         log->Printf("remapped %s -> %s%s", arg.str().c_str(),
@@ -1597,6 +1656,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
                         FileSpec(resource_dir, false), triple);
 
+  // Apply the working directory to all relative paths.
+  std::vector<std::string> DeserializedArgs = swift_ast_sp->GetClangArguments();
+  swift_ast_sp->GetClangImporterOptions().ExtraArgs.clear();
+  swift_ast_sp->AddExtraClangArgs(DeserializedArgs);
   // Apply source path remappings found in the module's dSYM.
   swift_ast_sp->RemapClangImporterOptions(module.GetSourceMappingList());
   
@@ -1902,23 +1965,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
                   ast_context->GetFrameworkSearchPathAtIndex(fsi);
               swift_ast_sp->AddFrameworkSearchPath(search_path);
             }
-
-            std::string clang_argument;
-            for (const std::string &arg : ast_context->GetClangArguments()) {
-              // Join multi-arg -D and -U options for uniquing.
-              clang_argument += arg;
-              if (clang_argument == "-D" || clang_argument == "-U")
-                continue;
-
-              // Enable uniquing for -D and -U options.
-              bool force = true;
-              if (clang_argument.size() >= 2 && clang_argument[0] == '-' &&
-                  (clang_argument[1] == 'D' || clang_argument[1] == 'U'))
-                force = false;
-
-              swift_ast_sp->AddClangArgument(clang_argument, force);
-              clang_argument.clear();
-            }
+            swift_ast_sp->AddExtraClangArgs(ast_context->GetClangArguments());
           }
 
           swift_ast_sp->RegisterSectionModules(*module_sp, module_names);
@@ -2978,13 +3025,13 @@ bool SwiftASTContext::AddFrameworkSearchPath(const char *path) {
   return false;
 }
 
-bool SwiftASTContext::AddClangArgument(std::string clang_arg, bool force) {
+bool SwiftASTContext::AddClangArgument(std::string clang_arg, bool unique) {
   if (clang_arg.empty())
     return false;
 
   swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
   // Avoid inserting the same option twice.
-  if (!force)
+  if (unique)
     for (std::string &arg : importer_options.ExtraArgs)
       if (arg == clang_arg)
         return false;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1904,10 +1904,9 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
             }
 
             std::string clang_argument;
-            for (size_t osi = 0, ose = ast_context->GetNumClangArguments();
-                 osi < ose; ++osi) {
+            for (const std::string &arg : ast_context->GetClangArguments()) {
               // Join multi-arg -D and -U options for uniquing.
-              clang_argument += ast_context->GetClangArgumentAtIndex(osi);
+              clang_argument += arg;
               if (clang_argument == "-D" || clang_argument == "-U")
                 continue;
 
@@ -3052,24 +3051,14 @@ const char *SwiftASTContext::GetFrameworkSearchPathAtIndex(size_t idx) const {
 
   if (m_ast_context_ap.get()) {
     if (idx < m_ast_context_ap->SearchPathOpts.FrameworkSearchPaths.size())
-      return m_ast_context_ap->SearchPathOpts.FrameworkSearchPaths[idx].Path.c_str();
+      return m_ast_context_ap->SearchPathOpts.FrameworkSearchPaths[idx]
+          .Path.c_str();
   }
   return NULL;
 }
 
-size_t SwiftASTContext::GetNumClangArguments() {
-  swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
-
-  return importer_options.ExtraArgs.size();
-}
-
-const char *SwiftASTContext::GetClangArgumentAtIndex(size_t idx) {
-  swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
-
-  if (idx < importer_options.ExtraArgs.size())
-    return importer_options.ExtraArgs[idx].c_str();
-
-  return NULL;
+const std::vector<std::string> &SwiftASTContext::GetClangArguments() {
+  return GetClangImporterOptions().ExtraArgs;
 }
 
 swift::ModuleDecl *

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2971,7 +2971,8 @@ bool SwiftASTContext::AddFrameworkSearchPath(const char *path) {
     }
 
     if (add_search_path) {
-      ast->SearchPathOpts.FrameworkSearchPaths.push_back({path, /*isSystem=*/false});
+      ast->SearchPathOpts.FrameworkSearchPaths.push_back(
+          {path, /*isSystem=*/false});
       return true;
     }
   }
@@ -2979,26 +2980,18 @@ bool SwiftASTContext::AddFrameworkSearchPath(const char *path) {
 }
 
 bool SwiftASTContext::AddClangArgument(std::string clang_arg, bool force) {
-  if (!clang_arg.empty()) {
-    swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
+  if (clang_arg.empty())
+    return false;
 
-    bool add_hmap = true;
+  swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
+  // Avoid inserting the same option twice.
+  if (!force)
+    for (std::string &arg : importer_options.ExtraArgs)
+      if (arg == clang_arg)
+        return false;
 
-    if (!force) {
-      for (std::string &arg : importer_options.ExtraArgs) {
-        if (!arg.compare(clang_arg)) {
-          add_hmap = false;
-          break;
-        }
-      }
-    }
-
-    if (add_hmap) {
-      importer_options.ExtraArgs.push_back(clang_arg);
-      return true;
-    }
-  }
-  return false;
+  importer_options.ExtraArgs.push_back(clang_arg);
+  return true;
 }
 
 bool SwiftASTContext::AddClangArgumentPair(const char *clang_arg_1,


### PR DESCRIPTION
Remap relative search paths into the appropriate working directory  …
when building the scratch context.

The header search options for a scratch context often look like
```
  -working-directory /path/to/foo-dylib
  -I./bar
  -working-directory /path/to/baz-dylib
  -I./blarg
```

after this patch, they will be
```
  -I/path/to/foo-dylib/./ba
  -I/path/to/baz-dylib/./blarg
```

<rdar://problem/46876039>