### PR TITLE
add code completion to the SBAPI

### DIFF
--- a/include/lldb/API/LLDB.h
+++ b/include/lldb/API/LLDB.h
@@ -58,6 +58,9 @@
 #include "lldb/API/SBStream.h"
 #include "lldb/API/SBStringList.h"
 #include "lldb/API/SBStructuredData.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "lldb/API/SBCompletionMatch.h"
+#include "lldb/API/SBCompletionResponse.h"
 #include "lldb/API/SBSymbol.h"
 #include "lldb/API/SBSymbolContext.h"
 #include "lldb/API/SBSymbolContextList.h"

--- a/include/lldb/API/SBCompletionMatch.h
+++ b/include/lldb/API/SBCompletionMatch.h
@@ -1,0 +1,44 @@
+//===-- SBCompletionMatch.h -------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SBCompletionMatch_h_
+#define LLDB_SBCompletionMatch_h_
+
+#include "lldb/API/SBDefines.h"
+#include "lldb/Target/CompletionMatch.h"
+
+namespace lldb {
+
+class LLDB_API SBCompletionMatch {
+public:
+  SBCompletionMatch();
+
+  SBCompletionMatch(const SBCompletionMatch &rhs);
+
+  const SBCompletionMatch &operator=(const SBCompletionMatch &rhs);
+
+  const char *GetDisplay() const;
+
+  const char *GetInsertable() const;
+
+protected:
+  friend class SBCompletionResponse;
+
+  SBCompletionMatch(const lldb_private::CompletionMatch *response);
+
+private:
+  std::unique_ptr<lldb_private::CompletionMatch> m_opaque_ap;
+};
+
+} // namespace lldb
+
+#endif // LLDB_SBCompletionMatch_h_

--- a/include/lldb/API/SBCompletionResponse.h
+++ b/include/lldb/API/SBCompletionResponse.h
@@ -1,0 +1,48 @@
+//===-- SBCompletionResponse.h ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SBCompletionResponse_h_
+#define LLDB_SBCompletionResponse_h_
+
+#include "lldb/API/SBDefines.h"
+#include "lldb/Target/CompletionResponse.h"
+
+namespace lldb {
+
+class LLDB_API SBCompletionResponse {
+public:
+  SBCompletionResponse();
+
+  SBCompletionResponse(const SBCompletionResponse &rhs);
+
+  const SBCompletionResponse &operator=(const SBCompletionResponse &rhs);
+
+  const char *GetErrorMessage() const;
+
+  const char *GetPrefix() const;
+
+  uint32_t GetNumMatches() const;
+
+  SBCompletionMatch GetMatchAtIndex(size_t idx) const;
+
+protected:
+  friend class SBTarget;
+
+  SBCompletionResponse(const lldb_private::CompletionResponse *response);
+
+private:
+  std::unique_ptr<lldb_private::CompletionResponse> m_opaque_ap;
+};
+
+} // namespace lldb
+
+#endif // LLDB_SBCompletionResponse_h_

--- a/include/lldb/API/SBDefines.h
+++ b/include/lldb/API/SBDefines.h
@@ -42,6 +42,8 @@ class LLDB_API SBCommandPluginInterface;
 class LLDB_API SBCommandReturnObject;
 class LLDB_API SBCommunication;
 class LLDB_API SBCompileUnit;
+class LLDB_API SBCompletionMatch;
+class LLDB_API SBCompletionResponse;
 class LLDB_API SBData;
 class LLDB_API SBDebugger;
 class LLDB_API SBDeclaration;

--- a/include/lldb/API/SBTarget.h
+++ b/include/lldb/API/SBTarget.h
@@ -893,6 +893,12 @@ public:
   lldb::SBValue EvaluateExpression(const char *expr,
                                    const SBExpressionOptions &options);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  SBCompletionResponse
+  CompleteCode(lldb::LanguageType language,
+               const lldb::SBSymbolContext *symbol_context,
+               const char *current_code);
+
   lldb::addr_t GetStackRedZoneSize();
 
   lldb::SBLaunchInfo GetLaunchInfo() const;

--- a/include/lldb/Target/CompletionMatch.h
+++ b/include/lldb/Target/CompletionMatch.h
@@ -1,0 +1,27 @@
+//===--- CompletionMatch.h --------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CompletionMatch_h_
+#define CompletionMatch_h_
+
+#include <string>
+
+namespace lldb_private {
+
+struct CompletionMatch {
+  std::string Display;
+  std::string Insertable;
+};
+
+} // namespace lldb_private
+
+#endif // CompletionMatch_h_

--- a/include/lldb/Target/CompletionResponse.h
+++ b/include/lldb/Target/CompletionResponse.h
@@ -25,7 +25,7 @@ struct CompletionResponse {
   std::string Prefix;
   std::vector<CompletionMatch> Matches;
 
-  static CompletionResponse error(std::string ErrorMessage) {
+  static CompletionResponse error(const std::string &ErrorMessage) {
     CompletionResponse Response;
     Response.ErrorMessage = ErrorMessage;
     return Response;

--- a/include/lldb/Target/CompletionResponse.h
+++ b/include/lldb/Target/CompletionResponse.h
@@ -1,0 +1,37 @@
+//===--- CompletionResponse.h -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CompletionResponse_h_
+#define CompletionResponse_h_
+
+#include "lldb/Target/CompletionMatch.h"
+
+#include <string>
+#include <vector>
+
+namespace lldb_private {
+
+struct CompletionResponse {
+  std::string ErrorMessage;
+  std::string Prefix;
+  std::vector<CompletionMatch> Matches;
+
+  static CompletionResponse error(std::string ErrorMessage) {
+    CompletionResponse Response;
+    Response.ErrorMessage = ErrorMessage;
+    return Response;
+  }
+};
+
+} // namespace lldb_private
+
+#endif // CompletionResponse_h_

--- a/include/lldb/Target/Language.h
+++ b/include/lldb/Target/Language.h
@@ -25,6 +25,8 @@
 #include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/DataFormatters/FormatClasses.h"
 #include "lldb/DataFormatters/StringPrinter.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "lldb/Target/CompletionResponse.h"
 #include "lldb/lldb-private.h"
 #include "lldb/lldb-public.h"
 
@@ -230,6 +232,10 @@ public:
 
   static void GetDefaultExceptionResolverDescription(bool catch_on,
                                                      bool throw_on, Stream &s);
+
+  // SWIFT_ENABLE_TENSORFLOW
+  virtual CompletionResponse CompleteCode(Target &target,
+                                          std::string entered_code);
 
   // These are accessors for general information about the Languages lldb knows
   // about:

--- a/include/lldb/Target/Language.h
+++ b/include/lldb/Target/Language.h
@@ -235,7 +235,7 @@ public:
 
   // SWIFT_ENABLE_TENSORFLOW
   virtual CompletionResponse CompleteCode(Target &target,
-                                          std::string entered_code);
+                                          const std::string &entered_code);
 
   // These are accessors for general information about the Languages lldb knows
   // about:

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -39,6 +39,8 @@
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Target/ABI.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "lldb/Target/CompletionResponse.h"
 #include "lldb/Target/ExecutionContextScope.h"
 #include "lldb/Target/PathMappingList.h"
 #include "lldb/Target/ProcessLaunchInfo.h"
@@ -1216,6 +1218,10 @@ public:
       lldb::ValueObjectSP &result_valobj_sp,
       const EvaluateExpressionOptions &options = EvaluateExpressionOptions(),
       std::string *fixed_expression = nullptr);
+
+  // SWIFT_ENABLE_TENSORFLOW
+  CompletionResponse CompleteCode(lldb::LanguageType language,
+                                  llvm::StringRef current_code);
 
   // Look up a symbol by name and type in both the target's symbols and the
   // persistent symbols from the

--- a/scripts/interface/SBCompletionMatch.i
+++ b/scripts/interface/SBCompletionMatch.i
@@ -1,0 +1,38 @@
+//===-- SWIG Interface for SBCompletionMatch --------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+namespace lldb {
+
+%feature("docstring", "
+Represents a single possible completion.
+") SBCompletionMatch;
+class SBCompletionMatch
+{
+public:
+    %feature("docstring", "
+    Returns a detailed string describing this completion that is suitable for
+    displaying to a user in a list of completion possibilities. This string
+    is not suitable for inserting into the code because it may contain
+    information about the match (like type information) that doesn't go in
+    code.
+    ") GetDisplay;
+    const char *
+    GetDisplay () const;
+
+    %feature("docstring", "
+    Returns a string that can be inserted into the code.
+    ") GetInsertable;
+    const char *
+    GetInsertable () const;
+};
+
+} // namespace lldb

--- a/scripts/interface/SBCompletionResponse.i
+++ b/scripts/interface/SBCompletionResponse.i
@@ -1,0 +1,49 @@
+//===-- SWIG Interface for SBCompletionResponse -----------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+namespace lldb {
+
+%feature("docstring", "
+Represents a set of completions, or an error describing why completions could
+not be calculated."
+) SBCompletionResponse;
+class SBCompletionResponse
+{
+public:
+    %feature("docstring", "
+    Return the error message, if any. The length is 0 if and only if the
+    completion calculation was a success.
+    ") GetErrorMessage;
+    const char *
+    GetErrorMessage() const;
+
+    %feature("docstring", "
+    Returns a common prefix of all the matches. This prefix is present in the
+    code for which the completion was requested.
+    ") GetPrefix;
+    const char *
+    GetPrefix () const;
+
+    %feature("docstring", "
+    Returns the number of matches that this response contains.
+    ") GetNumMatches;
+    uint32_t
+    GetNumMatches () const;
+
+    %feature("docstring", "
+    Returns the match at `idx`.
+    ") SBCompletionMatch;
+    lldb::SBCompletionMatch
+    GetMatchAtIndex (size_t idx) const;
+};
+
+} // namespace lldb

--- a/scripts/interface/SBTarget.i
+++ b/scripts/interface/SBTarget.i
@@ -1035,6 +1035,21 @@ public:
     lldb::SBValue
     EvaluateExpression (const char *expr, const lldb::SBExpressionOptions &options);
 
+    // SWIFT_ENABLE_TENSORFLOW
+    %feature("docstring", "
+    Complete code.
+    Parameters:
+      language          -- the language to use
+      symbol_context    -- the context in which to do the completion
+      current_code      -- the code to complete
+    Returns an SBCompletionResponse with completions that fit immediately after
+    the last character of `current_code`.
+    ") CompleteCode;
+    lldb::SBCompletionResponse
+    CompleteCode (lldb::LanguageType language,
+                  const lldb::SBSymbolContext *symbol_context,
+                  const char *current_code);
+
     %pythoncode %{
         class modules_access(object):
             '''A helper object that will lazily hand out lldb.SBModule objects for a target when supplied an index, or by full or partial path.'''

--- a/scripts/lldb.swig
+++ b/scripts/lldb.swig
@@ -88,6 +88,9 @@ import six
 #include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBCommunication.h"
 #include "lldb/API/SBCompileUnit.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "lldb/API/SBCompletionMatch.h"
+#include "lldb/API/SBCompletionResponse.h"
 #include "lldb/API/SBData.h"
 #include "lldb/API/SBDebugger.h"
 #include "lldb/API/SBDeclaration.h"
@@ -175,6 +178,9 @@ import six
 %include "./interface/SBCommandReturnObject.i"
 %include "./interface/SBCommunication.i"
 %include "./interface/SBCompileUnit.i"
+// SWIFT_ENABLE_TENSORFLOW
+%include "./interface/SBCompletionMatch.i"
+%include "./interface/SBCompletionResponse.i"
 %include "./interface/SBData.i"
 %include "./interface/SBDebugger.i"
 %include "./interface/SBDeclaration.i"

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -22,6 +22,8 @@ add_lldb_library(liblldb SHARED
   SBCommandReturnObject.cpp
   SBCommunication.cpp
   SBCompileUnit.cpp
+  SBCompletionMatch.cpp
+  SBCompletionResponse.cpp
   SBData.cpp
   SBDebugger.cpp
   SBDeclaration.cpp

--- a/source/API/SBCompletionMatch.cpp
+++ b/source/API/SBCompletionMatch.cpp
@@ -1,0 +1,40 @@
+//===-- SBCompletionMatch.cpp -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/API/SBCompletionMatch.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+SBCompletionMatch::SBCompletionMatch()
+    : m_opaque_ap(new lldb_private::CompletionMatch()) {}
+
+SBCompletionMatch::SBCompletionMatch(const SBCompletionMatch &rhs)
+    : m_opaque_ap(new lldb_private::CompletionMatch(*rhs.m_opaque_ap)) {}
+
+const SBCompletionMatch &SBCompletionMatch::
+operator=(const SBCompletionMatch &rhs) {
+  m_opaque_ap.reset(new lldb_private::CompletionMatch(*rhs.m_opaque_ap));
+  return *this;
+}
+
+const char *SBCompletionMatch::GetDisplay() const {
+  return m_opaque_ap->Display.c_str();
+}
+
+const char *SBCompletionMatch::GetInsertable() const {
+  return m_opaque_ap->Insertable.c_str();
+}
+
+SBCompletionMatch::SBCompletionMatch(
+    const lldb_private::CompletionMatch *response)
+    : m_opaque_ap(new lldb_private::CompletionMatch(*response)) {}

--- a/source/API/SBCompletionResponse.cpp
+++ b/source/API/SBCompletionResponse.cpp
@@ -1,0 +1,48 @@
+//===-- SBCompletionResponse.cpp --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/API/SBCompletionResponse.h"
+#include "lldb/API/SBCompletionMatch.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+SBCompletionResponse::SBCompletionResponse()
+    : m_opaque_ap(new CompletionResponse()) {}
+
+SBCompletionResponse::SBCompletionResponse(const SBCompletionResponse &rhs)
+    : m_opaque_ap(new CompletionResponse(*rhs.m_opaque_ap)) {}
+
+SBCompletionResponse::SBCompletionResponse(const CompletionResponse *response)
+    : m_opaque_ap(new CompletionResponse(*response)) {}
+
+const SBCompletionResponse &SBCompletionResponse::
+operator=(const SBCompletionResponse &rhs) {
+  m_opaque_ap.reset(new CompletionResponse(*rhs.m_opaque_ap));
+  return *this;
+}
+
+const char *SBCompletionResponse::GetErrorMessage() const {
+  return m_opaque_ap->ErrorMessage.c_str();
+}
+
+const char *SBCompletionResponse::GetPrefix() const {
+  return m_opaque_ap->Prefix.c_str();
+}
+
+uint32_t SBCompletionResponse::GetNumMatches() const {
+  return m_opaque_ap->Matches.size();
+}
+
+SBCompletionMatch SBCompletionResponse::GetMatchAtIndex(size_t idx) const {
+  return SBCompletionMatch(&m_opaque_ap->Matches[idx]);
+}

--- a/source/API/SBTarget.cpp
+++ b/source/API/SBTarget.cpp
@@ -13,6 +13,8 @@
 
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/API/SBDebugger.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "lldb/API/SBCompletionResponse.h"
 #include "lldb/API/SBEvent.h"
 #include "lldb/API/SBExpressionOptions.h"
 #include "lldb/API/SBFileSpec.h"
@@ -2302,6 +2304,15 @@ lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
 #endif
 
   return expr_result;
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+SBCompletionResponse
+SBTarget::CompleteCode(lldb::LanguageType language,
+                       const lldb::SBSymbolContext *symbol_context,
+                       const char *current_code) {
+  auto response = GetSP()->CompleteCode(language, current_code);
+  return SBCompletionResponse(&response);
 }
 
 lldb::addr_t SBTarget::GetStackRedZoneSize() {

--- a/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/source/Plugins/Language/Swift/CMakeLists.txt
@@ -5,6 +5,8 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   ObjCRuntimeSyntheticProvider.cpp
   SwiftArray.cpp
   SwiftBasicTypes.cpp
+  # SWIFT_ENABLE_TENSORFLOW
+  SwiftCodeCompletion.cpp
   SwiftDictionary.cpp
   SwiftFormatters.cpp
   SwiftHashedContainer.cpp

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -1,0 +1,244 @@
+//===--- SwiftCodeCompletion.cpp - Code Completion for Swift ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftCodeCompletion.h"
+
+#include "swift/IDE/CodeCompletion.h"
+#include "swift/IDE/CodeCompletionCache.h"
+#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/DelayedParsingCallbacks.h"
+#include "swift/Subsystems.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace llvm;
+using namespace swift;
+using namespace ide;
+
+static std::string toInsertableString(CodeCompletionResult *Result) {
+  std::string Str;
+  for (auto C : Result->getCompletionString()->getChunks()) {
+    switch (C.getKind()) {
+    case CodeCompletionString::Chunk::ChunkKind::AccessControlKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::OverrideKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::ThrowsKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::RethrowsKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::DeclAttrKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::DeclIntroducer:
+    case CodeCompletionString::Chunk::ChunkKind::Text:
+    case CodeCompletionString::Chunk::ChunkKind::LeftParen:
+    case CodeCompletionString::Chunk::ChunkKind::RightParen:
+    case CodeCompletionString::Chunk::ChunkKind::LeftBracket:
+    case CodeCompletionString::Chunk::ChunkKind::RightBracket:
+    case CodeCompletionString::Chunk::ChunkKind::LeftAngle:
+    case CodeCompletionString::Chunk::ChunkKind::RightAngle:
+    case CodeCompletionString::Chunk::ChunkKind::Dot:
+    case CodeCompletionString::Chunk::ChunkKind::Ellipsis:
+    case CodeCompletionString::Chunk::ChunkKind::Comma:
+    case CodeCompletionString::Chunk::ChunkKind::ExclamationMark:
+    case CodeCompletionString::Chunk::ChunkKind::QuestionMark:
+    case CodeCompletionString::Chunk::ChunkKind::Ampersand:
+    case CodeCompletionString::Chunk::ChunkKind::Equal:
+    case CodeCompletionString::Chunk::ChunkKind::Whitespace:
+    case CodeCompletionString::Chunk::ChunkKind::DynamicLookupMethodCallTail:
+    case CodeCompletionString::Chunk::ChunkKind::OptionalMethodCallTail:
+      if (!C.isAnnotation())
+        Str += C.getText();
+      break;
+
+    case CodeCompletionString::Chunk::ChunkKind::CallParameterName:
+    case CodeCompletionString::Chunk::ChunkKind::CallParameterInternalName:
+    case CodeCompletionString::Chunk::ChunkKind::CallParameterColon:
+    case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamColon:
+    case CodeCompletionString::Chunk::ChunkKind::CallParameterType:
+    case CodeCompletionString::Chunk::ChunkKind::CallParameterClosureType:
+    case CodeCompletionString::Chunk::ChunkKind::OptionalBegin:
+    case CodeCompletionString::Chunk::ChunkKind::CallParameterBegin:
+    case CodeCompletionString::Chunk::ChunkKind::GenericParameterBegin:
+    case CodeCompletionString::Chunk::ChunkKind::GenericParameterName:
+    case CodeCompletionString::Chunk::ChunkKind::TypeAnnotation:
+      return Str;
+
+    case CodeCompletionString::Chunk::ChunkKind::BraceStmtWithCursor:
+      Str += " {";
+      break;
+    }
+  }
+  return Str;
+}
+
+static std::string toDisplayString(CodeCompletionResult *Result) {
+  std::string Str;
+  for (auto C : Result->getCompletionString()->getChunks()) {
+    if (C.getKind() ==
+        CodeCompletionString::Chunk::ChunkKind::BraceStmtWithCursor) {
+      Str += ' ';
+      continue;
+    }
+    if (!C.isAnnotation() && C.hasText()) {
+      Str += C.getText();
+      continue;
+    }
+    if (C.getKind() == CodeCompletionString::Chunk::ChunkKind::TypeAnnotation) {
+      if (Result->getKind() == CodeCompletionResult::Declaration) {
+        switch (Result->getAssociatedDeclKind()) {
+        case CodeCompletionDeclKind::Module:
+        case CodeCompletionDeclKind::PrecedenceGroup:
+        case CodeCompletionDeclKind::Class:
+        case CodeCompletionDeclKind::Struct:
+        case CodeCompletionDeclKind::Enum:
+          continue;
+
+        case CodeCompletionDeclKind::EnumElement:
+          Str += ": ";
+          break;
+
+        case CodeCompletionDeclKind::Protocol:
+        case CodeCompletionDeclKind::TypeAlias:
+        case CodeCompletionDeclKind::AssociatedType:
+        case CodeCompletionDeclKind::GenericTypeParam:
+        case CodeCompletionDeclKind::Constructor:
+        case CodeCompletionDeclKind::Destructor:
+          continue;
+
+        case CodeCompletionDeclKind::Subscript:
+        case CodeCompletionDeclKind::StaticMethod:
+        case CodeCompletionDeclKind::InstanceMethod:
+        case CodeCompletionDeclKind::PrefixOperatorFunction:
+        case CodeCompletionDeclKind::PostfixOperatorFunction:
+        case CodeCompletionDeclKind::InfixOperatorFunction:
+        case CodeCompletionDeclKind::FreeFunction:
+          Str += " -> ";
+          break;
+
+        case CodeCompletionDeclKind::StaticVar:
+        case CodeCompletionDeclKind::InstanceVar:
+        case CodeCompletionDeclKind::LocalVar:
+        case CodeCompletionDeclKind::GlobalVar:
+          Str += ": ";
+          break;
+        }
+      } else {
+        Str += ": ";
+      }
+      Str += C.getText();
+    }
+  }
+  return Str;
+}
+
+namespace lldb_private {
+
+class CodeCompletionConsumer : public SimpleCachingCodeCompletionConsumer {
+  CompletionResponse &Response;
+
+public:
+  CodeCompletionConsumer(CompletionResponse &Response) : Response(Response) {}
+
+  void handleResults(MutableArrayRef<CodeCompletionResult *> Results) override {
+    CodeCompletionContext::sortCompletionResults(Results);
+    for (auto *Result : Results) {
+      Response.Matches.push_back(
+          {toDisplayString(Result), toInsertableString(Result)});
+    }
+  }
+};
+
+/// Calculates completions at the end of `EnteredCode`.
+static unsigned
+doCodeCompletion(SourceFile &SF, StringRef EnteredCode,
+                 CodeCompletionCallbacksFactory *CompletionCallbacksFactory) {
+  ASTContext &Ctx = SF.getASTContext();
+  DiagnosticTransaction DelayedDiags(Ctx.Diags);
+
+  std::string AugmentedCode = EnteredCode.str();
+  AugmentedCode += '\0';
+  const unsigned BufferID =
+      Ctx.SourceMgr.addMemBufferCopy(AugmentedCode, "<REPL Input>");
+
+  const unsigned CodeCompletionOffset = AugmentedCode.size() - 1;
+
+  Ctx.SourceMgr.setCodeCompletionPoint(BufferID, CodeCompletionOffset);
+
+  const unsigned OriginalDeclCount = SF.Decls.size();
+
+  PersistentParserState PersistentState(Ctx);
+  std::unique_ptr<DelayedParsingCallbacks> DelayedCB(
+      new CodeCompleteDelayedCallbacks(Ctx.SourceMgr.getCodeCompletionLoc()));
+  bool Done;
+  do {
+    parseIntoSourceFile(SF, BufferID, &Done, nullptr, &PersistentState,
+                        DelayedCB.get());
+  } while (!Done);
+  performTypeChecking(SF, PersistentState.getTopLevelContext(), None,
+                      OriginalDeclCount);
+
+  performDelayedParsing(&SF, PersistentState, CompletionCallbacksFactory);
+
+  SF.Decls.resize(OriginalDeclCount);
+  DelayedDiags.abort();
+
+  return BufferID;
+}
+
+CompletionResponse SwiftCompleteCode(SourceFile &SF, StringRef EnteredCode) {
+  ASTContext &Ctx = SF.getASTContext();
+
+  // Set up `Response` to collect results, and set up a callback handler that
+  // puts the results into `Response`.
+  CompletionResponse Response;
+  CodeCompletionConsumer Consumer(Response);
+  CodeCompletionCache CompletionCache;
+  CodeCompletionContext CompletionContext(CompletionCache);
+  std::unique_ptr<CodeCompletionCallbacksFactory> CompletionCallbacksFactory(
+      ide::makeCodeCompletionCallbacksFactory(CompletionContext, Consumer));
+
+  // Not sure what this first call to `doCodeCompletion` is for. It seems not to
+  // return any results, but perhaps it prepares the buffer in some useful way
+  // so that the next call works.
+  const unsigned BufferID =
+      doCodeCompletion(SF, EnteredCode, CompletionCallbacksFactory.get());
+
+  // Now we tokenize it, and we treat the last token as a prefix for the
+  // completion that we are looking for. We request completions for the code
+  // with the last token removed. This gives us a bunch of completions that fit
+  // in the context where the last token is, but these completions are not
+  // filtered to match the prefix. So we filter them.
+  auto Tokens = tokenize(Ctx.LangOpts, Ctx.SourceMgr, BufferID);
+  if (!Tokens.empty() && Tokens.back().is(tok::code_complete))
+    Tokens.pop_back();
+  if (!Tokens.empty()) {
+    Token &LastToken = Tokens.back();
+    if (LastToken.is(tok::identifier) || LastToken.isKeyword()) {
+      Response.Prefix = LastToken.getText();
+      const unsigned Offset =
+          Ctx.SourceMgr.getLocOffsetInBuffer(LastToken.getLoc(), BufferID);
+      doCodeCompletion(SF, EnteredCode.substr(0, Offset),
+                       CompletionCallbacksFactory.get());
+
+      std::vector<CompletionMatch> FilteredMatches;
+      for (auto &Match : Response.Matches) {
+        if (!StringRef(Match.Insertable).startswith(Response.Prefix))
+          continue;
+        FilteredMatches.push_back(
+            {Match.Display, Match.Insertable.substr(Response.Prefix.size())});
+      }
+      Response.Matches = FilteredMatches;
+    }
+  }
+
+  return Response;
+}
+
+} // namespace lldb_private

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.h
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.h
@@ -1,0 +1,30 @@
+//===--- SwiftCodeCompletion.h - Code Completion for Swift ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SwiftCodeCompletion_h_
+#define SwiftCodeCompletion_h_
+
+#include "lldb/Target/CompletionResponse.h"
+#include "lldb/Target/Target.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include "swift/AST/Module.h"
+
+namespace lldb_private {
+
+CompletionResponse SwiftCompleteCode(swift::SourceFile &SF,
+                                     llvm::StringRef EnteredCode);
+
+} // namespace lldb_private
+
+#endif // SwiftCodeCompletion_h_

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -30,6 +30,7 @@
 #include "lldb/Target/SwiftLanguageRuntime.h"
 
 #include "ObjCRuntimeSyntheticProvider.h"
+#include "SwiftCodeCompletion.h"
 #include "SwiftFormatters.h"
 
 #include <functional>
@@ -1664,6 +1665,36 @@ bool SwiftLanguage::GetFunctionDisplayName(
 void SwiftLanguage::GetExceptionResolverDescription(bool catch_on,
                                                     bool throw_on, Stream &s) {
   s.Printf("Swift Error breakpoint");
+}
+
+CompletionResponse SwiftLanguage::CompleteCode(Target &target,
+                                               std::string entered_code) {
+  Status error;
+  SwiftASTContext *swift_ast =
+      target.GetScratchSwiftASTContext(error, nullptr).get();
+  if (!swift_ast)
+    return CompletionResponse::error("could not get Swift ASTContext");
+
+  swift::ASTContext *ast = swift_ast->GetASTContext();
+  static ConstString g_repl_module_name("repl");
+  swift::ModuleDecl *repl_module =
+      swift_ast->GetModule(g_repl_module_name, error);
+  if (!repl_module) {
+    repl_module = swift_ast->CreateModule(g_repl_module_name, error);
+    const swift::SourceFile::ImplicitModuleImportKind implicit_import_kind =
+        swift::SourceFile::ImplicitModuleImportKind::Stdlib;
+    llvm::Optional<unsigned> bufferID;
+    swift::SourceFile *repl_source_file = new (*ast)
+        swift::SourceFile(*repl_module, swift::SourceFileKind::REPL, bufferID,
+                          implicit_import_kind, /*Keep tokens*/ false);
+    repl_module->addFile(*repl_source_file);
+  }
+  if (!repl_module)
+    return CompletionResponse::error("could not get repl module");
+
+  swift::SourceFile &repl_source_file =
+      repl_module->getMainSourceFile(swift::SourceFileKind::REPL);
+  return SwiftCompleteCode(repl_source_file, entered_code);
 }
 
 //------------------------------------------------------------------

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1667,8 +1667,8 @@ void SwiftLanguage::GetExceptionResolverDescription(bool catch_on,
   s.Printf("Swift Error breakpoint");
 }
 
-CompletionResponse SwiftLanguage::CompleteCode(Target &target,
-                                               std::string entered_code) {
+CompletionResponse
+SwiftLanguage::CompleteCode(Target &target, const std::string &entered_code) {
   Status error;
   SwiftASTContext *swift_ast =
       target.GetScratchSwiftASTContext(error, nullptr).get();

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -75,7 +75,8 @@ public:
                                        Stream &s) override;
 
   // SWIFT_ENABLE_TENSORFLOW
-  CompletionResponse CompleteCode(Target &target, std::string entered_code);
+  CompletionResponse CompleteCode(Target &target,
+                                  const std::string &entered_code);
 
   //------------------------------------------------------------------
   // Static Functions

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -74,6 +74,9 @@ public:
   void GetExceptionResolverDescription(bool catch_on, bool throw_on,
                                        Stream &s) override;
 
+  // SWIFT_ENABLE_TENSORFLOW
+  CompletionResponse CompleteCode(Target &target, std::string entered_code);
+
   //------------------------------------------------------------------
   // Static Functions
   //------------------------------------------------------------------

--- a/source/Target/Language.cpp
+++ b/source/Target/Language.cpp
@@ -445,6 +445,12 @@ void Language::GetDefaultExceptionResolverDescription(bool catch_on,
   s.Printf("Exception breakpoint (catch: %s throw: %s)",
            catch_on ? "on" : "off", throw_on ? "on" : "off");
 }
+
+CompletionResponse Language::CompleteCode(Target &target,
+                                          std::string entered_code) {
+  return CompletionResponse::error("completion unsupported for this language");
+}
+
 //----------------------------------------------------------------------
 // Constructor
 //----------------------------------------------------------------------

--- a/source/Target/Language.cpp
+++ b/source/Target/Language.cpp
@@ -447,7 +447,7 @@ void Language::GetDefaultExceptionResolverDescription(bool catch_on,
 }
 
 CompletionResponse Language::CompleteCode(Target &target,
-                                          std::string entered_code) {
+                                          const std::string &entered_code) {
   return CompletionResponse::error("completion unsupported for this language");
 }
 

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -2644,6 +2644,15 @@ ExpressionResults Target::EvaluateExpression(
   return execution_results;
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+CompletionResponse Target::CompleteCode(lldb::LanguageType language,
+                                        llvm::StringRef current_code) {
+  auto *plugin = Language::FindPlugin(language);
+  if (!plugin)
+    return CompletionResponse::error("language plugin not found");
+  return plugin->CompleteCode(*this, current_code);
+}
+
 lldb::ExpressionVariableSP
 Target::GetPersistentVariable(const ConstString &name) {
   lldb::ExpressionVariableSP variable_sp;


### PR DESCRIPTION
This PR has two things:
* A code completer in SwiftCodeCompletion.cpp. This is a simplified copy of [REPLCodeCompletion.cpp](https://github.com/apple/swift/blob/master/lib/IDE/REPLCodeCompletion.cpp). It is not very good right now, but I plan to experiment with it and iterate on it. I want it separate from REPLCodeCompletion.cpp because REPLCodeCompletion.cpp has a bunch of features that are irrelevant for the jupyter kernel that would slow down my experimentation and iteration.
* A bunch of plumbing to expose this to Python through the SBAPI. I think the plumbing is not quite abstract and indirect as it should be: SBTarget things aren't supposed to be language-specific. But I think I can deal with this later.