### PR TITLE
 Add a missing return statement to the default implementation of Fixup...

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -107,7 +107,9 @@ public:
 
   /// This allows a language runtime to adjust references depending on the type.
   /// \return true on success.
-  virtual bool FixupReference(lldb::addr_t &addr, CompilerType type) {}
+  virtual bool FixupReference(lldb::addr_t &addr, CompilerType type) {
+    return true;
+  }
 
   virtual void SetExceptionBreakpoints() {}
 


### PR DESCRIPTION
…Reference.

This is supposed to be a successful no-op everywhere but in Swift.

<rdar://problem/47402084>