### PR TITLE
Make RemapClangImporterOptions more robust.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -34,6 +34,8 @@ libFoo.dylib: Foo.swift
 	echo '  <dict>'>>$$PLIST; \
 	echo "    <key>$(BOTDIR)</key>">>$$PLIST; \
 	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
+	echo "    <key>/nonexisting-rootdir</key>">>$$PLIST; \
+	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
 	echo '  </dict>'>>$$PLIST; \
 	echo '</dict>'>>$$PLIST; \
 	echo '</plist>'>>$$PLIST

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -65,25 +65,15 @@ class TestSwiftRewriteClangPaths(TestBase):
         plist = self.find_plist()
         self.assertTrue(os.path.isfile(plist))
         if remap:
-            self.runCmd("settings set target.source-map %s %s" %
-                        (botdir, userdir))
+            self.runCmd("settings set target.source-map %s %s %s %s" %
+                        (botdir, userdir, '/nonexisting-rootdir', userdir))
         else:
             # Also delete the remapping plist from the .dSYM to verify
             # that this doesn't work by happy accident without it.
             os.remove(plist)
-            
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
 
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        foo_breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', lldb.SBFileSpec('Foo.swift'))
-
-        process = target.LaunchSimple(None, None, os.getcwd())
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('Foo.swift'))
 
         if remap:
             comment = "returns correct value"
@@ -100,9 +90,13 @@ class TestSwiftRewriteClangPaths(TestBase):
         found_i1 = 0
         found_i2 = 0
         found_rel = 0
+        found_abs = 0
         logfile = open(log, "r")
         for line in logfile:
-            if " remapped " in line: continue
+            self.assertFalse("remapped -iquote" in line)
+            if " remapped " in line:
+                if line[:-1].endswith('/user'): found_abs += 1;
+                continue
             if "error: missing required module 'CFoo'" in line:
                 errs += 1
                 continue
@@ -121,6 +115,7 @@ class TestSwiftRewriteClangPaths(TestBase):
             self.assertEqual(found_i2, 2)
             self.assertEqual(found_f, 4)
             self.assertEqual(found_rel, 0)
+            self.assertEqual(found_abs, 1)
         else:
             self.assertTrue(errs > 0, "expected module import error")
         

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/dylib.mk
@@ -9,6 +9,7 @@ SWIFTFLAGS_EXTRAS = \
 	    -Xcc -I./buildbot/I-single \
 	    -Xcc -F./buildbot/Frameworks \
 	    -Xcc -F -Xcc buildbot/Frameworks \
+	    -Xcc -iquote -Xcc /nonexisting-rootdir \
 	    -import-objc-header $(BOTDIR)/Foo/bridge.h
 
 include $(LEVEL)/Makefile.rules

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1374,6 +1374,30 @@ bool HasSwiftModules(Module &module) {
 }
 
 namespace {
+
+/// Calls arg.consume_front(<options>) and returns true on success.
+/// \param prefix contains the consumed prefix.
+bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
+  static StringRef options[] = {"-I",
+                                "-F",
+                                "-iquote",
+                                "-idirafter",
+                                "-iframeworkwithsysroot",
+                                "-iframework",
+                                "-iprefix",
+                                "-iwithprefixbefore",
+                                "-iwithprefix",
+                                "-isystemafter",
+                                "-isystem",
+                                "-isysroot"};
+  for (StringRef &option : options)
+    if (arg.consume_front(option)) {
+      prefix = option;
+      return true;
+    }
+  return false;
+}
+
 /// Turn relative paths in clang options into absolute paths based on
 /// \c cur_working_dir.
 template <typename SmallString>
@@ -1381,16 +1405,14 @@ void ApplyWorkingDir(SmallString &clang_argument,
                      StringRef cur_working_dir) {
   StringRef arg = clang_argument.str();
   StringRef prefix;
-  // Ignore the option part of a double-arg include option.
-  if (arg == "-I" || arg == "-F")
-    return;
-  if (arg.consume_front("-I"))
-    prefix = "-I";
-  else if (arg.consume_front("-F"))
-    prefix = "-F";
-  else if (arg.startswith("-"))
+  if (ConsumeIncludeOption(arg, prefix)) {
+    // Ignore the option part of a double-arg include option.
+    if (arg.empty())
+      return;
+  } else if (arg.startswith("-")) {
     // Assume this is a compiler arg and not a path starting with "-".
     return;
+  }
   // There is most probably a path in arg now.
   if (!llvm::sys::path::is_relative(arg))
     return;
@@ -1441,18 +1463,32 @@ void SwiftASTContext::RemapClangImporterOptions(
                   remapped.c_str());
     options.BridgingHeader = remapped;
   }
+
+  // Previous argument was the dash-option of an option pair.
+  bool remap_next = false;
   for (auto &arg_string : options.ExtraArgs) {
     StringRef prefix;
     StringRef arg = arg_string;
-    if (arg.consume_front("-I"))
-      prefix = "-I";
-    else if (arg.consume_front("-F"))
-      prefix = "-F";
+
+    if (remap_next)
+      remap_next = false;
+    else if (ConsumeIncludeOption(arg, prefix)) {
+      if (arg.empty()) {
+        // Option pair.
+        remap_next = true;
+        continue;
+      }
+      // Single-arg include option with prefix.
+    } else {
+      // Not a recognized option.
+      continue;
+    }
+
     if (path_map.RemapPath(arg, remapped)) {
       if (log)
         log->Printf("remapped %s -> %s%s", arg.str().c_str(),
                     prefix.str().c_str(), remapped.c_str());
-      arg_string = prefix.str()+remapped;
+      arg_string = prefix.str() + remapped;
     }
   }
 }


### PR DESCRIPTION
Due to a bug absolute path remapping would be applied to -iquote
*options* rather than their arguments. The fixed code only whitelists
a few search path options that it actually understands.

This patch also adds support for -iquote/some/path.

rdar://problem/48078809