### PR TITLE
[5.0][Swift] Disable delayed parsing in the expression evaluator.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
+++ b/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals())

--- a/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/delayed_parsing_crash/main.swift
@@ -1,0 +1,9 @@
+private class V
+{ 
+    func layoutSubviews() {
+        print("patatino") //%self.expect('expr typealias $MyV = V')
+    }
+}
+
+private var my_v = V()
+my_v.layoutSubviews()

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1341,8 +1341,9 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
   swift::PersistentParserState persistent_state(*ast_context);
 
   while (!done) {
+    // Note, we disable delayed parsing for the swift expression parser.
     swift::parseIntoSourceFile(*source_file, buffer_id, &done, nullptr,
-                               &persistent_state);
+                               &persistent_state, nullptr, true);
 
     if (swift_ast_context->HasErrors())
       return make_error<SwiftASTContextError>();


### PR DESCRIPTION
Cherry-picking to 5.0

<rdar://problem/38396444>