### PR TITLE
Remove a warning in DynamicLoaderDarwin::UpdateImageLoadAddress

### DIFF
--- a/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -256,15 +256,7 @@ bool DynamicLoaderDarwin::UpdateImageLoadAddress(Module *module,
 
               changed = m_process->GetTarget().SetSectionLoadAddress(
                   section_sp, new_section_load_addr, warn_multiple);
-            } else {
-              Host::SystemLog(
-                  Host::eSystemLogWarning,
-                  "warning: unable to find and load segment named '%s' at "
-                  "0x%" PRIx64 " in '%s' in macosx dynamic loader plug-in.\n",
-                  info.segments[i].name.AsCString("<invalid>"),
-                  (uint64_t)new_section_load_addr,
-                  image_object_file->GetFileSpec().GetPath().c_str());
-            }
+            } 
           }
         }
 


### PR DESCRIPTION
Remove a warning in DynamicLoaderDarwin::UpdateImageLoadAddress
when the binary loaded in memory has a section that we cannot find
in the on-disk version.  I added this warning out of an overabundance
of caution originally, but I've never seen an instance of it being
hit in the past few years, and there are some changes for the shared
cache on darwin systems where a segment is added when the shared
cache is constructed so we're now hitting this warning.  I've decided
to remove it altogether.

<rdar://problem/46889346> 



git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@352158 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 6e6d86341cf7e8b0b3c86316b724b3c668b95391)