### PR TITLE
Retire IsPossibleZeroSizeType()

### DIFF
--- a/include/lldb/Core/ValueObject.h
+++ b/include/lldb/Core/ValueObject.h
@@ -1024,11 +1024,6 @@ protected:
   const char *GetLocationAsCStringImpl(const Value &value,
                                        const DataExtractor &data);
 
-  virtual lldb_private::Status
-  GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
-                 uint32_t data_offset, Module *module,
-                 bool mask_error_on_zerosize_type = true);
-
   bool IsChecksumEmpty();
 
   void SetPreferredDisplayLanguageIfNeeded(lldb::LanguageType);

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -302,9 +302,8 @@ public:
 
   struct IntegralTemplateArgument;
 
-  uint64_t GetByteSize(ExecutionContextScope *exe_scope) const;
-
-  uint64_t GetBitSize(ExecutionContextScope *exe_scope) const;
+  llvm::Optional<uint64_t> GetByteSize(ExecutionContextScope *exe_scope) const;
+  llvm::Optional<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
 
   uint64_t GetByteStride() const;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -476,10 +476,6 @@ public:
 
   static bool IsSelfArchetypeType(const CompilerType &compiler_type);
 
-  static bool
-  IsPossibleZeroSizeType(const CompilerType &compiler_type,
-                         ExecutionContextScope *exe_scope);
-
   bool IsTrivialOptionSetType(const CompilerType &compiler_type);
 
   bool IsErrorType(const CompilerType &compiler_type);

--- a/include/lldb/Target/ProcessStructReader.h
+++ b/include/lldb/Target/ProcessStructReader.h
@@ -60,18 +60,20 @@ public:
         return;
       auto size = field_type.GetByteSize(nullptr);
       // no support for things larger than a uint64_t (yet)
-      if (size > 8)
+      if (!size || *size > 8)
         return;
       ConstString const_name = ConstString(name.c_str());
       size_t byte_index = static_cast<size_t>(bit_offset / 8);
       m_fields[const_name] =
-          FieldImpl{field_type, byte_index, static_cast<size_t>(size)};
+          FieldImpl{field_type, byte_index, static_cast<size_t>(*size)};
     }
-    size_t total_size = struct_type.GetByteSize(nullptr);
-    lldb::DataBufferSP buffer_sp(new DataBufferHeap(total_size, 0));
+    auto total_size = struct_type.GetByteSize(nullptr);
+    if (!total_size)
+      return;
+    lldb::DataBufferSP buffer_sp(new DataBufferHeap(*total_size, 0));
     Status error;
     process->ReadMemoryFromInferior(base_addr, buffer_sp->GetBytes(),
-                                    total_size, error);
+                                    *total_size, error);
     if (error.Fail())
       return;
     m_data = DataExtractor(buffer_sp, m_byte_order, m_addr_byte_size);

--- a/source/API/SBType.cpp
+++ b/source/API/SBType.cpp
@@ -103,10 +103,10 @@ bool SBType::IsValid() const {
 }
 
 uint64_t SBType::GetByteSize() {
-  if (!IsValid())
-    return 0;
-
-  return m_opaque_sp->GetCompilerType(false).GetByteSize(nullptr);
+  if (IsValid())
+    if (auto size = m_opaque_sp->GetCompilerType(false).GetByteSize(nullptr))
+      return *size;
+  return 0;
 }
 
 bool SBType::IsPointerType() {

--- a/source/Commands/CommandObjectMemory.cpp
+++ b/source/Commands/CommandObjectMemory.cpp
@@ -528,15 +528,15 @@ protected:
         --pointer_count;
       }
 
-      m_format_options.GetByteSizeValue() = clang_ast_type.GetByteSize(nullptr);
-
-      if (m_format_options.GetByteSizeValue() == 0) {
+      auto size = clang_ast_type.GetByteSize(nullptr);
+      if (!size) {
         result.AppendErrorWithFormat(
             "unable to get the byte size of the type '%s'\n",
             view_as_type_cstr);
         result.SetStatus(eReturnStatusFailed);
         return false;
       }
+      m_format_options.GetByteSizeValue() = *size;
 
       if (!m_format_options.GetCountValue().OptionWasSet())
         m_format_options.GetCountValue() = 1;
@@ -651,12 +651,15 @@ protected:
       if (!m_format_options.GetFormatValue().OptionWasSet())
         m_format_options.GetFormatValue().SetCurrentValue(eFormatDefault);
 
-      bytes_read = clang_ast_type.GetByteSize(nullptr) *
-                   m_format_options.GetCountValue().GetCurrentValue();
+      auto size = clang_ast_type.GetByteSize(nullptr);
+      if (!size) {
+        result.AppendError("can't get size of type");
+        return false;
+      }
+      bytes_read = *size * m_format_options.GetCountValue().GetCurrentValue();
 
       if (argc > 0)
-        addr = addr + (clang_ast_type.GetByteSize(nullptr) *
-                       m_memory_options.m_offset.GetCurrentValue());
+        addr = addr + (*size * m_memory_options.m_offset.GetCurrentValue());
     } else if (m_format_options.GetFormatValue().GetCurrentValue() !=
                eFormatCString) {
       data_sp.reset(new DataBufferHeap(total_byte_size, '\0'));
@@ -1068,7 +1071,10 @@ protected:
                m_memory_options.m_expr.GetStringValue(), frame, result_sp)) &&
           result_sp) {
         uint64_t value = result_sp->GetValueAsUnsigned(0);
-        switch (result_sp->GetCompilerType().GetByteSize(nullptr)) {
+        auto size = result_sp->GetCompilerType().GetByteSize(nullptr);
+        if (!size)
+          return false;
+        switch (*size) {
         case 1: {
           uint8_t byte = (uint8_t)value;
           buffer.CopyData(&byte, 1);

--- a/source/Core/Value.cpp
+++ b/source/Core/Value.cpp
@@ -210,39 +210,31 @@ bool Value::ValueOf(ExecutionContext *exe_ctx) {
 }
 
 uint64_t Value::GetValueByteSize(Status *error_ptr, ExecutionContext *exe_ctx) {
-  uint64_t byte_size = 0;
-
   switch (m_context_type) {
   case eContextTypeRegisterInfo: // RegisterInfo *
-    if (GetRegisterInfo())
-      byte_size = GetRegisterInfo()->byte_size;
+    if (GetRegisterInfo()) {
+      if (error_ptr)
+        error_ptr->Clear();
+      return GetRegisterInfo()->byte_size;
+    }
     break;
 
   case eContextTypeInvalid:
   case eContextTypeLLDBType: // Type *
   case eContextTypeVariable: // Variable *
   {
-    const CompilerType &ast_type = GetCompilerType();
-    ExecutionContextScope *exe_scope =
-        exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
-    if (auto size = ast_type.GetByteSize(
-            exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
-      byte_size = *size;
-    if (*byte_size == 0 &&
-        SwiftASTContext::IsPossibleZeroSizeType(ast_type, exe_scope))
-      return 0;
-  } break;
-  }
-
-  if (error_ptr) {
-    if (byte_size == 0) {
-      if (error_ptr->Success())
-        error_ptr->SetErrorString("Unable to determine byte size.");
-    } else {
-      error_ptr->Clear();
+    auto *scope = exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
+    if (llvm::Optional<uint64_t> size = GetCompilerType().GetByteSize(scope)) {
+      if (error_ptr)
+        error_ptr->Clear();
+      return *size;
     }
+    break;
   }
-  return byte_size;
+  }
+  if (error_ptr && error_ptr->Success())
+    error_ptr->SetErrorString("Unable to determine byte size.");
+  return 0;
 }
 
 const CompilerType &Value::GetCompilerType() {
@@ -331,6 +323,12 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
   AddressType address_type = eAddressTypeFile;
   Address file_so_addr;
   const CompilerType &ast_type = GetCompilerType();
+  llvm::Optional<uint64_t> type_size = ast_type.GetByteSize(
+      exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
+  // Nothing to be done for a zero-sized type.
+  if (type_size && *type_size == 0)
+    return error;
+
   switch (m_value_type) {
   case eValueTypeVector:
     if (ast_type.IsValid())
@@ -349,11 +347,8 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
 
     uint32_t limit_byte_size = UINT32_MAX;
 
-    if (ast_type.IsValid()) {
-      if (auto size = ast_type.GetByteSize(
-              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
-        limit_byte_size = *size;
-    }
+    if (type_size)
+      limit_byte_size = *type_size;
 
     if (limit_byte_size <= m_value.GetByteSize()) {
       if (m_value.GetData(data, limit_byte_size))
@@ -526,10 +521,7 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
     return error;
 
   // No memory to read for zero-sized types.
-  if (byte_size == 0 &&
-      SwiftASTContext::IsPossibleZeroSizeType(
-          GetCompilerType(),
-          exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
+  if (byte_size == 0)
     return error;
 
   // Make sure we have enough room within "data", and if we don't make

--- a/source/Core/Value.cpp
+++ b/source/Core/Value.cpp
@@ -225,9 +225,10 @@ uint64_t Value::GetValueByteSize(Status *error_ptr, ExecutionContext *exe_ctx) {
     const CompilerType &ast_type = GetCompilerType();
     ExecutionContextScope *exe_scope =
         exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
-    if (ast_type.IsValid())
-      byte_size = ast_type.GetByteSize(exe_scope);
-    if (byte_size == 0 &&
+    if (auto size = ast_type.GetByteSize(
+            exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
+      byte_size = *size;
+    if (*byte_size == 0 &&
         SwiftASTContext::IsPossibleZeroSizeType(ast_type, exe_scope))
       return 0;
   } break;
@@ -349,8 +350,9 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
     uint32_t limit_byte_size = UINT32_MAX;
 
     if (ast_type.IsValid()) {
-      limit_byte_size = ast_type.GetByteSize(
-          exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
+      if (auto size = ast_type.GetByteSize(
+              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
+        limit_byte_size = *size;
     }
 
     if (limit_byte_size <= m_value.GetByteSize()) {

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -846,10 +846,12 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
-  const uint64_t item_type_size = pointee_or_element_compiler_type.GetByteSize(
+  auto item_type_size = pointee_or_element_compiler_type.GetByteSize(
       exe_ctx.GetBestExecutionContextScope());
-  const uint64_t bytes = item_count * item_type_size;
-  const uint64_t offset = item_idx * item_type_size;
+  if (!item_type_size)
+    return 0;
+  const uint64_t bytes = item_count * *item_type_size;
+  const uint64_t offset = item_idx * *item_type_size;
 
   if (item_idx == 0 && item_count == 1) // simply a deref
   {
@@ -912,10 +914,10 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       }
     } break;
     case eAddressTypeHost: {
-      const uint64_t max_bytes =
+      auto max_bytes =
           GetCompilerType().GetByteSize(exe_ctx.GetBestExecutionContextScope());
-      if (max_bytes > offset) {
-        size_t bytes_read = std::min<uint64_t>(max_bytes - offset, bytes);
+      if (max_bytes && *max_bytes > offset) {
+        size_t bytes_read = std::min<uint64_t>(*max_bytes - offset, bytes);
         addr = m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
         if (addr == 0 || addr == LLDB_INVALID_ADDRESS)
           break;
@@ -1935,14 +1937,15 @@ ValueObjectSP ValueObject::GetSyntheticChildAtOffset(
     return synthetic_child_sp;
 
   if (!can_create)
-    return ValueObjectSP();
+    return {};
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
-
-  ValueObjectChild *synthetic_child = new ValueObjectChild(
-      *this, type, name_const_str,
-      type.GetByteSize(exe_ctx.GetBestExecutionContextScope()), offset, 0, 0,
-      false, false, eAddressTypeInvalid, 0);
+  auto size = type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  if (!size)
+    return {};
+  ValueObjectChild *synthetic_child =
+      new ValueObjectChild(*this, type, name_const_str, *size, offset, 0, 0,
+                           false, false, eAddressTypeInvalid, 0);
   if (synthetic_child) {
     AddSyntheticChild(name_const_str, synthetic_child);
     synthetic_child_sp = synthetic_child->GetSP();
@@ -1973,16 +1976,17 @@ ValueObjectSP ValueObject::GetSyntheticBase(uint32_t offset,
     return synthetic_child_sp;
 
   if (!can_create)
-    return ValueObjectSP();
+    return {};
 
   const bool is_base_class = true;
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
-
-  ValueObjectChild *synthetic_child = new ValueObjectChild(
-      *this, type, name_const_str,
-      type.GetByteSize(exe_ctx.GetBestExecutionContextScope()), offset, 0, 0,
-      is_base_class, false, eAddressTypeInvalid, 0);
+  auto size = type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  if (!size)
+    return {};
+  ValueObjectChild *synthetic_child =
+      new ValueObjectChild(*this, type, name_const_str, *size, offset, 0, 0,
+                           is_base_class, false, eAddressTypeInvalid, 0);
   if (synthetic_child) {
     AddSyntheticChild(name_const_str, synthetic_child);
     synthetic_child_sp = synthetic_child->GetSP();

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -468,19 +468,6 @@ const char *ValueObject::GetLocationAsCStringImpl(const Value &value,
   return m_location_str.c_str();
 }
 
-lldb_private::Status
-ValueObject::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
-                            uint32_t data_offset, Module *module,
-                            bool mask_error_on_zerosize_type) {
-  Status err = m_value.GetValueAsData(exe_ctx, data, data_offset, module);
-  if (err.Fail() && mask_error_on_zerosize_type &&
-      SwiftASTContext::IsPossibleZeroSizeType(
-          GetCompilerType(),
-          exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr))
-    return Status();
-  return err;
-}
-
 Value &ValueObject::GetValue() { return m_value; }
 
 const Value &ValueObject::GetValue() const { return m_value; }

--- a/source/Core/ValueObjectConstResult.cpp
+++ b/source/Core/ValueObjectConstResult.cpp
@@ -198,10 +198,11 @@ lldb::ValueType ValueObjectConstResult::GetValueType() const {
 
 uint64_t ValueObjectConstResult::GetByteSize() {
   ExecutionContext exe_ctx(GetExecutionContextRef());
-
-  if (m_byte_size == 0)
-    SetByteSize(
-        GetCompilerType().GetByteSize(exe_ctx.GetBestExecutionContextScope()));
+  if (m_byte_size == 0) {
+    if (auto size =
+        GetCompilerType().GetByteSize(exe_ctx.GetBestExecutionContextScope()))
+      SetByteSize(*size);
+  }
   return m_byte_size;
 }
 

--- a/source/Core/ValueObjectDynamicValue.cpp
+++ b/source/Core/ValueObjectDynamicValue.cpp
@@ -226,7 +226,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
     ClearDynamicTypeInformation();
     m_dynamic_type_info.Clear();
     m_value = m_parent->GetValue();
-    m_error = GetValueAsData(&exe_ctx, m_data, 0, GetModule().get());
+    m_error = m_value.GetValueAsData(&exe_ctx, m_data, 0, GetModule().get());
     return m_error.Success();
   }
 
@@ -274,7 +274,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
   if (m_address.IsValid() && m_dynamic_type_info) {
     // The variable value is in the Scalar value inside the m_value.
     // We can point our m_data right to it.
-    m_error = GetValueAsData(&exe_ctx, m_data, 0, GetModule().get());
+    m_error = m_value.GetValueAsData(&exe_ctx, m_data, 0, GetModule().get());
     if (m_error.Success()) {
       if (!CanProvideValue()) {
         // this value object represents an aggregate type whose children have

--- a/source/Core/ValueObjectMemory.cpp
+++ b/source/Core/ValueObjectMemory.cpp
@@ -138,7 +138,9 @@ size_t ValueObjectMemory::CalculateNumChildren(uint32_t max) {
 uint64_t ValueObjectMemory::GetByteSize() {
   if (m_type_sp)
     return m_type_sp->GetByteSize();
-  return m_compiler_type.GetByteSize(nullptr);
+  if (auto size = m_compiler_type.GetByteSize(nullptr))
+    return *size;
+  return 0;
 }
 
 lldb::ValueType ValueObjectMemory::GetValueType() const {

--- a/source/Core/ValueObjectSyntheticFilter.cpp
+++ b/source/Core/ValueObjectSyntheticFilter.cpp
@@ -323,7 +323,7 @@ lldb::ValueObjectSP ValueObjectSynthetic::GetNonSyntheticValue() {
 void ValueObjectSynthetic::CopyValueData(ValueObject *source) {
   m_value = (source->UpdateValueIfNeeded(), source->GetValue());
   ExecutionContext exe_ctx(GetExecutionContextRef());
-  m_error = GetValueAsData(&exe_ctx, m_data, 0, GetModule().get());
+  m_error = m_value.GetValueAsData(&exe_ctx, m_data, 0, GetModule().get());
 }
 
 bool ValueObjectSynthetic::CanProvideValue() {

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -146,8 +146,9 @@ bool ValueObjectVariable::UpdateValue() {
       CompilerType var_type(GetCompilerTypeImpl());
       if (var_type.IsValid()) {
         ExecutionContext exe_ctx(GetExecutionContextRef());
-        if (SwiftASTContext::IsPossibleZeroSizeType(
-                var_type, exe_ctx.GetBestExecutionContextScope()))
+        llvm::Optional<uint64_t> size =
+            var_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+        if (size && *size == 0)
           m_value.SetCompilerType(var_type);
         else
           m_error.SetErrorString("empty constant data");

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -118,7 +118,8 @@ uint64_t ValueObjectVariable::GetByteSize() {
   if (!type.IsValid())
     return 0;
 
-  return type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  auto size = type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  return size ? *size : 0;
 }
 
 lldb::ValueType ValueObjectVariable::GetValueType() const {

--- a/source/DataFormatters/TypeFormat.cpp
+++ b/source/DataFormatters/TypeFormat.cpp
@@ -70,6 +70,11 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
     } else {
       CompilerType compiler_type = value.GetCompilerType();
       if (compiler_type) {
+        ExecutionContextScope *exe_scope =
+            exe_ctx.GetBestExecutionContextScope();
+        auto size = compiler_type.GetByteSize(exe_scope);
+        if (!size)
+          return false;
         // put custom bytes to display in the DataExtractor to override the
         // default value logic
         if (GetFormat() == eFormatCString) {
@@ -91,20 +96,13 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
                 data.SetData(buffer_sp);
             }
           }
-        } else {
+        } else if (!size || *size > 0) {
           Status error;
           valobj->GetData(data, error);
-          if (error.Fail() &&
-              !SwiftASTContext::IsPossibleZeroSizeType(
-                  compiler_type, exe_ctx.GetBestExecutionContextScope()))
+          if (error.Fail())
             return false;
         }
 
-        ExecutionContextScope *exe_scope =
-            exe_ctx.GetBestExecutionContextScope();
-        auto size = compiler_type.GetByteSize(exe_scope);
-        if (!size)
-          return false;
         StreamString sstr;
         compiler_type.DumpTypeValue(
             &sstr,                          // The stream to use for display

--- a/source/DataFormatters/TypeFormat.cpp
+++ b/source/DataFormatters/TypeFormat.cpp
@@ -100,16 +100,18 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
             return false;
         }
 
+        ExecutionContextScope *exe_scope =
+            exe_ctx.GetBestExecutionContextScope();
+        auto size = compiler_type.GetByteSize(exe_scope);
+        if (!size)
+          return false;
         StreamString sstr;
-        ExecutionContextScope *exe_scope(
-            exe_ctx.GetBestExecutionContextScope());
         compiler_type.DumpTypeValue(
-            &sstr,       // The stream to use for display
-            GetFormat(), // Format to display this type with
-            data,        // Data to extract from
-            0,           // Byte offset into "m_data"
-            compiler_type.GetByteSize(
-                exe_scope),                 // Byte size of item in "m_data"
+            &sstr,                          // The stream to use for display
+            GetFormat(),                    // Format to display this type with
+            data,                           // Data to extract from
+            0,                              // Byte offset into "m_data"
+            *size,                          // Byte size of item in "m_data"
             valobj->GetBitfieldBitSize(),   // Bitfield bit size
             valobj->GetBitfieldBitOffset(), // Bitfield bit offset
             exe_scope,

--- a/source/DataFormatters/VectorType.cpp
+++ b/source/DataFormatters/VectorType.cpp
@@ -178,10 +178,10 @@ static size_t CalculateNumChildren(
   auto container_size = container_type.GetByteSize(exe_scope);
   auto element_size = element_type.GetByteSize(exe_scope);
 
-  if (element_size) {
-    if (container_size % element_size)
+  if (container_size && element_size && *element_size) {
+    if (*container_size % *element_size)
       return 0;
-    return container_size / element_size;
+    return *container_size / *element_size;
   }
   return 0;
 }
@@ -201,8 +201,11 @@ public:
 
   lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
     if (idx >= CalculateNumChildren())
-      return lldb::ValueObjectSP();
-    auto offset = idx * m_child_type.GetByteSize(nullptr);
+      return {};
+    auto size = m_child_type.GetByteSize(nullptr);
+    if (!size)
+      return {};
+    auto offset = idx * *size;
     StreamString idx_name;
     idx_name.Printf("[%" PRIu64 "]", (uint64_t)idx);
     ValueObjectSP child_sp(m_backend.GetSyntheticChildAtOffset(

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -50,7 +50,8 @@ uint32_t Materializer::AddStructMember(Entity &entity) {
 }
 
 void Materializer::Entity::SetSizeAndAlignmentFromType(CompilerType &type) {
-  m_size = type.GetByteSize(nullptr);
+  if (auto size = type.GetByteSize(nullptr))
+    m_size = *size;
 
   uint32_t bit_alignment = type.GetTypeBitAlign();
 
@@ -859,7 +860,11 @@ public:
 
       ExecutionContextScope *exe_scope = map.GetBestExecutionContextScope();
 
-      size_t byte_size = m_type.GetByteSize(exe_scope);
+      auto byte_size = m_type.GetByteSize(exe_scope);
+      if (!byte_size) {
+        err.SetErrorString("can't get size of type");
+        return;
+      }
       size_t bit_align = m_type.GetTypeBitAlign();
       size_t byte_align = (bit_align + 7) / 8;
 
@@ -870,10 +875,10 @@ public:
       const bool zero_memory = true;
 
       m_temporary_allocation = map.Malloc(
-          byte_size, byte_align,
+          *byte_size, byte_align,
           lldb::ePermissionsReadable | lldb::ePermissionsWritable,
           IRMemoryMap::eAllocationPolicyMirror, zero_memory, alloc_error);
-      m_temporary_allocation_size = byte_size;
+      m_temporary_allocation_size = *byte_size;
 
       if (!alloc_error.Success()) {
         err.SetErrorStringWithFormat(

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -542,10 +542,13 @@ public:
         Status extract_error;
         valobj_sp->GetData(data, extract_error);
         if (!extract_error.Success()) {
-          if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift &&
-              valobj_type.GetByteSize(frame_sp.get()) == 0) {
-            // We don't need to materialize empty structs in Swift.
-            return;
+          if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
+            llvm::Optional<uint64_t> size =
+                valobj_type.GetByteSize(frame_sp.get());
+            if (size && *size == 0) {
+              // We don't need to materialize empty structs in Swift.
+              return;
+            }
           }
           err.SetErrorStringWithFormat("couldn't get the value of %s: %s",
                                        m_variable_sp->GetName().AsCString(),
@@ -691,10 +694,12 @@ public:
                         extract_error);
 
       if (!extract_error.Success()) {
-        if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift &&
-            valobj_type.GetByteSize(frame_sp.get()) == 0) {
-          // We don't need to dematerialize empty structs in Swift.
-          return;
+        if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
+          llvm::Optional<uint64_t> size =
+              valobj_type.GetByteSize(frame_sp.get());
+          if (size && *size == 0)
+            // We don't need to dematerialize empty structs in Swift.
+            return;
         }
         
         err.SetErrorStringWithFormat("couldn't get the data for variable %s",

--- a/source/Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.cpp
+++ b/source/Plugins/ABI/MacOSX-arm/ABIMacOSX_arm.cpp
@@ -1474,14 +1474,16 @@ bool ABIMacOSX_arm::GetArgumentValues(Thread &thread, ValueList &values) const {
     if (compiler_type) {
       bool is_signed = false;
       size_t bit_width = 0;
-      if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-        bit_width = compiler_type.GetBitSize(&thread);
-      } else if (compiler_type.IsPointerOrReferenceType()) {
-        bit_width = compiler_type.GetBitSize(&thread);
-      } else {
+      auto bit_size = compiler_type.GetBitSize(&thread);
+      if (!bit_size)
+        return false;
+      if (compiler_type.IsIntegerOrEnumerationType(is_signed))
+        bit_width = *bit_size;
+      else if (compiler_type.IsPointerOrReferenceType())
+        bit_width = *bit_size;
+      else
         // We only handle integer, pointer and reference types currently...
         return false;
-      }
 
       if (bit_width <= (exe_ctx.GetProcessRef().GetAddressByteSize() * 8)) {
         if (value_idx < 4) {
@@ -1578,9 +1580,11 @@ ValueObjectSP ABIMacOSX_arm::GetReturnValueObjectImpl(
 
   const RegisterInfo *r0_reg_info = reg_ctx->GetRegisterInfoByName("r0", 0);
   if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-    size_t bit_width = compiler_type.GetBitSize(&thread);
+    auto bit_width = compiler_type.GetBitSize(&thread);
+    if (!bit_width)
+      return return_valobj_sp;
 
-    switch (bit_width) {
+    switch (*bit_width) {
     default:
       return return_valobj_sp;
     case 128:
@@ -1596,14 +1600,16 @@ ValueObjectSP ABIMacOSX_arm::GetReturnValueObjectImpl(
           const RegisterInfo *r3_reg_info =
               reg_ctx->GetRegisterInfoByName("r3", 0);
           if (r1_reg_info && r2_reg_info && r3_reg_info) {
-            const size_t byte_size = compiler_type.GetByteSize(&thread);
+            auto byte_size = compiler_type.GetByteSize(&thread);
+            if (!byte_size)
+              return return_valobj_sp;
             ProcessSP process_sp(thread.GetProcess());
-            if (byte_size <= r0_reg_info->byte_size + r1_reg_info->byte_size +
-                                 r2_reg_info->byte_size +
-                                 r3_reg_info->byte_size &&
+            if (*byte_size <= r0_reg_info->byte_size + r1_reg_info->byte_size +
+                                  r2_reg_info->byte_size +
+                                  r3_reg_info->byte_size &&
                 process_sp) {
               std::unique_ptr<DataBufferHeap> heap_data_ap(
-                  new DataBufferHeap(byte_size, 0));
+                  new DataBufferHeap(*byte_size, 0));
               const ByteOrder byte_order = process_sp->GetByteOrder();
               RegisterValue r0_reg_value;
               RegisterValue r1_reg_value;

--- a/source/Plugins/ABI/MacOSX-arm64/ABIMacOSX_arm64.cpp
+++ b/source/Plugins/ABI/MacOSX-arm64/ABIMacOSX_arm64.cpp
@@ -1765,90 +1765,92 @@ bool ABIMacOSX_arm64::GetArgumentValues(Thread &thread,
       return false;
 
     CompilerType value_type = value->GetCompilerType();
-    if (value_type) {
-      bool is_signed = false;
-      size_t bit_width = 0;
-      if (value_type.IsIntegerOrEnumerationType(is_signed)) {
-        bit_width = value_type.GetBitSize(&thread);
-      } else if (value_type.IsPointerOrReferenceType()) {
-        bit_width = value_type.GetBitSize(&thread);
-      } else {
-        // We only handle integer, pointer and reference types currently...
-        return false;
-      }
+    auto bit_size = value_type.GetBitSize(&thread);
+    if (!bit_size)
+      return false;
 
-      if (bit_width <= (exe_ctx.GetProcessRef().GetAddressByteSize() * 8)) {
-        if (value_idx < 8) {
-          // Arguments 1-6 are in x0-x5...
-          const RegisterInfo *reg_info = nullptr;
-          // Search by generic ID first, then fall back to by name
-          uint32_t arg_reg_num = reg_ctx->ConvertRegisterKindToRegisterNumber(
-              eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1 + value_idx);
-          if (arg_reg_num != LLDB_INVALID_REGNUM) {
-            reg_info = reg_ctx->GetRegisterInfoAtIndex(arg_reg_num);
-          } else {
-            switch (value_idx) {
-            case 0:
-              reg_info = reg_ctx->GetRegisterInfoByName("x0");
-              break;
-            case 1:
-              reg_info = reg_ctx->GetRegisterInfoByName("x1");
-              break;
-            case 2:
-              reg_info = reg_ctx->GetRegisterInfoByName("x2");
-              break;
-            case 3:
-              reg_info = reg_ctx->GetRegisterInfoByName("x3");
-              break;
-            case 4:
-              reg_info = reg_ctx->GetRegisterInfoByName("x4");
-              break;
-            case 5:
-              reg_info = reg_ctx->GetRegisterInfoByName("x5");
-              break;
-            case 6:
-              reg_info = reg_ctx->GetRegisterInfoByName("x6");
-              break;
-            case 7:
-              reg_info = reg_ctx->GetRegisterInfoByName("x7");
-              break;
-            }
-          }
+    bool is_signed = false;
+    size_t bit_width = 0;
+    if (value_type.IsIntegerOrEnumerationType(is_signed)) {
+      bit_width = *bit_size;
+    } else if (value_type.IsPointerOrReferenceType()) {
+      bit_width = *bit_size;
+    } else {
+      // We only handle integer, pointer and reference types currently...
+      return false;
+    }
 
-          if (reg_info) {
-            RegisterValue reg_value;
-
-            if (reg_ctx->ReadRegister(reg_info, reg_value)) {
-              if (is_signed)
-                reg_value.SignExtend(bit_width);
-              if (!reg_value.GetScalarValue(value->GetScalar()))
-                return false;
-              continue;
-            }
-          }
-          return false;
+    if (bit_width <= (exe_ctx.GetProcessRef().GetAddressByteSize() * 8)) {
+      if (value_idx < 8) {
+        // Arguments 1-6 are in x0-x5...
+        const RegisterInfo *reg_info = nullptr;
+        // Search by generic ID first, then fall back to by name
+        uint32_t arg_reg_num = reg_ctx->ConvertRegisterKindToRegisterNumber(
+            eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1 + value_idx);
+        if (arg_reg_num != LLDB_INVALID_REGNUM) {
+          reg_info = reg_ctx->GetRegisterInfoAtIndex(arg_reg_num);
         } else {
-          if (sp == 0) {
-            // Read the stack pointer if we already haven't read it
-            sp = reg_ctx->GetSP(0);
-            if (sp == 0)
+          switch (value_idx) {
+          case 0:
+            reg_info = reg_ctx->GetRegisterInfoByName("x0");
+            break;
+          case 1:
+            reg_info = reg_ctx->GetRegisterInfoByName("x1");
+            break;
+          case 2:
+            reg_info = reg_ctx->GetRegisterInfoByName("x2");
+            break;
+          case 3:
+            reg_info = reg_ctx->GetRegisterInfoByName("x3");
+            break;
+          case 4:
+            reg_info = reg_ctx->GetRegisterInfoByName("x4");
+            break;
+          case 5:
+            reg_info = reg_ctx->GetRegisterInfoByName("x5");
+            break;
+          case 6:
+            reg_info = reg_ctx->GetRegisterInfoByName("x6");
+            break;
+          case 7:
+            reg_info = reg_ctx->GetRegisterInfoByName("x7");
+            break;
+          }
+        }
+
+        if (reg_info) {
+          RegisterValue reg_value;
+
+          if (reg_ctx->ReadRegister(reg_info, reg_value)) {
+            if (is_signed)
+              reg_value.SignExtend(bit_width);
+            if (!reg_value.GetScalarValue(value->GetScalar()))
               return false;
+            continue;
           }
-
-          // Arguments 5 on up are on the stack
-          const uint32_t arg_byte_size = (bit_width + (8 - 1)) / 8;
-          Status error;
-          if (!exe_ctx.GetProcessRef().ReadScalarIntegerFromMemory(
-                  sp, arg_byte_size, is_signed, value->GetScalar(), error))
+        }
+        return false;
+      } else {
+        if (sp == 0) {
+          // Read the stack pointer if we already haven't read it
+          sp = reg_ctx->GetSP(0);
+          if (sp == 0)
             return false;
+        }
 
-          sp += arg_byte_size;
-          // Align up to the next 8 byte boundary if needed
-          if (sp % 8) {
-            sp >>= 3;
-            sp += 1;
-            sp <<= 3;
-          }
+        // Arguments 5 on up are on the stack
+        const uint32_t arg_byte_size = (bit_width + (8 - 1)) / 8;
+        Status error;
+        if (!exe_ctx.GetProcessRef().ReadScalarIntegerFromMemory(
+                sp, arg_byte_size, is_signed, value->GetScalar(), error))
+          return false;
+
+        sp += arg_byte_size;
+        // Align up to the next 8 byte boundary if needed
+        if (sp % 8) {
+          sp >>= 3;
+          sp += 1;
+          sp <<= 3;
         }
       }
     }
@@ -2112,13 +2114,12 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     uint32_t &NGRN,       // NGRN (see ABI documentation)
     uint32_t &NSRN,       // NSRN (see ABI documentation)
     DataExtractor &data) {
-  const size_t byte_size = value_type.GetByteSize(nullptr);
-
-  if (byte_size == 0)
+  auto byte_size = value_type.GetByteSize(nullptr);
+  if (!byte_size || *byte_size == 0)
     return false;
 
   std::unique_ptr<DataBufferHeap> heap_data_ap(
-      new DataBufferHeap(byte_size, 0));
+      new DataBufferHeap(*byte_size, 0));
   const ByteOrder byte_order = exe_ctx.GetProcessRef().GetByteOrder();
   Status error;
 
@@ -2130,7 +2131,9 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     if (NSRN < 8 && (8 - NSRN) >= homogeneous_count) {
       if (!base_type)
         return false;
-      const size_t base_byte_size = base_type.GetByteSize(nullptr);
+      auto base_byte_size = base_type.GetByteSize(nullptr);
+      if (!base_byte_size)
+        return false;
       uint32_t data_offset = 0;
 
       for (uint32_t i = 0; i < homogeneous_count; ++i) {
@@ -2141,7 +2144,7 @@ static bool LoadValueFromConsecutiveGPRRegisters(
         if (reg_info == nullptr)
           return false;
 
-        if (base_byte_size > reg_info->byte_size)
+        if (*base_byte_size > reg_info->byte_size)
           return false;
 
         RegisterValue reg_value;
@@ -2150,11 +2153,11 @@ static bool LoadValueFromConsecutiveGPRRegisters(
           return false;
 
         // Make sure we have enough room in "heap_data_ap"
-        if ((data_offset + base_byte_size) <= heap_data_ap->GetByteSize()) {
+        if ((data_offset + *base_byte_size) <= heap_data_ap->GetByteSize()) {
           const size_t bytes_copied = reg_value.GetAsMemoryData(
-              reg_info, heap_data_ap->GetBytes() + data_offset, base_byte_size,
+              reg_info, heap_data_ap->GetBytes() + data_offset, *base_byte_size,
               byte_order, error);
-          if (bytes_copied != base_byte_size)
+          if (bytes_copied != *base_byte_size)
             return false;
           data_offset += bytes_copied;
           ++NSRN;
@@ -2169,10 +2172,10 @@ static bool LoadValueFromConsecutiveGPRRegisters(
   }
 
   const size_t max_reg_byte_size = 16;
-  if (byte_size <= max_reg_byte_size) {
-    size_t bytes_left = byte_size;
+  if (*byte_size <= max_reg_byte_size) {
+    size_t bytes_left = *byte_size;
     uint32_t data_offset = 0;
-    while (data_offset < byte_size) {
+    while (data_offset < *byte_size) {
       if (NGRN >= 8)
         return false;
 
@@ -2264,7 +2267,9 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
   if (!reg_ctx)
     return return_valobj_sp;
 
-  const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+  auto byte_size = return_compiler_type.GetByteSize(nullptr);
+  if (!byte_size)
+    return return_valobj_sp;
 
   const uint32_t type_flags = return_compiler_type.GetTypeInfo(nullptr);
   if (type_flags & eTypeIsScalar || type_flags & eTypeIsPointer) {
@@ -2273,7 +2278,7 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
     bool success = false;
     if (type_flags & eTypeIsInteger || type_flags & eTypeIsPointer) {
       // Extract the register context so we can read arguments from registers
-      if (byte_size <= 8) {
+      if (*byte_size <= 8) {
         const RegisterInfo *x0_reg_info =
             reg_ctx->GetRegisterInfoByName("x0", 0);
         if (x0_reg_info) {
@@ -2281,7 +2286,7 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
               thread.GetRegisterContext()->ReadRegisterAsUnsigned(x0_reg_info,
                                                                   0);
           const bool is_signed = (type_flags & eTypeIsSigned) != 0;
-          switch (byte_size) {
+          switch (*byte_size) {
           default:
             break;
           case 16: // uint128_t
@@ -2291,10 +2296,10 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
                   reg_ctx->GetRegisterInfoByName("x1", 0);
 
               if (x1_reg_info) {
-                if (byte_size <=
+                if (*byte_size <=
                     x0_reg_info->byte_size + x1_reg_info->byte_size) {
                   std::unique_ptr<DataBufferHeap> heap_data_ap(
-                      new DataBufferHeap(byte_size, 0));
+                      new DataBufferHeap(*byte_size, 0));
                   const ByteOrder byte_order =
                       exe_ctx.GetProcessRef().GetByteOrder();
                   RegisterValue x0_reg_value;
@@ -2359,7 +2364,7 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
       if (type_flags & eTypeIsComplex) {
         // Don't handle complex yet.
       } else {
-        if (byte_size <= sizeof(long double)) {
+        if (*byte_size <= sizeof(long double)) {
           const RegisterInfo *v0_reg_info =
               reg_ctx->GetRegisterInfoByName("v0", 0);
           RegisterValue v0_value;
@@ -2367,13 +2372,13 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
             DataExtractor data;
             if (v0_value.GetData(data)) {
               lldb::offset_t offset = 0;
-              if (byte_size == sizeof(float)) {
+              if (*byte_size == sizeof(float)) {
                 value.GetScalar() = data.GetFloat(&offset);
                 success = true;
-              } else if (byte_size == sizeof(double)) {
+              } else if (*byte_size == sizeof(double)) {
                 value.GetScalar() = data.GetDouble(&offset);
                 success = true;
-              } else if (byte_size == sizeof(long double)) {
+              } else if (*byte_size == sizeof(long double)) {
                 value.GetScalar() = data.GetLongDouble(&offset);
                 success = true;
               }
@@ -2387,14 +2392,14 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
       return_valobj_sp = ValueObjectConstResult::Create(
           thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
   } else if (type_flags & eTypeIsVector) {
-    if (byte_size > 0) {
+    if (*byte_size > 0) {
 
       const RegisterInfo *v0_info = reg_ctx->GetRegisterInfoByName("v0", 0);
 
       if (v0_info) {
-        if (byte_size <= v0_info->byte_size) {
+        if (*byte_size <= v0_info->byte_size) {
           std::unique_ptr<DataBufferHeap> heap_data_ap(
-              new DataBufferHeap(byte_size, 0));
+              new DataBufferHeap(*byte_size, 0));
           const ByteOrder byte_order = exe_ctx.GetProcessRef().GetByteOrder();
           RegisterValue reg_value;
           if (reg_ctx->ReadRegister(v0_info, reg_value)) {

--- a/source/Plugins/ABI/MacOSX-i386/ABIMacOSX_i386.cpp
+++ b/source/Plugins/ABI/MacOSX-i386/ABIMacOSX_i386.cpp
@@ -828,18 +828,15 @@ bool ABIMacOSX_i386::GetArgumentValues(Thread &thread,
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type(value->GetCompilerType());
-    if (compiler_type) {
+    auto bit_size = compiler_type.GetBitSize(&thread);
+    if (bit_size) {
       bool is_signed;
-
-      if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-        ReadIntegerArgument(value->GetScalar(),
-                            compiler_type.GetBitSize(&thread), is_signed,
+      if (compiler_type.IsIntegerOrEnumerationType(is_signed))
+        ReadIntegerArgument(value->GetScalar(), *bit_size, is_signed,
                             thread.GetProcess().get(), current_stack_argument);
-      } else if (compiler_type.IsPointerType()) {
-        ReadIntegerArgument(value->GetScalar(),
-                            compiler_type.GetBitSize(&thread), false,
+      else if (compiler_type.IsPointerType())
+        ReadIntegerArgument(value->GetScalar(), *bit_size, false,
                             thread.GetProcess().get(), current_stack_argument);
-      }
     }
   }
 
@@ -940,14 +937,15 @@ ABIMacOSX_i386::GetReturnValueObjectImpl(Thread &thread,
   bool is_signed;
 
   if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-    size_t bit_width = compiler_type.GetBitSize(&thread);
-
+    auto bit_width = compiler_type.GetBitSize(&thread);
+    if (!bit_width)
+      return return_valobj_sp;
     unsigned eax_id =
         reg_ctx->GetRegisterInfoByName("eax", 0)->kinds[eRegisterKindLLDB];
     unsigned edx_id =
         reg_ctx->GetRegisterInfoByName("edx", 0)->kinds[eRegisterKindLLDB];
 
-    switch (bit_width) {
+    switch (*bit_width) {
     default:
     case 128:
       // Scalar can't hold 128-bit literals, so we don't handle this

--- a/source/Plugins/ABI/SysV-arm/ABISysV_arm.cpp
+++ b/source/Plugins/ABI/SysV-arm/ABISysV_arm.cpp
@@ -1478,10 +1478,10 @@ bool ABISysV_arm::GetArgumentValues(Thread &thread, ValueList &values) const {
     if (compiler_type) {
       bool is_signed = false;
       size_t bit_width = 0;
-      if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-        bit_width = compiler_type.GetBitSize(&thread);
-      } else if (compiler_type.IsPointerOrReferenceType()) {
-        bit_width = compiler_type.GetBitSize(&thread);
+      if (compiler_type.IsIntegerOrEnumerationType(is_signed) ||
+          compiler_type.IsPointerOrReferenceType()) {
+        if (auto size = compiler_type.GetBitSize(&thread))
+          bit_width = *size;
       } else {
         // We only handle integer, pointer and reference types currently...
         return false;
@@ -1587,11 +1587,13 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
 
   const RegisterInfo *r0_reg_info =
       reg_ctx->GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1);
-  size_t bit_width = compiler_type.GetBitSize(&thread);
-  size_t byte_size = compiler_type.GetByteSize(&thread);
+  auto bit_width = compiler_type.GetBitSize(&thread);
+  auto byte_size = compiler_type.GetByteSize(&thread);
+  if (!bit_width || !byte_size)
+    return return_valobj_sp;
 
   if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-    switch (bit_width) {
+    switch (*bit_width) {
     default:
       return return_valobj_sp;
     case 64: {
@@ -1638,28 +1640,28 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
         UINT32_MAX;
     value.GetScalar() = ptr;
   } else if (compiler_type.IsVectorType(nullptr, nullptr)) {
-    if (IsArmHardFloat(thread) && (byte_size == 8 || byte_size == 16)) {
+    if (IsArmHardFloat(thread) && (*byte_size == 8 || *byte_size == 16)) {
       is_vfp_candidate = true;
       vfp_byte_size = 8;
-      vfp_count = (byte_size == 8 ? 1 : 2);
-    } else if (byte_size <= 16) {
+      vfp_count = (*byte_size == 8 ? 1 : 2);
+    } else if (*byte_size <= 16) {
       DataBufferHeap buffer(16, 0);
       uint32_t *buffer_ptr = (uint32_t *)buffer.GetBytes();
 
-      for (uint32_t i = 0; 4 * i < byte_size; ++i) {
+      for (uint32_t i = 0; 4 * i < *byte_size; ++i) {
         const RegisterInfo *reg_info = reg_ctx->GetRegisterInfo(
             eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1 + i);
         buffer_ptr[i] =
             reg_ctx->ReadRegisterAsUnsigned(reg_info, 0) & UINT32_MAX;
       }
-      value.SetBytes(buffer.GetBytes(), byte_size);
+      value.SetBytes(buffer.GetBytes(), *byte_size);
     } else {
-      if (!GetReturnValuePassedInMemory(thread, reg_ctx, byte_size, value))
+      if (!GetReturnValuePassedInMemory(thread, reg_ctx, *byte_size, value))
         return return_valobj_sp;
     }
   } else if (compiler_type.IsFloatingPointType(float_count, is_complex)) {
     if (float_count == 1 && !is_complex) {
-      switch (bit_width) {
+      switch (*bit_width) {
       default:
         return return_valobj_sp;
       case 64: {
@@ -1707,9 +1709,9 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
     } else if (is_complex && float_count == 2) {
       if (IsArmHardFloat(thread)) {
         is_vfp_candidate = true;
-        vfp_byte_size = byte_size / 2;
+        vfp_byte_size = *byte_size / 2;
         vfp_count = 2;
-      } else if (!GetReturnValuePassedInMemory(thread, reg_ctx, bit_width / 8,
+      } else if (!GetReturnValuePassedInMemory(thread, reg_ctx, *bit_width / 8,
                                                value))
         return return_valobj_sp;
     } else
@@ -1722,19 +1724,20 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
           compiler_type.IsHomogeneousAggregate(&base_type);
 
       if (homogeneous_count > 0 && homogeneous_count <= 4) {
+        auto base_byte_size = base_type.GetByteSize(nullptr);
         if (base_type.IsVectorType(nullptr, nullptr)) {
-          uint64_t base_byte_size = base_type.GetByteSize(nullptr);
-          if (base_byte_size == 8 || base_byte_size == 16) {
+          if (base_byte_size &&
+              (*base_byte_size == 8 || *base_byte_size == 16)) {
             is_vfp_candidate = true;
             vfp_byte_size = 8;
-            vfp_count =
-                (base_type.GetByteSize(nullptr) == 8 ? homogeneous_count
-                                                     : homogeneous_count * 2);
+            vfp_count = (*base_byte_size == 8 ? homogeneous_count
+                                              : homogeneous_count * 2);
           }
         } else if (base_type.IsFloatingPointType(float_count, is_complex)) {
           if (float_count == 1 && !is_complex) {
             is_vfp_candidate = true;
-            vfp_byte_size = base_type.GetByteSize(nullptr);
+            if (base_byte_size)
+              vfp_byte_size = *base_byte_size;
             vfp_count = homogeneous_count;
           }
         }
@@ -1749,12 +1752,13 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
                 compiler_type.GetFieldAtIndex(index, name, NULL, NULL, NULL);
 
             if (base_type.IsFloatingPointType(float_count, is_complex)) {
+              auto base_byte_size = base_type.GetByteSize(nullptr);
               if (float_count == 2 && is_complex) {
-                if (index != 0 &&
-                    vfp_byte_size != base_type.GetByteSize(nullptr))
+                if (index != 0 && base_byte_size &&
+                    vfp_byte_size != *base_byte_size)
                   break;
-                else
-                  vfp_byte_size = base_type.GetByteSize(nullptr);
+                else if (base_byte_size)
+                  vfp_byte_size = *base_byte_size;
               } else
                 break;
             } else
@@ -1770,13 +1774,13 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
       }
     }
 
-    if (byte_size <= 4) {
+    if (*byte_size <= 4) {
       RegisterValue r0_reg_value;
       uint32_t raw_value =
           reg_ctx->ReadRegisterAsUnsigned(r0_reg_info, 0) & UINT32_MAX;
-      value.SetBytes(&raw_value, byte_size);
+      value.SetBytes(&raw_value, *byte_size);
     } else if (!is_vfp_candidate) {
-      if (!GetReturnValuePassedInMemory(thread, reg_ctx, byte_size, value))
+      if (!GetReturnValuePassedInMemory(thread, reg_ctx, *byte_size, value))
         return return_valobj_sp;
     }
   } else {
@@ -1788,7 +1792,7 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
     ProcessSP process_sp(thread.GetProcess());
     ByteOrder byte_order = process_sp->GetByteOrder();
 
-    DataBufferSP data_sp(new DataBufferHeap(byte_size, 0));
+    DataBufferSP data_sp(new DataBufferHeap(*byte_size, 0));
     uint32_t data_offset = 0;
 
     for (uint32_t reg_index = 0; reg_index < vfp_count; reg_index++) {
@@ -1823,7 +1827,7 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
       }
     }
 
-    if (data_offset == byte_size) {
+    if (data_offset == *byte_size) {
       DataExtractor data;
       data.SetByteOrder(byte_order);
       data.SetAddressByteSize(process_sp->GetAddressByteSize());

--- a/source/Plugins/ABI/SysV-arm64/ABISysV_arm64.cpp
+++ b/source/Plugins/ABI/SysV-arm64/ABISysV_arm64.cpp
@@ -1771,10 +1771,13 @@ bool ABISysV_arm64::GetArgumentValues(Thread &thread, ValueList &values) const {
     if (value_type) {
       bool is_signed = false;
       size_t bit_width = 0;
+      auto bit_size = value_type.GetBitSize(&thread);
+      if (!bit_size)
+        return false;
       if (value_type.IsIntegerOrEnumerationType(is_signed)) {
-        bit_width = value_type.GetBitSize(&thread);
+        bit_width = *bit_size;
       } else if (value_type.IsPointerOrReferenceType()) {
-        bit_width = value_type.GetBitSize(&thread);
+        bit_width = *bit_size;
       } else {
         // We only handle integer, pointer and reference types currently...
         return false;
@@ -2087,13 +2090,13 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     uint32_t &NGRN,       // NGRN (see ABI documentation)
     uint32_t &NSRN,       // NSRN (see ABI documentation)
     DataExtractor &data) {
-  const size_t byte_size = value_type.GetByteSize(nullptr);
+  auto byte_size = value_type.GetByteSize(nullptr);
 
-  if (byte_size == 0)
+  if (byte_size || *byte_size == 0)
     return false;
 
   std::unique_ptr<DataBufferHeap> heap_data_ap(
-      new DataBufferHeap(byte_size, 0));
+      new DataBufferHeap(*byte_size, 0));
   const ByteOrder byte_order = exe_ctx.GetProcessRef().GetByteOrder();
   Status error;
 
@@ -2105,7 +2108,9 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     if (NSRN < 8 && (8 - NSRN) >= homogeneous_count) {
       if (!base_type)
         return false;
-      const size_t base_byte_size = base_type.GetByteSize(nullptr);
+      auto base_byte_size = base_type.GetByteSize(nullptr);
+      if (!base_byte_size)
+        return false;
       uint32_t data_offset = 0;
 
       for (uint32_t i = 0; i < homogeneous_count; ++i) {
@@ -2116,7 +2121,7 @@ static bool LoadValueFromConsecutiveGPRRegisters(
         if (reg_info == nullptr)
           return false;
 
-        if (base_byte_size > reg_info->byte_size)
+        if (*base_byte_size > reg_info->byte_size)
           return false;
 
         RegisterValue reg_value;
@@ -2125,11 +2130,11 @@ static bool LoadValueFromConsecutiveGPRRegisters(
           return false;
 
         // Make sure we have enough room in "heap_data_ap"
-        if ((data_offset + base_byte_size) <= heap_data_ap->GetByteSize()) {
+        if ((data_offset + *base_byte_size) <= heap_data_ap->GetByteSize()) {
           const size_t bytes_copied = reg_value.GetAsMemoryData(
-              reg_info, heap_data_ap->GetBytes() + data_offset, base_byte_size,
+              reg_info, heap_data_ap->GetBytes() + data_offset, *base_byte_size,
               byte_order, error);
-          if (bytes_copied != base_byte_size)
+          if (bytes_copied != *base_byte_size)
             return false;
           data_offset += bytes_copied;
           ++NSRN;
@@ -2144,10 +2149,10 @@ static bool LoadValueFromConsecutiveGPRRegisters(
   }
 
   const size_t max_reg_byte_size = 16;
-  if (byte_size <= max_reg_byte_size) {
-    size_t bytes_left = byte_size;
+  if (*byte_size <= max_reg_byte_size) {
+    size_t bytes_left = *byte_size;
     uint32_t data_offset = 0;
-    while (data_offset < byte_size) {
+    while (data_offset < *byte_size) {
       if (NGRN >= 8)
         return false;
 
@@ -2232,7 +2237,9 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
   if (!reg_ctx)
     return return_valobj_sp;
 
-  const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+  auto byte_size = return_compiler_type.GetByteSize(nullptr);
+  if (!byte_size)
+    return return_valobj_sp;
 
   const uint32_t type_flags = return_compiler_type.GetTypeInfo(nullptr);
   if (type_flags & eTypeIsScalar || type_flags & eTypeIsPointer) {
@@ -2241,7 +2248,7 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
     bool success = false;
     if (type_flags & eTypeIsInteger || type_flags & eTypeIsPointer) {
       // Extract the register context so we can read arguments from registers
-      if (byte_size <= 8) {
+      if (*byte_size <= 8) {
         const RegisterInfo *x0_reg_info = nullptr;
         x0_reg_info = reg_ctx->GetRegisterInfo(eRegisterKindGeneric,
                                                LLDB_REGNUM_GENERIC_ARG1);
@@ -2250,7 +2257,7 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
               thread.GetRegisterContext()->ReadRegisterAsUnsigned(x0_reg_info,
                                                                   0);
           const bool is_signed = (type_flags & eTypeIsSigned) != 0;
-          switch (byte_size) {
+          switch (*byte_size) {
           default:
             break;
           case 16: // uint128_t
@@ -2261,10 +2268,10 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
                                                      LLDB_REGNUM_GENERIC_ARG2);
 
               if (x1_reg_info) {
-                if (byte_size <=
+                if (*byte_size <=
                     x0_reg_info->byte_size + x1_reg_info->byte_size) {
                   std::unique_ptr<DataBufferHeap> heap_data_ap(
-                      new DataBufferHeap(byte_size, 0));
+                      new DataBufferHeap(*byte_size, 0));
                   const ByteOrder byte_order =
                       exe_ctx.GetProcessRef().GetByteOrder();
                   RegisterValue x0_reg_value;
@@ -2329,7 +2336,7 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
       if (type_flags & eTypeIsComplex) {
         // Don't handle complex yet.
       } else {
-        if (byte_size <= sizeof(long double)) {
+        if (*byte_size <= sizeof(long double)) {
           const RegisterInfo *v0_reg_info =
               reg_ctx->GetRegisterInfoByName("v0", 0);
           RegisterValue v0_value;
@@ -2337,13 +2344,13 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
             DataExtractor data;
             if (v0_value.GetData(data)) {
               lldb::offset_t offset = 0;
-              if (byte_size == sizeof(float)) {
+              if (*byte_size == sizeof(float)) {
                 value.GetScalar() = data.GetFloat(&offset);
                 success = true;
-              } else if (byte_size == sizeof(double)) {
+              } else if (*byte_size == sizeof(double)) {
                 value.GetScalar() = data.GetDouble(&offset);
                 success = true;
-              } else if (byte_size == sizeof(long double)) {
+              } else if (*byte_size == sizeof(long double)) {
                 value.GetScalar() = data.GetLongDouble(&offset);
                 success = true;
               }
@@ -2356,13 +2363,13 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
     if (success)
       return_valobj_sp = ValueObjectConstResult::Create(
           thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
-  } else if (type_flags & eTypeIsVector && byte_size <= 16) {
-    if (byte_size > 0) {
+  } else if (type_flags & eTypeIsVector && *byte_size <= 16) {
+    if (*byte_size > 0) {
       const RegisterInfo *v0_info = reg_ctx->GetRegisterInfoByName("v0", 0);
 
       if (v0_info) {
         std::unique_ptr<DataBufferHeap> heap_data_ap(
-            new DataBufferHeap(byte_size, 0));
+            new DataBufferHeap(*byte_size, 0));
         const ByteOrder byte_order = exe_ctx.GetProcessRef().GetByteOrder();
         RegisterValue reg_value;
         if (reg_ctx->ReadRegister(v0_info, reg_value)) {
@@ -2379,7 +2386,7 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
       }
     }
   } else if (type_flags & eTypeIsStructUnion || type_flags & eTypeIsClass ||
-             (type_flags & eTypeIsVector && byte_size > 16)) {
+             (type_flags & eTypeIsVector && *byte_size > 16)) {
     DataExtractor data;
 
     uint32_t NGRN = 0; // Search ABI docs for NGRN

--- a/source/Plugins/ABI/SysV-i386/ABISysV_i386.cpp
+++ b/source/Plugins/ABI/SysV-i386/ABISysV_i386.cpp
@@ -312,15 +312,14 @@ bool ABISysV_i386::GetArgumentValues(Thread &thread, ValueList &values) const {
 
     // Currently: Support for extracting values with Clang QualTypes only.
     CompilerType compiler_type(value->GetCompilerType());
-    if (compiler_type) {
+    auto bit_size = compiler_type.GetBitSize(&thread);
+    if (bit_size) {
       bool is_signed;
       if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-        ReadIntegerArgument(value->GetScalar(),
-                            compiler_type.GetBitSize(&thread), is_signed,
+        ReadIntegerArgument(value->GetScalar(), *bit_size, is_signed,
                             thread.GetProcess().get(), current_stack_argument);
       } else if (compiler_type.IsPointerType()) {
-        ReadIntegerArgument(value->GetScalar(),
-                            compiler_type.GetBitSize(&thread), false,
+        ReadIntegerArgument(value->GetScalar(), *bit_size, false,
                             thread.GetProcess().get(), current_stack_argument);
       }
     }
@@ -518,7 +517,9 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
              (type_flags & eTypeIsEnumeration)) //'Integral' + 'Floating Point'
   {
     value.SetValueType(Value::eValueTypeScalar);
-    const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+    auto byte_size = return_compiler_type.GetByteSize(nullptr);
+    if (!byte_size)
+      return return_valobj_sp;
     bool success = false;
 
     if (type_flags & eTypeIsInteger) // 'Integral' except enum
@@ -532,7 +533,7 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
            0xffffffff)
           << 32;
 
-      switch (byte_size) {
+      switch (*byte_size) {
       default:
         break;
 
@@ -588,7 +589,7 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
           thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
     } else if (type_flags & eTypeIsFloat) // 'Floating Point'
     {
-      if (byte_size <= 12) // handles float, double, long double, __float80
+      if (*byte_size <= 12) // handles float, double, long double, __float80
       {
         const RegisterInfo *st0_info = reg_ctx->GetRegisterInfoByName("st0", 0);
         RegisterValue st0_value;
@@ -599,21 +600,20 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
             lldb::offset_t offset = 0;
             long double value_long_double = data.GetLongDouble(&offset);
 
-            if (byte_size == 4) // float is 4 bytes
-            {
+            // float is 4 bytes.
+            if (*byte_size == 4) {
               float value_float = (float)value_long_double;
               value.GetScalar() = value_float;
               success = true;
-            } else if (byte_size == 8) // double is 8 bytes
-            {
+            } else if (*byte_size == 8) {
+              // double is 8 bytes
               // On Android Platform: long double is also 8 bytes It will be
               // handled here only.
               double value_double = (double)value_long_double;
               value.GetScalar() = value_double;
               success = true;
-            } else if (byte_size ==
-                       12) // long double and __float80 are 12 bytes on i386
-            {
+            } else if (*byte_size == 12) {
+              // long double and __float80 are 12 bytes on i386.
               value.GetScalar() = value_long_double;
               success = true;
             }
@@ -623,7 +623,7 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
         if (success)
           return_valobj_sp = ValueObjectConstResult::Create(
               thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
-      } else if (byte_size == 16) // handles __float128
+      } else if (*byte_size == 16) // handles __float128
       {
         lldb::addr_t storage_addr = (uint32_t)(
             thread.GetRegisterContext()->ReadRegisterAsUnsigned(eax_id, 0) &
@@ -641,18 +641,18 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
     // ToDo: Yet to be implemented
   } else if (type_flags & eTypeIsVector) // 'Packed'
   {
-    const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
-    if (byte_size > 0) {
+    auto byte_size = return_compiler_type.GetByteSize(nullptr);
+    if (byte_size && *byte_size > 0) {
       const RegisterInfo *vec_reg = reg_ctx->GetRegisterInfoByName("xmm0", 0);
       if (vec_reg == nullptr)
         vec_reg = reg_ctx->GetRegisterInfoByName("mm0", 0);
 
       if (vec_reg) {
-        if (byte_size <= vec_reg->byte_size) {
+        if (*byte_size <= vec_reg->byte_size) {
           ProcessSP process_sp(thread.GetProcess());
           if (process_sp) {
             std::unique_ptr<DataBufferHeap> heap_data_ap(
-                new DataBufferHeap(byte_size, 0));
+                new DataBufferHeap(*byte_size, 0));
             const ByteOrder byte_order = process_sp->GetByteOrder();
             RegisterValue reg_value;
             if (reg_ctx->ReadRegister(vec_reg, reg_value)) {
@@ -669,14 +669,14 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
               }
             }
           }
-        } else if (byte_size <= vec_reg->byte_size * 2) {
+        } else if (*byte_size <= vec_reg->byte_size * 2) {
           const RegisterInfo *vec_reg2 =
               reg_ctx->GetRegisterInfoByName("xmm1", 0);
           if (vec_reg2) {
             ProcessSP process_sp(thread.GetProcess());
             if (process_sp) {
               std::unique_ptr<DataBufferHeap> heap_data_ap(
-                  new DataBufferHeap(byte_size, 0));
+                  new DataBufferHeap(*byte_size, 0));
               const ByteOrder byte_order = process_sp->GetByteOrder();
               RegisterValue reg_value;
               RegisterValue reg_value2;

--- a/source/Plugins/ABI/SysV-mips/ABISysV_mips.cpp
+++ b/source/Plugins/ABI/SysV-mips/ABISysV_mips.cpp
@@ -816,9 +816,11 @@ ValueObjectSP ABISysV_mips::GetReturnValueObjectImpl(
 
   // In MIPS register "r2" (v0) holds the integer function return values
   const RegisterInfo *r2_reg_info = reg_ctx->GetRegisterInfoByName("r2", 0);
-  size_t bit_width = return_compiler_type.GetBitSize(&thread);
+  auto bit_width = return_compiler_type.GetBitSize(&thread);
+  if (!bit_width)
+    return return_valobj_sp;
   if (return_compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-    switch (bit_width) {
+    switch (*bit_width) {
     default:
       return return_valobj_sp;
     case 64: {
@@ -877,7 +879,7 @@ ValueObjectSP ABISysV_mips::GetReturnValueObjectImpl(
       uint64_t raw_value = reg_ctx->ReadRegisterAsUnsigned(r2_reg_info, 0);
       if (count != 1 && is_complex)
         return return_valobj_sp;
-      switch (bit_width) {
+      switch (*bit_width) {
       default:
         return return_valobj_sp;
       case 32:
@@ -909,7 +911,7 @@ ValueObjectSP ABISysV_mips::GetReturnValueObjectImpl(
       lldb::offset_t offset = 0;
 
       if (count == 1 && !is_complex) {
-        switch (bit_width) {
+        switch (*bit_width) {
         default:
           return return_valobj_sp;
         case 64: {

--- a/source/Plugins/ABI/SysV-mips64/ABISysV_mips64.cpp
+++ b/source/Plugins/ABI/SysV-mips64/ABISysV_mips64.cpp
@@ -766,7 +766,9 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
   Target *target = exe_ctx.GetTargetPtr();
   const ArchSpec target_arch = target->GetArchitecture();
   ByteOrder target_byte_order = target_arch.GetByteOrder();
-  const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+  auto byte_size = return_compiler_type.GetByteSize(nullptr);
+  if (!byte_size)
+    return return_valobj_sp;
   const uint32_t type_flags = return_compiler_type.GetTypeInfo(nullptr);
   uint32_t fp_flag =
       target_arch.GetFlags() & lldb_private::ArchSpec::eMIPS_ABI_FP_mask;
@@ -785,7 +787,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
       uint64_t raw_value = reg_ctx->ReadRegisterAsUnsigned(r2_info, 0);
 
       const bool is_signed = (type_flags & eTypeIsSigned) != 0;
-      switch (byte_size) {
+      switch (*byte_size) {
       default:
         break;
 
@@ -826,7 +828,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
         // Don't handle complex yet.
       } else if (IsSoftFloat(fp_flag)) {
         uint64_t raw_value = reg_ctx->ReadRegisterAsUnsigned(r2_info, 0);
-        switch (byte_size) {
+        switch (*byte_size) {
         case 4:
           value.GetScalar() = *((float *)(&raw_value));
           success = true;
@@ -851,7 +853,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
         }
 
       } else {
-        if (byte_size <= sizeof(long double)) {
+        if (*byte_size <= sizeof(long double)) {
           const RegisterInfo *f0_info = reg_ctx->GetRegisterInfoByName("f0", 0);
 
           RegisterValue f0_value;
@@ -862,13 +864,13 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
           f0_value.GetData(f0_data);
 
           lldb::offset_t offset = 0;
-          if (byte_size == sizeof(float)) {
+          if (*byte_size == sizeof(float)) {
             value.GetScalar() = (float)f0_data.GetFloat(&offset);
             success = true;
-          } else if (byte_size == sizeof(double)) {
+          } else if (*byte_size == sizeof(double)) {
             value.GetScalar() = (double)f0_data.GetDouble(&offset);
             success = true;
-          } else if (byte_size == sizeof(long double)) {
+          } else if (*byte_size == sizeof(long double)) {
             const RegisterInfo *f2_info =
                 reg_ctx->GetRegisterInfoByName("f2", 0);
             RegisterValue f2_value;
@@ -883,21 +885,21 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
             if (target_byte_order == eByteOrderLittle) {
               copy_from_extractor = &f0_data;
               copy_from_extractor->CopyByteOrderedData(
-                  0, 8, data_sp->GetBytes(), byte_size - 8, target_byte_order);
+                  0, 8, data_sp->GetBytes(), *byte_size - 8, target_byte_order);
               f2_value.GetData(f2_data);
               copy_from_extractor = &f2_data;
               copy_from_extractor->CopyByteOrderedData(
-                  0, 8, data_sp->GetBytes() + 8, byte_size - 8,
+                  0, 8, data_sp->GetBytes() + 8, *byte_size - 8,
                   target_byte_order);
             } else {
               copy_from_extractor = &f0_data;
               copy_from_extractor->CopyByteOrderedData(
-                  0, 8, data_sp->GetBytes() + 8, byte_size - 8,
+                  0, 8, data_sp->GetBytes() + 8, *byte_size - 8,
                   target_byte_order);
               f2_value.GetData(f2_data);
               copy_from_extractor = &f2_data;
               copy_from_extractor->CopyByteOrderedData(
-                  0, 8, data_sp->GetBytes(), byte_size - 8, target_byte_order);
+                  0, 8, data_sp->GetBytes(), *byte_size - 8, target_byte_order);
             }
 
             return_valobj_sp = ValueObjectConstResult::Create(
@@ -914,7 +916,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
   } else if (type_flags & eTypeIsStructUnion || type_flags & eTypeIsClass ||
              type_flags & eTypeIsVector) {
     // Any structure of up to 16 bytes in size is returned in the registers.
-    if (byte_size <= 16) {
+    if (*byte_size <= 16) {
       DataBufferSP data_sp(new DataBufferHeap(16, 0));
       DataExtractor return_ext(data_sp, target_byte_order,
                                target->GetArchitecture().GetAddressByteSize());
@@ -972,8 +974,9 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
             CompilerType field_compiler_type =
                 return_compiler_type.GetFieldAtIndex(
                     idx, name, &field_bit_offset, nullptr, nullptr);
-            const size_t field_byte_width =
-                field_compiler_type.GetByteSize(nullptr);
+            auto field_byte_width = field_compiler_type.GetByteSize(nullptr);
+            if (!field_byte_width)
+              return return_valobj_sp;
 
             DataExtractor *copy_from_extractor = nullptr;
             uint64_t return_value[2];
@@ -981,7 +984,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
 
             if (idx == 0) {
               // This case is for long double type.
-              if (field_byte_width == 16) {
+              if (*field_byte_width == 16) {
 
                 // If structure contains long double type, then it is returned
                 // in fp0/fp1 registers.
@@ -999,7 +1002,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
                   return_value[0] = f1_data.GetU64(&offset);
                 }
 
-                f0_data.SetData(return_value, field_byte_width,
+                f0_data.SetData(return_value, *field_byte_width,
                                 target_byte_order);
               }
               copy_from_extractor = &f0_data; // This is in f0, copy from
@@ -1013,13 +1016,13 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
 
             // Sanity check to avoid crash
             if (!copy_from_extractor ||
-                field_byte_width > copy_from_extractor->GetByteSize())
+                *field_byte_width > copy_from_extractor->GetByteSize())
               return return_valobj_sp;
 
             // copy the register contents into our data buffer
             copy_from_extractor->CopyByteOrderedData(
-                0, field_byte_width,
-                data_sp->GetBytes() + (field_bit_offset / 8), field_byte_width,
+                0, *field_byte_width,
+                data_sp->GetBytes() + (field_bit_offset / 8), *field_byte_width,
                 target_byte_order);
           }
 
@@ -1042,12 +1045,11 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
 
         CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
             idx, name, &field_bit_offset, nullptr, nullptr);
-        const size_t field_byte_width =
-            field_compiler_type.GetByteSize(nullptr);
+        auto field_byte_width = field_compiler_type.GetByteSize(nullptr);
 
         // if we don't know the size of the field (e.g. invalid type), just
         // bail out
-        if (field_byte_width == 0)
+        if (!field_byte_width || *field_byte_width == 0)
           break;
 
         uint32_t field_byte_offset = field_bit_offset / 8;
@@ -1059,24 +1061,24 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
 
           if (integer_bytes < 8) {
             // We have not yet consumed r2 completely.
-            if (integer_bytes + field_byte_width + padding <= 8) {
+            if (integer_bytes + *field_byte_width + padding <= 8) {
               // This field fits in r2, copy its value from r2 to our result
               // structure
-              integer_bytes = integer_bytes + field_byte_width +
+              integer_bytes = integer_bytes + *field_byte_width +
                               padding; // Increase the consumed bytes.
               use_r2 = 1;
             } else {
               // There isn't enough space left in r2 for this field, so this
               // will be in r3.
-              integer_bytes = integer_bytes + field_byte_width +
+              integer_bytes = integer_bytes + *field_byte_width +
                               padding; // Increase the consumed bytes.
               use_r3 = 1;
             }
           }
           // We already have consumed at-least 8 bytes that means r2 is done,
           // and this field will be in r3. Check if this field can fit in r3.
-          else if (integer_bytes + field_byte_width + padding <= 16) {
-            integer_bytes = integer_bytes + field_byte_width + padding;
+          else if (integer_bytes + *field_byte_width + padding <= 16) {
+            integer_bytes = integer_bytes + *field_byte_width + padding;
             use_r3 = 1;
           } else {
             // There isn't any space left for this field, this should not
@@ -1089,7 +1091,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
       }
       // Vector types up to 16 bytes are returned in GP return registers
       if (type_flags & eTypeIsVector) {
-        if (byte_size <= 8)
+        if (*byte_size <= 8)
           use_r2 = 1;
         else {
           use_r2 = 1;

--- a/source/Plugins/ABI/SysV-ppc/ABISysV_ppc.cpp
+++ b/source/Plugins/ABI/SysV-ppc/ABISysV_ppc.cpp
@@ -402,19 +402,18 @@ bool ABISysV_ppc::GetArgumentValues(Thread &thread, ValueList &values) const {
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    if (!compiler_type)
+    auto bit_size = compiler_type.GetBitSize(&thread);
+    if (!bit_size)
       return false;
     bool is_signed;
-
-    if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          is_signed, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
-    } else if (compiler_type.IsPointerType()) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          false, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
-    }
+    if (compiler_type.IsIntegerOrEnumerationType(is_signed))
+      ReadIntegerArgument(value->GetScalar(), *bit_size, is_signed, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
+    else if (compiler_type.IsPointerType())
+      ReadIntegerArgument(value->GetScalar(), *bit_size, false, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
   }
 
   return true;
@@ -471,8 +470,12 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       error.SetErrorString(
           "We don't support returning complex values at present");
     else {
-      size_t bit_width = compiler_type.GetBitSize(frame_sp.get());
-      if (bit_width <= 64) {
+      auto bit_width = compiler_type.GetBitSize(frame_sp.get());
+      if (!bit_width) {
+        error.SetErrorString("can't get type size");
+        return error;
+      }
+      if (*bit_width <= 64) {
         DataExtractor data;
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
@@ -530,11 +533,13 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
     if (type_flags & eTypeIsInteger) {
       // Extract the register context so we can read arguments from registers
 
-      const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+      auto byte_size = return_compiler_type.GetByteSize(nullptr);
+      if (!byte_size)
+        return return_valobj_sp;
       uint64_t raw_value = thread.GetRegisterContext()->ReadRegisterAsUnsigned(
           reg_ctx->GetRegisterInfoByName("r3", 0), 0);
       const bool is_signed = (type_flags & eTypeIsSigned) != 0;
-      switch (byte_size) {
+      switch (*byte_size) {
       default:
         break;
 
@@ -574,18 +579,18 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
       if (type_flags & eTypeIsComplex) {
         // Don't handle complex yet.
       } else {
-        const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
-        if (byte_size <= sizeof(long double)) {
+        auto byte_size = return_compiler_type.GetByteSize(nullptr);
+        if (byte_size && *byte_size <= sizeof(long double)) {
           const RegisterInfo *f1_info = reg_ctx->GetRegisterInfoByName("f1", 0);
           RegisterValue f1_value;
           if (reg_ctx->ReadRegister(f1_info, f1_value)) {
             DataExtractor data;
             if (f1_value.GetData(data)) {
               lldb::offset_t offset = 0;
-              if (byte_size == sizeof(float)) {
+              if (*byte_size == sizeof(float)) {
                 value.GetScalar() = (float)data.GetFloat(&offset);
                 success = true;
-              } else if (byte_size == sizeof(double)) {
+              } else if (*byte_size == sizeof(double)) {
                 value.GetScalar() = (double)data.GetDouble(&offset);
                 success = true;
               }
@@ -607,15 +612,15 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
     return_valobj_sp = ValueObjectConstResult::Create(
         thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
   } else if (type_flags & eTypeIsVector) {
-    const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
-    if (byte_size > 0) {
+    auto byte_size = return_compiler_type.GetByteSize(nullptr);
+    if (byte_size && *byte_size > 0) {
       const RegisterInfo *altivec_reg = reg_ctx->GetRegisterInfoByName("v2", 0);
       if (altivec_reg) {
-        if (byte_size <= altivec_reg->byte_size) {
+        if (*byte_size <= altivec_reg->byte_size) {
           ProcessSP process_sp(thread.GetProcess());
           if (process_sp) {
             std::unique_ptr<DataBufferHeap> heap_data_ap(
-                new DataBufferHeap(byte_size, 0));
+                new DataBufferHeap(*byte_size, 0));
             const ByteOrder byte_order = process_sp->GetByteOrder();
             RegisterValue reg_value;
             if (reg_ctx->ReadRegister(altivec_reg, reg_value)) {
@@ -624,9 +629,10 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
                       altivec_reg, heap_data_ap->GetBytes(),
                       heap_data_ap->GetByteSize(), byte_order, error)) {
                 DataExtractor data(DataBufferSP(heap_data_ap.release()),
-                                   byte_order, process_sp->GetTarget()
-                                                   .GetArchitecture()
-                                                   .GetAddressByteSize());
+                                   byte_order,
+                                   process_sp->GetTarget()
+                                       .GetArchitecture()
+                                       .GetAddressByteSize());
                 return_valobj_sp = ValueObjectConstResult::Create(
                     &thread, return_compiler_type, ConstString(""), data);
               }
@@ -656,11 +662,13 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
   if (!reg_ctx_sp)
     return return_valobj_sp;
 
-  const size_t bit_width = return_compiler_type.GetBitSize(&thread);
+  auto bit_width = return_compiler_type.GetBitSize(&thread);
+  if (!bit_width)
+    return return_valobj_sp;
   if (return_compiler_type.IsAggregateType()) {
     Target *target = exe_ctx.GetTargetPtr();
     bool is_memory = true;
-    if (bit_width <= 128) {
+    if (*bit_width <= 128) {
       ByteOrder target_byte_order = target->GetArchitecture().GetByteOrder();
       DataBufferSP data_sp(new DataBufferHeap(16, 0));
       DataExtractor return_ext(data_sp, target_byte_order,
@@ -698,15 +706,17 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
 
         CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
             idx, name, &field_bit_offset, nullptr, nullptr);
-        const size_t field_bit_width = field_compiler_type.GetBitSize(&thread);
+        auto field_bit_width = field_compiler_type.GetBitSize(&thread);
+        if (!field_bit_width)
+          return return_valobj_sp;
 
         // If there are any unaligned fields, this is stored in memory.
-        if (field_bit_offset % field_bit_width != 0) {
+        if (field_bit_offset % *field_bit_width != 0) {
           is_memory = true;
           break;
         }
 
-        uint32_t field_byte_width = field_bit_width / 8;
+        uint32_t field_byte_width = *field_bit_width / 8;
         uint32_t field_byte_offset = field_bit_offset / 8;
 
         DataExtractor *copy_from_extractor = nullptr;
@@ -739,13 +749,13 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
           }
         } else if (field_compiler_type.IsFloatingPointType(count, is_complex)) {
           // Structs with long doubles are always passed in memory.
-          if (field_bit_width == 128) {
+          if (*field_bit_width == 128) {
             is_memory = true;
             break;
-          } else if (field_bit_width == 64) {
+          } else if (*field_bit_width == 64) {
             copy_from_offset = 0;
             fp_bytes += field_byte_width;
-          } else if (field_bit_width == 32) {
+          } else if (*field_bit_width == 32) {
             // This one is kind of complicated.  If we are in an "eightbyte"
             // with another float, we'll be stuffed into an xmm register with
             // it.  If we are in an "eightbyte" with one or more ints, then we

--- a/source/Plugins/ABI/SysV-ppc64/ABISysV_ppc64.cpp
+++ b/source/Plugins/ABI/SysV-ppc64/ABISysV_ppc64.cpp
@@ -284,18 +284,19 @@ bool ABISysV_ppc64::GetArgumentValues(Thread &thread, ValueList &values) const {
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    if (!compiler_type)
+    auto bit_size = compiler_type.GetBitSize(&thread);
+    if (!bit_size)
       return false;
     bool is_signed;
 
     if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          is_signed, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
+      ReadIntegerArgument(value->GetScalar(), *bit_size, is_signed, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
     } else if (compiler_type.IsPointerType()) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          false, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
+      ReadIntegerArgument(value->GetScalar(), *bit_size, false, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
     }
   }
 
@@ -353,8 +354,12 @@ Status ABISysV_ppc64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       error.SetErrorString(
           "We don't support returning complex values at present");
     else {
-      size_t bit_width = compiler_type.GetBitSize(frame_sp.get());
-      if (bit_width <= 64) {
+      auto bit_width = compiler_type.GetBitSize(frame_sp.get());
+      if (!bit_width) {
+        error.SetErrorString("can't get size of type");
+        return error;
+      }
+      if (*bit_width <= 64) {
         DataExtractor data;
         Status data_error;
         size_t num_bytes = new_value_sp->GetData(data, data_error);
@@ -575,7 +580,8 @@ private:
   ReturnValueExtractor(Thread &thread, CompilerType &type,
                        RegisterContext *reg_ctx, ProcessSP process_sp)
       : m_thread(thread), m_type(type),
-        m_byte_size(m_type.GetByteSize(nullptr)),
+        m_byte_size(m_type.GetByteSize(nullptr) ? *m_type.GetByteSize(nullptr)
+                                                : 0),
         m_data_ap(new DataBufferHeap(m_byte_size, 0)), m_reg_ctx(reg_ctx),
         m_process_sp(process_sp), m_byte_order(process_sp->GetByteOrder()),
         m_addr_size(
@@ -643,7 +649,7 @@ private:
     uint64_t raw_data;
     auto reg = GetFPR(reg_index);
     if (!reg.GetRawData(raw_data))
-      return ValueSP();
+      return {};
 
     // build value from data
     ValueSP value_sp(NewScalarValue(type));
@@ -651,8 +657,10 @@ private:
     DataExtractor de(&raw_data, sizeof(raw_data), m_byte_order, m_addr_size);
 
     offset_t offset = 0;
-    size_t byte_size = type.GetByteSize(nullptr);
-    switch (byte_size) {
+    auto byte_size = type.GetByteSize(nullptr);
+    if (!byte_size)
+      return {};
+    switch (*byte_size) {
     case sizeof(float):
       value_sp->GetScalar() = (float)de.GetDouble(&offset);
       break;
@@ -759,7 +767,7 @@ private:
       uint64_t addr;
       auto reg = GetGPR(0);
       if (!reg.GetRawData(addr))
-        return ValueObjectSP();
+        return {};
 
       Status error;
       size_t rc = m_process_sp->ReadMemory(addr, m_data_ap->GetBytes(),
@@ -776,34 +784,36 @@ private:
     uint32_t n = m_type.GetNumChildren(omit_empty_base_classes, nullptr);
     if (!n) {
       LLDB_LOG(m_log, LOG_PREFIX "No children found in struct");
-      return ValueObjectSP();
+      return {};
     }
 
     // case 2: homogeneous double or float aggregate
     CompilerType elem_type;
     if (m_type.IsHomogeneousAggregate(&elem_type)) {
       uint32_t type_flags = elem_type.GetTypeInfo();
-      uint64_t elem_size = elem_type.GetByteSize(nullptr);
+      auto elem_size = elem_type.GetByteSize(nullptr);
+      if (!elem_size)
+        return {};
       if (type_flags & eTypeIsComplex || !(type_flags & eTypeIsFloat)) {
         LLDB_LOG(m_log,
                  LOG_PREFIX "Unexpected type found in homogeneous aggregate");
-        return ValueObjectSP();
+        return {};
       }
 
       for (uint32_t i = 0; i < n; i++) {
         ValueSP val_sp = GetFloatValue(elem_type, i);
         if (!val_sp)
-          return ValueObjectSP();
+          return {};
 
         // copy to buffer
         Status error;
         size_t rc = val_sp->GetScalar().GetAsMemoryData(
-            m_data_ap->GetBytes() + m_dst_offs, elem_size, m_byte_order, error);
-        if (rc != elem_size) {
+            m_data_ap->GetBytes() + m_dst_offs, *elem_size, m_byte_order, error);
+        if (rc != *elem_size) {
           LLDB_LOG(m_log, LOG_PREFIX "Failed to get float data");
-          return ValueObjectSP();
+          return {};
         }
-        m_dst_offs += elem_size;
+        m_dst_offs += *elem_size;
       }
       return BuildValueObject();
     }

--- a/source/Plugins/ABI/SysV-s390x/ABISysV_s390x.cpp
+++ b/source/Plugins/ABI/SysV-s390x/ABISysV_s390x.cpp
@@ -380,18 +380,19 @@ bool ABISysV_s390x::GetArgumentValues(Thread &thread, ValueList &values) const {
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    if (!compiler_type)
+    auto bit_size = compiler_type.GetBitSize(&thread);
+    if (!bit_size)
       return false;
     bool is_signed;
 
     if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          is_signed, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
+      ReadIntegerArgument(value->GetScalar(), *bit_size, is_signed, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
     } else if (compiler_type.IsPointerType()) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          false, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
+      ReadIntegerArgument(value->GetScalar(), *bit_size, false, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
     }
   }
 
@@ -449,8 +450,12 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       error.SetErrorString(
           "We don't support returning complex values at present");
     else {
-      size_t bit_width = compiler_type.GetBitSize(frame_sp.get());
-      if (bit_width <= 64) {
+      auto bit_width = compiler_type.GetBitSize(frame_sp.get());
+      if (!bit_width) {
+        error.SetErrorString("can't get type size");
+        return error;
+      }
+      if (*bit_width <= 64) {
         const RegisterInfo *f0_info = reg_ctx->GetRegisterInfoByName("f0", 0);
         RegisterValue f0_value;
         DataExtractor data;
@@ -512,11 +517,13 @@ ValueObjectSP ABISysV_s390x::GetReturnValueObjectSimple(
     if (type_flags & eTypeIsInteger) {
       // Extract the register context so we can read arguments from registers
 
-      const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+      auto byte_size = return_compiler_type.GetByteSize(nullptr);
+      if (!byte_size)
+        return return_valobj_sp;
       uint64_t raw_value = thread.GetRegisterContext()->ReadRegisterAsUnsigned(
           reg_ctx->GetRegisterInfoByName("r2", 0), 0);
       const bool is_signed = (type_flags & eTypeIsSigned) != 0;
-      switch (byte_size) {
+      switch (*byte_size) {
       default:
         break;
 
@@ -556,21 +563,21 @@ ValueObjectSP ABISysV_s390x::GetReturnValueObjectSimple(
       if (type_flags & eTypeIsComplex) {
         // Don't handle complex yet.
       } else {
-        const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
-        if (byte_size <= sizeof(long double)) {
+        auto byte_size = return_compiler_type.GetByteSize(nullptr);
+        if (byte_size && *byte_size <= sizeof(long double)) {
           const RegisterInfo *f0_info = reg_ctx->GetRegisterInfoByName("f0", 0);
           RegisterValue f0_value;
           if (reg_ctx->ReadRegister(f0_info, f0_value)) {
             DataExtractor data;
             if (f0_value.GetData(data)) {
               lldb::offset_t offset = 0;
-              if (byte_size == sizeof(float)) {
+              if (*byte_size == sizeof(float)) {
                 value.GetScalar() = (float)data.GetFloat(&offset);
                 success = true;
-              } else if (byte_size == sizeof(double)) {
+              } else if (*byte_size == sizeof(double)) {
                 value.GetScalar() = (double)data.GetDouble(&offset);
                 success = true;
-              } else if (byte_size == sizeof(long double)) {
+              } else if (*byte_size == sizeof(long double)) {
                 // Don't handle long double yet.
               }
             }

--- a/source/Plugins/ABI/SysV-x86_64/ABISysV_x86_64.cpp
+++ b/source/Plugins/ABI/SysV-x86_64/ABISysV_x86_64.cpp
@@ -1267,18 +1267,19 @@ bool ABISysV_x86_64::GetArgumentValues(Thread &thread,
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    if (!compiler_type)
+    auto bit_size = compiler_type.GetBitSize(&thread);
+    if (!bit_size)
       return false;
     bool is_signed;
 
     if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          is_signed, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
+      ReadIntegerArgument(value->GetScalar(), *bit_size, is_signed, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
     } else if (compiler_type.IsPointerType()) {
-      ReadIntegerArgument(value->GetScalar(), compiler_type.GetBitSize(&thread),
-                          false, thread, argument_register_ids,
-                          current_argument_register, current_stack_argument);
+      ReadIntegerArgument(value->GetScalar(), *bit_size, false, thread,
+                          argument_register_ids, current_argument_register,
+                          current_stack_argument);
     }
   }
 
@@ -1336,8 +1337,12 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       error.SetErrorString(
           "We don't support returning complex values at present");
     else {
-      size_t bit_width = compiler_type.GetBitSize(frame_sp.get());
-      if (bit_width <= 64) {
+      auto bit_width = compiler_type.GetBitSize(frame_sp.get());
+      if (!bit_width) {
+        error.SetErrorString("can't get type size");
+        return error;
+      }
+      if (*bit_width <= 64) {
         const RegisterInfo *xmm0_info =
             reg_ctx->GetRegisterInfoByName("xmm0", 0);
         RegisterValue xmm0_value;
@@ -1400,11 +1405,13 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
     if (type_flags & eTypeIsInteger) {
       // Extract the register context so we can read arguments from registers
 
-      const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
+      auto byte_size = return_compiler_type.GetByteSize(nullptr);
+      if (!byte_size)
+        return return_valobj_sp;
       uint64_t raw_value = thread.GetRegisterContext()->ReadRegisterAsUnsigned(
           reg_ctx->GetRegisterInfoByName("rax", 0), 0);
       const bool is_signed = (type_flags & eTypeIsSigned) != 0;
-      switch (byte_size) {
+      switch (*byte_size) {
       default:
         break;
 
@@ -1444,8 +1451,8 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
       if (type_flags & eTypeIsComplex) {
         // Don't handle complex yet.
       } else {
-        const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
-        if (byte_size <= sizeof(long double)) {
+        auto byte_size = return_compiler_type.GetByteSize(nullptr);
+        if (byte_size && *byte_size <= sizeof(long double)) {
           const RegisterInfo *xmm0_info =
               reg_ctx->GetRegisterInfoByName("xmm0", 0);
           RegisterValue xmm0_value;
@@ -1453,13 +1460,13 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
             DataExtractor data;
             if (xmm0_value.GetData(data)) {
               lldb::offset_t offset = 0;
-              if (byte_size == sizeof(float)) {
+              if (*byte_size == sizeof(float)) {
                 value.GetScalar() = (float)data.GetFloat(&offset);
                 success = true;
-              } else if (byte_size == sizeof(double)) {
+              } else if (*byte_size == sizeof(double)) {
                 value.GetScalar() = (double)data.GetDouble(&offset);
                 success = true;
-              } else if (byte_size == sizeof(long double)) {
+              } else if (*byte_size == sizeof(long double)) {
                 // Don't handle long double since that can be encoded as 80 bit
                 // floats...
               }
@@ -1483,19 +1490,19 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
     return_valobj_sp = ValueObjectConstResult::Create(
         thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
   } else if (type_flags & eTypeIsVector) {
-    const size_t byte_size = return_compiler_type.GetByteSize(nullptr);
-    if (byte_size > 0) {
+    auto byte_size = return_compiler_type.GetByteSize(nullptr);
+    if (byte_size && *byte_size > 0) {
       const RegisterInfo *altivec_reg =
           reg_ctx->GetRegisterInfoByName("xmm0", 0);
       if (altivec_reg == nullptr)
         altivec_reg = reg_ctx->GetRegisterInfoByName("mm0", 0);
 
       if (altivec_reg) {
-        if (byte_size <= altivec_reg->byte_size) {
+        if (*byte_size <= altivec_reg->byte_size) {
           ProcessSP process_sp(thread.GetProcess());
           if (process_sp) {
             std::unique_ptr<DataBufferHeap> heap_data_ap(
-                new DataBufferHeap(byte_size, 0));
+                new DataBufferHeap(*byte_size, 0));
             const ByteOrder byte_order = process_sp->GetByteOrder();
             RegisterValue reg_value;
             if (reg_ctx->ReadRegister(altivec_reg, reg_value)) {
@@ -1512,14 +1519,14 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
               }
             }
           }
-        } else if (byte_size <= altivec_reg->byte_size * 2) {
+        } else if (*byte_size <= altivec_reg->byte_size * 2) {
           const RegisterInfo *altivec_reg2 =
               reg_ctx->GetRegisterInfoByName("xmm1", 0);
           if (altivec_reg2) {
             ProcessSP process_sp(thread.GetProcess());
             if (process_sp) {
               std::unique_ptr<DataBufferHeap> heap_data_ap(
-                  new DataBufferHeap(byte_size, 0));
+                  new DataBufferHeap(*byte_size, 0));
               const ByteOrder byte_order = process_sp->GetByteOrder();
               RegisterValue reg_value;
               RegisterValue reg_value2;
@@ -1806,7 +1813,9 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
   if (!reg_ctx_sp)
     return return_valobj_sp;
 
-  const size_t bit_width = return_compiler_type.GetBitSize(&thread);
+  auto bit_width = return_compiler_type.GetBitSize(&thread);
+  if (!bit_width)
+    return return_valobj_sp;
   if (return_compiler_type.IsAggregateType()) {
     Target *target = exe_ctx.GetTargetPtr();
     bool is_memory = true;
@@ -1815,7 +1824,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
     uint32_t max_register_value_bit_width = 128;
     if (is_swift_type)
       max_register_value_bit_width += 128;
-    if (bit_width <= max_register_value_bit_width) {
+    if (*bit_width <= max_register_value_bit_width) {
       const ArchSpec &arch = target->GetArchitecture();
       ByteOrder byte_order = arch.GetByteOrder();
       DataBufferSP data_sp(
@@ -1890,7 +1899,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
 
         CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
             idx, name, &field_bit_offset, nullptr, nullptr);
-        const size_t field_bit_width = field_compiler_type.GetBitSize(&thread);
+        auto field_bit_width = field_compiler_type.GetBitSize(&thread);
 
         bool child_is_base_class = false;
         int32_t child_byte_offset = 0;
@@ -1915,16 +1924,16 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
 
         // if we don't know the size of the field (e.g. invalid type), just
         // bail out
-        if (field_bit_width == 0)
+        if (!field_bit_width || *field_bit_width == 0)
           break;
 
         // If there are any unaligned fields, this is stored in memory.
-        if (field_bit_offset % field_bit_width != 0) {
+        if (field_bit_offset % *field_bit_width != 0) {
           is_memory = true;
           break;
         }
 
-        uint32_t field_byte_width = field_bit_width / 8;
+        uint32_t field_byte_width = *field_bit_width / 8;
         uint32_t field_byte_offset = field_bit_offset / 8;
 
         DataExtractor *copy_from_extractor = nullptr;
@@ -1998,10 +2007,10 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
           }
         } else if (field_compiler_type.IsFloatingPointType(count, is_complex)) {
           // Structs with long doubles are always passed in memory.
-          if (field_bit_width == 128) {
+          if (*field_bit_width == 128) {
             is_memory = true;
             break;
-          } else if (field_bit_width == 64) {
+          } else if (*field_bit_width == 64) {
             // These have to be in a single xmm register.
             if (fp_bytes == 0)
               copy_from_extractor = &xmm0_data;
@@ -2010,7 +2019,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
 
             copy_from_offset = 0;
             fp_bytes += field_byte_width;
-          } else if (field_bit_width == 32) {
+          } else if (*field_bit_width == 32) {
             // This one is kind of complicated.  If we are in an "eightbyte"
             // with another float, we'll be stuffed into an xmm register with
             // it.  If we are in an "eightbyte" with one or more ints, then we

--- a/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -310,12 +310,14 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
 
   lldb::TargetSP target_sp(m_execution_unit.GetTarget());
   lldb_private::ExecutionContext exe_ctx(target_sp, true);
-  if (m_result_type.GetBitSize(exe_ctx.GetBestExecutionContextScope()) == 0) {
+  auto bit_size =
+      m_result_type.GetBitSize(exe_ctx.GetBestExecutionContextScope());
+  if (!bit_size) {
     lldb_private::StreamString type_desc_stream;
     m_result_type.DumpTypeDescription(&type_desc_stream);
 
     if (log)
-      log->Printf("Result type has size 0");
+      log->Printf("Result type has unknown size");
 
     m_error_stream.Printf("Error [IRForTarget]: Size of result type '%s' "
                           "couldn't be determined\n",
@@ -334,7 +336,10 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
 
   if (log)
     log->Printf("Creating a new result global: \"%s\" with size 0x%" PRIx64,
-                m_result_name.GetCString(), m_result_type.GetByteSize(nullptr));
+                m_result_name.GetCString(),
+                m_result_type.GetByteSize(nullptr)
+                    ? *m_result_type.GetByteSize(nullptr)
+                    : 0);
 
   // Construct a new result global and set up its metadata
 
@@ -1376,7 +1381,9 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
       value_type = global_variable->getType();
     }
 
-    const uint64_t value_size = compiler_type.GetByteSize(nullptr);
+    auto value_size = compiler_type.GetByteSize(nullptr);
+    if (!value_size)
+      return false;
     lldb::offset_t value_alignment =
         (compiler_type.GetTypeBitAlign() + 7ull) / 8ull;
 
@@ -1387,13 +1394,13 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
                   lldb_private::ClangUtil::GetQualType(compiler_type)
                       .getAsString()
                       .c_str(),
-                  PrintType(value_type).c_str(), value_size, value_alignment);
+                  PrintType(value_type).c_str(), *value_size, value_alignment);
     }
 
     if (named_decl &&
         !m_decl_map->AddValueToStruct(
             named_decl, lldb_private::ConstString(name.c_str()), llvm_value_ptr,
-            value_size, value_alignment)) {
+            *value_size, value_alignment)) {
       if (!global_variable->hasExternalLinkage())
         return true;
       else

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1168,8 +1168,9 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
     // this check scattered in several places in the codebase, we should at
     // some point centralize it.
     lldb::StackFrameSP stack_frame_sp = stack_frame_wp.lock();
-    if (repl && SwiftASTContext::IsPossibleZeroSizeType(variable.GetType(),
-                                                        stack_frame_sp.get())) {
+    llvm::Optional<uint64_t> size =
+        variable.GetType().GetByteSize(stack_frame_sp.get());
+    if (repl && size && *size == 0) {
       auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
       offset = repl_mat.AddREPLResultVariable(
           variable.GetType(), variable.GetDecl(),

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -189,8 +189,9 @@ public:
       demangle_ctx.clear();
     }
 
-    if (SwiftASTContext::IsPossibleZeroSizeType(m_type,
-            execution_unit->GetBestExecutionContextScope())) {
+    llvm::Optional<uint64_t> size =
+        m_type.GetByteSize(execution_unit->GetBestExecutionContextScope());
+    if (size && *size == 0) {
       MakeREPLResult(*execution_unit, err, nullptr);
       return;
     }

--- a/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -100,8 +100,11 @@ bool lldb_private::formatters::WCharStringSummaryProvider(
   if (!wchar_compiler_type)
     return false;
 
-  const uint32_t wchar_size = wchar_compiler_type.GetBitSize(
-      nullptr); // Safe to pass NULL for exe_scope here
+  // Safe to pass nullptr for exe_scope here.
+  auto size = wchar_compiler_type.GetBitSize(nullptr);
+  if (!size)
+    return false;
+  const uint32_t wchar_size = *size;
 
   StringPrinter::ReadStringAndDumpToStreamOptions options(valobj);
   options.SetLocation(valobj_addr);
@@ -194,8 +197,11 @@ bool lldb_private::formatters::WCharSummaryProvider(
   if (!wchar_compiler_type)
     return false;
 
-  const uint32_t wchar_size = wchar_compiler_type.GetBitSize(
-      nullptr); // Safe to pass NULL for exe_scope here
+    // Safe to pass nullptr for exe_scope here.
+  auto size = wchar_compiler_type.GetBitSize(nullptr);
+  if (!size)
+    return false;
+  const uint32_t wchar_size = *size;
 
   StringPrinter::ReadBufferAndDumpToStreamOptions options(valobj);
   options.SetData(data);

--- a/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -229,9 +229,14 @@ bool lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::Update() {
         m_pair_ptr = nullptr;
         return false;
       }
-      CompilerType pair_type(__i_->GetCompilerType().GetTypeTemplateArgument(0));
-      std::string name; uint64_t bit_offset_ptr; uint32_t bitfield_bit_size_ptr; bool is_bitfield_ptr;
-      pair_type = pair_type.GetFieldAtIndex(0, name, &bit_offset_ptr, &bitfield_bit_size_ptr, &is_bitfield_ptr);
+      CompilerType pair_type(
+          __i_->GetCompilerType().GetTypeTemplateArgument(0));
+      std::string name;
+      uint64_t bit_offset_ptr;
+      uint32_t bitfield_bit_size_ptr;
+      bool is_bitfield_ptr;
+      pair_type = pair_type.GetFieldAtIndex(
+          0, name, &bit_offset_ptr, &bitfield_bit_size_ptr, &is_bitfield_ptr);
       if (!pair_type) {
         m_pair_ptr = nullptr;
         return false;
@@ -239,27 +244,38 @@ bool lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::Update() {
 
       auto addr(m_pair_ptr->GetValueAsUnsigned(LLDB_INVALID_ADDRESS));
       m_pair_ptr = nullptr;
-      if (addr && addr!=LLDB_INVALID_ADDRESS) {
-        ClangASTContext *ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(pair_type.GetTypeSystem());
+      if (addr && addr != LLDB_INVALID_ADDRESS) {
+        ClangASTContext *ast_ctx =
+            llvm::dyn_cast_or_null<ClangASTContext>(pair_type.GetTypeSystem());
         if (!ast_ctx)
           return false;
-        CompilerType tree_node_type = ast_ctx->CreateStructForIdentifier(ConstString(), {
-          {"ptr0",ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType()},
-          {"ptr1",ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType()},
-          {"ptr2",ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType()},
-          {"cw",ast_ctx->GetBasicType(lldb::eBasicTypeBool)},
-          {"payload",pair_type}
-        });
-        DataBufferSP buffer_sp(new DataBufferHeap(tree_node_type.GetByteSize(nullptr),0));
+        CompilerType tree_node_type = ast_ctx->CreateStructForIdentifier(
+            ConstString(),
+            {{"ptr0",
+              ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType()},
+             {"ptr1",
+              ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType()},
+             {"ptr2",
+              ast_ctx->GetBasicType(lldb::eBasicTypeVoid).GetPointerType()},
+             {"cw", ast_ctx->GetBasicType(lldb::eBasicTypeBool)},
+             {"payload", pair_type}});
+        auto size = tree_node_type.GetByteSize(nullptr);
+        if (!size)
+          return false;
+        DataBufferSP buffer_sp(new DataBufferHeap(*size, 0));
         ProcessSP process_sp(target_sp->GetProcessSP());
         Status error;
-        process_sp->ReadMemory(addr, buffer_sp->GetBytes(), buffer_sp->GetByteSize(), error);
+        process_sp->ReadMemory(addr, buffer_sp->GetBytes(),
+                               buffer_sp->GetByteSize(), error);
         if (error.Fail())
           return false;
-        DataExtractor extractor(buffer_sp, process_sp->GetByteOrder(), process_sp->GetAddressByteSize());
-        auto pair_sp = CreateValueObjectFromData("pair", extractor, valobj_sp->GetExecutionContextRef(), tree_node_type);
+        DataExtractor extractor(buffer_sp, process_sp->GetByteOrder(),
+                                process_sp->GetAddressByteSize());
+        auto pair_sp = CreateValueObjectFromData(
+            "pair", extractor, valobj_sp->GetExecutionContextRef(),
+            tree_node_type);
         if (pair_sp)
-          m_pair_sp = pair_sp->GetChildAtIndex(4,true);
+          m_pair_sp = pair_sp->GetChildAtIndex(4, true);
       }
     }
   }
@@ -564,6 +580,8 @@ bool lldb_private::formatters::LibcxxWStringSummaryProvider(
                           ->GetScratchClangASTContext()
                           ->GetBasicType(lldb::eBasicTypeWChar)
                           .GetByteSize(nullptr);
+  if (!wchar_t_size)
+    return false;
 
   options.SetData(extractor);
   options.SetStream(&stream);
@@ -572,7 +590,7 @@ bool lldb_private::formatters::LibcxxWStringSummaryProvider(
   options.SetSourceSize(size);
   options.SetBinaryZeroIsTerminator(false);
 
-  switch (wchar_t_size) {
+  switch (*wchar_t_size) {
   case 1:
     StringPrinter::ReadBufferAndDumpToStream<
         lldb_private::formatters::StringPrinter::StringElementType::UTF8>(

--- a/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -98,12 +98,11 @@ bool lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::
   if (!m_element_type.IsValid())
     return false;
 
-  m_element_size = m_element_type.GetByteSize(nullptr);
-
-  if (m_element_size > 0)
-    m_start =
-        m_backend.GetChildMemberWithName(g___begin_, true)
-            .get(); // store raw pointers or end up with a circular dependency
+  if (auto size = m_element_type.GetByteSize(nullptr)) {
+    m_element_size = *size;
+    // Store raw pointers or end up with a circular dependency.
+    m_start = m_backend.GetChildMemberWithName(g___begin_, true).get();
+  }
 
   return false;
 }

--- a/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -149,14 +149,16 @@ bool lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::Update() {
   if (!data_type_finder_sp)
     return false;
   m_element_type = data_type_finder_sp->GetCompilerType().GetPointeeType();
-  m_element_size = m_element_type.GetByteSize(nullptr);
+  if (auto size = m_element_type.GetByteSize(nullptr)) {
+    m_element_size = *size;
 
-  if (m_element_size > 0) {
-    // store raw pointers or end up with a circular dependency
-    m_start =
-        m_backend.GetChildMemberWithName(ConstString("__begin_"), true).get();
-    m_finish =
-        m_backend.GetChildMemberWithName(ConstString("__end_"), true).get();
+    if (m_element_size > 0) {
+      // store raw pointers or end up with a circular dependency
+      m_start =
+          m_backend.GetChildMemberWithName(ConstString("__begin_"), true).get();
+      m_finish =
+          m_backend.GetChildMemberWithName(ConstString("__end_"), true).get();
+    }
   }
   return false;
 }
@@ -196,27 +198,29 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::GetChildAtIndex(
   if (iter != end)
     return iter->second;
   if (idx >= m_count)
-    return ValueObjectSP();
+    return {};
   if (m_base_data_address == 0 || m_count == 0)
-    return ValueObjectSP();
+    return {};
   if (!m_bool_type)
-    return ValueObjectSP();
+    return {};
   size_t byte_idx = (idx >> 3); // divide by 8 to get byte index
   size_t bit_index = (idx & 7); // efficient idx % 8 for bit index
   lldb::addr_t byte_location = m_base_data_address + byte_idx;
   ProcessSP process_sp(m_exe_ctx_ref.GetProcessSP());
   if (!process_sp)
-    return ValueObjectSP();
+    return {};
   uint8_t byte = 0;
   uint8_t mask = 0;
   Status err;
   size_t bytes_read = process_sp->ReadMemory(byte_location, &byte, 1, err);
   if (err.Fail() || bytes_read == 0)
-    return ValueObjectSP();
+    return {};
   mask = 1 << bit_index;
   bool bit_set = ((byte & mask) != 0);
-  DataBufferSP buffer_sp(
-      new DataBufferHeap(m_bool_type.GetByteSize(nullptr), 0));
+  auto size = m_bool_type.GetByteSize(nullptr);
+  if (!size)
+    return {};
+  DataBufferSP buffer_sp(new DataBufferHeap(*size, 0));
   if (bit_set && buffer_sp && buffer_sp->GetBytes()) {
     // regardless of endianness, anything non-zero is true
     *(buffer_sp->GetBytes()) = 1;

--- a/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -301,8 +301,11 @@ bool lldb_private::formatters::LibStdcppWStringSummaryProvider(
       if (!wchar_compiler_type)
         return false;
 
-      const uint32_t wchar_size = wchar_compiler_type.GetBitSize(
-          nullptr); // Safe to pass NULL for exe_scope here
+      // Safe to pass nullptr for exe_scope here.
+      auto size = wchar_compiler_type.GetBitSize(nullptr);
+      if (!size)
+        return false;
+      const uint32_t wchar_size = *size;
 
       StringPrinter::ReadStringAndDumpToStreamOptions options(valobj);
       Status error;

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -68,7 +68,7 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
     : m_metadata_ptr(LLDB_INVALID_ADDRESS),
       m_reserved_word(LLDB_INVALID_ADDRESS), m_size(0), m_capacity(0),
       m_first_elem_ptr(LLDB_INVALID_ADDRESS), m_elem_type(elem_type),
-      m_element_size(elem_type.GetByteSize(nullptr)),
+      m_element_size(elem_type.GetByteSize(nullptr).getValueOr(0)),
       m_element_stride(elem_type.GetByteStride()),
       m_exe_ctx_ref(valobj.GetExecutionContextRef()) {
   if (native_ptr == LLDB_INVALID_ADDRESS)
@@ -192,7 +192,7 @@ SwiftArraySliceBufferHandler::GetElementAtIndex(size_t idx) {
 SwiftArraySliceBufferHandler::SwiftArraySliceBufferHandler(
     ValueObject &valobj, CompilerType elem_type)
     : m_size(0), m_first_elem_ptr(LLDB_INVALID_ADDRESS), m_elem_type(elem_type),
-      m_element_size(elem_type.GetByteSize(nullptr)),
+      m_element_size(elem_type.GetByteSize(nullptr).getValueOr(0)),
       m_element_stride(elem_type.GetByteStride()),
       m_exe_ctx_ref(valobj.GetExecutionContextRef()), m_native_buffer(false),
       m_start_index(0) {

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -521,10 +521,11 @@ void ClassDescriptorV2::iVarsStorage::fill(AppleObjCRuntimeV2 &runtime,
     CompilerType ivar_type =
         encoding_to_type_sp->RealizeType(type, for_expression);
     if (ivar_type) {
+      auto ivar_size = ivar_type.GetByteSize(nullptr);
       LLDB_LOGV(log,
                 "name = {0}, encoding = {1}, offset_ptr = {2:x}, size = "
                 "{3}, type_size = {4}",
-                name, type, offset_ptr, size, ivar_type.GetByteSize(nullptr));
+                name, type, offset_ptr, size, ivar_size ? *ivar_size : 0);
       Scalar offset_scalar;
       Status error;
       const int offset_ptr_size = 4;

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1865,12 +1865,13 @@ TypeSP DWARFASTParserClang::ParseTypeFromDWARF(const SymbolContext &sc,
           clang_type = ClangASTContext::CreateMemberPointerType(
               class_clang_type, pointee_clang_type);
 
-          byte_size = clang_type.GetByteSize(nullptr);
-
-          type_sp.reset(new Type(die.GetID(), dwarf, type_name_const_str,
-                                 byte_size, NULL, LLDB_INVALID_UID,
-                                 Type::eEncodingIsUID, NULL, clang_type,
-                                 Type::eResolveStateForward));
+          if (auto clang_type_size = clang_type.GetByteSize(nullptr)) {
+            byte_size = *clang_type_size;
+            type_sp.reset(new Type(die.GetID(), dwarf, type_name_const_str,
+                                   byte_size, NULL, LLDB_INVALID_UID,
+                                   Type::eEncodingIsUID, NULL, clang_type,
+                                   Type::eResolveStateForward));
+          }
         }
 
         break;
@@ -2060,7 +2061,10 @@ bool DWARFASTParserClang::ParseTemplateDIE(
         clang_type.IsIntegerOrEnumerationType(is_signed);
 
         if (tag == DW_TAG_template_value_parameter && uval64_valid) {
-          llvm::APInt apint(clang_type.GetBitSize(nullptr), uval64, is_signed);
+          auto size = clang_type.GetBitSize(nullptr);
+          if (!size)
+            return false;
+          llvm::APInt apint(*size, uval64, is_signed);
           template_param_infos.args.push_back(
               clang::TemplateArgument(*ast, llvm::APSInt(apint, !is_signed),
                                       ClangUtil::GetQualType(clang_type)));

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -218,7 +218,8 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   if (compiler_type) {
     type_sp = TypeSP(new Type(
         die.GetID(), die.GetDWARF(), compiler_type.GetTypeName(),
-        is_clang_type ? dwarf_byte_size : compiler_type.GetByteSize(nullptr),
+        is_clang_type ? dwarf_byte_size
+                      : compiler_type.GetByteSize(nullptr).getValueOr(0),
         NULL, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl, compiler_type,
         is_clang_type ? Type::eResolveStateForward : Type::eResolveStateFull));
     // FIXME: This ought to work lazily, too.

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -962,9 +962,10 @@ CompilerType ClangASTContext::GetBasicType(ASTContext *ast,
 
 uint32_t ClangASTContext::GetPointerByteSize() {
   if (m_pointer_byte_size == 0)
-    m_pointer_byte_size = GetBasicType(lldb::eBasicTypeVoid)
-                              .GetPointerType()
-                              .GetByteSize(nullptr);
+    if (auto size = GetBasicType(lldb::eBasicTypeVoid)
+                        .GetPointerType()
+                        .GetByteSize(nullptr))
+      m_pointer_byte_size = *size;
   return m_pointer_byte_size;
 }
 
@@ -4345,7 +4346,8 @@ ClangASTContext::GetArrayElementType(lldb::opaque_compiler_type_t type,
 
     // TODO: the real stride will be >= this value.. find the real one!
     if (stride)
-      *stride = element_type.GetByteSize(nullptr);
+      if (auto size = element_type.GetByteSize(nullptr))
+        *stride = *size;
 
     return element_type;
   }
@@ -6620,9 +6622,11 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
             CompilerType base_class_clang_type(getASTContext(),
                                                base_class->getType());
             child_name = base_class_clang_type.GetTypeName().AsCString("");
-            uint64_t base_class_clang_type_bit_size =
-                base_class_clang_type.GetBitSize(
-                    exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
+            auto size = base_class_clang_type.GetBitSize(
+                exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
+            if (!size)
+              return {};
+            uint64_t base_class_clang_type_bit_size = *size;
 
             // Base classes bit sizes should be a multiple of 8 bits in size
             assert(base_class_clang_type_bit_size % 8 == 0);
@@ -6650,8 +6654,11 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
           // alignment (field_type_info.second) from the AST context.
           CompilerType field_clang_type(getASTContext(), field->getType());
           assert(field_idx < record_layout.getFieldCount());
-          child_byte_size = field_clang_type.GetByteSize(
+          auto size = field_clang_type.GetByteSize(
               exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
+          if (!size)
+            return {};
+          child_byte_size = *size;
           const uint32_t child_bit_size = child_byte_size * 8;
 
           // Figure out the field offset within the current struct/union/class
@@ -6822,10 +6829,12 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
 
         // We have a pointer to an simple type
         if (idx == 0 && pointee_clang_type.GetCompleteType()) {
-          child_byte_size = pointee_clang_type.GetByteSize(
-              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
-          child_byte_offset = 0;
-          return pointee_clang_type;
+          if (auto size = pointee_clang_type.GetByteSize(
+                  exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL)) {
+            child_byte_size = *size;
+            child_byte_offset = 0;
+            return pointee_clang_type;
+          }
         }
       }
     }
@@ -6843,10 +6852,12 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
           ::snprintf(element_name, sizeof(element_name), "[%" PRIu64 "]",
                      static_cast<uint64_t>(idx));
           child_name.assign(element_name);
-          child_byte_size = element_type.GetByteSize(
-              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
-          child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
-          return element_type;
+          if (auto size = element_type.GetByteSize(
+                  exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL)) {
+            child_byte_size = *size;
+            child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
+            return element_type;
+          }
         }
       }
     }
@@ -6860,10 +6871,12 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
         CompilerType element_type(getASTContext(), array->getElementType());
         if (element_type.GetCompleteType()) {
           child_name = llvm::formatv("[{0}]", idx);
-          child_byte_size = element_type.GetByteSize(
-              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
-          child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
-          return element_type;
+          if (auto size = element_type.GetByteSize(
+                  exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL)) {
+            child_byte_size = *size;
+            child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
+            return element_type;
+          }
         }
       }
     }
@@ -6897,10 +6910,12 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
 
       // We have a pointer to an simple type
       if (idx == 0) {
-        child_byte_size = pointee_clang_type.GetByteSize(
-            exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
-        child_byte_offset = 0;
-        return pointee_clang_type;
+        if (auto size = pointee_clang_type.GetByteSize(
+                exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL)) {
+          child_byte_size = *size;
+          child_byte_offset = 0;
+          return pointee_clang_type;
+        }
       }
     }
     break;
@@ -6932,10 +6947,12 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
 
         // We have a pointer to an simple type
         if (idx == 0) {
-          child_byte_size = pointee_clang_type.GetByteSize(
-              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
-          child_byte_offset = 0;
-          return pointee_clang_type;
+          if (auto size = pointee_clang_type.GetByteSize(
+                  exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL)) {
+            child_byte_size = *size;
+            child_byte_offset = 0;
+            return pointee_clang_type;
+          }
         }
       }
     }

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -551,15 +551,18 @@ CompilerType::GetBasicTypeFromAST(lldb::BasicType basic_type) const {
 // Exploring the type
 //----------------------------------------------------------------------
 
-uint64_t CompilerType::GetBitSize(ExecutionContextScope *exe_scope) const {
-  if (IsValid()) {
+llvm::Optional<uint64_t>
+CompilerType::GetBitSize(ExecutionContextScope *exe_scope) const {
+  if (IsValid())
     return m_type_system->GetBitSize(m_type, exe_scope);
-  }
-  return 0;
+  return {};
 }
 
-uint64_t CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
-  return (GetBitSize(exe_scope) + 7) / 8;
+llvm::Optional<uint64_t>
+CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
+  if (auto bit_size = GetBitSize(exe_scope))
+    return (*bit_size + 7) / 8;
+  return {};
 }
 
 uint64_t CompilerType::GetByteStride() const {
@@ -885,7 +888,9 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
     if (encoding == lldb::eEncodingInvalid || count != 1)
       return false;
 
-    const uint64_t byte_size = GetByteSize(nullptr);
+    auto byte_size = GetByteSize(nullptr);
+    if (!byte_size)
+      return false;
     lldb::offset_t offset = data_byte_offset;
     switch (encoding) {
     case lldb::eEncodingInvalid:
@@ -893,15 +898,15 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
     case lldb::eEncodingVector:
       break;
     case lldb::eEncodingUint:
-      if (byte_size <= sizeof(unsigned long long)) {
-        uint64_t uval64 = data.GetMaxU64(&offset, byte_size);
-        if (byte_size <= sizeof(unsigned int)) {
+      if (*byte_size <= sizeof(unsigned long long)) {
+        uint64_t uval64 = data.GetMaxU64(&offset, *byte_size);
+        if (*byte_size <= sizeof(unsigned int)) {
           value = (unsigned int)uval64;
           return true;
-        } else if (byte_size <= sizeof(unsigned long)) {
+        } else if (*byte_size <= sizeof(unsigned long)) {
           value = (unsigned long)uval64;
           return true;
-        } else if (byte_size <= sizeof(unsigned long long)) {
+        } else if (*byte_size <= sizeof(unsigned long long)) {
           value = (unsigned long long)uval64;
           return true;
         } else
@@ -910,15 +915,15 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
       break;
 
     case lldb::eEncodingSint:
-      if (byte_size <= sizeof(long long)) {
-        int64_t sval64 = data.GetMaxS64(&offset, byte_size);
-        if (byte_size <= sizeof(int)) {
+      if (*byte_size <= sizeof(long long)) {
+        int64_t sval64 = data.GetMaxS64(&offset, *byte_size);
+        if (*byte_size <= sizeof(int)) {
           value = (int)sval64;
           return true;
-        } else if (byte_size <= sizeof(long)) {
+        } else if (*byte_size <= sizeof(long)) {
           value = (long)sval64;
           return true;
-        } else if (byte_size <= sizeof(long long)) {
+        } else if (*byte_size <= sizeof(long long)) {
           value = (long long)sval64;
           return true;
         } else
@@ -927,10 +932,10 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
       break;
 
     case lldb::eEncodingIEEE754:
-      if (byte_size <= sizeof(long double)) {
+      if (*byte_size <= sizeof(long double)) {
         uint32_t u32;
         uint64_t u64;
-        if (byte_size == sizeof(float)) {
+        if (*byte_size == sizeof(float)) {
           if (sizeof(float) == sizeof(uint32_t)) {
             u32 = data.GetU32(&offset);
             value = *((float *)&u32);
@@ -940,7 +945,7 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
             value = *((float *)&u64);
             return true;
           }
-        } else if (byte_size == sizeof(double)) {
+        } else if (*byte_size == sizeof(double)) {
           if (sizeof(double) == sizeof(uint32_t)) {
             u32 = data.GetU32(&offset);
             value = *((double *)&u32);
@@ -950,7 +955,7 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
             value = *((double *)&u64);
             return true;
           }
-        } else if (byte_size == sizeof(long double)) {
+        } else if (*byte_size == sizeof(long double)) {
           if (sizeof(long double) == sizeof(uint32_t)) {
             u32 = data.GetU32(&offset);
             value = *((long double *)&u32);
@@ -981,12 +986,15 @@ bool CompilerType::SetValueFromScalar(const Scalar &value, Stream &strm) {
     if (encoding == lldb::eEncodingInvalid || count != 1)
       return false;
 
-    const uint64_t bit_width = GetBitSize(nullptr);
-    // This function doesn't currently handle non-byte aligned assignments
-    if ((bit_width % 8) != 0)
+    auto bit_width = GetBitSize(nullptr);
+    if (!bit_width)
       return false;
 
-    const uint64_t byte_size = (bit_width + 7) / 8;
+    // This function doesn't currently handle non-byte aligned assignments
+    if ((*bit_width % 8) != 0)
+      return false;
+
+    const uint64_t byte_size = (*bit_width + 7) / 8;
     switch (encoding) {
     case lldb::eEncodingInvalid:
       break;
@@ -1063,20 +1071,23 @@ bool CompilerType::ReadFromMemory(lldb_private::ExecutionContext *exe_ctx,
   if (!GetCompleteType())
     return false;
 
-  const uint64_t byte_size =
+  auto byte_size =
       GetByteSize(exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
-  if (data.GetByteSize() < byte_size) {
-    lldb::DataBufferSP data_sp(new DataBufferHeap(byte_size, '\0'));
+  if (!byte_size)
+    return false;
+
+  if (data.GetByteSize() < *byte_size) {
+    lldb::DataBufferSP data_sp(new DataBufferHeap(*byte_size, '\0'));
     data.SetData(data_sp);
   }
 
-  uint8_t *dst = const_cast<uint8_t *>(data.PeekData(0, byte_size));
+  uint8_t *dst = const_cast<uint8_t *>(data.PeekData(0, *byte_size));
   if (dst != nullptr) {
     if (address_type == eAddressTypeHost) {
       if (addr == 0)
         return false;
       // The address is an address in this process, so just copy it
-      memcpy(dst, reinterpret_cast<uint8_t *>(addr), byte_size);
+      memcpy(dst, reinterpret_cast<uint8_t *>(addr), *byte_size);
       return true;
     } else {
       Process *process = nullptr;
@@ -1084,7 +1095,7 @@ bool CompilerType::ReadFromMemory(lldb_private::ExecutionContext *exe_ctx,
         process = exe_ctx->GetProcessPtr();
       if (process) {
         Status error;
-        return process->ReadMemory(addr, dst, byte_size, error) == byte_size;
+        return process->ReadMemory(addr, dst, *byte_size, error) == *byte_size;
       }
     }
   }
@@ -1105,13 +1116,15 @@ bool CompilerType::WriteToMemory(lldb_private::ExecutionContext *exe_ctx,
   if (!GetCompleteType())
     return false;
 
-  const uint64_t byte_size =
+  auto byte_size =
       GetByteSize(exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL);
+  if (!byte_size)
+    return false;
 
-  if (byte_size > 0) {
+  if (*byte_size > 0) {
     if (address_type == eAddressTypeHost) {
       // The address is an address in this process, so just copy it
-      memcpy((void *)addr, new_value.GetData(), byte_size);
+      memcpy((void *)addr, new_value.GetData(), *byte_size);
       return true;
     } else {
       Process *process = nullptr;
@@ -1119,8 +1132,8 @@ bool CompilerType::WriteToMemory(lldb_private::ExecutionContext *exe_ctx,
         process = exe_ctx->GetProcessPtr();
       if (process) {
         Status error;
-        return process->WriteMemory(addr, new_value.GetData(), byte_size,
-                                    error) == byte_size;
+        return process->WriteMemory(addr, new_value.GetData(), *byte_size,
+                                    error) == *byte_size;
       }
     }
   }

--- a/source/Symbol/Type.cpp
+++ b/source/Symbol/Type.cpp
@@ -325,7 +325,8 @@ uint64_t Type::GetByteSize() {
       if (encoding_type)
         m_byte_size = encoding_type->GetByteSize();
       if (m_byte_size == 0)
-        m_byte_size = GetLayoutCompilerType().GetByteSize(nullptr);
+        if (auto size = GetLayoutCompilerType().GetByteSize(nullptr))
+          m_byte_size = *size;
     } break;
 
     // If we are a pointer or reference, then this is just a pointer size;

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2269,11 +2269,13 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Struct(
     Address &address) {
   class_type_or_name.SetCompilerType(bound_type);
 
+  llvm::Optional<uint64_t> size = bound_type.GetByteSize(
+      in_value.GetExecutionContextRef().GetFrameSP().get());
+  if (!size)
+    return false;
   lldb::addr_t struct_address = in_value.GetAddressOf(true, nullptr);
-  if (!struct_address || struct_address == LLDB_INVALID_ADDRESS)
-    if (!SwiftASTContext::IsPossibleZeroSizeType(
-            bound_type, in_value.GetExecutionContextRef().GetFrameSP().get()))
-      return false;
+  if (*size && (!struct_address || struct_address == LLDB_INVALID_ADDRESS))
+    return false;
 
   address.SetLoadAddress(struct_address, in_value.GetTargetSP().get());
   return true;
@@ -2285,11 +2287,13 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Enum(
     Address &address) {
   class_type_or_name.SetCompilerType(bound_type);
 
+  llvm::Optional<uint64_t> size = bound_type.GetByteSize(
+      in_value.GetExecutionContextRef().GetFrameSP().get());
+  if (!size)
+    return false;
   lldb::addr_t enum_address = in_value.GetAddressOf(true, nullptr);
-  if (!enum_address || LLDB_INVALID_ADDRESS == enum_address)
-    if (!SwiftASTContext::IsPossibleZeroSizeType(
-            bound_type, in_value.GetExecutionContextRef().GetFrameSP().get()))
-      return false;
+  if (*size && (!enum_address || LLDB_INVALID_ADDRESS == enum_address))
+    return false;
 
   address.SetLoadAddress(enum_address, in_value.GetTargetSP().get());
   return true;
@@ -3765,7 +3769,8 @@ protected:
           CompilerType base_type(base_object_sp->GetCompilerType());
           ConstString base_type_name(base_type.GetTypeName());
           if (base_type_name.IsEmpty() ||
-              !SwiftLanguageRuntime::IsSwiftClassName(base_type_name.GetCString()))
+              !SwiftLanguageRuntime::IsSwiftClassName(
+                  base_type_name.GetCString()))
             return base_object_sp;
           base_object_sp = m_backend.GetSyntheticBase(
               0, base_type, true,
@@ -3880,12 +3885,14 @@ void SwiftLanguageRuntime::WillStartExecutingUserExpression() {
       return;
     }
     ConstString BoolName("bool");
-    size_t bool_size =
-      type_system->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
+    llvm::Optional<uint64_t> bool_size =
+        type_system->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
+    if (!bool_size)
+      return;
 
     Scalar original_value;
     m_process->ReadScalarIntegerFromMemory(*m_dynamic_exclusivity_flag_addr,
-                                           bool_size, false, original_value,
+                                           *bool_size, false, original_value,
                                            error);
 
     m_original_dynamic_exclusivity_flag_state = original_value.UInt() != 0;
@@ -3898,7 +3905,7 @@ void SwiftLanguageRuntime::WillStartExecutingUserExpression() {
     } else {
       Scalar new_value(1U);
       m_process->WriteScalarToMemory(*m_dynamic_exclusivity_flag_addr,
-                                     new_value, bool_size, error);
+                                     new_value, *bool_size, error);
       if (error.Fail()) {
         if (log)
           log->Printf("SwiftLanguageRuntime: Unable to set "
@@ -3944,12 +3951,14 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression() {
       return;
     }
     ConstString BoolName("bool");
-    size_t bool_size =
-      type_system->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
+    llvm::Optional<uint64_t> bool_size =
+        type_system->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
+    if (!bool_size)
+      return;
 
     Scalar original_value(m_original_dynamic_exclusivity_flag_state ? 1U : 0U);
     m_process->WriteScalarToMemory(*m_dynamic_exclusivity_flag_addr,
-                                   original_value, bool_size, error);
+                                   original_value, *bool_size, error);
     if (error.Fail()) {
       if (log)
         log->Printf("SwiftLanguageRuntime: Unable to reset "


### PR DESCRIPTION
TypeSystem::GetSizeinBits() now supports 0 as a non-error value, which
makes this function redundant.

<rdar://problem/47178964>