### PR TITLE
[Swift] Add initial support and tests for Swift parseable interface files (.swiftinterface)

### DIFF
--- a/include/lldb/Core/SwiftForward.h
+++ b/include/lldb/Core/SwiftForward.h
@@ -50,6 +50,7 @@ class NominalTypeDecl;
 class ProtocolDecl;
 class SearchPathOptions;
 class SerializedModuleLoader;
+class ParseableInterfaceModuleLoader;
 class SILModule;
 class SILOptions;
 class SourceFile;

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -833,6 +833,7 @@ protected:
   std::unique_ptr<swift::SILModule> m_sil_module_ap;
   /// Owned by the AST.
   swift::SerializedModuleLoader *m_serialized_module_loader = nullptr;
+  swift::ParseableInterfaceModuleLoader *m_parseable_module_loader = nullptr;
   swift::ClangImporter *m_clang_importer = nullptr;
   swift::DWARFImporter *m_dwarf_importer = nullptr;
   SwiftModuleMap m_swift_module_cache;

--- a/lit/SwiftREPL/Inputs/A.swift
+++ b/lit/SwiftREPL/Inputs/A.swift
@@ -1,0 +1,21 @@
+public class Foo {
+  public static func foo() -> String  {
+    print("A")
+    return "A"
+  }
+}
+
+public struct MyPoint {
+  let x: Int
+  let y: Int
+
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  public var magnitudeSquared: Int {
+    return x*x + y*y
+  }
+}

--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -2,16 +2,18 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: %target-swiftc -module-name A -emit-parseable-module-interface-path %t/A.swiftinterface -emit-library -o %t/libA%target-shared-library-suffix %S/Inputs/A.swift
-// RUN: %lldb --repl="-I%t -L%t -lA -enable-parseable-module-interface" < %s | FileCheck %s
+// RUN: cp %S/Inputs/A.swift %t/AA.swift
+// RUN: %target-swiftc -module-name AA -emit-parseable-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: rm %t/AA.swift
+// RUN: %lldb --repl="-I%t -L%t -lAA -enable-parseable-module-interface" < %s | FileCheck %s
 
-import A
+import AA
 
 Foo.foo()
 // CHECK: ${{R0}}: String = "A"
 
 let y = MyPoint(x: 2, y: 2)
-// CHECK: {{^}}y: A.MyPoint = {
+// CHECK: {{^}}y: AA.MyPoint = {
 
 y.magnitudeSquared
 // CHECK: {{^}}${{R1}}: Int = 8

--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -1,8 +1,9 @@
 // Test that .swiftinterface files can be loaded via the repl.
 
-// RUN: mkdir -p %t
-// RUN: %target-swiftc -module-name A -emit-parseable-module-interface-path %t/A.swiftinterface -emit-library -o %t/libA.dylib %S/Inputs/A.swift
-// RUN: %lldb --repl="-I%t -L%t -lA" < %s | FileCheck %s
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swiftc -module-name A -emit-parseable-module-interface-path %t/A.swiftinterface -emit-library -o %t/libA%target-shared-library-suffix %S/Inputs/A.swift
+// RUN: %lldb --repl="-I%t -L%t -lA -enable-parseable-module-interface" < %s | FileCheck %s
 
 import A
 

--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -1,0 +1,16 @@
+// Test that .swiftinterface files can be loaded via the repl.
+
+// RUN: mkdir -p %t
+// RUN: %target-swiftc -module-name A -emit-parseable-module-interface-path %t/A.swiftinterface -emit-library -o %t/libA.dylib %S/Inputs/A.swift
+// RUN: %lldb --repl="-I%t -L%t -lA" < %s | FileCheck %s
+
+import A
+
+Foo.foo()
+// CHECK: ${{R0}}: String = "A"
+
+let y = MyPoint(x: 2, y: 2)
+// CHECK: {{^}}y: A.MyPoint = {
+
+y.magnitudeSquared
+// CHECK: {{^}}${{R1}}: Int = 8

--- a/lit/helper/toolchain.py
+++ b/lit/helper/toolchain.py
@@ -98,6 +98,9 @@ def use_support_substitutions(config):
     elif platform.system() in ['OpenBSD', 'Linux']:
         flags = ['-pthread']
 
+    config.target_shared_library_suffix = '.dylib' if platform.system() in ['Darwin'] else '.so'
+    config.substitutions.append(('%target-shared-library-suffix', config.target_shared_library_suffix))
+
     # Swift support
     swift_sdk = [' -sdk ', sdk_path] if platform.system() in ['Darwin'] else []
     tools = [

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/Makefile
@@ -4,6 +4,7 @@ EXE := main
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC -Xlinker -rpath -Xlinker $(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -enable-parseable-module-interface -I$(BUILDDIR)
+SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 
 # setup `all` to run each of the below before building the main executable
 all: setup sharedA sharedB sharedC clear_modules
@@ -20,27 +21,32 @@ setup:
 
 sharedA:
 	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=AA -f $(SRCDIR)/libs/Makefile
 
 sharedB:
 	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=BB SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" LD_EXTRAS="-L$(BUILDDIR) -lAA" -f $(SRCDIR)/libs/Makefile
 
 sharedC:
 	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=CC -f $(SRCDIR)/libs/Makefile
 
 clear_modules:
 	# make sure we only have .swiftinterface files for the generated modules:
 	# remove the copied sources and the swiftmodules from the build directory
-	rm -rf *.swiftmodule
+	rm -f *.swiftmodule
 	rm -rf libs
+	rm -rf MCP
 
 clean::
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=BB -f $(SRCDIR)/libs/Makefile clean
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
 	rm -rf libs
+	rm -rf MCP

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/Makefile
@@ -1,0 +1,46 @@
+LEVEL := ../../../make
+
+EXE := main
+SWIFT_SOURCES := main.swift
+LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC -Xlinker -rpath -Xlinker $(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -enable-parseable-module-interface -I$(BUILDDIR)
+
+# setup `all` to run each of the below before building the main executable
+all: setup sharedA sharedB sharedC clear_modules
+
+include $(LEVEL)/Makefile.rules
+
+setup:
+	# copy the source files into the build directory because we delete them
+	# to be really sure we only have/use the .dylibs and .swiftinterfaces
+	mkdir -p libs
+	cp $(SRCDIR)/libs/A.swift libs/AA.swift
+	cp $(SRCDIR)/libs/B.swift libs/BB.swift
+	cp $(SRCDIR)/libs/C.swift libs/CC.swift
+
+sharedA:
+	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		BASENAME=AA -f $(SRCDIR)/libs/Makefile
+
+sharedB:
+	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		BASENAME=BB SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" LD_EXTRAS="-L$(BUILDDIR) -lAA" -f $(SRCDIR)/libs/Makefile
+
+sharedC:
+	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		BASENAME=CC -f $(SRCDIR)/libs/Makefile
+
+clear_modules:
+	# make sure we only have .swiftinterface files for the generated modules:
+	# remove the copied sources and the swiftmodules from the build directory
+	rm -rf *.swiftmodule
+	rm -rf libs
+
+clean::
+	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
+	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=BB -f $(SRCDIR)/libs/Makefile clean
+	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
+	rm -rf libs

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
@@ -44,12 +44,11 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
 
     def do_test(self):
-        # A custom module cache location
-        mod_cache = self.getBuildArtifact("module-cache-dir")
+        # The custom module cache location
+        mod_cache = self.getBuildArtifact("MCP")
 
-        # Clear the module cache if it already exists
-        if os.path.isdir(mod_cache):
-          shutil.rmtree(mod_cache)
+        # Clear the module cache (populated by the Makefile build)
+        shutil.rmtree(mod_cache)
         self.assertFalse(os.path.isdir(mod_cache),
                          "module cache should not exist")
 

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
@@ -36,17 +36,26 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
         self.build()
         self.do_test()
 
+    @decorators.swiftTest
+    def test_swift_interface_fallback(self):
+        """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
+        self.build()
+        # Install invalid modules in the build directory first to check we
+        # still fall back to the .swiftinterface.
+        modules = ['AA.swiftmodule', 'BB.swiftmodule', 'CC.swiftmodule']
+        for module in modules:
+            open(self.getBuildArtifact(module), 'w').close()
+        self.do_test()
 
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"
 
-
     def do_test(self):
-        # The custom module cache location
+        # The custom swift module cache location
         swift_mod_cache = self.getBuildArtifact("MCP")
 
-        # Clear the module cache (populated by the Makefile build)
+        # Clear the swift module cache (populated by the Makefile build)
         shutil.rmtree(swift_mod_cache)
         self.assertFalse(os.path.isdir(swift_mod_cache),
                          "module cache should not exist")

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
@@ -1,0 +1,136 @@
+# TestSwiftInterfaceNoDebugInfo.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+"""
+Test that we load and handle modules that only have textual .swiftinterface
+files -- i.e. no associated .swiftmodule file -- and no debug info. The module
+loader should generate the .swiftmodule for any .swiftinterface it finds unless
+it is already in the module cache.
+"""
+
+import commands
+import glob
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import unittest2
+
+
+class TestSwiftInterfaceNoDebugInfo(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    def test_swift_interface(self):
+        """Test that we load and handle modules that only have textual .swiftinterface files"""
+        self.build()
+        self.do_test()
+
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+
+    def do_test(self):
+        # A custom module cache location
+        mod_cache = self.getBuildArtifact("module-cache-dir")
+
+        # Clear the module cache if it already exists
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+        self.assertFalse(os.path.isdir(mod_cache),
+                         "module cache should not exist")
+
+        # Update the settings to use the custom module cache location
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"' % mod_cache)
+
+        # Set a breakpoint in and launch the main executable
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                "break here", self.main_source_spec,
+                exe_name="main")
+
+        self.frame = thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+
+        # Check we are able to access the public fields of variables whose
+        # types are from the .swiftinterface-only dylibs
+        var = self.frame.FindVariable("x")
+        lldbutil.check_variable(self, var, False, typename="AA.MyPoint")
+
+        child_y = var.GetChildMemberWithName("y") # MyPoint.y is public
+        lldbutil.check_variable(self, child_y, False, value="0")
+
+        child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
+        self.assertFalse(child_x.IsValid())
+
+        # Expression evaluation using types from the .swiftinterface only
+        # dylibs should work too
+        lldbutil.check_expression(self, self.frame, "y.magnitudeSquared", "404", use_summary=False)
+        lldbutil.check_expression(self, self.frame, "MyPoint(x: 1, y: 2).magnitudeSquared", "5", use_summary=False)
+
+        # Check the module cache was populated with the .swiftmodule files of
+        # the loaded modules
+        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+        a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
+        b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
+        c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
+        self.assertEqual(len(a_modules), 1)
+        self.assertEqual(len(b_modules), 1)
+        self.assertEqual(len(c_modules), 0)
+
+        # Update the timestamps of the modules to a time well in the past
+        for file in a_modules + b_modules:
+            make_old(file)
+
+        # Re-import module A and B
+        self.runCmd("expr import AA")
+        self.runCmd("expr import BB")
+
+        # Import C for the first time and check we can evaluate expressions
+        # involving types from it
+        self.runCmd("expr import CC")
+        lldbutil.check_expression(self, self.frame, "Baz.baz()", "23", use_summary=False)
+
+        # Check we still have a single .swiftmodule in the cache for A and B
+        # and that there is now one for C too
+        a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
+        b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
+        c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
+        self.assertEqual(len(a_modules), 1, "unexpected number of swiftmodules for A.swift")
+        self.assertEqual(len(b_modules), 1, "unexpected number of swiftmodules for B.swift")
+        self.assertEqual(len(c_modules), 1, "unexpected number of swiftmodules for C.swift")
+
+        # Make sure the .swiftmodule files of A and B were re-used rather than
+        # re-generated when they were re-imported
+        for file in a_modules + b_modules:
+            self.assertTrue(is_old(file), "Swiftmodule file was regenerated rather than reused")
+
+
+OLD_TIMESTAMP = 1390550700 # 2014-01-24T08:05:00+00:00
+
+def make_old(file):
+    """Sets the access and modified time of the given file to a time long past"""
+    os.utime(file, (OLD_TIMESTAMP, OLD_TIMESTAMP))
+
+def is_old(file):
+    """Checks the modified time of the given file matches the timestamp set my make_old"""
+    return os.stat(file).st_mtime == OLD_TIMESTAMP
+
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/A.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/A.swift
@@ -1,0 +1,20 @@
+public class Foo {
+  public static func foo() {
+    print("first")
+  }
+}
+
+public struct MyPoint {
+  let x: Int
+  public let y: Int
+
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  public var magnitudeSquared: Int {
+    return x*x + y*y
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/B.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/B.swift
@@ -1,0 +1,7 @@
+import AA
+
+public class Bar {
+  public static func bar() {
+    Foo.foo()
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/C.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/C.swift
@@ -1,0 +1,5 @@
+public class Baz {
+  public static func baz() -> Int {
+    return 23
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
@@ -1,0 +1,13 @@
+LEVEL = ../../../make
+
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
+
+# don't use the default swift flags, as we don't want -g for the libraries in
+# this test
+SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface
+
+include $(LEVEL)/Makefile.rules
+
+clean::
+	rm -rf $(BASENAME).swiftinterface

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
@@ -3,11 +3,14 @@ LEVEL = ../../../make
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
-# don't use the default swift flags, as we don't want -g for the libraries in
-# this test
+# Don't use the default swift flags, as we don't want -g for the libraries in
+# this test.
 SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface
 
-# don't include the wrapped .swiftmodule on linux to make sure we actually use the .swiftinterface
+# Don't include the wrapped .swiftmodule on Linux to make sure we actually use
+# the .swiftinterface. The issue here is that if the .swiftmodule is wrapped
+# and linked into the dylib, LLDB will find it there and load it before the
+# .swiftinterface loading path can be exercised.
 EXCLUDE_WRAPPED_SWIFTMODULE=1
 
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
@@ -7,7 +7,11 @@ DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 # this test
 SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface
 
+# don't include the wrapped .swiftmodule on linux to make sure we actually use the .swiftinterface
+EXCLUDE_WRAPPED_SWIFTMODULE=1
+
 include $(LEVEL)/Makefile.rules
 
 clean::
-	rm -rf $(BASENAME).swiftinterface
+	rm -f $(BASENAME).swiftinterface
+	rm -f $(CLANG_MODULE_CACHE_DIR)/$(BASENAME)-*.swiftmodule

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/main.swift
@@ -1,0 +1,14 @@
+import AA
+import BB
+
+func foo() {
+  let x = MyPoint(x: 10, y: 0)
+  let y = MyPoint(x: -2, y: 20)
+
+  print(x.magnitudeSquared)
+  print(y.magnitudeSquared)
+
+  Bar.bar() // break here
+}
+
+foo()

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/Makefile
@@ -1,0 +1,49 @@
+LEVEL := ../../../make
+
+EXE := main
+SWIFT_SOURCES := main.swift
+LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC
+SWIFTFLAGS_EXTRAS = -enable-parseable-module-interface -I$(BUILDDIR)
+
+# setup `all` to run each of the below before building the main executable
+all: setup staticA staticB staticC clear_modules
+
+include $(LEVEL)/Makefile.rules
+
+setup:
+	# copy the source files into the build directory because we delete them
+	# to be really sure we only have/use the .dylibs and .swiftinterfaces
+	mkdir -p libs
+	cp $(SRCDIR)/libs/A.swift libs/AA.swift
+	cp $(SRCDIR)/libs/B.swift libs/BB.swift
+	cp $(SRCDIR)/libs/C.swift libs/CC.swift
+
+staticA:
+	# Because we override VPATH to point to the build directory, we need to pass
+	# down SWIFTC too (it's default value is relative to VPATH)
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		BASENAME=AA -f $(SRCDIR)/libs/Makefile static_only
+
+staticB:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		BASENAME=BB SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
+		LD_EXTRAS="-L$(BUILDDIR)" -f $(SRCDIR)/libs/Makefile static_only
+
+staticC:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		BASENAME=CC -f $(SRCDIR)/libs/Makefile static_only
+
+clear_modules:
+	# make sure we only have .swiftinterface files for the generated modules:
+	# remove the copied sources and the swiftmodules from the build directory
+	rm -rf *.swiftmodule
+	rm -rf libs
+
+clean::
+	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
+	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=BB -f $(SRCDIR)/libs/Makefile clean
+	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
+	rm -rf libs

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/Makefile
@@ -4,6 +4,7 @@ EXE := main
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC
 SWIFTFLAGS_EXTRAS = -enable-parseable-module-interface -I$(BUILDDIR)
+SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 
 # setup `all` to run each of the below before building the main executable
 all: setup staticA staticB staticC clear_modules
@@ -22,28 +23,33 @@ staticA:
 	# Because we override VPATH to point to the build directory, we need to pass
 	# down SWIFTC too (it's default value is relative to VPATH)
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=AA -f $(SRCDIR)/libs/Makefile static_only
 
 staticB:
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=BB SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
 		LD_EXTRAS="-L$(BUILDDIR)" -f $(SRCDIR)/libs/Makefile static_only
 
 staticC:
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
-		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) VPATH=$(BUILDDIR) SWIFTSDKROOT=$(SWIFTSDKROOT) \
+		SWIFT_MODULE_CACHE_FLAGS="$(SWIFT_MODULE_CACHE_FLAGS)" \
 		BASENAME=CC -f $(SRCDIR)/libs/Makefile static_only
 
 clear_modules:
 	# make sure we only have .swiftinterface files for the generated modules:
 	# remove the copied sources and the swiftmodules from the build directory
-	rm -rf *.swiftmodule
+	rm -f *.swiftmodule
 	rm -rf libs
+	rm -rf MCP
 
 clean::
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=BB -f $(SRCDIR)/libs/Makefile clean
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
 	rm -rf libs
+	rm -rf MCP

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -44,12 +44,11 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
 
 
     def do_test(self):
-        # A custom module cache location
-        mod_cache = self.getBuildArtifact("module-cache-dir")
+        # The custom module cache location
+        mod_cache = self.getBuildArtifact("MCP")
 
-        # Clear the module cache if it already exists
-        if os.path.isdir(mod_cache):
-          shutil.rmtree(mod_cache)
+        # Clear the module cache (populated by the Makefile build)
+        shutil.rmtree(mod_cache)
         self.assertFalse(os.path.isdir(mod_cache),
                          "module cache should not exist")
 
@@ -86,9 +85,9 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
         a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
         b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
         c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
-        self.assertTrue(len(a_modules) == 1)
-        self.assertTrue(len(b_modules) == 1)
-        self.assertTrue(len(c_modules) == 0)
+        self.assertEqual(len(a_modules), 1)
+        self.assertEqual(len(b_modules), 1)
+        self.assertEqual(len(c_modules), 0)
 
         # Update the timestamps of the modules to a time well in the past
         for file in a_modules + b_modules:
@@ -109,9 +108,9 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
         a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
         b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
         c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
-        self.assertTrue(len(a_modules) == 1, "unexpected number of swiftmodules for A.swift")
-        self.assertTrue(len(b_modules) == 1, "unexpected number of swiftmodules for B.swift")
-        self.assertTrue(len(c_modules) == 1, "unexpected number of swiftmodules for C.swift")
+        self.assertEqual(len(a_modules), 1, "unexpected number of swiftmodules for A.swift")
+        self.assertEqual(len(b_modules), 1, "unexpected number of swiftmodules for B.swift")
+        self.assertEqual(len(c_modules), 1, "unexpected number of swiftmodules for C.swift")
 
         # Make sure the .swiftmodule files of A and B were re-used rather than
         # re-generated when they were re-imported

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -10,10 +10,10 @@
 #
 # -----------------------------------------------------------------------------
 """
-Test that we load and handle modules that only have textual .swiftinterface
-files -- i.e. no associated .swiftmodule file -- and no debug info. The module
-loader should generate the .swiftmodule for any .swiftinterface it finds unless
-it is already in the module cache.
+Test that we load and handle swift modules that only have textual
+.swiftinterface files -- i.e. no associated .swiftmodule file -- and no debug
+info. The module loader should generate the .swiftmodule for any
+.swiftinterface it finds unless it is already in the module cache.
 """
 
 import commands
@@ -40,28 +40,26 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"
-        self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
 
     def do_test(self):
         # The custom module cache location
-        mod_cache = self.getBuildArtifact("MCP")
+        swift_mod_cache = self.getBuildArtifact("MCP")
 
         # Clear the module cache (populated by the Makefile build)
-        shutil.rmtree(mod_cache)
-        self.assertFalse(os.path.isdir(mod_cache),
+        shutil.rmtree(swift_mod_cache)
+        self.assertFalse(os.path.isdir(swift_mod_cache),
                          "module cache should not exist")
 
         # Update the settings to use the custom module cache location
-        self.runCmd('settings set symbols.clang-modules-cache-path "%s"' % mod_cache)
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"' % swift_mod_cache)
 
         # Set a breakpoint in and launch the main executable
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
-                "break here", self.main_source_spec,
+                "break here", lldb.SBFileSpec(self.main_source),
                 exe_name="main")
 
         self.frame = thread.frames[0]
-        self.assertTrue(self.frame, "Frame 0 is valid.")
 
         # Check we are able to access the public fields of variables whose
         # types are from the .swiftinterface-only modules
@@ -79,12 +77,12 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
         lldbutil.check_expression(self, self.frame, "y.magnitudeSquared", "404", use_summary=False)
         lldbutil.check_expression(self, self.frame, "MyPoint(x: 1, y: 2).magnitudeSquared", "5", use_summary=False)
 
-        # Check the module cache was populated with the .swiftmodule files of
-        # the loaded modules
-        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
-        a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
-        b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
-        c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
+        # Check the swift module cache was populated with the .swiftmodule
+        # files of the loaded modules
+        self.assertTrue(os.path.isdir(swift_mod_cache), "module cache exists")
+        a_modules = glob.glob(os.path.join(swift_mod_cache, 'AA-*.swiftmodule'))
+        b_modules = glob.glob(os.path.join(swift_mod_cache, 'BB-*.swiftmodule'))
+        c_modules = glob.glob(os.path.join(swift_mod_cache, 'CC-*.swiftmodule'))
         self.assertEqual(len(a_modules), 1)
         self.assertEqual(len(b_modules), 1)
         self.assertEqual(len(c_modules), 0)
@@ -105,9 +103,9 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
 
         # Check we still have a single .swiftmodule in the cache for A and B
         # and that there is now one for C too
-        a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
-        b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
-        c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
+        a_modules = glob.glob(os.path.join(swift_mod_cache, 'AA-*.swiftmodule'))
+        b_modules = glob.glob(os.path.join(swift_mod_cache, 'BB-*.swiftmodule'))
+        c_modules = glob.glob(os.path.join(swift_mod_cache, 'CC-*.swiftmodule'))
         self.assertEqual(len(a_modules), 1, "unexpected number of swiftmodules for A.swift")
         self.assertEqual(len(b_modules), 1, "unexpected number of swiftmodules for B.swift")
         self.assertEqual(len(c_modules), 1, "unexpected number of swiftmodules for C.swift")

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -1,0 +1,137 @@
+# TestSwiftInterfaceNoDebugInfo.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+"""
+Test that we load and handle modules that only have textual .swiftinterface
+files -- i.e. no associated .swiftmodule file -- and no debug info. The module
+loader should generate the .swiftmodule for any .swiftinterface it finds unless
+it is already in the module cache.
+"""
+
+import commands
+import glob
+import lldb
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.decorators as decorators
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import unittest2
+
+
+class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    def test_swift_interface(self):
+        """Test that we load and handle modules that only have textual .swiftinterface files"""
+        self.build()
+        self.do_test()
+
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+
+
+    def do_test(self):
+        # A custom module cache location
+        mod_cache = self.getBuildArtifact("module-cache-dir")
+
+        # Clear the module cache if it already exists
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+        self.assertFalse(os.path.isdir(mod_cache),
+                         "module cache should not exist")
+
+        # Update the settings to use the custom module cache location
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"' % mod_cache)
+
+        # Set a breakpoint in and launch the main executable
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
+                "break here", self.main_source_spec,
+                exe_name="main")
+
+        self.frame = thread.frames[0]
+        self.assertTrue(self.frame, "Frame 0 is valid.")
+
+        # Check we are able to access the public fields of variables whose
+        # types are from the .swiftinterface-only modules
+        var = self.frame.FindVariable("x")
+        lldbutil.check_variable(self, var, False, typename="AA.MyPoint")
+
+        child_y = var.GetChildMemberWithName("y") # MyPoint.y is public
+        lldbutil.check_variable(self, child_y, False, value="0")
+
+        child_x = var.GetChildMemberWithName("x") # MyPoint.x isn't public
+        self.assertFalse(child_x.IsValid())
+
+        # Expression evaluation using types from the .swiftinterface only
+        # modules should work too
+        lldbutil.check_expression(self, self.frame, "y.magnitudeSquared", "404", use_summary=False)
+        lldbutil.check_expression(self, self.frame, "MyPoint(x: 1, y: 2).magnitudeSquared", "5", use_summary=False)
+
+        # Check the module cache was populated with the .swiftmodule files of
+        # the loaded modules
+        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+        a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
+        b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
+        c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
+        self.assertTrue(len(a_modules) == 1)
+        self.assertTrue(len(b_modules) == 1)
+        self.assertTrue(len(c_modules) == 0)
+
+        # Update the timestamps of the modules to a time well in the past
+        for file in a_modules + b_modules:
+            make_old(file)
+
+        # Re-import module A and B
+        self.runCmd("expr import AA")
+        self.runCmd("expr import BB")
+
+        # Import C for the first time
+        self.runCmd("expr import CC")
+
+        # Not clear why this doesn't work here, when it does with a dylib...
+        lldbutil.check_expression(self, self.frame, "Baz.baz()", None, use_summary=False)
+
+        # Check we still have a single .swiftmodule in the cache for A and B
+        # and that there is now one for C too
+        a_modules = glob.glob(os.path.join(mod_cache, 'AA-*.swiftmodule'))
+        b_modules = glob.glob(os.path.join(mod_cache, 'BB-*.swiftmodule'))
+        c_modules = glob.glob(os.path.join(mod_cache, 'CC-*.swiftmodule'))
+        self.assertTrue(len(a_modules) == 1, "unexpected number of swiftmodules for A.swift")
+        self.assertTrue(len(b_modules) == 1, "unexpected number of swiftmodules for B.swift")
+        self.assertTrue(len(c_modules) == 1, "unexpected number of swiftmodules for C.swift")
+
+        # Make sure the .swiftmodule files of A and B were re-used rather than
+        # re-generated when they were re-imported
+        for file in a_modules + b_modules:
+            self.assertTrue(is_old(file), "Swiftmodule file was regenerated rather than reused")
+
+
+OLD_TIMESTAMP = 1390550700 # 2014-01-24T08:05:00+00:00
+
+def make_old(file):
+    """Sets the access and modified time of the given file to a time long past"""
+    os.utime(file, (OLD_TIMESTAMP, OLD_TIMESTAMP))
+
+def is_old(file):
+    """Checks the modified time of the given file matches the timestamp set my make_old"""
+    return os.stat(file).st_mtime == OLD_TIMESTAMP
+
+
+if __name__ == '__main__':
+    import atexit
+    lldb.SBDebugger.Initialize()
+    atexit.register(lldb.SBDebugger.Terminate)
+    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/A.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/A.swift
@@ -1,0 +1,20 @@
+public class Foo {
+  public static func foo() {
+    print("first")
+  }
+}
+
+public struct MyPoint {
+  let x: Int
+  public let y: Int
+
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  public var magnitudeSquared: Int {
+    return x*x + y*y
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/B.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/B.swift
@@ -1,0 +1,7 @@
+import AA
+
+public class Bar {
+  public static func bar() {
+    Foo.foo()
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/C.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/C.swift
@@ -1,0 +1,5 @@
+public class Baz {
+  public static func baz() -> Int {
+    return 23
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
@@ -9,6 +9,9 @@ DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 # this test
 SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface -parse-as-library
 
+# don't include the wrapped .swiftmodule on linux
+EXCLUDE_WRAPPED_SWIFTMODULE=1
+
 # activates the rules for generating a static lib based on the .o files
 # corresponding to the dylib swift sources above
 ARCHIVE_NAME := lib$(BASENAME).a
@@ -27,4 +30,4 @@ endif
 static_only: $(ARCHIVE_NAME)
 
 clean::
-	rm -rf $(BASENAME).swiftinterface
+	rm -f $(BASENAME).swiftinterface

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
@@ -1,19 +1,22 @@
 LEVEL = ../../../make
 
-# set the dylib variables so the rules for generating swift objects and
-# modules are active
+# Set the dylib variables so the rules for generating swift objects and
+# modules are active.
 DYLIB_NAME := $(BASENAME)
 DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
-# don't use the default swift flags, as we don't want -g for the libraries in
-# this test
+# Don't use the default swift flags, as we don't want -g for the libraries in
+# this test.
 SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface -parse-as-library
 
-# don't include the wrapped .swiftmodule on linux
+# Don't include the wrapped .swiftmodule on Linux to make sure we use
+# the .swiftinterface. The issue here is that if the .swiftmodule is wrapped
+# and linked into the library, LLDB may find it there and load it before the
+# .swiftinterface loading path can be exercised.
 EXCLUDE_WRAPPED_SWIFTMODULE=1
 
-# activates the rules for generating a static lib based on the .o files
-# corresponding to the dylib swift sources above
+# Activates the rules for generating a static lib based on the .o files
+# corresponding to the dylib swift sources above.
 ARCHIVE_NAME := lib$(BASENAME).a
 ARCHIVE_OBJECTS = $(strip $(DYLIB_SWIFT_SOURCES:.swift=.o))
 
@@ -21,12 +24,7 @@ $(ARCHIVE_NAME): $(BASENAME).swiftmodule
 
 include $(LEVEL)/Makefile.rules
 
-# on Linux we need to wrap the swiftmodule as a .o and include it too
-ifneq "$(OS)" "Darwin"
-ARCHIVE_OBJECTS += $(BASENAME).swiftmodule.o
-endif
-
-# generate only the static lib (all would generate a dylib as well)
+# Generate only the static lib (all would generate a dylib as well).
 static_only: $(ARCHIVE_NAME)
 
 clean::

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
@@ -1,0 +1,30 @@
+LEVEL = ../../../make
+
+# set the dylib variables so the rules for generating swift objects and
+# modules are active
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
+
+# don't use the default swift flags, as we don't want -g for the libraries in
+# this test
+SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface -parse-as-library
+
+# activates the rules for generating a static lib based on the .o files
+# corresponding to the dylib swift sources above
+ARCHIVE_NAME := lib$(BASENAME).a
+ARCHIVE_OBJECTS = $(strip $(DYLIB_SWIFT_SOURCES:.swift=.o))
+
+$(ARCHIVE_NAME): $(BASENAME).swiftmodule
+
+include $(LEVEL)/Makefile.rules
+
+# on Linux we need to wrap the swiftmodule as a .o and include it too
+ifneq "$(OS)" "Darwin"
+ARCHIVE_OBJECTS += $(BASENAME).swiftmodule.o
+endif
+
+# generate only the static lib (all would generate a dylib as well)
+static_only: $(ARCHIVE_NAME)
+
+clean::
+	rm -rf $(BASENAME).swiftinterface

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/main.swift
@@ -1,0 +1,14 @@
+import AA
+import BB
+
+func foo() {
+  let x = MyPoint(x: 10, y: 0)
+  let y = MyPoint(x: -2, y: 20)
+
+  print(x.magnitudeSquared)
+  print(y.magnitudeSquared)
+
+  Bar.bar() // break here
+}
+
+foo()

--- a/packages/Python/lldbsuite/test/lldbutil.py
+++ b/packages/Python/lldbsuite/test/lldbutil.py
@@ -1277,6 +1277,16 @@ class RecursiveDecentFormatter(BasicFormatter):
         return output.getvalue()
 
 
+def check_expression(test, frame, expression, expected_result, use_summary=True):
+    """Asserts that the result of evaluating the given expression gives the passed expected result"""
+    value = frame.EvaluateExpression(expression)
+    test.assertTrue(value.IsValid(), expression + "returned a valid value")
+    answer = value.GetSummary() if use_summary else value.GetValue()
+    report_str = "%s expected: %s got: %s" % (
+        expression, expected_result, answer)
+    test.assertTrue(answer == expected_result, report_str)
+
+
 def check_variable(
         test,
         valobj,

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -687,6 +687,7 @@ $(MODULENAME).swiftmodule: $(OBJECTS) $(DYLIB_OBJECTS)
 	@echo "### Merging swift modules for $(MODULENAME)"
 	$(SWIFT_FE) $(SWIFT_FEFLAGS) -merge-modules \
 	  -emit-module $(patsubst %.swift,%.partial.swiftmodule,$(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)) \
+	  -emit-parseable-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface \
 	  -parse-as-library -sil-merge-partial-modules \
 	  -disable-diagnostic-passes -disable-sil-perf-optzns \
 	  -module-name $(MODULENAME) \
@@ -732,6 +733,7 @@ endif
 ifneq "$(ARCHIVE_NAME)" ""
 ifeq "$(OS)" "Darwin"
 $(ARCHIVE_NAME) : $(ARCHIVE_OBJECTS)
+	@echo "### Creating archive $(ARCHIVE_NAME)"
 	$(AR) $(ARFLAGS) $(ARCHIVE_NAME) $(ARCHIVE_OBJECTS)
 	$(RM) $(ARCHIVE_OBJECTS)
 else
@@ -743,11 +745,13 @@ endif
 # Make the dylib
 #----------------------------------------------------------------------
 ifeq "$(USESWIFTDRIVER)" "1"
+ifeq "$(OS)" "Darwin"
+LD_SWIFT_FLAGS=-Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule \
+	  -Xlinker -install_name -Xlinker @executable_path/$(shell basename $@)
+endif
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS)
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
-	$(SWIFTC) $(LD_EXTRAS) -o $@ $^ -Xlinker -dylib \
-	  -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule \
-	  -Xlinker -install_name -Xlinker @executable_path/$(shell basename $@)
+	$(SWIFTC) -emit-library $(LD_SWIFT_FLAGS) $(LD_EXTRAS) -o $@ $^
 else
 $(DYLIB_OBJECTS) : CFLAGS += -DCOMPILING_LLDB_TEST_DLL
 

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -337,7 +337,7 @@ CLANG_MODULE_CACHE_DIR := $(BUILDDIR)/module-cache
 $(warning failed to set the shared clang module cache dir)
 endif
 
-SWIFT_MODULE_CACHE_FLAGS = -module-cache-path $(CLANG_MODULE_CACHE_DIR)
+SWIFT_MODULE_CACHE_FLAGS ?= -module-cache-path $(CLANG_MODULE_CACHE_DIR)
 SWIFTFLAGS += $(SWIFT_MODULE_CACHE_FLAGS)
 
 MANDATORY_MODULE_BUILD_CFLAGS := -fmodules -gmodules -fmodules-cache-path=$(CLANG_MODULE_CACHE_DIR)
@@ -676,7 +676,11 @@ endif
 else # OS = Linux
 $(EXE): $(MODULENAME).swiftmodule.o $(OBJECTS)
 	@echo "### Linking" $(EXE)
+ifneq "$(EXCLUDE_WRAPPED_SWIFTMODULE)" ""
+	$(SWIFTC) $(LD_EXTRAS) $(patsubst %.swiftmodule.o,,$^) $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
+else
 	$(SWIFTC) $(LD_EXTRAS) $^ $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
+endif
 
 $(MODULENAME).swiftmodule.o: $(MODULENAME).swiftmodule
 	@echo "### Wrapping swift module"
@@ -751,7 +755,11 @@ LD_SWIFT_FLAGS=-Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule \
 endif
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS)
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
+ifneq "$(EXCLUDE_WRAPPED_SWIFTMODULE)" ""
+	$(SWIFTC) -emit-library $(LD_SWIFT_FLAGS) $(LD_EXTRAS) -o $@ $(patsubst %.swiftmodule.o,,$^)
+else
 	$(SWIFTC) -emit-library $(LD_SWIFT_FLAGS) $(LD_EXTRAS) -o $@ $^
+endif
 else
 $(DYLIB_OBJECTS) : CFLAGS += -DCOMPILING_LLDB_TEST_DLL
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2985,15 +2985,6 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       GetDiagnosticEngine().addConsumer(
           *new swift::PrintingDiagnosticConsumer());
     }
-    // Install the serialized module loader.
-    std::unique_ptr<swift::ModuleLoader> serialized_module_loader_ap(
-        swift::SerializedModuleLoader::create(*m_ast_context_ap));
-
-    if (serialized_module_loader_ap) {
-      m_serialized_module_loader =
-          (swift::SerializedModuleLoader *)serialized_module_loader_ap.get();
-      m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));
-    }
 
     // Install the parseable interface module loader.
     std::string ModuleCachePath = GetClangImporterOptions().ModuleCachePath;
@@ -3008,6 +2999,16 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       m_parseable_module_loader =
       (swift::ParseableInterfaceModuleLoader *)parseable_module_loader_ap.get();
       m_ast_context_ap->addModuleLoader(std::move(parseable_module_loader_ap));
+    }
+
+    // Install the serialized module loader.
+    std::unique_ptr<swift::ModuleLoader> serialized_module_loader_ap(
+        swift::SerializedModuleLoader::create(*m_ast_context_ap));
+
+    if (serialized_module_loader_ap) {
+      m_serialized_module_loader =
+          (swift::SerializedModuleLoader *)serialized_module_loader_ap.get();
+      m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));
     }
 
     // Set up the required state for the evaluator in the TypeChecker.

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2995,6 +2995,21 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));
     }
 
+    // Install the parseable interface module loader
+    std::string ModuleCachePath = GetClangImporterOptions().ModuleCachePath;
+    StringRef PrebuiltModuleCachePath =
+      GetCompilerInvocation().getFrontendOptions().PrebuiltModuleCachePath;
+    std::unique_ptr<swift::ModuleLoader> parseable_module_loader_ap(
+      swift::ParseableInterfaceModuleLoader::create(
+        *m_ast_context_ap, ModuleCachePath, PrebuiltModuleCachePath,
+        /*tracker=*/nullptr, swift::ModuleLoadingMode::PreferSerialized));
+
+    if (parseable_module_loader_ap) {
+      m_parseable_module_loader =
+      (swift::ParseableInterfaceModuleLoader *)parseable_module_loader_ap.get();
+      m_ast_context_ap->addModuleLoader(std::move(parseable_module_loader_ap));
+    }
+
     // Set up the required state for the evaluator in the TypeChecker.
     registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2985,7 +2985,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       GetDiagnosticEngine().addConsumer(
           *new swift::PrintingDiagnosticConsumer());
     }
-    // Install the serialized module loader
+    // Install the serialized module loader.
     std::unique_ptr<swift::ModuleLoader> serialized_module_loader_ap(
         swift::SerializedModuleLoader::create(*m_ast_context_ap));
 
@@ -2995,7 +2995,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       m_ast_context_ap->addModuleLoader(std::move(serialized_module_loader_ap));
     }
 
-    // Install the parseable interface module loader
+    // Install the parseable interface module loader.
     std::string ModuleCachePath = GetClangImporterOptions().ModuleCachePath;
     StringRef PrebuiltModuleCachePath =
       GetCompilerInvocation().getFrontendOptions().PrebuiltModuleCachePath;


### PR DESCRIPTION
This patch registers a `ParseableInterfaceModuleLoader` with LLDB's `SwiftASTContext` so it can load .swiftinterface files and adds tests that we can still debug executables that link to and use types from libraries with only a .swiftinterface (i.e. no .swiftmodule) and no debug info.

Fixes rdar://problem/43905961