### PR TITLE
[CMake] Fix RPATH for repl

### DIFF
--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -66,6 +66,7 @@ if(LLDB_BUILD_FRAMEWORK)
   set(LLDB_FRAMEWORK_VERSION A CACHE STRING "LLDB.framework version (default is A)")
   set(LLDB_FRAMEWORK_BUILD_DIR bin CACHE STRING "Output directory for LLDB.framework")
   set(LLDB_FRAMEWORK_INSTALL_DIR Library/Frameworks CACHE STRING "Install directory for LLDB.framework")
+  set(LLDB_FRAMEWORK_RESOURCE_DIR Versions/${LLDB_FRAMEWORK_VERSION}/Resources)
   set(LLDB_FRAMEWORK_TOOLS darwin-debug;debugserver;lldb-argdumper;lldb-server CACHE INTERNAL
       "List of tools to include in LLDB.framework/Resources")
 

--- a/cmake/modules/LLDBFramework.cmake
+++ b/cmake/modules/LLDBFramework.cmake
@@ -6,7 +6,7 @@ get_filename_component(
 
 message(STATUS "LLDB.framework: build path is '${framework_target_dir}'")
 message(STATUS "LLDB.framework: install path is '${LLDB_FRAMEWORK_INSTALL_DIR}'")
-message(STATUS "LLDB.framework: resources subdirectory is 'Versions/${LLDB_FRAMEWORK_VERSION}/Resources'")
+message(STATUS "LLDB.framework: resources subdirectory is '${LLDB_FRAMEWORK_RESOURCE_DIR}'")
 
 # Configure liblldb as a framework bundle
 set_target_properties(liblldb PROPERTIES

--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Set the correct rpath to locate libswiftCore.
 if (LLDB_BUILD_FRAMEWORK)
-  set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath \
-      -Wl,${CMAKE_BINARY_DIR}/${LLDB_FRAMEWORK_INSTALL_DIR}/${LLDB_FRAMEWORK_RESOURCE_DIR}/Swift/macosx")
+  get_target_property(framework_target_dir liblldb LIBRARY_OUTPUT_DIRECTORY)
+  set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath -Wl,${framework_target_dir}/LLDB.framework/${LLDB_FRAMEWORK_RESOURCE_DIR}/Swift/macosx")
 elseif( CMAKE_SYSTEM_NAME MATCHES "Linux" )
   # Set the correct rpath to locate libswiftCore
   set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-x86_64/lib${LLVM_LIBDIR_SUFFIX}/swift/linux -Wl,-ldl")
@@ -25,6 +25,5 @@ if (LLDB_BUILD_FRAMEWORK)
   add_custom_command(TARGET repl_swift POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_BINARY_DIR}/bin/repl_swift
-            ${CMAKE_BINARY_DIR}/${LLDB_FRAMEWORK_INSTALL_DIR}/${LLDB_FRAMEWORK_RESOURCE_DIR}/repl_swift
-    )
+            ${framework_target_dir}/LLDB.framework/${LLDB_FRAMEWORK_RESOURCE_DIR}/repl_swift)
 endif()


### PR DESCRIPTION
Due to r350391 we could no longer construct the correct RPATH for the
repl. In order to construct the correct path we need to get the path to
the LLDB framework by reading the LIBRARY_OUTPUT_DIRECTORY property from
liblldb. We also need the LLDB_FRAMEWORK_RESOURCE_DIR which was
previously removed, and re-introduced in this patch.