### PR TITLE
Fix deserialization errors caused by incorrect persistent state.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -215,10 +215,13 @@ public:
   }
 
   // SWIFT_ENABLE_TENSORFLOW
+  bool UseSerialization() { return getenv("LLDB_USE_SERIALIZATION"); }
+
+  // SWIFT_ENABLE_TENSORFLOW
   // Returns true if successful, false otherwise.
   bool InitializeReplExprModulesDir() {
     // Return if we should not use serialization.
-    if (!getenv("LLDB_USE_SERIALIZATION"))
+    if (!UseSerialization())
       return true;
     // Return if this is already initialized!
     if (GetReplExprModulesDir())


### PR DESCRIPTION
LLDB maintains a symbol table of the decls seen so far and the symbol table is updated at [SwiftExpressionParser.cpp:1647](https://github.com/apple/swift-lldb/blob/f1bb31a9c3b8a9a5a1b0d10dbe1aea940574ba3c/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp#L1647). 

When we use serialization, we use the module generated from the serialized AST to the list of loaded modules, instead of the one generated by parsing the REPL line. This PR makes sure that the decls in the symbol table belong to the module generated from the serialized AST. Otherwise, there will be deserialization errors. 

(This is admittedly a hacky, but should suffice for now to enable differentiation across cells in jupyter/colab.)