### PR TITLE
[unittest] Fix missing user-provided default constructor

### DIFF
--- a/unittests/Utility/ReproducerInstrumentationTest.cpp
+++ b/unittests/Utility/ReproducerInstrumentationTest.cpp
@@ -41,6 +41,8 @@ struct Pod {
   unsigned long long k = 7;
   unsigned long l = 8;
   unsigned short m = 9;
+
+  Pod() {}
 };
 
 class TestingRegistry : public Registry {


### PR DESCRIPTION
error: default initialization of an object of const type 'const Pod'
without a user-provided default constructor

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@354602 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 30ca75512100625a324e5e5c5ab3cb0318371b05)