### PR TITLE
Make RemapClangImporterOptions more robust.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -34,6 +34,8 @@ libFoo.dylib: Foo.swift
 	echo '  <dict>'>>$$PLIST; \
 	echo "    <key>$(BOTDIR)</key>">>$$PLIST; \
 	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
+	echo "    <key>/nonexisting-rootdir</key>">>$$PLIST; \
+	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
 	echo '  </dict>'>>$$PLIST; \
 	echo '</dict>'>>$$PLIST; \
 	echo '</plist>'>>$$PLIST

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -66,25 +66,15 @@ class TestSwiftRewriteClangPaths(TestBase):
         plist = self.find_plist()
         self.assertTrue(os.path.isfile(plist))
         if remap:
-            self.runCmd("settings set target.source-map %s %s" %
-                        (botdir, userdir))
+            self.runCmd("settings set target.source-map %s %s %s %s" %
+                        (botdir, userdir, '/nonexisting-rootdir', userdir))
         else:
             # Also delete the remapping plist from the .dSYM to verify
             # that this doesn't work by happy accident without it.
             os.remove(plist)
-            
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
 
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        foo_breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', lldb.SBFileSpec('Foo.swift'))
-
-        process = target.LaunchSimple(None, None, os.getcwd())
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('Foo.swift'))
 
         if remap:
             comment = "returns correct value"
@@ -101,9 +91,13 @@ class TestSwiftRewriteClangPaths(TestBase):
         found_i1 = 0
         found_i2 = 0
         found_rel = 0
+        found_abs = 0
         logfile = open(log, "r")
         for line in logfile:
-            if " remapped " in line: continue
+            self.assertFalse("remapped -iquote" in line)
+            if " remapped " in line:
+                if line[:-1].endswith('/user'): found_abs += 1;
+                continue
             if "error: missing required module 'CFoo'" in line:
                 errs += 1
                 continue
@@ -122,6 +116,7 @@ class TestSwiftRewriteClangPaths(TestBase):
             self.assertEqual(found_i2, 2)
             self.assertEqual(found_f, 4)
             self.assertEqual(found_rel, 0)
+            self.assertEqual(found_abs, 1)
         else:
             self.assertTrue(errs > 0, "expected module import error")
         

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/dylib.mk
@@ -9,6 +9,7 @@ SWIFTFLAGS_EXTRAS = \
 	    -Xcc -I./buildbot/I-single \
 	    -Xcc -F./buildbot/Frameworks \
 	    -Xcc -F -Xcc buildbot/Frameworks \
+	    -Xcc -iquote -Xcc /nonexisting-rootdir \
 	    -import-objc-header $(BOTDIR)/Foo/bridge.h
 
 include $(LEVEL)/Makefile.rules


### PR DESCRIPTION
Due to a bug absolute path remapping would be applied to -iquote
*options* rather than their arguments. The fixed code only whitelists
a few search path options that it actually understands.

rdar://problem/48078809