### PR TITLE
Un-comment-out a few things that were removed due to swift using old llvm

### DIFF
--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -1032,7 +1032,7 @@ protected:
     std::unique_ptr<clang::SelectorTable>           m_selector_table_ap;
     std::unique_ptr<clang::Builtin::Context>        m_builtins_ap;
     std::unique_ptr<DWARFASTParserClang>            m_dwarf_ast_parser_ap;
-    // std::unique_ptr<PDBASTParser>                   m_pdb_ast_parser_ap;
+    std::unique_ptr<PDBASTParser>                   m_pdb_ast_parser_ap;
     std::unique_ptr<ClangASTSource>                 m_scratch_ast_source_ap;
     std::unique_ptr<clang::MangleContext>           m_mangle_ctx_ap;
     CompleteTagDeclCallback                         m_callback_tag_decl;

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -9791,14 +9791,9 @@ DWARFASTParser *ClangASTContext::GetDWARFParser() {
 }
 
 PDBASTParser *ClangASTContext::GetPDBParser() {
-// TODO add this back in once swift-llvm catches up to llvm and lldb.
-#if 0
     if (!m_pdb_ast_parser_ap)
         m_pdb_ast_parser_ap.reset(new PDBASTParser(*this));
     return m_pdb_ast_parser_ap.get();
-#else
-  return nullptr;
-#endif
 }
 
 bool ClangASTContext::LayoutRecordType(


### PR DESCRIPTION
A few PDB specific chunks of code were commented out due to swift-llvm
being too far behind upstream llvm. Readd these lines since swift-llvm
has since caught up.