### PR TITLE
Use RemoteAST in GetDynamicTypeAndAddress()

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -357,11 +357,6 @@ protected:
                                          TypeAndOrName &class_type_or_name,
                                          Address &address);
 
-  bool GetDynamicTypeAndAddress_GenericTypeParam(
-      ValueObject &in_value, SwiftASTContext &scratch_ctx,
-      lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
-      Address &address);
-
   bool GetDynamicTypeAndAddress_Value(ValueObject &in_value,
                                        CompilerType &bound_type,
                                        lldb::DynamicValueType use_dynamic,
@@ -371,12 +366,6 @@ protected:
   bool GetDynamicTypeAndAddress_IndirectEnumCase(
       ValueObject &in_value, lldb::DynamicValueType use_dynamic,
       TypeAndOrName &class_type_or_name, Address &address);
-
-  bool GetDynamicTypeAndAddress_Promise(ValueObject &in_value,
-                                        MetadataPromiseSP promise_sp,
-                                        lldb::DynamicValueType use_dynamic,
-                                        TypeAndOrName &class_type_or_name,
-                                        Address &address);
 
   MetadataPromiseSP GetPromiseForTypeNameAndFrame(const char *type_name,
                                                   StackFrame *frame);

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -351,6 +351,7 @@ protected:
                                       Address &address);
 
   bool GetDynamicTypeAndAddress_Protocol(ValueObject &in_value,
+                                         CompilerType protocol_type,
                                          SwiftASTContext &scratch_ctx,
                                          lldb::DynamicValueType use_dynamic,
                                          TypeAndOrName &class_type_or_name,

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -438,6 +438,10 @@ protected:
 
   std::shared_ptr<swift::remote::MemoryReader> GetMemoryReader();
 
+  void PushLocalBuffer(uint64_t local_buffer, uint64_t local_buffer_size);
+
+  void PopLocalBuffer();
+
   std::unordered_set<std::string> m_library_negative_cache; // We have to load
                                                             // swift dependent
                                                             // libraries by

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -412,17 +412,11 @@ protected:
                                       TypeAndOrName &class_type_or_name,
                                       Address &address);
 
-  bool GetDynamicTypeAndAddress_Struct(ValueObject &in_value,
+  bool GetDynamicTypeAndAddress_Value(ValueObject &in_value,
                                        CompilerType &bound_type,
                                        lldb::DynamicValueType use_dynamic,
                                        TypeAndOrName &class_type_or_name,
                                        Address &address);
-
-  bool GetDynamicTypeAndAddress_Enum(ValueObject &in_value,
-                                     CompilerType &bound_type,
-                                     lldb::DynamicValueType use_dynamic,
-                                     TypeAndOrName &class_type_or_name,
-                                     Address &address);
 
   bool GetDynamicTypeAndAddress_IndirectEnumCase(
       ValueObject &in_value, lldb::DynamicValueType use_dynamic,

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -214,50 +214,10 @@ public:
 
   static const std::string GetCurrentMangledName(const char *mangled_name);
 
-  struct SwiftErrorDescriptor {
-  public:
-    struct SwiftBridgeableNativeError {
-    public:
-      lldb::addr_t metadata_location;
-      lldb::addr_t metadata_ptr_value;
-    };
-
-    struct SwiftPureNativeError {
-    public:
-      lldb::addr_t metadata_location;
-      lldb::addr_t payload_ptr;
-    };
-
-    struct SwiftNSError {
-    public:
-      lldb::addr_t instance_ptr_value;
-    };
-
-    enum class Kind {
-      eSwiftBridgeableNative,
-      eSwiftPureNative,
-      eBridged,
-      eNotAnError
-    };
-
-    Kind m_kind;
-    SwiftBridgeableNativeError m_bridgeable_native;
-    SwiftPureNativeError m_pure_native;
-    SwiftNSError m_bridged;
-
-    operator bool() { return m_kind != Kind::eNotAnError; }
-
-    SwiftErrorDescriptor();
-
-    SwiftErrorDescriptor(const SwiftErrorDescriptor &rhs) = default;
-  };
-
   // provide a quick and yet somewhat reasonable guess as to whether
   // this ValueObject represents something that validly conforms
   // to the magic ErrorType protocol
-  virtual bool
-  IsValidErrorValue(ValueObject &in_value,
-                    SwiftErrorDescriptor *out_error_descriptor = nullptr);
+  virtual bool IsValidErrorValue(ValueObject &in_value);
 
   virtual lldb::BreakpointResolverSP
   CreateExceptionResolver(Breakpoint *bkpt, bool catch_bp,
@@ -395,11 +355,6 @@ protected:
                                          lldb::DynamicValueType use_dynamic,
                                          TypeAndOrName &class_type_or_name,
                                          Address &address);
-
-  bool GetDynamicTypeAndAddress_ErrorType(ValueObject &in_value,
-                                          lldb::DynamicValueType use_dynamic,
-                                          TypeAndOrName &class_type_or_name,
-                                          Address &address);
 
   bool GetDynamicTypeAndAddress_GenericTypeParam(
       ValueObject &in_value, SwiftASTContext &scratch_ctx,

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -406,12 +406,6 @@ protected:
       lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
       Address &address);
 
-  bool GetDynamicTypeAndAddress_Tuple(ValueObject &in_value,
-                                      SwiftASTContext &scratch_ctx,
-                                      lldb::DynamicValueType use_dynamic,
-                                      TypeAndOrName &class_type_or_name,
-                                      Address &address);
-
   bool GetDynamicTypeAndAddress_Value(ValueObject &in_value,
                                        CompilerType &bound_type,
                                        lldb::DynamicValueType use_dynamic,

--- a/lit/SwiftREPL/ErrorReturnObjC.test
+++ b/lit/SwiftREPL/ErrorReturnObjC.test
@@ -1,0 +1,29 @@
+// Test that we can correctly print (resilient) Foundation
+// types when they're stored in REPL-defined globals.
+
+// REQUIRES: darwin
+
+// RUN: %lldb --repl < %s | FileCheck %s
+
+import Foundation
+
+class ClassError : NSError {
+  required init(coder: NSCoder) { fatalError() }
+  init() {
+    super.init(domain: "ClassError", code: 10, userInfo: [:])
+  }
+  var message = "Hello error"
+}
+
+func throwsClassError() throws {
+  throw ClassError()
+}
+
+try throwsClassError()
+
+// CHECK: $E0: ClassError = {
+// CHECK:   Foundation.NSError = domain: "ClassError" - code: 10 {
+// CHECK:     _userInfo = 0 key/value pairs
+// CHECK:   }
+// CHECK:   message = "Hello error"
+// CHECK: }

--- a/lit/SwiftREPL/NSString.test
+++ b/lit/SwiftREPL/NSString.test
@@ -5,7 +5,7 @@
 
 import Foundation
 var aString = "patatino" as NSString
-// NSSTRING: aString: NSTaggedPointerString = "patatino"
+// NSSTRING: aString: NSString = "patatino"
 
 aString.substring(to: 3)
 // NSSTRING: $R0: String = "pat"

--- a/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_error_tuple/main.swift
@@ -15,12 +15,12 @@ enum CErr : Error {
 
 func g<T, U>(_ tuple : (T, U)) -> T {
   return tuple.0 //%self.expect("frame var -d run-target -- tuple",
-                 //%            substrs=['(a.CErr, Int)', 'Topolino', '42'])
+                 //%            substrs=['(Error, Int)', 'Topolino', '42'])
 }
 
 func h<U, V>(_ tuple : (U, V)) -> (U, V) {
   return tuple //%self.expect("frame var -d run-target -- tuple", 
-               //%             substrs=['(a.PayloadErr, a.MyOtherErr) tuple',
+               //%             substrs=['(a.PayloadErr, a.PayloadErr) tuple',
                //%                      '0 =', '(x = 23)',
                //%                      'a.PayloadErr = {', 'x = 42'])
                //%self.expect("expr -d run-target -- tuple",

--- a/packages/Python/lldbsuite/test/lang/swift/generic_existentials/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/generic_existentials/main.swift
@@ -1,14 +1,50 @@
-class Pat : Error {
-  var x : Int
-  init(_ x : Int) {
+class MyClass {
+  var x: Int
+  init(_ x: Int) {
     self.x = x
   }
 }
 
 func f<T>(_ x : T) -> T {
-  return x //%self.expect("frame var -d run-target -- x", substrs=['(a.Pat) x', '(x = 23)'])
-           //%self.expect("expr -d run-target -- x", substrs=['(a.Pat) $R', '(x = 23)'])
+  return x //%self.expect("frame var -d run-target -- x", substrs=['(a.MyClass) x', '(x = 23)'])
+           //%self.expect("expr -d run-target -- x", substrs=['(a.MyClass) $R', '(x = 23)'])
 }
 
-let patatino = Pat(23) as AnyObject
-f(patatino)
+f(MyClass(23) as Any)
+f(MyClass(23) as AnyObject)
+
+func g<T>(_ x : T) -> T {
+  return x //%self.expect("frame var -d run-target -- x", substrs=['(a.MyStruct) x', '(x = 23)'])
+           //%self.expect("expr -d run-target -- x", substrs=['(a.MyStruct) $R', '(x = 23)'])
+}
+
+struct MyStruct {
+  var x: Int
+
+  init(_ x: Int) {
+    self.x = x
+  }
+}
+
+g(MyStruct(23) as Any)
+
+func h<T>(_ x : T) -> T {
+  return x //%self.expect("frame var -d run-target -- x", substrs=['(a.MyBigStruct) x', '(x = 23, y = 24, z = 25, w = 26)'])
+           //%self.expect("expr -d run-target -- x", substrs=['(a.MyBigStruct) $R', '(x = 23, y = 24, z = 25, w = 26)'])
+}
+
+struct MyBigStruct {
+  var x: Int
+  var y: Int
+  var z: Int
+  var w: Int
+
+  init(_ x: Int) {
+    self.x = x
+    self.y = x + 1
+    self.z = x + 2
+    self.w = x + 3
+  }
+}
+
+h(MyBigStruct(23) as Any)

--- a/packages/Python/lldbsuite/test/lang/swift/tagged_pointer/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/tagged_pointer/main.swift
@@ -14,10 +14,21 @@ import Foundation
 func main() {
   var a: NSObject = 3 as NSNumber
   var b: AnyObject = 3 as NSNumber
-  print("break here") //% self.expect('frame variable -d run -- a', substrs=['Int64(3)'])
+
+  var c: NSObject = "hi" as NSString
+  var d: AnyObject = "hi" as NSString
+
+   //% self.expect('frame variable -d run -- a', substrs=['Int64(3)'])
    //% self.expect('frame variable -d run -- b', substrs=['Int64(3)'])
-    //% self.expect('expr -d run -- a', substrs=['Int64(3)'])
-     //% self.expect('expr -d run -- b', substrs=['Int64(3)'])
+
+   //% self.expect('frame variable -d run -- c', substrs=['"hi"'])
+   //% self.expect('frame variable -d run -- d', substrs=['"hi"'])
+
+   //% self.expect('expr -d run -- a', substrs=['Int64(3)'])
+   //% self.expect('expr -d run -- b', substrs=['Int64(3)'])
+
+   //% self.expect('expr -d run -- c', substrs=['"hi"'])
+   //% self.expect('expr -d run -- d', substrs=['"hi"'])
 }
 
 main()

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -475,15 +475,6 @@ public:
     // In the case where the value is of Swift generic type, unbox it.
     CompilerType valobj_type = valobj_sp->GetCompilerType();
 
-    if (m_is_generic) {
-      auto dyn_obj = valobj_sp->GetDynamicValue(lldb::eDynamicDontRunTarget);
-      if (dyn_obj) {
-        // Update the type to refer to the dynamic type.
-        valobj_sp = dyn_obj;
-        valobj_type = valobj_sp->GetCompilerType();
-      }
-    }
-
     if (m_is_reference) {
       DataExtractor valobj_extractor;
       Status extract_error;

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -710,15 +710,6 @@ static void CountLocals(
         } else {
           var_type = valobj_sp->GetCompilerType();
         }
-
-        if (var_type.IsValid() && !SwiftASTContext::IsFullyRealized(var_type)) {
-          lldb::ValueObjectSP dynamic_valobj_sp =
-              valobj_sp->GetDynamicValue(lldb::eDynamicDontRunTarget);
-
-          if (!dynamic_valobj_sp || dynamic_valobj_sp->GetError().Fail()) {
-            continue;
-          }
-        }
       }
 
       if (!var_type.IsValid()) {

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -5109,27 +5109,22 @@ bool SwiftASTContext::IsPossibleDynamicType(void *type,
   VALID_OR_RETURN(false);
 
   if (type && check_swift) {
-    // FIXME: use the dynamic_pointee_type.
-    Flags type_flags(GetTypeInfo(type, nullptr));
+    auto can_type = GetCanonicalSwiftType(type);
 
-    if (type_flags.AnySet(eTypeIsGenericTypeParam | eTypeIsClass |
-                          eTypeIsProtocol))
+    if (can_type->getClassOrBoundGenericClass() ||
+        can_type->isAnyExistentialType())
       return true;
 
-    if (type_flags.AnySet(eTypeIsStructUnion | eTypeIsEnumeration |
-                          eTypeIsTuple)) {
-      CompilerType compiler_type(GetCanonicalSwiftType(type));
-      return !SwiftASTContext::IsFullyRealized(compiler_type);
-    }
+    if (can_type->hasArchetype() || can_type->hasTypeParameter())
+      return true;
 
-    auto can_type = GetCanonicalSwiftType(type).getPointer();
-    if (can_type == GetASTContext()->TheRawPointerType.getPointer())
+    if (can_type == GetASTContext()->TheRawPointerType)
       return true;
-    if (can_type == GetASTContext()->TheUnknownObjectType.getPointer())
+    if (can_type == GetASTContext()->TheUnknownObjectType)
       return true;
-    if (can_type == GetASTContext()->TheNativeObjectType.getPointer())
+    if (can_type == GetASTContext()->TheNativeObjectType)
       return true;
-    if (can_type == GetASTContext()->TheBridgeObjectType.getPointer())
+    if (can_type == GetASTContext()->TheBridgeObjectType)
       return true;
   }
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6997,26 +6997,6 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   } break;
 
   case swift::TypeKind::Tuple: {
-    // Dynamic type resolution may actually change(!) the layout of a
-    // tuple, so we need to get the offset from the static (but
-    // archetype-bound) version.
-    auto static_value = valobj->GetStaticValue();
-    auto static_type = static_value->GetCompilerType();
-    auto static_swift_type = GetCanonicalSwiftType(static_type);
-    if (swift::isa<swift::TupleType>(static_swift_type.getPointer()))
-      swift_can_type = static_swift_type;
-    if (swift_can_type->hasTypeParameter()) {
-      if (!exe_ctx)
-        return {};
-      auto *exe_scope = exe_ctx->GetBestExecutionContextScope();
-      auto *frame = exe_scope->CalculateStackFrame().get();
-      auto *runtime = exe_scope->CalculateProcess()->GetSwiftLanguageRuntime();
-      if (!frame || !runtime)
-        return {};
-      auto bound = runtime->DoArchetypeBindingForType(*frame, static_type);
-      swift_can_type = GetCanonicalSwiftType(bound);
-    }
-
     auto tuple_type = cast<swift::TupleType>(swift_can_type);
     if (idx >= tuple_type->getNumElements()) break;
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1633,14 +1633,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     Address &address) {
   AddressType address_type;
   lldb::addr_t class_metadata_ptr = in_value.GetPointerValue(&address_type);
-  if (auto objc_runtime = GetObjCRuntime()) {
-    if (objc_runtime->IsTaggedPointer(class_metadata_ptr)) {
-      Value::ValueType value_type;
-      return objc_runtime->GetDynamicTypeAndAddress(
-          in_value, use_dynamic, class_type_or_name, address, value_type,
-          /* allow_swift = */ true);
-    }
-  }
   if (class_metadata_ptr == LLDB_INVALID_ADDRESS || class_metadata_ptr == 0)
     return false;
   address.SetRawAddress(class_metadata_ptr);

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2272,7 +2272,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Tuple(
   return true;
 }
 
-bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Struct(
+bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
     ValueObject &in_value, CompilerType &bound_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
     Address &address) {
@@ -2282,29 +2282,11 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Struct(
       in_value.GetExecutionContextRef().GetFrameSP().get());
   if (!size)
     return false;
-  lldb::addr_t struct_address = in_value.GetAddressOf(true, nullptr);
-  if (*size && (!struct_address || struct_address == LLDB_INVALID_ADDRESS))
+  lldb::addr_t val_address = in_value.GetAddressOf(true, nullptr);
+  if (*size && (!val_address || val_address == LLDB_INVALID_ADDRESS))
     return false;
 
-  address.SetLoadAddress(struct_address, in_value.GetTargetSP().get());
-  return true;
-}
-
-bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Enum(
-    ValueObject &in_value, CompilerType &bound_type,
-    lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
-    Address &address) {
-  class_type_or_name.SetCompilerType(bound_type);
-
-  llvm::Optional<uint64_t> size = bound_type.GetByteSize(
-      in_value.GetExecutionContextRef().GetFrameSP().get());
-  if (!size)
-    return false;
-  lldb::addr_t enum_address = in_value.GetAddressOf(true, nullptr);
-  if (*size && (!enum_address || LLDB_INVALID_ADDRESS == enum_address))
-    return false;
-
-  address.SetLoadAddress(enum_address, in_value.GetTargetSP().get());
+  address.SetLoadAddress(val_address, in_value.GetTargetSP().get());
   return true;
 }
 
@@ -2556,12 +2538,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
     if (!bound_type)
       return false;
 
-    else if (type_info.AnySet(eTypeIsEnumeration))
-      success = GetDynamicTypeAndAddress_Enum(in_value, bound_type, use_dynamic,
-                                              class_type_or_name, address);
-    else if (type_info.AnySet(eTypeIsStructUnion))
-      success = GetDynamicTypeAndAddress_Struct(
-          in_value, bound_type, use_dynamic, class_type_or_name, address);
+    success = GetDynamicTypeAndAddress_Value(in_value, bound_type, use_dynamic,
+                                             class_type_or_name, address);
   }
 
   if (success)

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -3281,20 +3281,9 @@ ValueObjectSP
 SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
                                           ConstString variable_name) {
   ProcessSP process_sp(frame_sp->GetThread()->GetProcess());
-  ABISP abi_sp(process_sp->GetABI());
-  ValueList argument_values;
-  Value input_value;
   Status error;
   Target *target = frame_sp->CalculateTarget().get();
   ValueObjectSP error_valobj_sp;
-
-  ClangASTContext *clang_ast_context = target->GetScratchClangASTContext();
-  CompilerType clang_void_ptr_type =
-      clang_ast_context->GetBasicType(eBasicTypeVoid).GetPointerType();
-
-  input_value.SetValueType(Value::eValueTypeScalar);
-  input_value.SetCompilerType(clang_void_ptr_type);
-  argument_values.PushValue(input_value);
 
   auto *runtime = process_sp->GetSwiftLanguageRuntime();
   if (!runtime)

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1122,165 +1122,199 @@ const CompilerType &SwiftLanguageRuntime::GetBoxMetadataType() {
   return m_box_metadata_type;
 }
 
-std::shared_ptr<swift::remote::MemoryReader>
-SwiftLanguageRuntime::GetMemoryReader() {
-  class MemoryReader : public swift::remote::MemoryReader {
-  public:
-    MemoryReader(Process *p, size_t max_read_amount = INT32_MAX)
-        : m_process(p) {
-      lldbassert(m_process && "MemoryReader requires a valid Process");
-      m_max_read_amount = max_read_amount;
+class LLDBMemoryReader : public swift::remote::MemoryReader {
+public:
+  LLDBMemoryReader(Process *p, size_t max_read_amount = INT32_MAX)
+      : m_process(p) {
+    lldbassert(m_process && "MemoryReader requires a valid Process");
+    m_max_read_amount = max_read_amount;
+  }
+
+  virtual ~LLDBMemoryReader() = default;
+
+  bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
+                        void *outBuffer) override {
+    switch (type) {
+      case DLQ_GetPointerSize: {
+        auto result = static_cast<uint8_t *>(outBuffer);
+        *result = m_process->GetAddressByteSize();
+        return true;
+      }
+      case DLQ_GetSizeSize: {
+        auto result = static_cast<uint8_t *>(outBuffer);
+        *result = m_process->GetAddressByteSize();  // FIXME: sizeof(size_t)
+        return true;
+      }
     }
 
-    virtual ~MemoryReader() = default;
+    return false;
+  }
 
-    bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
-                         void *outBuffer) override {
-      switch (type) {
-        case DLQ_GetPointerSize: {
-          auto result = static_cast<uint8_t *>(outBuffer);
-          *result = m_process->GetAddressByteSize();
-          return true;
-        }
-        case DLQ_GetSizeSize: {
-          auto result = static_cast<uint8_t *>(outBuffer);
-          *result = m_process->GetAddressByteSize();  // FIXME: sizeof(size_t)
-          return true;
+  swift::remote::RemoteAddress
+  getSymbolAddress(const std::string &name) override {
+    Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+
+    if (name.empty())
+      return swift::remote::RemoteAddress(nullptr);
+
+    if (log)
+      log->Printf("[MemoryReader] asked to retrieve address of symbol %s",
+                  name.c_str());
+
+    ConstString name_cs(name.c_str(), name.size());
+    SymbolContextList sc_list;
+    if (m_process->GetTarget().GetImages().FindSymbolsWithNameAndType(
+            name_cs, lldb::eSymbolTypeAny, sc_list)) {
+      SymbolContext sym_ctx;
+      // Remove undefined symbols from the list:
+      size_t num_sc_matches = sc_list.GetSize();
+      if (num_sc_matches > 1) {
+        SymbolContextList tmp_sc_list(sc_list);
+        sc_list.Clear();
+        for (size_t idx = 0; idx < num_sc_matches; idx++) {
+          tmp_sc_list.GetContextAtIndex(idx, sym_ctx);
+          if (sym_ctx.symbol &&
+              sym_ctx.symbol->GetType() != lldb::eSymbolTypeUndefined) {
+              sc_list.Append(sym_ctx);
+          }
         }
       }
+      if (sc_list.GetSize() == 1 && sc_list.GetContextAtIndex(0, sym_ctx)) {
+        if (sym_ctx.symbol) {
+          auto load_addr =
+              sym_ctx.symbol->GetLoadAddress(&m_process->GetTarget());
+          if (log)
+            log->Printf("[MemoryReader] symbol resolved to 0x%" PRIx64,
+                        load_addr);
+          return swift::remote::RemoteAddress(load_addr);
+        }
+      }
+    }
 
+    if (log)
+      log->Printf("[MemoryReader] symbol resolution failed");
+    return swift::remote::RemoteAddress(nullptr);
+  }
+
+  bool readBytes(swift::remote::RemoteAddress address, uint8_t *dest,
+                  uint64_t size) override {
+    if (m_local_buffer) {
+      auto addr = address.getAddressData();
+      if (addr >= m_local_buffer &&
+          addr + size <= m_local_buffer + m_local_buffer_size) {
+        memcpy(dest, (void *) addr, size);
+        return true;
+      }
+    }
+
+    Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+
+    if (log)
+      log->Printf("[MemoryReader] asked to read %" PRIu64
+                  " bytes at address 0x%" PRIx64,
+                  size, address.getAddressData());
+
+    if (size > m_max_read_amount) {
+      if (log)
+        log->Printf(
+            "[MemoryReader] memory read exceeds maximum allowed size");
       return false;
     }
 
-    swift::remote::RemoteAddress
-    getSymbolAddress(const std::string &name) override {
-      Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
-
-      if (name.empty())
-        return swift::remote::RemoteAddress(nullptr);
-
-      if (log)
-        log->Printf("[MemoryReader] asked to retrieve address of symbol %s",
-                    name.c_str());
-
-      ConstString name_cs(name.c_str(), name.size());
-      SymbolContextList sc_list;
-      if (m_process->GetTarget().GetImages().FindSymbolsWithNameAndType(
-              name_cs, lldb::eSymbolTypeAny, sc_list)) {
-        SymbolContext sym_ctx;
-        // Remove undefined symbols from the list:
-        size_t num_sc_matches = sc_list.GetSize();
-        if (num_sc_matches > 1) {
-          SymbolContextList tmp_sc_list(sc_list);
-          sc_list.Clear();
-          for (size_t idx = 0; idx < num_sc_matches; idx++) {
-            tmp_sc_list.GetContextAtIndex(idx, sym_ctx);
-            if (sym_ctx.symbol &&
-                sym_ctx.symbol->GetType() != lldb::eSymbolTypeUndefined) {
-                sc_list.Append(sym_ctx);
-            }
-          }
-        }
-        if (sc_list.GetSize() == 1 && sc_list.GetContextAtIndex(0, sym_ctx)) {
-          if (sym_ctx.symbol) {
-            auto load_addr =
-                sym_ctx.symbol->GetLoadAddress(&m_process->GetTarget());
-            if (log)
-              log->Printf("[MemoryReader] symbol resolved to 0x%" PRIx64,
-                          load_addr);
-            return swift::remote::RemoteAddress(load_addr);
-          }
-        }
-      }
-
-      if (log)
-        log->Printf("[MemoryReader] symbol resolution failed");
-      return swift::remote::RemoteAddress(nullptr);
-    }
-
-    bool readBytes(swift::remote::RemoteAddress address, uint8_t *dest,
-                   uint64_t size) override {
-      Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
-
-      if (log)
-        log->Printf("[MemoryReader] asked to read %" PRIu64
-                    " bytes at address 0x%" PRIx64,
-                    size, address.getAddressData());
-
-      if (size > m_max_read_amount) {
-        if (log)
-          log->Printf(
-              "[MemoryReader] memory read exceeds maximum allowed size");
-        return false;
-      }
-
-      Target &target(m_process->GetTarget());
-      Address addr(address.getAddressData());
-      Status error;
-      if (size > target.ReadMemory(addr, false, dest, size, error)) {
-        if (log)
-          log->Printf(
-              "[MemoryReader] memory read returned fewer bytes than asked for");
-        return false;
-      }
-      if (error.Fail()) {
-        if (log)
-          log->Printf("[MemoryReader] memory read returned error: %s",
-                      error.AsCString());
-        return false;
-      }
-
-      if (log && log->GetVerbose()) {
-        StreamString stream;
-        for (uint64_t i = 0; i < size; i++) {
-          stream.PutHex8(dest[i]);
-          stream.PutChar(' ');
-        }
-        log->Printf("[MemoryReader] memory read returned data: %s",
-                    stream.GetData());
-      }
-
-      return true;
-    }
-
-    bool readString(swift::remote::RemoteAddress address,
-                    std::string &dest) override {
-      Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
-
+    Target &target(m_process->GetTarget());
+    Address addr(address.getAddressData());
+    Status error;
+    if (size > target.ReadMemory(addr, false, dest, size, error)) {
       if (log)
         log->Printf(
-            "[MemoryReader] asked to read string data at address 0x%" PRIx64,
-            address.getAddressData());
-
-      uint32_t read_size = 50 * 1024;
-      std::vector<char> storage(read_size, 0);
-      Target &target(m_process->GetTarget());
-      Address addr(address.getAddressData());
-      Status error;
-      target.ReadCStringFromMemory(addr, &storage[0], storage.size(), error);
-      if (error.Success()) {
-        dest.assign(&storage[0]);
-        if (log)
-          log->Printf("[MemoryReader] memory read returned data: %s",
-                      dest.c_str());
-        return true;
-      } else {
-        if (log)
-          log->Printf("[MemoryReader] memory read returned error: %s",
-                      error.AsCString());
-        return false;
-      }
+            "[MemoryReader] memory read returned fewer bytes than asked for");
+      return false;
+    }
+    if (error.Fail()) {
+      if (log)
+        log->Printf("[MemoryReader] memory read returned error: %s",
+                    error.AsCString());
+      return false;
     }
 
-  private:
-    Process *m_process;
-    size_t m_max_read_amount;
-  };
+    if (log && log->GetVerbose()) {
+      StreamString stream;
+      for (uint64_t i = 0; i < size; i++) {
+        stream.PutHex8(dest[i]);
+        stream.PutChar(' ');
+      }
+      log->Printf("[MemoryReader] memory read returned data: %s",
+                  stream.GetData());
+    }
 
+    return true;
+  }
+
+  bool readString(swift::remote::RemoteAddress address,
+                  std::string &dest) override {
+    Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+
+    if (log)
+      log->Printf(
+          "[MemoryReader] asked to read string data at address 0x%" PRIx64,
+          address.getAddressData());
+
+    uint32_t read_size = 50 * 1024;
+    std::vector<char> storage(read_size, 0);
+    Target &target(m_process->GetTarget());
+    Address addr(address.getAddressData());
+    Status error;
+    target.ReadCStringFromMemory(addr, &storage[0], storage.size(), error);
+    if (error.Success()) {
+      dest.assign(&storage[0]);
+      if (log)
+        log->Printf("[MemoryReader] memory read returned data: %s",
+                    dest.c_str());
+      return true;
+    } else {
+      if (log)
+        log->Printf("[MemoryReader] memory read returned error: %s",
+                    error.AsCString());
+      return false;
+    }
+  }
+
+  void pushLocalBuffer(uint64_t local_buffer, uint64_t local_buffer_size) {
+    lldbassert(!m_local_buffer);
+    m_local_buffer = local_buffer;
+    m_local_buffer_size = local_buffer_size;
+  }
+
+  void popLocalBuffer() {
+    lldbassert(m_local_buffer);
+    m_local_buffer = 0;
+    m_local_buffer_size = 0;
+  }
+
+private:
+  Process *m_process;
+  size_t m_max_read_amount;
+
+  uint64_t m_local_buffer = 0;
+  uint64_t m_local_buffer_size = 0;
+};
+
+std::shared_ptr<swift::remote::MemoryReader>
+SwiftLanguageRuntime::GetMemoryReader() {
   if (!m_memory_reader_sp)
-    m_memory_reader_sp.reset(new MemoryReader(GetProcess()));
+    m_memory_reader_sp.reset(new LLDBMemoryReader(GetProcess()));
 
   return m_memory_reader_sp;
+}
+
+void SwiftLanguageRuntime::PushLocalBuffer(uint64_t local_buffer,
+                                           uint64_t local_buffer_size) {
+  ((LLDBMemoryReader *)GetMemoryReader().get())->pushLocalBuffer(
+        local_buffer, local_buffer_size);
+}
+
+void SwiftLanguageRuntime::PopLocalBuffer() {
+  ((LLDBMemoryReader *)GetMemoryReader().get())->popLocalBuffer();
 }
 
 SwiftLanguageRuntime::MetadataPromise::MetadataPromise(

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -3305,13 +3305,17 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   if (!ast_context || error.Fail())
     return error_valobj_sp;
 
+  lldb::DataBufferSP buffer(new lldb_private::DataBufferHeap(
+      arg0->GetScalar().GetBytes(), arg0->GetScalar().GetByteSize()));
+
   CompilerType swift_error_proto_type = ast_context->GetErrorType();
   if (!swift_error_proto_type.IsValid())
     return error_valobj_sp;
 
-  arg0->SetCompilerType(swift_error_proto_type);
-  error_valobj_sp =
-      ValueObjectConstResult::Create(exe_scope, *arg0, variable_name);
+  error_valobj_sp = ValueObjectConstResult::Create(
+      exe_scope, swift_error_proto_type,
+      variable_name, buffer, endian::InlHostByteOrder(),
+      exe_ctx.GetAddressByteSize());
   if (error_valobj_sp->GetError().Fail())
     return error_valobj_sp;
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceLoc.h"
@@ -1676,13 +1677,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
   return true;
 }
 
-SwiftLanguageRuntime::SwiftErrorDescriptor::SwiftErrorDescriptor()
-    : m_kind(Kind::eNotAnError) {}
-
-bool SwiftLanguageRuntime::IsValidErrorValue(
-    ValueObject &in_value, SwiftErrorDescriptor *out_error_descriptor) {
-  // see GetDynamicTypeAndAddress_ErrorType for details
-
+bool SwiftLanguageRuntime::IsValidErrorValue(ValueObject &in_value) {
   CompilerType var_type = in_value.GetStaticValue()->GetCompilerType();
   SwiftASTContext::ProtocolInfo protocol_info;
   if (!SwiftASTContext::GetProtocolTypeInfo(var_type, protocol_info))
@@ -1707,12 +1702,6 @@ bool SwiftLanguageRuntime::IsValidErrorValue(
         if (descriptor->GetISA() != m_SwiftNativeNSErrorISA.getValue()) {
           // not a __SwiftNativeNSError - but statically typed as ErrorType
           // return true here
-          if (out_error_descriptor) {
-            *out_error_descriptor = SwiftErrorDescriptor();
-            out_error_descriptor->m_kind = SwiftErrorDescriptor::Kind::eBridged;
-            out_error_descriptor->m_bridged.instance_ptr_value =
-                instance_type_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-          }
           return true;
         }
       }
@@ -1735,16 +1724,6 @@ bool SwiftLanguageRuntime::IsValidErrorValue(
     if (metadata_ptr_value == 0 || metadata_ptr_value == LLDB_INVALID_ADDRESS ||
         error.Fail())
       return false;
-
-    if (out_error_descriptor) {
-      *out_error_descriptor = SwiftErrorDescriptor();
-      out_error_descriptor->m_kind =
-          SwiftErrorDescriptor::Kind::eSwiftBridgeableNative;
-      out_error_descriptor->m_bridgeable_native.metadata_location =
-          metadata_location;
-      out_error_descriptor->m_bridgeable_native.metadata_ptr_value =
-          metadata_ptr_value;
-    }
   } else {
     // this is a swift native error and it has no way to be bridged to ObjC
     // so it adopts a more compact layout
@@ -1759,299 +1738,66 @@ bool SwiftLanguageRuntime::IsValidErrorValue(
     if (metadata_ptr_value == 0 || metadata_ptr_value == LLDB_INVALID_ADDRESS ||
         error.Fail())
       return false;
-
-    lldb::addr_t witness_table_location = metadata_location + ptr_size;
-    lldb::addr_t payload_location = witness_table_location + ptr_size;
-
-    if (out_error_descriptor) {
-      *out_error_descriptor = SwiftErrorDescriptor();
-      out_error_descriptor->m_kind =
-          SwiftErrorDescriptor::Kind::eSwiftPureNative;
-      out_error_descriptor->m_pure_native.metadata_location =
-          metadata_ptr_value;
-      out_error_descriptor->m_pure_native.payload_ptr = payload_location;
-    }
   }
 
   return true;
-}
-
-bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_ErrorType(
-    ValueObject &in_value, lldb::DynamicValueType use_dynamic,
-    TypeAndOrName &class_type_or_name, Address &address) {
-  // layout of error type
-  // pointer to -------> SwiftError {
-  // --------------
-  // CFRuntimeBase
-  // CFIndex
-  // CFStringRef
-  // CFDictionaryRef
-  // --------------
-  // Metadata
-  // WitnessTable
-  // hashable Metadata
-  // hashable WitnessTable
-  // --------------
-  // tail allocated actual object data *
-  // }
-  // * for a struct, it's the inline data
-  // * for a class, it's the inline pointer-to-the-data (aka, the swift class
-  // instance)
-  SwiftErrorDescriptor error_descriptor;
-  if (!IsValidErrorValue(in_value, &error_descriptor))
-    return false;
-
-  Status error;
-  CompilerType var_type(in_value.GetStaticValue()->GetCompilerType());
-  size_t ptr_size = m_process->GetAddressByteSize();
-  SwiftASTContext *swift_ast_ctx =
-      llvm::dyn_cast_or_null<SwiftASTContext>(var_type.GetTypeSystem());
-  if (!swift_ast_ctx)
-    return false;
-
-  switch (error_descriptor.m_kind) {
-  case SwiftErrorDescriptor::Kind::eNotAnError:
-    return false;
-  case SwiftErrorDescriptor::Kind::eSwiftBridgeableNative: {
-    MetadataPromiseSP promise_sp(GetMetadataPromise(
-        error_descriptor.m_bridgeable_native.metadata_ptr_value, in_value));
-    if (!promise_sp)
-      return false;
-    error_descriptor.m_bridgeable_native.metadata_location += 4 * ptr_size;
-    if (!promise_sp->IsStaticallyDetermined()) {
-      // figure out the actual dynamic type via the metadata at the "isa"
-      // pointer
-      error_descriptor.m_bridgeable_native.metadata_location =
-          m_process->ReadPointerFromMemory(
-              error_descriptor.m_bridgeable_native.metadata_location, error);
-      if (error_descriptor.m_bridgeable_native.metadata_location == 0 ||
-          error_descriptor.m_bridgeable_native.metadata_location ==
-              LLDB_INVALID_ADDRESS ||
-          error.Fail())
-        return false;
-      error_descriptor.m_bridgeable_native.metadata_ptr_value =
-          m_process->ReadPointerFromMemory(
-              error_descriptor.m_bridgeable_native.metadata_location, error);
-      if (error_descriptor.m_bridgeable_native.metadata_ptr_value == 0 ||
-          error_descriptor.m_bridgeable_native.metadata_ptr_value ==
-              LLDB_INVALID_ADDRESS ||
-          error.Fail())
-        return false;
-      promise_sp = GetMetadataPromise(
-          error_descriptor.m_bridgeable_native.metadata_ptr_value, in_value);
-      if (!promise_sp || !promise_sp->FulfillTypePromise()) {
-        // this could still be a random ObjC object
-        if (auto objc_runtime = GetObjCRuntime()) {
-          DataExtractor extractor(
-              &error_descriptor.m_bridgeable_native.metadata_location,
-              sizeof(error_descriptor.m_bridgeable_native.metadata_location),
-              GetProcess()->GetByteOrder(), GetProcess()->GetAddressByteSize());
-          ExecutionContext exe_ctx(GetProcess());
-          auto scratch_ast =
-              GetProcess()->GetTarget().GetScratchClangASTContext();
-          if (scratch_ast) {
-            auto valobj_sp = ValueObject::CreateValueObjectFromData(
-                in_value.GetName().AsCString(), extractor, exe_ctx,
-                scratch_ast->GetBasicType(eBasicTypeObjCID));
-            if (valobj_sp) {
-              Value::ValueType value_type;
-              if (objc_runtime->GetDynamicTypeAndAddress(
-                      *valobj_sp, use_dynamic, class_type_or_name, address,
-                      value_type)) {
-                address.SetLoadAddress(
-                    error_descriptor.m_bridgeable_native.metadata_location,
-                    &GetProcess()->GetTarget());
-                if (!class_type_or_name.GetCompilerType().IsPointerType()) {
-                  // the language runtimes do not return pointer-to-types when
-                  // doing dynamic type resolution
-                  // what usually happens is that the static type has
-                  // pointer-like traits that ValueObjectDynamic
-                  // then preserves in the dynamic value - since the static type
-                  // here is a Swift protocol object
-                  // the dynamic type won't know to pointerize. But we truly
-                  // need an ObjCObjectPointer here or else
-                  // type printing WILL be confused. Hence, make the pointer
-                  // type ourselves if we didn't get one already
-                  class_type_or_name.SetCompilerType(
-                      class_type_or_name.GetCompilerType().GetPointerType());
-                }
-                return true;
-              }
-            }
-          }
-        }
-
-        return false;
-      }
-    }
-
-    if (!promise_sp)
-      return false;
-    address.SetLoadAddress(
-        error_descriptor.m_bridgeable_native.metadata_location,
-        &m_process->GetTarget());
-    CompilerType metadata_type(promise_sp->FulfillTypePromise());
-    if (metadata_type.IsValid() && error.Success()) {
-      class_type_or_name.SetCompilerType(metadata_type);
-      return true;
-    }
-  } break;
-  case SwiftErrorDescriptor::Kind::eBridged: {
-    if (error_descriptor.m_bridged.instance_ptr_value != 0 &&
-        error_descriptor.m_bridged.instance_ptr_value != LLDB_INVALID_ADDRESS) {
-      Status error_type_lookup_error;
-      if (CompilerType error_type =
-              swift_ast_ctx->GetNSErrorType(error_type_lookup_error)) {
-        class_type_or_name.SetCompilerType(error_type);
-        address.SetRawAddress(error_descriptor.m_bridged.instance_ptr_value);
-        return true;
-      }
-    }
-  } break;
-  case SwiftErrorDescriptor::Kind::eSwiftPureNative: {
-    Status error;
-    if (MetadataPromiseSP promise_sp = GetMetadataPromise(
-            error_descriptor.m_pure_native.metadata_location, in_value)) {
-      if (promise_sp->IsStaticallyDetermined()) {
-        if (CompilerType compiler_type = promise_sp->FulfillTypePromise()) {
-          class_type_or_name.SetCompilerType(compiler_type);
-          address.SetRawAddress(error_descriptor.m_pure_native.payload_ptr);
-          return true;
-        }
-      } else {
-        error_descriptor.m_pure_native.metadata_location =
-            m_process->ReadPointerFromMemory(
-                error_descriptor.m_pure_native.payload_ptr, error);
-        if (error_descriptor.m_pure_native.metadata_location == 0 ||
-            error_descriptor.m_pure_native.metadata_location ==
-                LLDB_INVALID_ADDRESS ||
-            error.Fail())
-          return false;
-        error_descriptor.m_pure_native.payload_ptr =
-            error_descriptor.m_pure_native.metadata_location;
-        error_descriptor.m_pure_native.metadata_location =
-            m_process->ReadPointerFromMemory(
-                error_descriptor.m_pure_native.payload_ptr, error);
-        if (MetadataPromiseSP promise_sp = GetMetadataPromise(
-                error_descriptor.m_pure_native.metadata_location, in_value)) {
-          if (CompilerType compiler_type = promise_sp->FulfillTypePromise()) {
-            class_type_or_name.SetCompilerType(compiler_type);
-            address.SetRawAddress(error_descriptor.m_pure_native.payload_ptr);
-            return true;
-          }
-        }
-      }
-    }
-  } break;
-  }
-
-  return false;
 }
 
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
     ValueObject &in_value, SwiftASTContext &scratch_ctx,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
     Address &address) {
-  CompilerType var_type(in_value.GetCompilerType());
-  SwiftASTContext::ProtocolInfo protocol_info;
-  if (!SwiftASTContext::GetProtocolTypeInfo(var_type, protocol_info))
-    return false;
+  Log *log(GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
 
-  if (protocol_info.m_is_errortype)
-    return GetDynamicTypeAndAddress_ErrorType(in_value, use_dynamic,
-                                              class_type_or_name, address);
+  auto &target = m_process->GetTarget();
+  assert(IsScratchContextLocked(target) &&
+          "Swift scratch context not locked ahead");
+  auto &remote_ast = GetRemoteASTContext(scratch_ctx);
 
-  MetadataPromiseSP promise_sp;
-  ValueObjectSP instance_type_sp(
-                  in_value.GetStaticValue()->GetChildAtIndex(
-                                  protocol_info.GetInstanceTypeIndex(), true));
-  if (!instance_type_sp)
-    return false;
-  ValueObjectSP payload0_sp(
-      in_value.GetStaticValue()->GetChildAtIndex(0, true));
-  if (!payload0_sp)
-    return false;
+  CompilerType protocol_type(in_value.GetCompilerType());
 
-  auto ptr_size = m_process->GetAddressByteSize();
+  lldb::addr_t existential_address;
+  bool use_local_buffer = false;
 
-  // @objc protocols are automatically class-only, and there is no
-  // static/dynamic to deal with
-  bool is_class = protocol_info.m_is_objc || protocol_info.m_is_class_only ||
-                  protocol_info.m_is_anyobject;
-  if (!is_class) {
-    promise_sp =
-        GetMetadataPromise(instance_type_sp->GetValueAsUnsigned(0), in_value);
-    if (!promise_sp)
-      return false;
-    if (promise_sp->FulfillKindPromise().hasValue() &&
-        promise_sp->FulfillKindPromise().getValue() ==
-            swift::MetadataKind::Class)
-      is_class = true;
-  }
-  if (is_class) {
-    if (GetDynamicTypeAndAddress_Class(*payload0_sp, scratch_ctx, use_dynamic,
-                                       class_type_or_name, address))
-      return true;
+  if (in_value.GetValueType() == eValueTypeConstResult) {
+    if (log)
+      log->Printf("existential value is a const result");
 
-    // only for @objc protocols, try to fallback to the ObjC runtime as a source
-    // of type information
-    // this is not exactly a great solution and we need to be careful with how
-    // we use the results of this
-    // computation, but assuming some care, at least data formatters will work
-    if (!protocol_info.m_is_objc)
-      return false;
-    auto objc_runtime = GetObjCRuntime();
-    if (!objc_runtime)
-      return false;
-    auto descriptor_sp = objc_runtime->GetClassDescriptor(*payload0_sp);
-    if (!descriptor_sp)
-      return false;
-    std::vector<clang::NamedDecl *> decls;
-    DeclVendor *vendor = objc_runtime->GetDeclVendor();
-    if (!vendor)
-      return false;
-    vendor->FindDecls(descriptor_sp->GetClassName(), true, 1, decls);
-    if (decls.size() == 0)
-      return false;
-    CompilerType type = ClangASTContext::GetTypeForDecl(decls[0]);
-    if (!type.IsValid())
-      return false;
+    // We have a locally materialized value, so let our MemoryReader
+    // know where it is so that RemoteAST can read from it.
+    existential_address = in_value.GetValue().GetScalar().ULongLong();
 
-    lldb::addr_t class_metadata_ptr = payload0_sp->GetAddressOf();
-    if (class_metadata_ptr && class_metadata_ptr != LLDB_INVALID_ADDRESS)
-      address.SetRawAddress(class_metadata_ptr);
-
-    class_type_or_name.SetCompilerType(type.GetPointerType());
-    return class_type_or_name.GetCompilerType().IsValid();
+    use_local_buffer = true;
+  } else {
+    existential_address = in_value.GetAddressOf();
   }
 
-  if (promise_sp->FulfillKindPromise().hasValue() &&
-      (promise_sp->FulfillKindPromise().getValue() ==
-           swift::MetadataKind::Struct ||
-       promise_sp->FulfillKindPromise().getValue() ==
-           swift::MetadataKind::Enum ||
-       promise_sp->FulfillKindPromise().getValue() ==
-           swift::MetadataKind::Tuple)) {
-    Status error;
-    class_type_or_name.SetCompilerType(promise_sp->FulfillTypePromise());
-    if (error.Fail())
-      return false;
-    // Project the payload.
-    switch (SwiftASTContext::GetAllocationStrategy(
-        class_type_or_name.GetCompilerType())) {
-    case SwiftASTContext::TypeAllocationStrategy::eInline:
-      address.SetRawAddress(in_value.GetValue().GetScalar().ULongLong());
-      return true;
-    case SwiftASTContext::TypeAllocationStrategy::ePointer:
-      address.SetRawAddress(payload0_sp->GetValueAsUnsigned(0) +
-                            (ptr_size * 2));
-      return true;
-    default:
-      // TODO we don't know how to deal with the dynamic case quite yet
-      return false;
-    }
+  if (log)
+    log->Printf("existential address is %llu", existential_address);
+
+  if (!existential_address || existential_address == LLDB_INVALID_ADDRESS)
+    return false;
+
+  if (use_local_buffer)
+    PushLocalBuffer(existential_address, in_value.GetByteSize());
+
+  swift::remote::RemoteAddress remote_existential(existential_address);
+  auto result = remote_ast.getDynamicTypeAndAddressForExistential(
+      remote_existential, GetSwiftType(protocol_type));
+
+  if (use_local_buffer)
+    PopLocalBuffer();
+
+  if (!result.isSuccess()) {
+    if (log)
+      log->Printf("RemoteAST failed to get dynamic type of existential");
+    return false;
   }
-  return false;
+
+  auto type_and_address = result.getValue();
+  class_type_or_name.SetCompilerType(type_and_address.InstanceType);
+  address.SetRawAddress(type_and_address.PayloadAddress.getAddressData());
+  return true;
 }
 
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Promise(


### PR DESCRIPTION
There was a lot of redundant logic here that predates RemoteAST.

I started off by trying to simplify debug info emission in the Swift side by only emitting debug values for top-level generic parameter types and not member types; in lldb we should be able to look up member types just by calling `Type::subst()`. Unfortunately, this broke test cases where we were getting the dynamic type of values whose type is a member type. Turns out this was handled as part of a special "generic parameter or member type" code path, which would map the type to a concrete type, and then get the dynamic type of the concrete type.

This "get dynamic type of concrete type resulting from concretizing a generic parameter type" code path was totally different from the "get dynamic type of concrete type" code path. The former used RemoteAST, the latter did not. Merging these two code paths is what this PR is all about.

The non-RemoteAST code path handled a few cases that the RemoteAST code path did not, such as values materialized in host memory -- this is how results come back from the expression evaluator, which wants to "freeze" them so that they're available later. It also handled imported types and some other edge cases.

Now that RemoteAST on the Swift side is more capable, all it took was adding some support to lldb's MemoryReader implementation for reading memory from a specified local buffer to use RemoteAST for all the other cases as well.

Fixes <rdar://40706055> (but really a whole lot more than that).