### PR TITLE
Add initialization of the Swift runtime to Windows

### DIFF
--- a/source/API/SystemInitializerFull.cpp
+++ b/source/API/SystemInitializerFull.cpp
@@ -115,7 +115,7 @@
 #include "lldb/Host/windows/windows.h"
 #endif
 
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
 #include "Plugins/Language/Swift/SwiftLanguage.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #endif
@@ -271,14 +271,14 @@ SystemInitializerFull::SystemInitializerFull() {}
 SystemInitializerFull::~SystemInitializerFull() {}
 
 static void SwiftInitialize() {
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
   SwiftLanguage::Initialize();
   SwiftLanguageRuntime::Initialize();
 #endif
 }
 
 static void SwiftTerminate() {
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
   SwiftLanguage::Terminate();
   SwiftLanguageRuntime::Terminate();
 #endif


### PR DESCRIPTION
Swift builds and runs on Windows now and the LanguageRuntime and
Language subclasses are necessary to properly debug executables.