### PR TITLE
[DWARFASTParserSwift] Update after API change upstream.

### DIFF
--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -216,14 +216,17 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   }
 
   if (compiler_type) {
-    type_sp = TypeSP(new Type(
-        die.GetID(), die.GetDWARF(), compiler_type.GetTypeName(),
-        is_clang_type ? dwarf_byte_size : compiler_type.GetByteSize(nullptr),
-        NULL, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl, compiler_type,
-        is_clang_type ? Type::eResolveStateForward : Type::eResolveStateFull));
-    // FIXME: This ought to work lazily, too.
-    if (is_clang_type)
-      type_sp->GetFullCompilerType();
+    auto byte_size = compiler_type.GetByteSize(nullptr);
+    if (byte_size) {
+      type_sp = TypeSP(new Type(
+          die.GetID(), die.GetDWARF(), compiler_type.GetTypeName(),
+          is_clang_type ? dwarf_byte_size : *byte_size,
+          NULL, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl, compiler_type,
+          is_clang_type ? Type::eResolveStateForward : Type::eResolveStateFull));
+      // FIXME: This ought to work lazily, too.
+      if (is_clang_type)
+        type_sp->GetFullCompilerType();
+    }
   }
 
   // Cache this type.


### PR DESCRIPTION
GetByteSize() now returns an optional to flag error conditions,
  rather than `0` as it did before, because, turns out, `0` is
  a valid size in swift (and somewhere else, presumably).