### PR TITLE
Revert "Assorted Swift generics cleanups"

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -474,6 +474,8 @@ public:
 
   static bool IsGenericType(const CompilerType &compiler_type);
 
+  static bool IsSelfArchetypeType(const CompilerType &compiler_type);
+
   bool IsTrivialOptionSetType(const CompilerType &compiler_type);
 
   bool IsErrorType(const CompilerType &compiler_type);

--- a/packages/Python/lldbsuite/test/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -18,6 +18,7 @@ class TestClassConstrainedProtocol(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @expectedFailureAll(bugnumber="rdar://31822623")
     def test_extension_weak_self (self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -230,7 +230,7 @@ __builtin_logger_initialize()
 
     const char *optional_extension =
         (language_flags & SwiftUserExpression::eLanguageFlagIsWeakSelf)
-            ? "Swift.Optional where Wrapped == "
+            ? "Swift.Optional where Wrapped: "
             : "";
 
     if (generic_info.class_bindings.size()) {
@@ -1446,7 +1446,8 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
                            nullptr, &m_source_file);
   swift::Type underlying_type = GetSwiftType(type);
   type_alias_decl->setUnderlyingType(underlying_type);
-  type_alias_decl->markAsDebuggerAlias(true);
+  if (underlying_type->hasArchetype())
+    type_alias_decl->markAsDebuggerAlias(true);
 
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
   if (log) {
@@ -1469,4 +1470,88 @@ swift::ValueDecl *SwiftASTManipulator::MakeGlobalTypealias(
   }
 
   return type_alias_decl;
+}
+
+SwiftASTManipulator::TypesForResultFixup
+SwiftASTManipulator::GetTypesForResultFixup(uint32_t language_flags) {
+  TypesForResultFixup ret;
+
+  for (swift::Decl *decl : m_source_file.Decls) {
+    if (auto extension_decl = llvm::dyn_cast<swift::ExtensionDecl>(decl)) {
+      if (language_flags & SwiftUserExpression::eLanguageFlagIsWeakSelf) {
+        if (extension_decl->getGenericParams() &&
+            extension_decl->getGenericParams()->getParams().size() == 1) {
+          swift::GenericTypeParamDecl *type_parameter =
+              extension_decl->getGenericParams()->getParams()[0];
+          swift::TypeAliasType *name_alias_type =
+              llvm::dyn_cast_or_null<swift::TypeAliasType>(
+                  type_parameter->getSuperclass().getPointer());
+
+          if (name_alias_type) {
+            // FIXME: What if the generic parameter is concrete?
+            ret.Wrapper_archetype = extension_decl->mapTypeIntoContext(
+                type_parameter->getDeclaredInterfaceType())
+                    ->castTo<swift::ArchetypeType>();
+            ret.context_alias = name_alias_type;
+            ret.context_real = name_alias_type->getSinglyDesugaredType();
+          } else {
+            ret.Wrapper_archetype = extension_decl->mapTypeIntoContext(
+                type_parameter->getDeclaredInterfaceType())
+                    ->castTo<swift::ArchetypeType>();
+            ret.context_real =
+                (swift::TypeBase *)type_parameter->getSuperclass().getPointer();
+          }
+        }
+      } else if (!ret.context_alias) {
+        swift::TypeAliasType *name_alias_type =
+            llvm::dyn_cast<swift::TypeAliasType>(
+                extension_decl->getExtendedType().getPointer());
+
+        if (name_alias_type) {
+          ret.context_alias = name_alias_type;
+          ret.context_real = name_alias_type->getSinglyDesugaredType();
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+static swift::Type ReplaceInType(swift::Type orig, swift::TypeBase *from,
+                                 swift::TypeBase *to) {
+  std::function<swift::Type(swift::Type)> Replacer =
+      [from, to](swift::Type orig_type) {
+        if (orig_type.getPointer() == from) {
+          return swift::Type(to);
+        } else {
+          return orig_type;
+        }
+      };
+
+  return orig.transform(Replacer);
+}
+
+swift::Type SwiftASTManipulator::FixupResultType(swift::Type &result_type,
+                                                 uint32_t language_flags) {
+  TypesForResultFixup result_fixup_types =
+      GetTypesForResultFixup(language_flags);
+
+  if (result_fixup_types.Wrapper_archetype && result_fixup_types.context_real) {
+    result_type =
+        ReplaceInType(result_type, result_fixup_types.Wrapper_archetype,
+                      result_fixup_types.context_real);
+  }
+
+  if (result_fixup_types.context_alias && result_fixup_types.context_real) {
+    // This is what we ought to do, but the printing logic doesn't handle the
+    // resulting types properly yet.
+    // result_type = ReplaceInType(result_type,
+    // result_fixup_types.context_alias, result_fixup_types.context_real);
+    if (result_type.getPointer() == result_fixup_types.context_alias) {
+      result_type = result_fixup_types.context_alias->getSinglyDesugaredType();
+    }
+  }
+
+  return result_type;
 }

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -162,6 +162,9 @@ public:
                                         CompilerType &type,
                                         bool make_private = true);
 
+  swift::Type FixupResultType(swift::Type &result_type,
+                              uint32_t language_flags);
+
   bool FixupResultAfterTypeChecking(Status &error);
 
   static const char *GetArgumentName() { return "$__lldb_arg"; }
@@ -211,6 +214,14 @@ private:
                     ResultLocationInfo &result_info);
 
   void InsertError(swift::VarDecl *error_var, swift::Type &error_type);
+
+  struct TypesForResultFixup {
+    swift::ArchetypeType *Wrapper_archetype = nullptr;
+    swift::TypeAliasType *context_alias = nullptr;
+    swift::TypeBase *context_real = nullptr;
+  };
+
+  TypesForResultFixup GetTypesForResultFixup(uint32_t language_flags);
 
   std::vector<ResultLocationInfo> m_result_info;
 };

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -543,13 +543,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   if (!imported_self_type.IsValid())
     return;
 
-  SwiftLanguageRuntime *swift_runtime =
-      stack_frame_sp->GetThread()->GetProcess()->GetSwiftLanguageRuntime();
-  auto *stack_frame = stack_frame_sp.get();
-  imported_self_type =
-      swift_runtime->DoArchetypeBindingForType(*stack_frame,
-                                               imported_self_type);
-
   // This might be a referenced type, in which case we really want to
   // extend the referent:
   imported_self_type =
@@ -563,6 +556,36 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
           ->GetInstanceType(imported_self_type.GetOpaqueQualType());
 
   Flags imported_self_type_flags(imported_self_type.GetTypeInfo());
+
+  // If 'self' is the Self archetype, resolve it to the actual
+  // metatype it is.
+  if (SwiftASTContext::IsSelfArchetypeType(imported_self_type)) {
+    SwiftLanguageRuntime *swift_runtime =
+        stack_frame_sp->GetThread()->GetProcess()->GetSwiftLanguageRuntime();
+    // Assume self is always the first type parameter.
+    if (CompilerType concrete_self_type = swift_runtime->GetConcreteType(
+            stack_frame_sp.get(), ConstString(u8"\u03C4_0_0"))) {
+      if (SwiftASTContext *concrete_self_type_ast_ctx =
+              llvm::dyn_cast_or_null<SwiftASTContext>(
+                  concrete_self_type.GetTypeSystem())) {
+        imported_self_type =
+            concrete_self_type_ast_ctx->CreateMetatypeType(concrete_self_type);
+        imported_self_type_flags.Reset(imported_self_type.GetTypeInfo());
+        imported_self_type = ImportType(swift_ast_context, imported_self_type);
+        if (imported_self_type_flags.AllSet(lldb::eTypeIsSwift |
+                                            lldb::eTypeIsMetatype)) {
+          imported_self_type = imported_self_type.GetInstanceType();
+        }
+      }
+    }
+  }
+
+  // Get the instance type.
+  if (imported_self_type_flags.AllSet(lldb::eTypeIsSwift |
+                                      lldb::eTypeIsMetatype)) {
+    imported_self_type = imported_self_type.GetInstanceType();
+    imported_self_type_flags.Reset(imported_self_type.GetTypeInfo());
+  }
 
   swift::Type object_type =
       GetSwiftType(imported_self_type)->getWithoutSpecifierType();
@@ -1031,7 +1054,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
 
     if (repl) {
       if (swift::Type swift_type = GetSwiftType(variable.GetType())) {
-        if (!swift_type->isVoid()) {
+        if (!swift_type->getCanonicalType()->isVoid()) {
           auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
           if (is_result)
             offset = repl_mat.AddREPLResultVariable(
@@ -1056,24 +1079,35 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                                                     ->GetProcess()
                                                     ->GetSwiftLanguageRuntime();
           if (swift_runtime) {
-            actual_type = swift_runtime->DoArchetypeBindingForType(
-                *stack_frame_sp, actual_type);
+            StreamString type_name;
+            if (SwiftLanguageRuntime::GetAbstractTypeName(type_name, swift_type))
+              actual_type = swift_runtime->GetConcreteType(
+                  stack_frame_sp.get(), ConstString(type_name.GetString()));
+            if (actual_type.IsValid())
+              variable.SetType(actual_type);
+            else
+              actual_type = variable.GetType();
           }
         }
       }
 
-      // Desugar '$lldb_context', etc.
-      auto transformed_type = GetSwiftType(actual_type).transform(
-        [](swift::Type t) -> swift::Type {
-          if (auto *aliasTy = swift::dyn_cast<swift::TypeAliasType>(t.getPointer())) {
-            if (aliasTy && aliasTy->getDecl()->isDebuggerAlias()) {
-              return aliasTy->getSinglyDesugaredType();
-            }
-          }
-          return t;
-      });
-      actual_type.SetCompilerType(actual_type.GetTypeSystem(),
-                                  transformed_type.getPointer());
+      if (stack_frame_sp) {
+        auto *ctx = llvm::cast<SwiftASTContext>(actual_type.GetTypeSystem());
+        actual_type = ctx->MapIntoContext(stack_frame_sp,
+                                          actual_type.GetOpaqueQualType());
+      }
+      swift::Type actual_swift_type = GetSwiftType(actual_type);
+      if (actual_swift_type->hasTypeParameter())
+        actual_swift_type = orig_swift_type;
+
+      swift::Type fixed_type = manipulator.FixupResultType(
+          actual_swift_type, user_expression.GetLanguageFlags());
+
+      if (!fixed_type.isNull()) {
+        actual_type =
+            CompilerType(actual_type.GetTypeSystem(), fixed_type.getPointer());
+        variable.SetType(actual_type);
+      }
 
       if (is_result)
         offset = materializer.AddResultVariable(

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5110,6 +5110,21 @@ bool SwiftASTContext::IsGenericType(const CompilerType &compiler_type) {
   return false;
 }
 
+bool SwiftASTContext::IsSelfArchetypeType(const CompilerType &compiler_type) {
+  if (!compiler_type.IsValid())
+    return false;
+
+  if (llvm::dyn_cast_or_null<SwiftASTContext>(compiler_type.GetTypeSystem())) {
+    if (swift::isa<swift::GenericTypeParamType>(
+            GetSwiftType(compiler_type).getPointer())) {
+      // Hack: Just assume if we have an generic parameter as the type of
+      //       'self', it's going to be a protocol 'Self' type.
+      return true;
+    }
+  }
+  return false;
+}
+
 static CompilerType BindAllArchetypes(CompilerType type,
                                       ExecutionContextScope *exe_scope) {
   if (!exe_scope)
@@ -5620,10 +5635,18 @@ CompilerType SwiftASTContext::GetInstanceType(void *type) {
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   assert((&swift_can_type->getASTContext() == GetASTContext()) &&
          "input type belongs to different SwiftASTContext");
-  auto metatype_type =
-      swift::dyn_cast<swift::AnyMetatypeType>(swift_can_type);
-  if (metatype_type)
-    return {metatype_type.getInstanceType().getPointer()};
+  switch (swift_can_type->getKind()) {
+  case swift::TypeKind::ExistentialMetatype:
+  case swift::TypeKind::Metatype: {
+    auto metatype_type =
+        swift::dyn_cast<swift::AnyMetatypeType>(swift_can_type);
+    if (metatype_type)
+      return {metatype_type.getInstanceType().getPointer()};
+    return {};
+  }
+  default:
+    break;
+  }
 
   return {GetSwiftType(type)};
 }


### PR DESCRIPTION
Reverts apple/swift-lldb#1259. It might breaking PR testing.