### PR TITLE
"LSP Snippets" option for completion API

### DIFF
--- a/include/lldb/API/LLDB.h
+++ b/include/lldb/API/LLDB.h
@@ -60,6 +60,7 @@
 #include "lldb/API/SBStructuredData.h"
 // SWIFT_ENABLE_TENSORFLOW
 #include "lldb/API/SBCompletionMatch.h"
+#include "lldb/API/SBCompletionOptions.h"
 #include "lldb/API/SBCompletionResponse.h"
 #include "lldb/API/SBSymbol.h"
 #include "lldb/API/SBSymbolContext.h"

--- a/include/lldb/API/SBCompletionOptions.h
+++ b/include/lldb/API/SBCompletionOptions.h
@@ -1,0 +1,48 @@
+//===-- SBCompletionOptions.h -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SBCompletionOptions_h_
+#define LLDB_SBCompletionOptions_h_
+
+#include "lldb/API/SBDefines.h"
+#include "lldb/Target/CompletionOptions.h"
+
+namespace lldb {
+
+class LLDB_API SBCompletionOptions {
+public:
+  SBCompletionOptions();
+
+  SBCompletionOptions(const SBCompletionOptions &rhs);
+
+  const SBCompletionOptions &operator=(const SBCompletionOptions &rhs);
+
+  lldb::LanguageType GetLanguage() const;
+  void SetLanguage(lldb::LanguageType Language);
+
+  bool GetInsertableLSPSnippets() const;
+  void SetInsertableLSPSnippets(bool Value);
+
+protected:
+  friend class SBTarget;
+
+  SBCompletionOptions(const lldb_private::CompletionOptions *options);
+
+  lldb_private::CompletionOptions *GetPointer() const;
+
+private:
+  std::unique_ptr<lldb_private::CompletionOptions> m_opaque_ap;
+};
+
+} // namespace lldb
+
+#endif // LLDB_SBCompletionOptions_h_

--- a/include/lldb/API/SBDefines.h
+++ b/include/lldb/API/SBDefines.h
@@ -42,7 +42,9 @@ class LLDB_API SBCommandPluginInterface;
 class LLDB_API SBCommandReturnObject;
 class LLDB_API SBCommunication;
 class LLDB_API SBCompileUnit;
+// SWIFT_ENABLE_TENSORFLOW
 class LLDB_API SBCompletionMatch;
+class LLDB_API SBCompletionOptions;
 class LLDB_API SBCompletionResponse;
 class LLDB_API SBData;
 class LLDB_API SBDebugger;

--- a/include/lldb/API/SBTarget.h
+++ b/include/lldb/API/SBTarget.h
@@ -895,7 +895,7 @@ public:
 
   // SWIFT_ENABLE_TENSORFLOW
   SBCompletionResponse
-  CompleteCode(lldb::LanguageType language,
+  CompleteCode(const lldb::SBCompletionOptions &options,
                const lldb::SBSymbolContext *symbol_context,
                const char *current_code);
 

--- a/include/lldb/Target/CompletionOptions.h
+++ b/include/lldb/Target/CompletionOptions.h
@@ -1,0 +1,25 @@
+//===--- CompletionOptions.h ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CompletionOptions_h_
+#define CompletionOptions_h_
+
+namespace lldb_private {
+
+struct CompletionOptions {
+  lldb::LanguageType Language;
+  bool InsertableLSPSnippets = false;
+};
+
+} // namespace lldb_private
+
+#endif // CompletionOptions_h_

--- a/include/lldb/Target/Language.h
+++ b/include/lldb/Target/Language.h
@@ -27,6 +27,7 @@
 #include "lldb/DataFormatters/StringPrinter.h"
 // SWIFT_ENABLE_TENSORFLOW
 #include "lldb/Target/CompletionResponse.h"
+#include "lldb/Target/CompletionOptions.h"
 #include "lldb/lldb-private.h"
 #include "lldb/lldb-public.h"
 
@@ -234,7 +235,8 @@ public:
                                                      bool throw_on, Stream &s);
 
   // SWIFT_ENABLE_TENSORFLOW
-  virtual CompletionResponse CompleteCode(ExecutionContextScope &exe_scope,
+  virtual CompletionResponse CompleteCode(const CompletionOptions &options,
+                                          ExecutionContextScope &exe_scope,
                                           const std::string &entered_code);
 
   // These are accessors for general information about the Languages lldb knows

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -40,6 +40,7 @@
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Target/ABI.h"
 // SWIFT_ENABLE_TENSORFLOW
+#include "lldb/Target/CompletionOptions.h"
 #include "lldb/Target/CompletionResponse.h"
 #include "lldb/Target/ExecutionContextScope.h"
 #include "lldb/Target/PathMappingList.h"
@@ -1220,8 +1221,9 @@ public:
       std::string *fixed_expression = nullptr);
 
   // SWIFT_ENABLE_TENSORFLOW
-  CompletionResponse CompleteCode(lldb::LanguageType language,
-                                  llvm::StringRef current_code);
+  CompletionResponse CompleteCode(
+      const lldb_private::CompletionOptions &options,
+      llvm::StringRef current_code);
 
   // Look up a symbol by name and type in both the target's symbols and the
   // persistent symbols from the

--- a/scripts/interface/SBCompletionOptions.i
+++ b/scripts/interface/SBCompletionOptions.i
@@ -1,0 +1,45 @@
+//===-- SWIG Interface for SBCompletionOptions ------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+namespace lldb {
+
+%feature("docstring", "
+Options for a completion request
+") SBCompletionOptions;
+class SBCompletionOptions
+{
+public:
+    %feature("docstring", "The language used for completions.")
+    GetLanguage;
+    lldb::LanguageType GetLanguage () const;
+
+    %feature("docstring", "Set the language used for completions.")
+    SetLanguage;
+    void SetLanguage (lldb::LanguageType Language);
+
+    %feature("docstring", "
+    When this is false, the insertable text in completion matches is plain text
+    that can be inserted directly into the code. When this is true, the
+    insertable text in completion matches is a Language Server Protocol Snippet
+    (https://microsoft.github.io/language-server-protocol/specification#textDocument_completion),
+    which includes things like placeholder tabstops for function arguments.
+    ") GetInsertableLSPSnippets;
+    bool GetInsertableLSPSnippets () const;
+
+    %feature("docstring", "
+    Set whether the insertable text in completion matches is a Language Server
+    Protocol Snippet. See the getter docstring for more information.
+    ") SetInsertableLSPSnippets;
+    void SetInsertableLSPSnippets (bool Value);
+};
+
+} // namespace lldb

--- a/scripts/interface/SBTarget.i
+++ b/scripts/interface/SBTarget.i
@@ -1039,14 +1039,14 @@ public:
     %feature("docstring", "
     Complete code.
     Parameters:
-      language          -- the language to use
+      options           -- the options to use
       symbol_context    -- the context in which to do the completion
       current_code      -- the code to complete
     Returns an SBCompletionResponse with completions that fit immediately after
     the last character of `current_code`.
     ") CompleteCode;
     lldb::SBCompletionResponse
-    CompleteCode (lldb::LanguageType language,
+    CompleteCode (const lldb::SBCompletionOptions &options,
                   const lldb::SBSymbolContext *symbol_context,
                   const char *current_code);
 

--- a/scripts/lldb.swig
+++ b/scripts/lldb.swig
@@ -90,6 +90,7 @@ import six
 #include "lldb/API/SBCompileUnit.h"
 // SWIFT_ENABLE_TENSORFLOW
 #include "lldb/API/SBCompletionMatch.h"
+#include "lldb/API/SBCompletionOptions.h"
 #include "lldb/API/SBCompletionResponse.h"
 #include "lldb/API/SBData.h"
 #include "lldb/API/SBDebugger.h"
@@ -180,6 +181,7 @@ import six
 %include "./interface/SBCompileUnit.i"
 // SWIFT_ENABLE_TENSORFLOW
 %include "./interface/SBCompletionMatch.i"
+%include "./interface/SBCompletionOptions.i"
 %include "./interface/SBCompletionResponse.i"
 %include "./interface/SBData.i"
 %include "./interface/SBDebugger.i"

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -23,6 +23,7 @@ add_lldb_library(liblldb SHARED
   SBCommunication.cpp
   SBCompileUnit.cpp
   SBCompletionMatch.cpp
+  SBCompletionOptions.cpp
   SBCompletionResponse.cpp
   SBData.cpp
   SBDebugger.cpp

--- a/source/API/SBCompletionOptions.cpp
+++ b/source/API/SBCompletionOptions.cpp
@@ -1,0 +1,53 @@
+//===-- SBCompletionOptions.cpp ---------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/API/SBCompletionOptions.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+SBCompletionOptions::SBCompletionOptions()
+    : m_opaque_ap(new lldb_private::CompletionOptions()) {}
+
+SBCompletionOptions::SBCompletionOptions(const SBCompletionOptions &rhs)
+    : m_opaque_ap(new lldb_private::CompletionOptions(*rhs.m_opaque_ap)) {}
+
+const SBCompletionOptions &SBCompletionOptions::
+operator=(const SBCompletionOptions &rhs) {
+  m_opaque_ap.reset(new lldb_private::CompletionOptions(*rhs.m_opaque_ap));
+  return *this;
+}
+
+lldb::LanguageType SBCompletionOptions::GetLanguage() const {
+  return m_opaque_ap->Language;
+}
+
+void SBCompletionOptions::SetLanguage(lldb::LanguageType Language) {
+  m_opaque_ap->Language = Language;
+}
+
+bool SBCompletionOptions::GetInsertableLSPSnippets() const {
+  return m_opaque_ap->InsertableLSPSnippets;
+}
+
+void SBCompletionOptions::SetInsertableLSPSnippets(bool Value) {
+  m_opaque_ap->InsertableLSPSnippets = Value;
+}
+
+SBCompletionOptions::SBCompletionOptions(
+    const lldb_private::CompletionOptions *options)
+    : m_opaque_ap(new lldb_private::CompletionOptions(*options)) {}
+
+
+lldb_private::CompletionOptions *SBCompletionOptions::GetPointer() const {
+  return m_opaque_ap.get();
+}

--- a/source/API/SBTarget.cpp
+++ b/source/API/SBTarget.cpp
@@ -14,6 +14,7 @@
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/API/SBDebugger.h"
 // SWIFT_ENABLE_TENSORFLOW
+#include "lldb/API/SBCompletionOptions.h"
 #include "lldb/API/SBCompletionResponse.h"
 #include "lldb/API/SBEvent.h"
 #include "lldb/API/SBExpressionOptions.h"
@@ -2308,10 +2309,10 @@ lldb::SBValue SBTarget::EvaluateExpression(const char *expr,
 
 // SWIFT_ENABLE_TENSORFLOW
 SBCompletionResponse
-SBTarget::CompleteCode(lldb::LanguageType language,
+SBTarget::CompleteCode(const lldb::SBCompletionOptions &options,
                        const lldb::SBSymbolContext *symbol_context,
                        const char *current_code) {
-  auto response = GetSP()->CompleteCode(language, current_code);
+  auto response = GetSP()->CompleteCode(*options.GetPointer(), current_code);
   return SBCompletionResponse(&response);
 }
 

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -98,8 +98,7 @@ static std::string toInsertableString(const lldb_private::CompletionOptions &Opt
                 callParameterSection == ChunkKind::CallParameterInternalName ||
                 (!hasParameterName &&
                     callParameterSection == ChunkKind::CallParameterColon) ||
-                callParameterSection == ChunkKind::CallParameterType ||
-                callParameterSection == ChunkKind::CallParameterClosureType))
+                callParameterSection == ChunkKind::CallParameterType))
           PlaceholderText += escapeForInsertableString(Options,
                                                        innerChunk.getText());
 

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.h
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.h
@@ -23,7 +23,8 @@
 namespace lldb_private {
 
 CompletionResponse
-SwiftCompleteCode(SwiftASTContext &SwiftCtx,
+SwiftCompleteCode(const CompletionOptions &Options,
+                  SwiftASTContext &SwiftCtx,
                   SwiftPersistentExpressionState &PersistentExpressionState,
                   llvm::StringRef EnteredCode);
 

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1668,7 +1668,8 @@ void SwiftLanguage::GetExceptionResolverDescription(bool catch_on,
 }
 
 CompletionResponse
-SwiftLanguage::CompleteCode(ExecutionContextScope &exe_scope,
+SwiftLanguage::CompleteCode(const CompletionOptions &options,
+                            ExecutionContextScope &exe_scope,
                             const std::string &entered_code) {
   Target &target = *exe_scope.CalculateTarget();
   Status error;
@@ -1679,7 +1680,7 @@ SwiftLanguage::CompleteCode(ExecutionContextScope &exe_scope,
   auto persistent_expression_state =
       target.GetSwiftPersistentExpressionState(exe_scope);
 
-  return SwiftCompleteCode(*swift_ast, *persistent_expression_state,
+  return SwiftCompleteCode(options, *swift_ast, *persistent_expression_state,
                            entered_code);
 }
 

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -75,7 +75,8 @@ public:
                                        Stream &s) override;
 
   // SWIFT_ENABLE_TENSORFLOW
-  CompletionResponse CompleteCode(ExecutionContextScope &exe_scope,
+  CompletionResponse CompleteCode(const CompletionOptions &options,
+                                  ExecutionContextScope &exe_scope,
                                   const std::string &entered_code);
 
   //------------------------------------------------------------------

--- a/source/Target/Language.cpp
+++ b/source/Target/Language.cpp
@@ -446,7 +446,8 @@ void Language::GetDefaultExceptionResolverDescription(bool catch_on,
            catch_on ? "on" : "off", throw_on ? "on" : "off");
 }
 
-CompletionResponse Language::CompleteCode(ExecutionContextScope &exe_scope,
+CompletionResponse Language::CompleteCode(const CompletionOptions &options,
+                                          ExecutionContextScope &exe_scope,
                                           const std::string &entered_code) {
   return CompletionResponse::error("completion unsupported for this language");
 }

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -2645,12 +2645,12 @@ ExpressionResults Target::EvaluateExpression(
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-CompletionResponse Target::CompleteCode(lldb::LanguageType language,
+CompletionResponse Target::CompleteCode(const CompletionOptions &options,
                                         llvm::StringRef current_code) {
-  auto *plugin = Language::FindPlugin(language);
+  auto *plugin = Language::FindPlugin(options.Language);
   if (!plugin)
     return CompletionResponse::error("language plugin not found");
-  return plugin->CompleteCode(*this, current_code);
+  return plugin->CompleteCode(options, *this, current_code);
 }
 
 lldb::ExpressionVariableSP


### PR DESCRIPTION
This adds an "LSP Snippets" option to the completion API, documented in SBCompletionOptions.i.

Basically, these allow us to insert placeholders for arguments when the user selects a function from the autocomplete menu. Monaco-based editors automatically highlight the placeholders and let the user tab between them, so that it's easy for them to fill in all the arguments. It looks like this:
![lsp_snippet_placeholders](https://user-images.githubusercontent.com/5945760/52756893-b7c25e00-2fb7-11e9-8eb8-93fbd9dfd69e.png)