### PR TITLE
[SwiftASTContext] Stop asking size for types that don't exist in memory.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5922,9 +5922,6 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
-  case swift::TypeKind::LValue:
-  case swift::TypeKind::UnboundGeneric:
-  case swift::TypeKind::GenericFunction:
   case swift::TypeKind::Function:
     return GetPointerByteSize() * 8;
   default:


### PR DESCRIPTION
<rdar://problem/47194104>