### PR TITLE
[Swift] Add a test-case for rdar://problem/30933988

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/TestMemberLookupCrash.py
+++ b/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/TestMemberLookupCrash.py
@@ -1,0 +1,8 @@
+"""
+Test that member lookup inside of generic container doesn't crash
+"""
+import lldbsuite.test.lldbinline as lldbinline
+import lldbsuite.test.decorators as decorators
+
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[decorators.skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Measurement where UnitType == UnitAngle {
+  var radians: CGFloat {
+    return CGFloat(self.converted(to: .radians).value)
+  }
+
+  var degrees: CGFloat {
+    return CGFloat(self.converted(to: .degrees).value)
+  }
+
+  func f() {
+    return //%self.expect('p self.radians', substrs=['is not convertible to'], error=True)
+  }
+}
+
+let measure = Measurement<UnitAngle>(value: 100, unit: UnitAngle.degrees)
+measure.f()


### PR DESCRIPTION
LLDB is using `-disable-access-control` flag which hasn't been
checked consistently by Swift type-checker which lead to crashes.