### PR TITLE
 Support zero-sized types in extensions.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -475,7 +475,9 @@ public:
 
   static bool IsSelfArchetypeType(const CompilerType &compiler_type);
 
-  static bool IsPossibleZeroSizeType(const CompilerType &compiler_type);
+  static bool
+  IsPossibleZeroSizeType(const CompilerType &compiler_type,
+                         ExecutionContextScope *exe_scope);
 
   bool IsTrivialOptionSetType(const CompilerType &compiler_type);
 

--- a/packages/Python/lldbsuite/test/lang/swift/zero_size_generic_self/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/zero_size_generic_self/main.swift
@@ -2,21 +2,40 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
+
+func use<T>(_ t : T) {}
+
 struct GenericSelf<T> {
   init(x: T) {
-    print(x) //%self.expect('frame variable -d run -- self', substrs=['GenericSelf<String>'])
+    use(x) //%self.expect('frame variable -d run -- self', substrs=['GenericSelf<String>'])
   }
 }
 
-func main() {
-  GenericSelf(x: "hello world")
+// More complex example with protocol extensions.
+
+protocol MyKey {}
+extension Int : MyKey {}
+protocol MyProtocol {
+  associatedtype Key : MyKey
+}
+struct MyStruct<S : MyKey> : MyProtocol {
+  typealias Key = S
+}
+extension MyProtocol {
+    func decode() {
+        use(self) //%self.expect('frame variable -d run -- self', substrs=['(a.MyStruct<Int>)', 'self', '=', '{}'])
+        return
+    }
 }
 
-main()
+// Run.
+GenericSelf(x: "hello world")
+let s = MyStruct<Int>()
+s.decode()

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -474,7 +474,9 @@ ValueObject::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
                             bool mask_error_on_zerosize_type) {
   Status err = m_value.GetValueAsData(exe_ctx, data, data_offset, module);
   if (err.Fail() && mask_error_on_zerosize_type &&
-      SwiftASTContext::IsPossibleZeroSizeType(GetCompilerType()))
+      SwiftASTContext::IsPossibleZeroSizeType(
+          GetCompilerType(),
+          exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
     return Status();
   return err;
 }

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -144,7 +144,9 @@ bool ValueObjectVariable::UpdateValue() {
     } else {
       CompilerType var_type(GetCompilerTypeImpl());
       if (var_type.IsValid()) {
-        if (SwiftASTContext::IsPossibleZeroSizeType(var_type))
+        ExecutionContext exe_ctx(GetExecutionContextRef());
+        if (SwiftASTContext::IsPossibleZeroSizeType(
+                var_type, exe_ctx.GetBestExecutionContextScope()))
           m_value.SetCompilerType(var_type);
         else
           m_error.SetErrorString("empty constant data");

--- a/source/DataFormatters/TypeFormat.cpp
+++ b/source/DataFormatters/TypeFormat.cpp
@@ -95,7 +95,8 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
           Status error;
           valobj->GetData(data, error);
           if (error.Fail() &&
-              !SwiftASTContext::IsPossibleZeroSizeType(compiler_type))
+              !SwiftASTContext::IsPossibleZeroSizeType(
+                  compiler_type, exe_ctx.GetBestExecutionContextScope()))
             return false;
         }
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1171,7 +1171,9 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
     // correctly handles zero-sized types. Unfortunately we currently have
     // this check scattered in several places in the codebase, we should at
     // some point centralize it.
-    if (repl && SwiftASTContext::IsPossibleZeroSizeType(variable.GetType())) {
+    lldb::StackFrameSP stack_frame_sp = stack_frame_wp.lock();
+    if (repl && SwiftASTContext::IsPossibleZeroSizeType(variable.GetType(),
+                                                        stack_frame_sp.get())) {
       auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
       offset = repl_mat.AddREPLResultVariable(
           variable.GetType(), variable.GetDecl(),

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -189,7 +189,8 @@ public:
       demangle_ctx.clear();
     }
 
-    if (SwiftASTContext::IsPossibleZeroSizeType(m_type)) {
+    if (SwiftASTContext::IsPossibleZeroSizeType(m_type,
+            execution_unit->GetBestExecutionContextScope())) {
       MakeREPLResult(*execution_unit, err, nullptr);
       return;
     }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2042,6 +2042,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(
     address.SetLoadAddress(val_ptr_addr, &m_process->GetTarget());
     return true;
   } break;
+  case swift::MetadataKind::Function:
   case swift::MetadataKind::Optional:
   case swift::MetadataKind::Struct:
   case swift::MetadataKind::Tuple: {
@@ -2276,7 +2277,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Struct(
 
   lldb::addr_t struct_address = in_value.GetAddressOf(true, nullptr);
   if (!struct_address || struct_address == LLDB_INVALID_ADDRESS)
-    if (!SwiftASTContext::IsPossibleZeroSizeType(bound_type))
+    if (!SwiftASTContext::IsPossibleZeroSizeType(
+            bound_type, in_value.GetExecutionContextRef().GetFrameSP().get()))
       return false;
 
   address.SetLoadAddress(struct_address, in_value.GetTargetSP().get());
@@ -2291,7 +2293,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Enum(
 
   lldb::addr_t enum_address = in_value.GetAddressOf(true, nullptr);
   if (!enum_address || LLDB_INVALID_ADDRESS == enum_address)
-    if (!SwiftASTContext::IsPossibleZeroSizeType(bound_type))
+    if (!SwiftASTContext::IsPossibleZeroSizeType(
+            bound_type, in_value.GetExecutionContextRef().GetFrameSP().get()))
       return false;
 
   address.SetLoadAddress(enum_address, in_value.GetTargetSP().get());


### PR DESCRIPTION
In order to correctly determine the size of a generic type it needs to
be mapped into the context first and archetypes need to be bound.

Note: It would be even better to change
CompilerType::GetBit/ByteSize() to return an Optional<uint64_t>, but
that needs happen upstream.

<rdar://problem/38231646>