### PR TITLE
Reinstate "Assorted Swift generics cleanups""

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -474,8 +474,6 @@ public:
 
   static bool IsGenericType(const CompilerType &compiler_type);
 
-  static bool IsSelfArchetypeType(const CompilerType &compiler_type);
-
   bool IsTrivialOptionSetType(const CompilerType &compiler_type);
 
   bool IsErrorType(const CompilerType &compiler_type);

--- a/packages/Python/lldbsuite/test/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -18,7 +18,6 @@ class TestClassConstrainedProtocol(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @expectedFailureAll(bugnumber="rdar://31822623")
     def test_extension_weak_self (self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -162,9 +162,6 @@ public:
                                         CompilerType &type,
                                         bool make_private = true);
 
-  swift::Type FixupResultType(swift::Type &result_type,
-                              uint32_t language_flags);
-
   bool FixupResultAfterTypeChecking(Status &error);
 
   static const char *GetArgumentName() { return "$__lldb_arg"; }
@@ -214,14 +211,6 @@ private:
                     ResultLocationInfo &result_info);
 
   void InsertError(swift::VarDecl *error_var, swift::Type &error_type);
-
-  struct TypesForResultFixup {
-    swift::ArchetypeType *Wrapper_archetype = nullptr;
-    swift::TypeAliasType *context_alias = nullptr;
-    swift::TypeBase *context_real = nullptr;
-  };
-
-  TypesForResultFixup GetTypesForResultFixup(uint32_t language_flags);
 
   std::vector<ResultLocationInfo> m_result_info;
 };

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -543,6 +543,13 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
   if (!imported_self_type.IsValid())
     return;
 
+  SwiftLanguageRuntime *swift_runtime =
+      stack_frame_sp->GetThread()->GetProcess()->GetSwiftLanguageRuntime();
+  auto *stack_frame = stack_frame_sp.get();
+  imported_self_type =
+      swift_runtime->DoArchetypeBindingForType(*stack_frame,
+                                               imported_self_type);
+
   // This might be a referenced type, in which case we really want to
   // extend the referent:
   imported_self_type =
@@ -556,36 +563,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
           ->GetInstanceType(imported_self_type.GetOpaqueQualType());
 
   Flags imported_self_type_flags(imported_self_type.GetTypeInfo());
-
-  // If 'self' is the Self archetype, resolve it to the actual
-  // metatype it is.
-  if (SwiftASTContext::IsSelfArchetypeType(imported_self_type)) {
-    SwiftLanguageRuntime *swift_runtime =
-        stack_frame_sp->GetThread()->GetProcess()->GetSwiftLanguageRuntime();
-    // Assume self is always the first type parameter.
-    if (CompilerType concrete_self_type = swift_runtime->GetConcreteType(
-            stack_frame_sp.get(), ConstString(u8"\u03C4_0_0"))) {
-      if (SwiftASTContext *concrete_self_type_ast_ctx =
-              llvm::dyn_cast_or_null<SwiftASTContext>(
-                  concrete_self_type.GetTypeSystem())) {
-        imported_self_type =
-            concrete_self_type_ast_ctx->CreateMetatypeType(concrete_self_type);
-        imported_self_type_flags.Reset(imported_self_type.GetTypeInfo());
-        imported_self_type = ImportType(swift_ast_context, imported_self_type);
-        if (imported_self_type_flags.AllSet(lldb::eTypeIsSwift |
-                                            lldb::eTypeIsMetatype)) {
-          imported_self_type = imported_self_type.GetInstanceType();
-        }
-      }
-    }
-  }
-
-  // Get the instance type.
-  if (imported_self_type_flags.AllSet(lldb::eTypeIsSwift |
-                                      lldb::eTypeIsMetatype)) {
-    imported_self_type = imported_self_type.GetInstanceType();
-    imported_self_type_flags.Reset(imported_self_type.GetTypeInfo());
-  }
 
   swift::Type object_type =
       GetSwiftType(imported_self_type)->getWithoutSpecifierType();
@@ -1054,7 +1031,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
 
     if (repl) {
       if (swift::Type swift_type = GetSwiftType(variable.GetType())) {
-        if (!swift_type->getCanonicalType()->isVoid()) {
+        if (!swift_type->isVoid()) {
           auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
           if (is_result)
             offset = repl_mat.AddREPLResultVariable(
@@ -1079,35 +1056,24 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                                                     ->GetProcess()
                                                     ->GetSwiftLanguageRuntime();
           if (swift_runtime) {
-            StreamString type_name;
-            if (SwiftLanguageRuntime::GetAbstractTypeName(type_name, swift_type))
-              actual_type = swift_runtime->GetConcreteType(
-                  stack_frame_sp.get(), ConstString(type_name.GetString()));
-            if (actual_type.IsValid())
-              variable.SetType(actual_type);
-            else
-              actual_type = variable.GetType();
+            actual_type = swift_runtime->DoArchetypeBindingForType(
+                *stack_frame_sp, actual_type);
           }
         }
       }
 
-      if (stack_frame_sp) {
-        auto *ctx = llvm::cast<SwiftASTContext>(actual_type.GetTypeSystem());
-        actual_type = ctx->MapIntoContext(stack_frame_sp,
-                                          actual_type.GetOpaqueQualType());
-      }
-      swift::Type actual_swift_type = GetSwiftType(actual_type);
-      if (actual_swift_type->hasTypeParameter())
-        actual_swift_type = orig_swift_type;
-
-      swift::Type fixed_type = manipulator.FixupResultType(
-          actual_swift_type, user_expression.GetLanguageFlags());
-
-      if (!fixed_type.isNull()) {
-        actual_type =
-            CompilerType(actual_type.GetTypeSystem(), fixed_type.getPointer());
-        variable.SetType(actual_type);
-      }
+      // Desugar '$lldb_context', etc.
+      auto transformed_type = GetSwiftType(actual_type).transform(
+        [](swift::Type t) -> swift::Type {
+          if (auto *aliasTy = swift::dyn_cast<swift::TypeAliasType>(t.getPointer())) {
+            if (aliasTy && aliasTy->getDecl()->isDebuggerAlias()) {
+              return aliasTy->getSinglyDesugaredType();
+            }
+          }
+          return t;
+      });
+      actual_type.SetCompilerType(actual_type.GetTypeSystem(),
+                                  transformed_type.getPointer());
 
       if (is_result)
         offset = materializer.AddResultVariable(

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -454,7 +454,14 @@ static bool GetObjectDescription_ObjectReference(Process *process, Stream &str,
   }
 }
 
-static bool GetObjectDescription_ObjectCopy(Process *process, Stream &str,
+static const ExecutionContextRef *GetSwiftExeCtx(ValueObject &valobj) {
+  return (valobj.GetPreferredDisplayLanguage() == eLanguageTypeSwift)
+             ? &valobj.GetExecutionContextRef()
+             : nullptr;
+}
+
+static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntime *runtime,
+                                            Process *process, Stream &str,
                                             ValueObject &object) {
   Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS));
 
@@ -474,10 +481,10 @@ static bool GetObjectDescription_ObjectCopy(Process *process, Stream &str,
       process->GetThreadList().GetSelectedThread()->GetSelectedFrame();
   auto *swift_ast_ctx =
       llvm::dyn_cast_or_null<SwiftASTContext>(static_type.GetTypeSystem());
-  if (swift_ast_ctx)
-    static_type =
-        swift_ast_ctx->MapIntoContext(frame_sp,
-                                      static_type.GetOpaqueQualType());
+  if (swift_ast_ctx) {
+    SwiftASTContextLock lock(GetSwiftExeCtx(object));
+    static_type = runtime->DoArchetypeBindingForType(*frame_sp, static_type);
+  }
 
   lldb::addr_t copy_location = process->AllocateMemory(
       static_type.GetByteStride(), ePermissionsReadable | ePermissionsWritable,
@@ -663,7 +670,7 @@ bool SwiftLanguageRuntime::GetObjectDescription(Stream &str,
 
   // in general, don't try to use the name of the ValueObject as it might end up
   // referring to the wrong thing
-  return GetObjectDescription_ObjectCopy(m_process, str, object);
+  return GetObjectDescription_ObjectCopy(this, m_process, str, object);
 }
 
 bool SwiftLanguageRuntime::GetObjectDescription(


### PR DESCRIPTION
Reverts apple/swift-lldb#1263. The original PR (#1259) was not in fact the cause of the PR testing failures we were seeing.