### PR TITLE
TF-239: Autocomplete crash when completing a keypath naming a struct with a private field

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py
@@ -258,4 +258,15 @@ class TestSwiftCompletions(TestBase):
             ["ReplacedStruct", "ReplacedStruct", "ReplacedStruct",
              "ReplacedStruct", "init()", "self"])
 
+        # === TF-249: Crashes when completing a keypath naming a struct with a
+        #             private field ===
+
+        self.assertCompletions(
+            """
+            struct TF249StructWithPrivateField {
+              private let x: Float
+              func bla() {
+                \TF249Struct""",
+            ["WithPrivateField"])
+
         # TODO: Test imports.


### PR DESCRIPTION
Some code in the Swift compiler that handles private fields (`SourceFile::getPrivateDiscriminator`) asserts that all the SourceFiles are distinguishable by name. The assertion fails for this autocompleter, because it uses two unnamed SourceFiles. So this PR gives one of the SourceFiles a name.