### PR TITLE
completion with persistent expression state

### DIFF
--- a/include/lldb/Target/Language.h
+++ b/include/lldb/Target/Language.h
@@ -234,7 +234,7 @@ public:
                                                      bool throw_on, Stream &s);
 
   // SWIFT_ENABLE_TENSORFLOW
-  virtual CompletionResponse CompleteCode(Target &target,
+  virtual CompletionResponse CompleteCode(ExecutionContextScope &exe_scope,
                                           const std::string &entered_code);
 
   // These are accessors for general information about the Languages lldb knows

--- a/packages/Python/lldbsuite/test/lang/swift/completions/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/completions/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
@@ -1,0 +1,177 @@
+# TestSwiftCompletions.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+
+import lldb
+from lldbsuite.test.lldbtest import *
+import unittest2
+
+
+class TestSwiftCompletions(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @decorators.swiftTest
+    @decorators.add_test_categories(["swiftpr"])
+    def test_completions(self):
+        self.build()
+        self.do_test()
+
+    def evaluate(self, code):
+        # TODO(TF-107): Remove this workaround.
+        code = '#sourceLocation(file: "test", line: 1)\n' + code
+
+        result = self.target.EvaluateExpression(code, self.expr_opts)
+        if result.error.type not in [lldb.eErrorTypeInvalid,
+                                     lldb.eErrorTypeGeneric]:
+          raise Exception("while evaluating:\n%s\n\nerror: %s" % (
+              code, str(result.error)))
+
+    def assertCompletions(self, code, expected_completions):
+        sbcompletions = self.target.CompleteCode(self.swift_lang, None, code)
+        completions = set()
+        for i in range(sbcompletions.GetNumMatches()):
+            completions.add(
+                sbcompletions.GetMatchAtIndex(i).GetInsertable())
+        self.assertTrue(completions == expected_completions,
+                        "expected: %s, got: %s" % (str(expected_completions),
+                                                   str(completions)))
+
+    def assertDisplayCompletions(self, code, expected_completions):
+        sbcompletions = self.target.CompleteCode(self.swift_lang, None, code)
+        completions = set()
+        for i in range(sbcompletions.GetNumMatches()):
+            completions.add(
+                sbcompletions.GetMatchAtIndex(i).GetDisplay())
+        self.assertTrue(completions == expected_completions,
+                        "expected: %s, got: %s" % (str(expected_completions),
+                                                   str(completions)))
+
+    def do_test(self):
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        self.expr_opts = lldb.SBExpressionOptions()
+        self.swift_lang = lldb.SBLanguageRuntime.GetLanguageTypeFromString(
+            "swift")
+        self.expr_opts.SetLanguage(self.swift_lang)
+
+        # REPL mode is necessary for previously-evaluated decls to persist.
+        self.expr_opts.SetREPLMode(True)
+
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        self.target = self.dbg.CreateTarget(exe)
+        self.assertTrue(self.target, VALID_TARGET)
+        self.breakpoint = self.target.BreakpointCreateBySourceRegex(
+            "Set breakpoint here", self.main_source_spec)
+        self.assertTrue(self.breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
+        self.process = self.target.LaunchSimple(None, None, os.getcwd())
+        self.assertTrue(self.process, PROCESS_IS_VALID)
+
+        # === Simple completions involving a custom struct ===
+
+        self.evaluate("""
+                      struct SimpleStruct {
+                        let intfield: Int = 10
+                        let strfield: String = "hello world"
+                      }""")
+        self.assertCompletions(
+            """let s = SimpleSt""",
+            set(["ruct"]))
+
+        self.evaluate("""let simpleValue = SimpleStruct()""")
+        self.assertCompletions(
+            """simpleVa""",
+            set(["lue"]))
+        self.assertCompletions(
+            """simpleValue.""",
+            set(["intfield", "strfield", "self"]))
+
+        # === Redefining a value ===
+
+        self.evaluate("""
+                      struct DifferentStruct {
+                        let differentfield: Int = 1
+                      }""")
+        self.evaluate("""let replacedValue = SimpleStruct()""")
+        # TODO: If you put the quotes that are after "replacedValue." on the
+        # next line, then this completion request segfaults. Perhaps newlines
+        # and/or whitespace confuse the completer? Investigate.
+        self.assertCompletions(
+            """
+            let replacedValue = DifferentStruct()
+            replacedValue.""",
+            set(["differentfield", "self"]))
+        self.evaluate("""let replacedValue = DifferentStruct()""")
+        self.assertCompletions(
+            """replacedValue.""",
+            set(["differentfield", "self"]))
+
+        # === Redefining a type ===
+
+        self.evaluate("""
+                      struct ReplacedStruct {
+                        let field1: Int = 1
+                      }
+                      """)
+        self.assertCompletions(
+            """
+            struct ReplacedStruct {
+              let field2: Int = 2
+            }
+            ReplacedStruct().""",
+            set(["field2", "self"]))
+        self.evaluate("""
+                      struct ReplacedStruct {
+                        let field2: Int = 2
+                      }
+                      """)
+        self.assertCompletions(
+            """ReplacedStruct().""",
+            set(["field2", "self"]))
+
+        # === Redefining a func ===
+
+        self.evaluate("""
+                      func replacedFunc(arglabel: Int) {}
+                      """)
+        self.assertDisplayCompletions(
+            """
+            func replacedFunc(arglabel: Int) -> Int { return 42 }
+            replacedFun""",
+            set(["replacedFunc(arglabel: Int) -> Int"]))
+        self.assertDisplayCompletions(
+            """
+            func replacedFunc(differentArglabel: Int) {}
+            replacedFun""",
+            set(["replacedFunc(arglabel: Int) -> Void",
+                 "replacedFunc(differentArglabel: Int) -> Void"]))
+        self.evaluate("""
+                      func replacedFunc(arglabel: Int) -> Int { return 42 }
+                      """)
+        # Huh? Both versions of the func show up in the completion below. Let's
+        # keep the test to document the current behavior, and we can figure out
+        # later why it happens.
+        self.assertDisplayCompletions(
+            """replacedFun""",
+            set(["replacedFunc(arglabel: Int) -> Void",
+                 "replacedFunc(arglabel: Int) -> Int"]))
+        self.evaluate("""
+                      func replacedFunc(differentArglabel: Int) {}
+                      """)
+        self.assertDisplayCompletions(
+            """replacedFun""",
+            set(["replacedFunc(arglabel: Int) -> Void",
+                 "replacedFunc(arglabel: Int) -> Int",
+                 "replacedFunc(differentArglabel: Int) -> Void"]))
+
+        # TODO: Test imports.

--- a/packages/Python/lldbsuite/test/lang/swift/completions/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/completions/main.swift
@@ -1,0 +1,17 @@
+// main.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+
+func main() -> Void {
+    // Set breakpoint here
+}
+
+main()

--- a/packages/Python/lldbsuite/test_event/formatter/__init__.py
+++ b/packages/Python/lldbsuite/test_event/formatter/__init__.py
@@ -80,7 +80,7 @@ def create_results_formatter(config):
         read_bytes = sock.recv(1)
         if read_bytes is None or (
                 len(read_bytes) < 1) or (
-                read_bytes[0] != SOCKET_ACK_BYTE_VALUE):
+                read_bytes != b'*'):
             raise Exception(
                 "listening socket did not respond with ack byte: response={}".format(read_bytes))
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -125,6 +125,13 @@ bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(
   }
 }
 
+// SWIFT_ENABLE_TENSORFLOW
+void SwiftPersistentExpressionState::SwiftDeclMap::GetAllDecls(
+    std::vector<swift::Decl *> &decls) {
+  for (auto &pair : m_swift_decls)
+    decls.push_back(std::get<1>(pair));
+}
+
 void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
     swift::ValueDecl *value_decl, bool check_existing,
     const ConstString &alias) {
@@ -220,4 +227,10 @@ bool SwiftPersistentExpressionState::GetSwiftPersistentDecls(
     std::vector<swift::ValueDecl *> &matches) {
   return m_swift_persistent_decls.FindMatchingDecls(name, excluding_equivalents,
                                                     matches);
+}
+
+// SWIFT_ENABLE_TENSORFLOW
+void SwiftPersistentExpressionState::GetAllDecls(
+    std::vector<swift::Decl *> &decls) {
+  m_swift_persistent_decls.GetAllDecls(decls);
 }

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -54,6 +54,10 @@ public:
     void CopyDeclsTo(SwiftDeclMap &target_map);
     static bool DeclsAreEquivalent(swift::Decl *lhs, swift::Decl *rhs);
 
+    // SWIFT_ENABLE_TENSORFLOW
+    /// Pushes all of this map's decls into `decls`.
+    void GetAllDecls(std::vector<swift::Decl *> &decls);
+
   private:
     typedef std::unordered_multimap<std::string, swift::ValueDecl *>
         SwiftDeclMapTy;
@@ -120,6 +124,10 @@ public:
     }
     return true;
   }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Pushes all the persistent decls into `decls`.
+  void GetAllDecls(std::vector<swift::Decl *> &decls);
 
 private:
   uint32_t m_next_persistent_variable_id; ///< The counter used by

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -269,14 +269,6 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
     SmallVector<SourceFile::ImportedModuleDesc, 8> NewImports;
     PersistentExpressionState.RunOverHandLoadedModules(
         [&](const ConstString ModuleName) -> bool {
-          // Skip these modules, to prevent "TestSwiftCompletions.py" from
-          // segfaulting.
-          // TODO: Investigate why this happens.
-          if (ModuleName == ConstString("SwiftOnoneSupport"))
-            return true;
-          if (ModuleName == ConstString("a"))
-            return true;
-
           ModuleDecl *Module = SwiftCtx.GetModule(ModuleName, Error);
           if (!Module)
             return true;
@@ -285,6 +277,7 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
           NewImports.push_back(SourceFile::ImportedModuleDesc(
               std::make_pair(ModuleDecl::AccessPathTy(), Module),
               SourceFile::ImportOptions()));
+          return true;
         });
     EnteredCodeFile->addImports(NewImports);
   }

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.h
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.h
@@ -22,8 +22,10 @@
 
 namespace lldb_private {
 
-CompletionResponse SwiftCompleteCode(swift::SourceFile &SF,
-                                     llvm::StringRef EnteredCode);
+CompletionResponse
+SwiftCompleteCode(SwiftASTContext &SwiftCtx,
+                  SwiftPersistentExpressionState &PersistentExpressionState,
+                  llvm::StringRef EnteredCode);
 
 } // namespace lldb_private
 

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -75,7 +75,7 @@ public:
                                        Stream &s) override;
 
   // SWIFT_ENABLE_TENSORFLOW
-  CompletionResponse CompleteCode(Target &target,
+  CompletionResponse CompleteCode(ExecutionContextScope &exe_scope,
                                   const std::string &entered_code);
 
   //------------------------------------------------------------------

--- a/source/Target/Language.cpp
+++ b/source/Target/Language.cpp
@@ -446,7 +446,7 @@ void Language::GetDefaultExceptionResolverDescription(bool catch_on,
            catch_on ? "on" : "off", throw_on ? "on" : "off");
 }
 
-CompletionResponse Language::CompleteCode(Target &target,
+CompletionResponse Language::CompleteCode(ExecutionContextScope &exe_scope,
                                           const std::string &entered_code) {
   return CompletionResponse::error("completion unsupported for this language");
 }

--- a/test/dotest.py
+++ b/test/dotest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 if __name__ == "__main__":
     import use_lldb_suite


### PR DESCRIPTION
Before this PR, the completer "remembered" decls from previously-evaluated code by concatenating all the previously-evaluated code in front of the code to be completed. The completer then sent this whole thing to the parser and typechecker, and used the parse and typecheck results to provide completions. This caused incorrect behavior with redefinitions, because the parse&typecheck steps did not handle redefinitions correctly.

This PR completely changes the approach. Now, the completer works like this:
0. Creates two `SourceFile`s named `PreviousDeclsFile` and `EnteredCodeFile` in the same module.
1. Put all the decls that are in `SwiftPersistentExpressionState` into `PreviousDeclsFile`.
2. Put all the imports that are in `SwiftPersistentExpressionState` into a `EnteredCodeFile`.
3. Parse just the current snippet of code, to find out if it declares anything. If it does declare something that was already in `SwiftPersistentExpressionState`, remove that decl from `PreviousDeclFile`.
4. Put the just current snippet of code into `EnteredCodeFile`.
5. Do parsing, typechecking, and completion on `EnteredCodeFile`. (Since previous decls are in `PreviousDeclFile`, which is in the same module, it is able to see them).

This approach handles redefinitions correctly, as far as I can tell with my initial tests.

This PR also adds some completion tests.