### PR TITLE
Changes for running LLDB test suite for Swift on PowerPC64LE

### DIFF
--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2678,6 +2678,9 @@ bool SwiftLanguageRuntime::FixupReference(lldb::addr_t &addr,
     case llvm::Triple::ArchType::systemz:
       addr &= ~SWIFT_ABI_S390X_SWIFT_SPARE_BITS_MASK;
       break;
+    case llvm::Triple::ArchType::ppc64le:
+      addr &= ~SWIFT_ABI_POWERPC64_SWIFT_SPARE_BITS_MASK;
+      break;
     default:
       break;
     }

--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -4,8 +4,13 @@ if (LLDB_BUILD_FRAMEWORK)
       -Wl,${CMAKE_BINARY_DIR}/${LLDB_FRAMEWORK_INSTALL_DIR}/${LLDB_FRAMEWORK_RESOURCE_DIR}/Swift/macosx")
 elseif( CMAKE_SYSTEM_NAME MATCHES "Linux" )
   # Set the correct rpath to locate libswiftCore
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-      -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-x86_64/lib${LLVM_LIBDIR_SUFFIX}/swift/linux -Wl,-ldl")
+  if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "ppc64le")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
+        -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-powerpc64le/lib${LLVM_LIBDIR_SUFFIX}/swift/linux/powerpc64le -Wl,-ldl")
+  else()
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
+        -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-x86_64/lib${LLVM_LIBDIR_SUFFIX}/swift/linux -Wl,-ldl")
+  endif()
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib/swift/linux:${CMAKE_INSTALL_RPATH}")
 endif()
 


### PR DESCRIPTION
The attached changes are required for running LLDB test suite related test cases for Apple Swift 5 on PowerPC64LE.

