### PR TITLE
[SwiftArray] Don't assume pointer size is 8.

### DIFF
--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -93,10 +93,10 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
     return;
   next_read += ptr_size;
   m_reserved_word =
-      process_sp->ReadUnsignedIntegerFromMemory(next_read, 8, 0, error);
+      process_sp->ReadUnsignedIntegerFromMemory(next_read, ptr_size, 0, error);
   if (error.Fail())
     return;
-  next_read += 8;
+  next_read += ptr_size;
   m_size =
       process_sp->ReadUnsignedIntegerFromMemory(next_read, ptr_size, 0, error);
   if (error.Fail())


### PR DESCRIPTION
Fixes yet another failure visible only on 32-bits architectures.
(TestSwiftieFormatting/TestNestedArray)

<rdar://problem/47272296>
<rdar://problem/47271440>