### PR TITLE
Host: remove Yield on Windows

### DIFF
--- a/include/lldb/Host/windows/windows.h
+++ b/include/lldb/Host/windows/windows.h
@@ -21,6 +21,7 @@
 #undef GetUserName
 #undef LoadImage
 #undef CreateProcess
+#undef Yield
 #undef far
 #undef near
 #undef FAR


### PR DESCRIPTION
Windows provides a Yield function-like macro that allows a thread to
yield the CPU.  However, this conflicts with `Yield` in swift.  Undefine
`Yield` to allow building lldb with swift support.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@348556 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 9ff72163bae767b066ba059e0c4f8bcf3063a91b)