### PR TITLE
XPASSES are now reported. Fix all of them on Linux.

### DIFF
--- a/packages/Python/lldbsuite/test/expression_command/expr-in-syscall/TestExpressionInSyscall.py
+++ b/packages/Python/lldbsuite/test/expression_command/expr-in-syscall/TestExpressionInSyscall.py
@@ -17,9 +17,6 @@ class ExprSyscallTestCase(TestBase):
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr21765, getpid() does not exist on Windows")
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="rdar://29054690")
     def test_setpgid(self):
         self.build()
         self.expr_syscall()

--- a/packages/Python/lldbsuite/test/functionalities/archives/TestBSDArchives.py
+++ b/packages/Python/lldbsuite/test/functionalities/archives/TestBSDArchives.py
@@ -25,16 +25,6 @@ class BSDArchivesTestCase(TestBase):
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24527.  Makefile.rules doesn't know how to build static libs on Windows")
-    @expectedFailureAll(
-        oslist=["linux"],
-        archs=[
-            "arm",
-            "aarch64"],
-        bugnumber="llvm.org/pr27795")
-    @expectedFailureAll(
-        oslist=["linux"],
-        archs=["x86_64"],
-        bugnumber="rdar://28181750")
     def test(self):
         """Break inside a() and b() defined within libfoo.a."""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/asan/TestMemoryHistory.py
+++ b/packages/Python/lldbsuite/test/functionalities/asan/TestMemoryHistory.py
@@ -18,9 +18,6 @@ class AsanTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)")
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote
     @skipUnlessAddressSanitizer

--- a/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
+++ b/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
@@ -18,9 +18,6 @@ class AsanTestReportDataCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="non-core functionality, need to reenable and fix later (DES 2014.11.07)")
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @skipIfRemote
     @skipUnlessAddressSanitizer

--- a/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
@@ -26,7 +26,6 @@ class ChangeProcessGroupTestCase(TestBase):
     @skipIfFreeBSD  # Times out on FreeBSD llvm.org/pr23731
     @skipIfWindows  # setpgid call does not exist on Windows
     @expectedFailureAndroid("http://llvm.org/pr23762", api_levels=[16])
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054632")
     def test_setpgid(self):
         self.build()
         exe = self.getBuildArtifact("a.out")

--- a/packages/Python/lldbsuite/test/functionalities/register/register_command/TestRegisters.py
+++ b/packages/Python/lldbsuite/test/functionalities/register/register_command/TestRegisters.py
@@ -30,7 +30,6 @@ class RegisterCommandsTestCase(TestBase):
 
     @skipIfiOSSimulator
     @skipIf(archs=no_match(['amd64', 'arm', 'i386', 'x86_64']))
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054801")
     @skipIfOutOfTreeDebugserver # rdar://38480016
     def test_register_commands(self):
         """Test commands related to registers, in particular vector registers."""
@@ -61,7 +60,6 @@ class RegisterCommandsTestCase(TestBase):
     # problem
     @skipIfTargetAndroid(archs=["i386"])
     @skipIf(archs=no_match(['amd64', 'arm', 'i386', 'x86_64']))
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054801")
     @skipIfOutOfTreeDebugserver # rdar://38480016
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
     def test_fp_register_write(self):
@@ -74,7 +72,6 @@ class RegisterCommandsTestCase(TestBase):
     @expectedFailureAndroid(archs=["i386"])
     @skipIfFreeBSD  # llvm.org/pr25057
     @skipIf(archs=no_match(['amd64', 'i386', 'x86_64']))
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054801")
     @expectedFailureDarwin(bugnumber="<rdar://problem/34092153>")  # CI bots need to use updated debugserver to match ftag size change in r311579.
     @skipIfOutOfTreeDebugserver
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
@@ -85,7 +82,6 @@ class RegisterCommandsTestCase(TestBase):
 
     @skipIfiOSSimulator
     @skipIf(archs=no_match(['amd64', 'arm', 'i386', 'x86_64']))
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054801")
     @skipIfOutOfTreeDebugserver # rdar://38480016
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37683")
     def test_register_expressions(self):

--- a/packages/Python/lldbsuite/test/functionalities/return-value/TestReturnValue.py
+++ b/packages/Python/lldbsuite/test/functionalities/return-value/TestReturnValue.py
@@ -37,7 +37,6 @@ class ReturnValueTestCase(TestBase):
         archs=["i386"])
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @add_test_categories(['pyapi'])
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054828")
     def test_with_python(self):
         """Test getting return values from stepping out."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/c/const_variables/TestConstVariables.py
+++ b/packages/Python/lldbsuite/test/lang/c/const_variables/TestConstVariables.py
@@ -15,29 +15,10 @@ class ConstVariableTestCase(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @expectedFailureAll(
-        oslist=["freebsd", "linux"],
-        compiler="clang", compiler_version=["<", "3.5"])
-    @expectedFailureAll(
-        oslist=["freebsd", "linux"],
-        compiler="clang", compiler_version=["=", "3.7"])
-    @expectedFailureAll(
-        oslist=["freebsd", "linux"],
-        compiler="clang", compiler_version=["=", "3.8"])
-    @expectedFailureAll(oslist=["freebsd", "linux"], compiler="icc")
     @expectedFailureAll(archs=['mips', 'mipsel', 'mips64', 'mips64el'])
-    @expectedFailureAll(
-        oslist=["linux"],
-        archs=[
-            'arm',
-            'aarch64'],
-        bugnumber="llvm.org/pr27883")
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24489: Name lookup not working correctly on Windows")
-    @expectedFailureAll(
-        debug_info="dwo", 
-        bugnumber="rdar://problem/30100738")
     def test_and_run_command(self):
         """Test interpreted and JITted expressions on constant values."""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/c/shared_lib_stripped_symbols/TestSharedLibStrippedSymbols.py
+++ b/packages/Python/lldbsuite/test/lang/c/shared_lib_stripped_symbols/TestSharedLibStrippedSymbols.py
@@ -15,7 +15,6 @@ class SharedLibStrippedTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @expectedFailureAll(oslist=["windows"])
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://28182015")
     def test_expr(self):
         """Test that types work when defined in a shared library and forwa/d-declared in the main executable"""
         if "clang" in self.getCompiler() and "3.4" in self.getCompilerVersion():

--- a/packages/Python/lldbsuite/test/python_api/lldbutil/process/TestPrintStackTraces.py
+++ b/packages/Python/lldbsuite/test/python_api/lldbutil/process/TestPrintStackTraces.py
@@ -26,8 +26,6 @@ class ThreadsStackTracesTestCase(TestBase):
 
     # We are unable to produce a backtrace of the main thread when the thread
     # is blocked in fgets
-    @expectedFailureAll("llvm.org/pr23043", ["linux"], archs=["i386"])
-    @expectedFailureAll(bugnumber="<rdar://problem/30931804>", oslist=["linux"])
     # The __thread_start function in libc doesn't contain any epilogue and prologue instructions
     # hence unwinding fail when we are stopped in __thread_start
     @expectedFailureAll(triple='mips*')

--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteRegisterState.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestGdbRemoteRegisterState.py
@@ -113,7 +113,6 @@ class TestGdbRemoteRegisterState(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.grp_register_save_restore_works(USE_THREAD_SUFFIX)
 
     @llgs_test
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054737")
     def test_grp_register_save_restore_works_with_suffix_llgs(self):
         USE_THREAD_SUFFIX = True
         self.init_llgs_test()
@@ -130,7 +129,6 @@ class TestGdbRemoteRegisterState(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.grp_register_save_restore_works(USE_THREAD_SUFFIX)
 
     @llgs_test
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054737")
     def test_grp_register_save_restore_works_no_suffix_llgs(self):
         USE_THREAD_SUFFIX = False
         self.init_llgs_test()

--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestLldbGdbServer.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestLldbGdbServer.py
@@ -603,7 +603,6 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase, DwarfOpcod
         self.p_returns_correct_data_size_for_each_qRegisterInfo()
 
     @llgs_test
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054771")
     def test_p_returns_correct_data_size_for_each_qRegisterInfo_launch_llgs(
             self):
         self.init_llgs_test()
@@ -621,7 +620,6 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase, DwarfOpcod
         self.p_returns_correct_data_size_for_each_qRegisterInfo()
 
     @llgs_test
-    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://29054771")
     def test_p_returns_correct_data_size_for_each_qRegisterInfo_attach_llgs(
             self):
         self.init_llgs_test()
@@ -813,8 +811,6 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase, DwarfOpcod
         # expectations about fixed signal numbers.
         self.Hc_then_Csignal_signals_correct_thread(self.TARGET_EXC_BAD_ACCESS)
 
-    # this is failing 1 in 4 times on some Ubuntu 14.04 and 15.10 setups
-    @unittest2.expectedFailure()
     @llgs_test
     def test_Hc_then_Csignal_signals_correct_thread_launch_llgs(self):
         self.init_llgs_test()


### PR DESCRIPTION
Same as stable, 5.1 version.