### PR TITLE
[5.0][Swift] Don't hardcode the pointer size.

### DIFF
--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -468,7 +468,7 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
   if (error.Fail())
     return false;
   lldb::addr_t raw0 =
-      process->ReadPointerFromMemory(address + startOffset + 8, error);
+      process->ReadPointerFromMemory(address + startOffset + ptr_size, error);
   if (error.Fail())
     return false;
 


### PR DESCRIPTION
Fixes another test failure on 32-bits architectures.

<rdar://problem/47226255>

Adrian reviewed the commit on `stable`.