### PR TITLE
[test] Fix the definition of getCompilerVersion().

### DIFF
--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -1295,14 +1295,12 @@ class Base(unittest2.TestCase):
         """Returns the compiler binary the test suite is running with."""
         return self.getCompiler().split()[0]
 
-    def getCompilerVersion(self):
+    def getCompilerVersion(self, compiler=None):
         """ Returns a string that represents the compiler version.
             Supports: llvm, clang.
         """
-        compiler = self.getCompilerBinary()
-        self.getCompilerVersion(compiler)
-
-    def getCompilerVersion(self, compiler):
+        if compiler is None:
+          compiler = self.getCompilerBinary()
         version = 'unknown'
         version_output = system([[compiler, "-v"]])[1]
         for line in version_output.split(os.linesep):


### PR DESCRIPTION
Fixes a bunch of failures on upstream-with-swift.