### PR TITLE
[tests] Re-enable unexpected successes

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/load_unload/TestLoadUnload.py
+++ b/packages/Python/lldbsuite/test/functionalities/load_unload/TestLoadUnload.py
@@ -221,7 +221,6 @@ class LoadUnloadTestCase(TestBase):
         triple='.*-android')
     @skipIfFreeBSD  # llvm.org/pr14424 - missing FreeBSD Makefiles/testcase support
     @skipIfWindows  # Windows doesn't have dlopen and friends, dynamic libraries work differently
-    @expectedFailureAll(bugnumber="rdar://38484268")
     def test_lldb_process_load_and_unload_commands(self):
         """Test that lldb process load/unload command work correctly."""
         self.copy_shlibs_to_remote()

--- a/packages/Python/lldbsuite/test/functionalities/process_launch/TestProcessLaunch.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_launch/TestProcessLaunch.py
@@ -85,7 +85,6 @@ class ProcessLaunchTestCase(TestBase):
     # not working?
     @not_remote_testsuite_ready
     @expectedFailureAll(oslist=["linux"], bugnumber="llvm.org/pr20265")
-    @expectedFailureAll(bugnumber="rdar://38484341")
     def test_set_working_dir_nonexisting(self):
         """Test that '-w dir' fails to set the working dir when running the inferior with a dir which doesn't exist."""
         d = {'CXX_SOURCES': 'print_cwd.cpp'}

--- a/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
+++ b/packages/Python/lldbsuite/test/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
@@ -14,6 +14,4 @@ from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
     __file__, globals(), decorators=
-    [skipUnlessDarwin,swiftTest,
-     expectedFailureAll(debug_info="dwarf",
-                        bugnumber="rdar://problem/44609153")])
+    [skipUnlessDarwin,swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/repl_in_c/TestSwiftReplInC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/repl_in_c/TestSwiftReplInC.py
@@ -19,7 +19,6 @@ class TestSwiftReplInC(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureAll(bugnumber="rdar://45579668")
     @add_test_categories(["swiftpr"])
     def test_repl_in_c(self):
         self.build()


### PR DESCRIPTION
Unexpected Passing Tests (4):
     lldb-Suite :: functionalities/load_unload/TestLoadUnload.py
     lldb-Suite :: functionalities/process_launch/TestProcessLaunch.py
     lldb-Suite :: lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
     lldb-Suite :: lang/swift/repl_in_c/TestSwiftReplInC.py