### PR TITLE
 Replace mapIntoContext with DWARF Archetype name lookup.

### DIFF
--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -172,7 +172,7 @@ public:
 
   ConstString GetTypeName() const;
 
-  ConstString GetDisplayTypeName() const;
+  ConstString GetDisplayTypeName(lldb::StackFrameSP = {}) const;
 
   ConstString GetTypeSymbolName() const;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -536,7 +536,8 @@ public:
 
   ConstString GetTypeName(void *type) override;
 
-  ConstString GetDisplayTypeName(void *type) override;
+  ConstString GetDisplayTypeName(void *type,
+                                 lldb::StackFrameSP frame_sp) override;
 
   ConstString GetTypeSymbolName(void *type) override;
 
@@ -722,9 +723,6 @@ public:
   CompilerType GetTypedefedType(void *type) override;
 
   CompilerType GetUnboundType(lldb::opaque_compiler_type_t type) override;
-  CompilerType MapIntoContext(lldb::StackFrameSP &frame_sp,
-                              lldb::opaque_compiler_type_t type) override;
-
 
   bool IsVectorType(void *type, CompilerType *element_type,
                     uint64_t *size) override;

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -227,7 +227,8 @@ public:
 
   // Defaults to GetTypeName(type).  Override if your language desires
   // specialized behavior.
-  virtual ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type);
+  virtual ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
+                                         lldb::StackFrameSP frame_sp = {});
 
   // Defaults to GetTypeName(type).  Override if your language desires
   // specialized behavior.
@@ -465,10 +466,6 @@ public:
   virtual CompilerType GetTypedefedType(lldb::opaque_compiler_type_t type) = 0;
 
   virtual CompilerType GetUnboundType(lldb::opaque_compiler_type_t type) = 0;
-  virtual CompilerType MapIntoContext(lldb::StackFrameSP &frame_sp,
-                                      lldb::opaque_compiler_type_t type) {
-    return {this, type};
-  };
 
   virtual bool IsVectorType(lldb::opaque_compiler_type_t type,
                             CompilerType *element_type, uint64_t *size) = 0;

--- a/source/Core/ValueObjectChild.cpp
+++ b/source/Core/ValueObjectChild.cpp
@@ -84,7 +84,7 @@ ConstString ValueObjectChild::GetQualifiedTypeName() {
 }
 
 ConstString ValueObjectChild::GetDisplayTypeName() {
-  ConstString display_name = GetCompilerType().GetDisplayTypeName();
+  ConstString display_name = GetCompilerType().GetDisplayTypeName(GetFrameSP());
   AdjustForBitfieldness(display_name, m_bitfield_bit_size);
   return display_name;
 }

--- a/source/Core/ValueObjectConstResult.cpp
+++ b/source/Core/ValueObjectConstResult.cpp
@@ -220,7 +220,7 @@ ConstString ValueObjectConstResult::GetTypeName() {
 }
 
 ConstString ValueObjectConstResult::GetDisplayTypeName() {
-  return GetCompilerType().GetDisplayTypeName();
+  return GetCompilerType().GetDisplayTypeName(GetFrameSP());
 }
 
 bool ValueObjectConstResult::UpdateValue() {

--- a/source/Core/ValueObjectDynamicValue.cpp
+++ b/source/Core/ValueObjectDynamicValue.cpp
@@ -86,7 +86,7 @@ ConstString ValueObjectDynamicValue::GetDisplayTypeName() {
   const bool success = UpdateValueIfNeeded(false);
   if (success) {
     if (m_dynamic_type_info.HasType())
-      return GetCompilerType().GetDisplayTypeName();
+      return GetCompilerType().GetDisplayTypeName(GetFrameSP());
     if (m_dynamic_type_info.HasName())
       return m_dynamic_type_info.GetName();
   }

--- a/source/Core/ValueObjectMemory.cpp
+++ b/source/Core/ValueObjectMemory.cpp
@@ -117,7 +117,7 @@ ConstString ValueObjectMemory::GetTypeName() {
 
 ConstString ValueObjectMemory::GetDisplayTypeName() {
   if (m_type_sp)
-    return m_type_sp->GetForwardCompilerType().GetDisplayTypeName();
+    return m_type_sp->GetForwardCompilerType().GetDisplayTypeName(GetFrameSP());
   return m_compiler_type.GetDisplayTypeName();
 }
 

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -79,14 +79,8 @@ ConstString ValueObjectVariable::GetTypeName() {
 
 ConstString ValueObjectVariable::GetDisplayTypeName() {
   Type *var_type = m_variable_sp->GetType();
-  if (var_type) {
-    CompilerType fwd_type = var_type->GetForwardCompilerType();
-    // FIXME: This is probably not the best place to do this.
-    auto ts = fwd_type.GetTypeSystem();
-    auto qual_type = fwd_type.GetOpaqueQualType();
-    auto stack_frame_sp = GetFrameSP();
-    return ts->MapIntoContext(stack_frame_sp, qual_type).GetDisplayTypeName();
-  }
+  if (var_type)
+    return var_type->GetForwardCompilerType().GetDisplayTypeName(GetFrameSP());
   return ConstString();
 }
 

--- a/source/DataFormatters/FormatManager.cpp
+++ b/source/DataFormatters/FormatManager.cpp
@@ -188,7 +188,8 @@ void FormatManager::GetPossibleMatches(
     entries.push_back(
         {type_name, reason, did_strip_ptr, did_strip_ref, did_strip_typedef});
 
-    ConstString display_type_name(compiler_type.GetDisplayTypeName());
+    lldb::StackFrameSP frame_sp = valobj.GetFrameSP();
+    ConstString display_type_name(compiler_type.GetDisplayTypeName(frame_sp));
     if (display_type_name != type_name)
       entries.push_back({display_type_name, reason, did_strip_ptr,
                          did_strip_ref, did_strip_typedef});

--- a/source/Plugins/Language/Swift/SwiftMetatype.cpp
+++ b/source/Plugins/Language/Swift/SwiftMetatype.cpp
@@ -30,6 +30,7 @@ bool lldb_private::formatters::swift::SwiftMetatype_SummaryProvider(
   if (metadata_ptr == LLDB_INVALID_ADDRESS || metadata_ptr == 0) {
     CompilerType compiler_metatype_type(valobj.GetCompilerType());
     CompilerType instancetype(compiler_metatype_type.GetInstanceType());
+
     const char *ptr = instancetype.GetDisplayTypeName().AsCString(nullptr);
     if (ptr && *ptr) {
       stream.Printf("%s", ptr);

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -320,9 +320,10 @@ ConstString CompilerType::GetTypeName() const {
   return ConstString("<invalid>");
 }
 
-ConstString CompilerType::GetDisplayTypeName() const {
+ConstString
+CompilerType::GetDisplayTypeName(lldb::StackFrameSP frame_sp) const {
   if (IsValid()) {
-    return m_type_system->GetDisplayTypeName(m_type);
+    return m_type_system->GetDisplayTypeName(m_type, frame_sp);
   }
   return ConstString();
 }

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -150,7 +150,8 @@ Status TypeSystem::IsCompatible() {
   return Status();
 }
 
-ConstString TypeSystem::GetDisplayTypeName(void *type) {
+ConstString TypeSystem::GetDisplayTypeName(void *type,
+                                           lldb::StackFrameSP frame_sp) {
   return GetTypeName(type);
 }
 


### PR DESCRIPTION
This change allows us to retire the last use of ide::getDeclFromMangledSymbolName().

rdar://problem/47798056