### PR TITLE
 [Swift] Add support for looking up Clang types using module debug info.

### DIFF
--- a/lit/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lit/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -7,11 +7,11 @@ func f() {
   // CHECK-DAG: (Builtin.RawPointer) ctype = 0x0000000000000400
   let ctype = size_t(1024)
   // This works as a Clang type via the Objective-C runtime.
-  // CHECK-DAG: (Class) object = 0x{{[0-9a-f]+$}}
-  // CHECK-DAG: (Class) object = {{.*}}Hello from Objective-C!
+  // CHECK-DAG: (ObjCClass) object = 0x{{[0-9a-f]+$}}
+  // CHECK-DAG: (ObjCClass) object = {{.*}}Hello from Objective-C!
   let object = ObjCClass()
   // The Objective-C runtime recognizes this as a tagged pointer.
-  // CHECK-DAG: (__NSCFNumber) inlined = 0x0000000000002a37 42
+  // CHECK-DAG: (__NSCFNumber) inlined = {{.*}}42
   let inlined = NSNumber(value: 42)
   print(object) // break here
 }

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/TestSwiftDWARFImporter.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/TestSwiftDWARFImporter.py
@@ -43,6 +43,10 @@ class TestSwiftDWARFImporter(lldbtest.TestBase):
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("pureSwift"),
                                 value="42")
+        lldbutil.check_variable(self,
+                                target.FindFirstGlobalVariable("point"),
+                                typename="Point", num_children=2)
+        self.expect("fr v point", substrs=["x = 1", "y = 2"])
 
 if __name__ == '__main__':
     import atexit

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -144,7 +144,7 @@ TypeSP DWARFASTParserClang::ParseTypeFromDWO(const DWARFDIE &die, Log *log) {
 
   // This type comes from an external DWO module.
   std::vector<CompilerContext> dwo_context;
-  die.GetDWOContext(dwo_context);
+  die.GetDeclContext(dwo_context);
   TypeMap dwo_types;
 
   if (!dwo_module_sp->GetSymbolVendor()->FindTypes(dwo_context, true,

--- a/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -166,13 +166,13 @@ void DWARFDIE::GetDWARFDeclContext(DWARFDeclContext &dwarf_decl_ctx) const {
   }
 }
 
-void DWARFDIE::GetDWOContext(std::vector<CompilerContext> &context) const {
+void DWARFDIE::GetDeclContext(std::vector<CompilerContext> &context) const {
   const dw_tag_t tag = Tag();
   if (tag == DW_TAG_compile_unit || tag == DW_TAG_partial_unit)
     return;
   DWARFDIE parent = GetParent();
   if (parent)
-    parent.GetDWOContext(context);
+    parent.GetDeclContext(context);
   switch (tag) {
   case DW_TAG_module:
     context.push_back(

--- a/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
@@ -90,7 +90,10 @@ public:
 
   void GetDWARFDeclContext(DWARFDeclContext &dwarf_decl_ctx) const;
 
-  void GetDWOContext(std::vector<lldb_private::CompilerContext> &context) const;
+  /// Return this DIE's decl context as it is needed to look up types
+  /// in Clang's -gmodules debug info format.
+  void
+  GetDeclContext(std::vector<lldb_private::CompilerContext> &context) const;
 
   //----------------------------------------------------------------------
   // Getting attribute values from the DIE.

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2602,7 +2602,7 @@ size_t SymbolFileDWARF::FindTypes(const std::vector<CompilerContext> &context,
 
       if (die) {
         std::vector<CompilerContext> die_context;
-        die.GetDWOContext(die_context);
+        die.GetDeclContext(die_context);
         if (die_context != context)
           continue;
 

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2601,6 +2601,10 @@ size_t SymbolFileDWARF::FindTypes(const std::vector<CompilerContext> &context,
       DWARFDIE die = GetDIE(die_ref);
 
       if (die) {
+        // LLDB never searches for Swift type definitions by context.
+        if (die.GetCU()->GetLanguageType() == eLanguageTypeSwift)
+          continue;
+
         std::vector<CompilerContext> die_context;
         die.GetDeclContext(die_context);
         if (die_context != context)


### PR DESCRIPTION
Previously all Clang fallback types were assumed to be of type
(id). By reading the -gmodules breadcrumbs, we can do much better.