### PR TITLE
Swift-side removal of SearchPathOptions::RuntimeLibraryImportPath

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4668,9 +4668,6 @@ void SwiftASTContext::DumpConfiguration(Log *log) {
               m_ast_context_ap->SearchPathOpts.RuntimeResourcePath.c_str());
   log->Printf("  Runtime library path         : %s",
               m_ast_context_ap->SearchPathOpts.RuntimeLibraryPath.c_str());
-  log->Printf(
-      "  Runtime library import path  : %s",
-      m_ast_context_ap->SearchPathOpts.RuntimeLibraryImportPath.c_str());
 
   log->Printf("  Framework search paths       : (%llu items)",
               (unsigned long long)


### PR DESCRIPTION
Support for apple/swift#21797. No functionality change, only affects log output.