### PR TITLE
[SwiftLanguageRuntime] Fix another case of hardcoded pointer size.

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1937,6 +1937,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
       in_value.GetStaticValue()->GetChildAtIndex(0, true));
   if (!payload0_sp)
     return false;
+
+  auto ptr_size = m_process->GetAddressByteSize();
+
   // @objc protocols are automatically class-only, and there is no
   // static/dynamic to deal with
   bool is_class = protocol_info.m_is_objc || protocol_info.m_is_class_only ||
@@ -2007,7 +2010,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
       return true;
     case SwiftASTContext::TypeAllocationStrategy::ePointer:
       address.SetRawAddress(payload0_sp->GetValueAsUnsigned(0) +
-                            (sizeof(lldb::addr_t) * 2));
+                            (ptr_size * 2));
       return true;
     default:
       // TODO we don't know how to deal with the dynamic case quite yet


### PR DESCRIPTION
Fixes TestOpaqueExistentials on 32-bits.

<rdar://problem/47305317>