### PR TITLE
 Ensure result variables of generic types are bound to the runtime type.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/generic_self/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_self/main.swift
@@ -2,45 +2,50 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
+func stop() {}
+
 class BlubbyUbby<T>
 {
-    var my_int : Int
-    var my_string : String
-    var my_t : T
-    
-    init(_ in_int: Int, _ in_string : String, _ in_t : T)
-    {
-        my_int = in_int
-        my_string = in_string
-        my_t = in_t
-    } //% self.expect('expr -d run -f hex -- my_t', substrs=['deadbeef'])
+  var my_int : Int
+  var my_string : String
+  var my_t : T
+  
+  init(_ in_int: Int, _ in_string : String, _ in_t : T) {
+    my_int = in_int
+    my_string = in_string
+    my_t = in_t
+    stop()
+    //% self.expect('expr -d run -f hex -- my_t', substrs=['deadbeef'])
     //% self.expect('fr var -d run -f hex -- self.my_t', substrs=['deadbeef'])
     //% self.expect('expr -d run -- self', substrs=['3735928559'])
     //% self.expect('fr var -d run -- self', substrs=['3735928559'])
-
-    func change_string (_ in_string : String)
-    {
-        my_string = in_string
-    }
-
-    func change_t (_ in_t : T)
-    {
-        my_t = in_t
-    }
+    stop()
+  }
 }
 
-func main()
-{
-    var my_blubby = BlubbyUbby<Int>(1, "some string", 0xDeadBeef)
-    my_blubby.change_t(3)
-    print (my_blubby)
+var _ = BlubbyUbby<Int>(1, "some string", 0xDeadBeef)
+
+struct S<T> {
+  var a : T
+  func foo() {
+    stop()
+    //% self.expect('expr -d run -- self', substrs=['(a.S<Int>)','a = 12'])
+    //% self.expect('fr v -d run -- self', substrs=['(a.S<Int>)','a = 12'])
+    //% self.expect('fr v -d no-dynamic-values -- self', substrs=['(a.S<T>)','000c'])
+    stop()
+  }
 }
 
-main()
+func test<T>(_ t : T) {
+  let a = S(a: t)
+  a.foo()
+}
+
+test(12)

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2148,6 +2148,9 @@ SwiftLanguageRuntime::DoArchetypeBindingForType(StackFrame &stack_frame,
 
   if (base_type.GetTypeInfo() & lldb::eTypeIsSwift) {
     swift::Type target_swift_type(GetSwiftType(base_type));
+    if (target_swift_type->hasArchetype())
+      target_swift_type = target_swift_type->mapTypeOutOfContext().getPointer();
+
     target_swift_type = target_swift_type.transform(
         [this, &stack_frame,
          &scratch_ctx](swift::Type candidate_type) -> swift::Type {


### PR DESCRIPTION
Rather than mapping type in and out of contexts a follow-up commit
should make sure that CompilerType::MapIntoContext isn't called where
it isn't needed.

Fixes <rdar://problem/47157089>