### PR TITLE
Include swift::ParseableInterfaceModuleLoader header

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -45,6 +45,7 @@
 #include "swift/Driver/Util.h"
 #include "swift/DWARFImporter/DWARFImporter.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/ParseableInterfaceModuleLoader.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/Utils.h"
 #include "swift/IRGen/Linking.h"


### PR DESCRIPTION
This is no longer exposed by Frontend.h, so we need to include it.