### PR TITLE
Add support for keeping around serialized modules in SwiftASTContext.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -214,6 +214,7 @@ public:
       m_resource_dir.clear();
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
   // Returns true if successful, false otherwise.
   bool InitializeReplExprModulesDir() {
     // Return if we should not use serialization.
@@ -883,7 +884,7 @@ protected:
                                     // target's process pointer be filled in
   std::string m_platform_sdk_path;
   std::string m_resource_dir;
-  std::string m_repl_expr_modules_dir;
+  std::string m_repl_expr_modules_dir;  // SWIFT_ENABLE_TENSORFLOW
   typedef std::map<Module *, std::vector<lldb::DataBufferSP>> ASTFileDataMap;
   ASTFileDataMap m_ast_file_data_map;
   // FIXME: this vector is needed because the LLDBNameLookup debugger clients

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -214,12 +214,35 @@ public:
       m_resource_dir.clear();
   }
 
+  // Returns true if successful, false otherwise.
+  bool InitializeReplExprModulesDir() {
+    // Return if we should not use serialization.
+    if (getenv("LLDB_DONT_USE_SERIALIZATION"))
+      return true;
+    // Return if this is already initialized!
+    if (GetReplExprModulesDir())
+      return true;
+    // Initialize now!
+    llvm::SmallString<256> module_dir;
+    std::error_code err =
+        llvm::sys::fs::createUniqueDirectory("repl-swift-modules", module_dir);
+    if (err) {
+      return false;
+    }
+    SetReplExprModulesDir(module_dir.c_str());
+    return true;
+  }
+
+  // Returns the directory containing the serialized modules for lldb
+  // expressions.
   const char *GetReplExprModulesDir() const {
     if (m_repl_expr_modules_dir.empty())
       return NULL;
     return m_repl_expr_modules_dir.c_str();
   }
 
+  // Updates the directory containing the serialized modules for lldb
+  // expressions.
   void SetReplExprModulesDir(const char *path) {
     if (path)
       m_repl_expr_modules_dir = path;

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -214,6 +214,19 @@ public:
       m_resource_dir.clear();
   }
 
+  const char *GetReplExprModulesDir() const {
+    if (m_repl_expr_modules_dir.empty())
+      return NULL;
+    return m_repl_expr_modules_dir.c_str();
+  }
+
+  void SetReplExprModulesDir(const char *path) {
+    if (path)
+      m_repl_expr_modules_dir = path;
+    else
+      m_repl_expr_modules_dir.clear();
+  }
+
   size_t GetNumModuleSearchPaths() const;
 
   const char *GetModuleSearchPathAtIndex(size_t idx) const;
@@ -847,6 +860,7 @@ protected:
                                     // target's process pointer be filled in
   std::string m_platform_sdk_path;
   std::string m_resource_dir;
+  std::string m_repl_expr_modules_dir;
   typedef std::map<Module *, std::vector<lldb::DataBufferSP>> ASTFileDataMap;
   ASTFileDataMap m_ast_file_data_map;
   // FIXME: this vector is needed because the LLDBNameLookup debugger clients

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -91,6 +91,7 @@ SwiftExpressionParser::SwiftExpressionParser(
 
   // TODO This code is copied from ClangExpressionParser.cpp.
   // Factor this out into common code.
+
   lldb::TargetSP target_sp;
   if (exe_scope) {
     target_sp = exe_scope->CalculateTarget();
@@ -1961,7 +1962,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   }
 
   runSILDiagnosticPasses(*sil_module);
-  
+
   // SWIFT_ENABLE_TENSORFLOW
   // FIXME: When partitioning joins the mandatory pass pipeline, we should be able to
   // stop running the optimization passes and drop the explicit call of the partitioning
@@ -1974,6 +1975,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // runs at -O0.  We need a proper deabstraction pass to do that though.
   runSILTFPartitionPass(*sil_module);
   // SWIFT_ENABLE_TENSORFLOW
+
 
   if (log) {
     std::string s;

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1941,6 +1941,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     log->PutCString(s.c_str());
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
   // Serialize the file if modules directory is set.
   if (auto expr_module_dir = swift_ast_ctx->GetReplExprModulesDir()) {
     llvm::SmallString<256> filename(expr_module_dir);
@@ -2041,7 +2042,7 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // list of loaded modules, and copy the Decls that were globalized
   // as part of the parse from the staging area in the external
   // lookup object into the SwiftPersistentExpressionState.
-  // SWIFT_ENABLE_TENSORFLOW: 
+  // SWIFT_ENABLE_TENSORFLOW
   swift::ModuleDecl *module = nullptr;
   if (!swift_ast_ctx->GetReplExprModulesDir()) {
     // Just reuse the module if no serialization is requested.

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1943,6 +1943,12 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
   // SWIFT_ENABLE_TENSORFLOW
   // Serialize the file if modules directory is set.
+  // Note that the serialization should be done immediately after
+  // SILGen and before any other passes run. This is important
+  // because of the following reasons:
+  //  - passes like differentation need to see the code before optimizations.
+  //  - Some passes may create new functions, but only the functions defined in
+  //    the lldb repl line should be serialized.
   if (auto expr_module_dir = swift_ast_ctx->GetReplExprModulesDir()) {
     llvm::SmallString<256> filename(expr_module_dir);
     std::string module_name;

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -88,19 +88,6 @@ public:
     return is_error ? "$E" : "$R";
   }
 
-  const char *GetReplExprModulesDir() const {
-    if (m_repl_expr_modules_dir.empty())
-      return NULL;
-    return m_repl_expr_modules_dir.c_str();
-  }
-
-  void SetReplExprModulesDir(const char *path) {
-    if (path)
-      m_repl_expr_modules_dir = path;
-    else
-      m_repl_expr_modules_dir.clear();
-  }
-
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 
   void RegisterSwiftPersistentDecl(swift::ValueDecl *value_decl);
@@ -143,8 +130,6 @@ private:
 
   SwiftDeclMap m_swift_persistent_decls; ///< The persistent functions declared
                                          ///by the user.
-
-  std::string m_repl_expr_modules_dir;
 
   typedef std::set<lldb_private::ConstString> HandLoadedModuleSet;
   HandLoadedModuleSet m_hand_loaded_modules; ///< These are the names of modules

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -88,6 +88,19 @@ public:
     return is_error ? "$E" : "$R";
   }
 
+  const char *GetReplExprModulesDir() const {
+    if (m_repl_expr_modules_dir.empty())
+      return NULL;
+    return m_repl_expr_modules_dir.c_str();
+  }
+
+  void SetReplExprModulesDir(const char *path) {
+    if (path)
+      m_repl_expr_modules_dir = path;
+    else
+      m_repl_expr_modules_dir.clear();
+  }
+
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 
   void RegisterSwiftPersistentDecl(swift::ValueDecl *value_decl);
@@ -130,6 +143,8 @@ private:
 
   SwiftDeclMap m_swift_persistent_decls; ///< The persistent functions declared
                                          ///by the user.
+
+  std::string m_repl_expr_modules_dir;
 
   typedef std::set<lldb_private::ConstString> HandLoadedModuleSet;
   HandLoadedModuleSet m_hand_loaded_modules; ///< These are the names of modules

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1194,6 +1194,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
         log->Printf("No resource dir available for module's SwiftASTContext.");
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
     // If we need to use serialization and the directory is not created already,
     // create a unique directory where we put serialized modules from REPL.
     if (!swift_ast_sp->InitializeReplExprModulesDir()) {
@@ -1350,7 +1351,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     pool.wait();
   }
 
-
+  // SWIFT_ENABLE_TENSORFLOW
   // Create a unique directory where we put serialized modules from REPL.
   if (!swift_ast_sp->InitializeReplExprModulesDir()) {
     logError("Unable to create directory for serialized modules.");
@@ -2546,6 +2547,7 @@ swift::SearchPathOptions &SwiftASTContext::GetSearchPathOptions() {
         ConfigureResourceDirs(GetCompilerInvocation(), resource_dir, triple);
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
     // Update search path if we are serializing the expressions.
     if (auto repl_modules_dir = GetReplExprModulesDir()) {
       Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));


### PR DESCRIPTION
This change is needed for some language features to work across cells in notebook environments such as colab and Jupyter.  

e.g., Differentiation in Swift requires that the body of a SIL function be present for generating the proper adjoint code. Suppose that the following function is defined in one lldb expression (or equivalently in one colab/jupyter cell):
```
1> func square(_ x: Float) -> Float { return x * x } 
```
If `gradient` of square is invoked in a different lldb expression, it will not work unless the body of `square` is available:
```
2> gradient(at: 4, in: square)
```

This PR adds an option to serialize an lldb expression so that the body of `square` is available in other cells. 