### PR TITLE
[SwiftASTContext] Move LoadOneModule back into implementation

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -29,8 +29,6 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/Threading.h"
 
-#include "swift/AST/Module.h"
-
 #include <map>
 #include <set>
 
@@ -42,6 +40,7 @@ class IRGenOptions;
 class NominalTypeDecl;
 class SILModule;
 class VarDecl;
+class ModuleDecl;
 struct PrintOptions;
 namespace irgen {
 class FixedTypeInfo;
@@ -771,14 +770,6 @@ public:
   lldb::TypeSP GetCachedType(const ConstString &mangled);
 
   void SetCachedType(const ConstString &mangled, const lldb::TypeSP &type_sp);
-
-  static bool
-  LoadOneModule(const ConstString &module_name,
-                SwiftASTContext &swift_ast_context,
-                lldb::StackFrameWP &stack_frame_wp,
-                llvm::SmallVectorImpl<swift::SourceFile::ImportedModuleDesc>
-                    &additional_imports,
-                Status &error);
 
   static bool PerformUserImport(SwiftASTContext &swift_ast_context,
                                 SymbolContext &sc,

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -27,6 +27,7 @@
 #include <mutex>
 
 #include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -8180,12 +8180,13 @@ static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
   }
 }
 
-bool SwiftASTContext::LoadOneModule(
-    const ConstString &module_name, SwiftASTContext &swift_ast_context,
-    lldb::StackFrameWP &stack_frame_wp,
-    llvm::SmallVectorImpl<swift::SourceFile::ImportedModuleDesc>
-        &additional_imports,
-    Status &error) {
+static bool
+LoadOneModule(const ConstString &module_name,
+              SwiftASTContext &swift_ast_context,
+              lldb::StackFrameWP &stack_frame_wp,
+              llvm::SmallVectorImpl<swift::SourceFile::ImportedModuleDesc>
+                  &additional_imports,
+              Status &error) {
   Log *log(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
   error.Clear();
   if (log)


### PR DESCRIPTION
LLDB's public headers shouldn't include swift headers. We can mostly
work around this by using forward declarations, however LoadOneModule's
signature contains a nested class, which cannot be forward declared. As
there don't seem to be any usages outside of the SwiftASTContext, I
propose removing it from the interface.