### PR TITLE
Cherry-pick "Merge target triple into module triple when constructing module from memory"

### DIFF
--- a/source/Core/Module.cpp
+++ b/source/Core/Module.cpp
@@ -314,6 +314,10 @@ ObjectFile *Module::GetMemoryObjectFile(const lldb::ProcessSP &process_sp,
           // file's architecture since it might differ in vendor/os if some
           // parts were unknown.
           m_arch = m_objfile_sp->GetArchitecture();
+
+          // Augment the arch with the target's information in case
+          // we are unable to extract the os/environment from memory.
+          m_arch.MergeFrom(process_sp->GetTarget().GetArchitecture());
         } else {
           error.SetErrorString("unable to find suitable object file plug-in");
         }


### PR DESCRIPTION
I'm cherry-picking this change because I'm trying to debug swift code on android and ran into issues when doing expression evaluation. Specifically, constructing `SwiftASTContext`s presented a problem because the modules being used to construct the SwiftASTContext had incomplete triples (e.g `aarch64---`). swift-lldb makes the assumption that if the OS is not set in the triple, then it should use the host OS (when not an apple platorm). That doesn't work for remote debugging, so let's try to make sure triples are constructed as accurately as possible.