### PR TITLE
[CMake] Restore some changes to standalone build prior to swift-5.1-branch merge

### DIFF
--- a/cmake/modules/LLDBStandalone.cmake
+++ b/cmake/modules/LLDBStandalone.cmake
@@ -13,12 +13,11 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   file(TO_CMAKE_PATH "${LLDB_PATH_TO_SWIFT_BUILD}" LLDB_PATH_TO_SWIFT_BUILD)
 
   file(TO_CMAKE_PATH "${LLDB_PATH_TO_SWIFT_SOURCE}" LLDB_PATH_TO_SWIFT_SOURCE)
-  # END Swift Mods
 
   find_package(LLVM REQUIRED CONFIG
     HINTS "${LLDB_PATH_TO_LLVM_BUILD}" NO_CMAKE_FIND_ROOT_PATH)
-  #find_package(Clang REQUIRED CONFIG
-  #  HINTS "${LLDB_PATH_TO_CLANG_BUILD}" NO_CMAKE_FIND_ROOT_PATH)
+  find_package(Clang REQUIRED CONFIG
+    HINTS "${LLDB_PATH_TO_CLANG_BUILD}" NO_CMAKE_FIND_ROOT_PATH)
 
   # We set LLVM_CMAKE_PATH so that GetSVN.cmake is found correctly when building SVNVersion.inc
   set(LLVM_CMAKE_PATH ${LLVM_CMAKE_DIR} CACHE PATH "Path to LLVM CMake modules")
@@ -68,6 +67,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # We append the directory in which LLVMConfig.cmake lives. We expect LLVM's
   # CMake modules to be in that directory as well.
   list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${LLDB_PATH_TO_SWIFT_SOURCE}/cmake/modules/")
   include(AddLLVM)
   include(TableGen)
   include(HandleLLVMOptions)
@@ -87,8 +87,6 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   endif()
 
   # Start Swift Mods
-  find_package(Clang REQUIRED CONFIG
-    HINTS "${LLDB_PATH_TO_CLANG_BUILD}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   find_package(Swift REQUIRED CONFIG
     HINTS "${LLDB_PATH_TO_SWIFT_BUILD}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   # End Swift Mods


### PR DESCRIPTION
Some logic got changed when swift-5.1-branch was merged. This commit restores it back to what it was before.

cc @compnerd @weliveindetail @fredriss 

Edit: "swift-5.1-branch was removed" -> "swift-5.1-branch was merged".