### PR TITLE
[lldb-testsuite] Re-enable TestSwiftAnyType on Linux.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/any/TestSwiftAnyType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/any/TestSwiftAnyType.py
@@ -25,7 +25,6 @@ class TestSwiftAnyType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://35671239")
     def test_any_type(self):
         """Test the Any type"""
         self.build()


### PR DESCRIPTION
<rdar://problem/35671239>