### PR TITLE
Fix use of non-existing variable in crashlog.py

### DIFF
--- a/examples/python/crashlog.py
+++ b/examples/python/crashlog.py
@@ -260,7 +260,7 @@ class CrashLog(symbolication.Symbolicator):
             if not self.resolved_path:
                 self.unavailable = True
                 print("error\n    error: unable to locate '%s' with UUID %s"
-                      % (self.path, uuid_str))
+                      % (self.path, self.get_normalized_uuid_string()))
                 return False
 
         def locate_module_and_debug_symbols(self):


### PR DESCRIPTION
Summary:
The method find_matching_slice(self) uses uuid_str on one of the paths but the variable does not exist and so this results in a NameError exception if we take that path.

Differential Revision: https://reviews.llvm.org/D57467

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@352772 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit cf4db884f6adf7f1a6901469656a803ae30a0ee7)