### PR TITLE
 Show original Archetype names in backtraces.

### DIFF
--- a/include/lldb/Core/Mangled.h
+++ b/include/lldb/Core/Mangled.h
@@ -176,7 +176,9 @@ public:
   /// @return
   ///     A const reference to the demangled name string object.
   //----------------------------------------------------------------------
-  const ConstString &GetDemangledName(lldb::LanguageType language) const;
+  const ConstString &
+  GetDemangledName(lldb::LanguageType language,
+                   const SymbolContext *sc = nullptr) const;
 
   //----------------------------------------------------------------------
   /// Display demangled name get accessor.
@@ -184,7 +186,8 @@ public:
   /// @return
   ///     A const reference to the display demangled name string object.
   //----------------------------------------------------------------------
-  ConstString GetDisplayDemangledName(lldb::LanguageType language) const;
+  ConstString GetDisplayDemangledName(lldb::LanguageType language,
+                                      const SymbolContext *sc = nullptr) const;
 
   void SetDemangledName(const ConstString &name) { m_demangled = name; }
 
@@ -218,7 +221,8 @@ public:
   ///     other name is returned.
   //----------------------------------------------------------------------
   ConstString GetName(lldb::LanguageType language,
-                      NamePreference preference = ePreferDemangled) const;
+                      NamePreference preference = ePreferDemangled,
+                      const SymbolContext *sc = nullptr) const;
 
   //----------------------------------------------------------------------
   /// Check if "name" matches either the mangled or demangled name.

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -172,7 +172,7 @@ public:
 
   ConstString GetTypeName() const;
 
-  ConstString GetDisplayTypeName(lldb::StackFrameSP = {}) const;
+  ConstString GetDisplayTypeName(const SymbolContext *sc = nullptr) const;
 
   ConstString GetTypeSymbolName() const;
 

--- a/include/lldb/Symbol/Function.h
+++ b/include/lldb/Symbol/Function.h
@@ -516,11 +516,11 @@ public:
   //------------------------------------------------------------------
   const DWARFExpression &GetFrameBaseExpression() const { return m_frame_base; }
 
-  ConstString GetName() const;
+  ConstString GetName(const SymbolContext *sc = nullptr) const;
 
-  ConstString GetNameNoArguments() const;
+  ConstString GetNameNoArguments(const SymbolContext *sc = nullptr) const;
 
-  ConstString GetDisplayName() const;
+  ConstString GetDisplayName(const SymbolContext *sc = nullptr) const;
 
   const Mangled &GetMangled() const { return m_mangled; }
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -536,8 +536,7 @@ public:
 
   ConstString GetTypeName(void *type) override;
 
-  ConstString GetDisplayTypeName(void *type,
-                                 lldb::StackFrameSP frame_sp) override;
+  ConstString GetDisplayTypeName(void *type, const SymbolContext *sc) override;
 
   ConstString GetTypeSymbolName(void *type) override;
 

--- a/include/lldb/Symbol/SymbolContext.h
+++ b/include/lldb/Symbol/SymbolContext.h
@@ -181,7 +181,7 @@ public:
                        const Address &so_addr, bool show_fullpaths,
                        bool show_module, bool show_inlined_frames,
                        bool show_function_arguments,
-                       bool show_function_name) const;
+                       bool show_function_name);
 
   //------------------------------------------------------------------
   /// Get the address range contained within a symbol context.

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -227,8 +227,9 @@ public:
 
   // Defaults to GetTypeName(type).  Override if your language desires
   // specialized behavior.
+  // \param sc  An optional symbol context of the function the type appears in.
   virtual ConstString GetDisplayTypeName(lldb::opaque_compiler_type_t type,
-                                         lldb::StackFrameSP frame_sp = {});
+                                         const SymbolContext *sc = nullptr);
 
   // Defaults to GetTypeName(type).  Override if your language desires
   // specialized behavior.

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -198,12 +198,18 @@ public:
   virtual bool GetObjectDescription(Stream &str, Value &value,
                                     ExecutionContextScope *exe_scope) override;
 
-  static std::string DemangleSymbolAsString(const char *symbol,
-                                            bool simplified = false);
+  /// A pair of depth and index.
+  using ArchetypePath = std::pair<uint64_t, uint64_t>;
+  /// Populate a map with the names of all archetypes in a function's generic
+  /// context.
+  static void GetArchetypeNamesForFunction(
+      const SymbolContext &sc,
+      llvm::DenseMap<ArchetypePath, llvm::StringRef> &dict);
 
-  static std::string DemangleSymbolAsString(const ConstString &symbol, 
-                                            bool simplified = false);
-  
+  static std::string
+  DemangleSymbolAsString(llvm::StringRef symbol, bool simplified = false,
+                         const SymbolContext *sc = nullptr);
+
   // Use these passthrough functions rather than calling into Swift directly,
   // since some day we may want to support more than one swift variant.
   static bool IsSwiftMangledName(const char *name);

--- a/packages/Python/lldbsuite/test/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/packages/Python/lldbsuite/test/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -54,7 +54,10 @@ class TestSwiftBacktracePrinting(TestBase):
 
         self.assertTrue(process, PROCESS_IS_VALID)
 
-        self.expect("bt", substrs=['arg1=12', 'arg2="Hello world"'])
+        self.expect("bt", substrs=['h<T>',
+                                   'g<U, T>', 'pair', '12', "Hello world",
+                                   'arg1=12', 'arg2="Hello world"'])
+        self.expect("breakpoint set -p other", substrs=['g<U, T>'])
 
 if __name__ == '__main__':
     import atexit

--- a/packages/Python/lldbsuite/test/lang/swift/bt_printing/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/bt_printing/main.swift
@@ -2,15 +2,24 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-func foo(_ arg1: Int, _ arg2: String) -> Int {
-  return 12 // break here
+
+func h<T>(_ t: T) -> T {
+    return t // break here
 }
 
-foo(12, "Hello world")
+func g<U, T>(_ pair : (T, U)) -> T {
+  return h(pair.0) // other breakpoint
+}
+
+func f(_ arg1: Int, _ arg2: String) -> Int {
+    return g((arg1, arg2))
+}
+
+f(12, "Hello world")

--- a/source/Core/ValueObjectChild.cpp
+++ b/source/Core/ValueObjectChild.cpp
@@ -84,7 +84,10 @@ ConstString ValueObjectChild::GetQualifiedTypeName() {
 }
 
 ConstString ValueObjectChild::GetDisplayTypeName() {
-  ConstString display_name = GetCompilerType().GetDisplayTypeName(GetFrameSP());
+  const SymbolContext *sc = nullptr;
+  if (GetFrameSP())
+    sc = &GetFrameSP()->GetSymbolContext(lldb::eSymbolContextFunction);
+  ConstString display_name = GetCompilerType().GetDisplayTypeName(sc);
   AdjustForBitfieldness(display_name, m_bitfield_bit_size);
   return display_name;
 }

--- a/source/Core/ValueObjectConstResult.cpp
+++ b/source/Core/ValueObjectConstResult.cpp
@@ -220,7 +220,10 @@ ConstString ValueObjectConstResult::GetTypeName() {
 }
 
 ConstString ValueObjectConstResult::GetDisplayTypeName() {
-  return GetCompilerType().GetDisplayTypeName(GetFrameSP());
+  const SymbolContext *sc = nullptr;
+  if (GetFrameSP())
+    sc = &GetFrameSP()->GetSymbolContext(eSymbolContextFunction);
+  return GetCompilerType().GetDisplayTypeName(sc);
 }
 
 bool ValueObjectConstResult::UpdateValue() {

--- a/source/Core/ValueObjectDynamicValue.cpp
+++ b/source/Core/ValueObjectDynamicValue.cpp
@@ -85,8 +85,12 @@ ConstString ValueObjectDynamicValue::GetQualifiedTypeName() {
 ConstString ValueObjectDynamicValue::GetDisplayTypeName() {
   const bool success = UpdateValueIfNeeded(false);
   if (success) {
-    if (m_dynamic_type_info.HasType())
-      return GetCompilerType().GetDisplayTypeName(GetFrameSP());
+    if (m_dynamic_type_info.HasType()) {
+      const SymbolContext *sc = nullptr;
+      if (GetFrameSP())
+        sc = &GetFrameSP()->GetSymbolContext(eSymbolContextFunction);
+      return GetCompilerType().GetDisplayTypeName(sc);
+    }
     if (m_dynamic_type_info.HasName())
       return m_dynamic_type_info.GetName();
   }

--- a/source/Core/ValueObjectMemory.cpp
+++ b/source/Core/ValueObjectMemory.cpp
@@ -116,9 +116,13 @@ ConstString ValueObjectMemory::GetTypeName() {
 }
 
 ConstString ValueObjectMemory::GetDisplayTypeName() {
+  const SymbolContext *sc = nullptr;
+  if (GetFrameSP())
+    sc = &GetFrameSP()->GetSymbolContext(eSymbolContextFunction);
+
   if (m_type_sp)
-    return m_type_sp->GetForwardCompilerType().GetDisplayTypeName(GetFrameSP());
-  return m_compiler_type.GetDisplayTypeName();
+    return m_type_sp->GetForwardCompilerType().GetDisplayTypeName(sc);
+  return m_compiler_type.GetDisplayTypeName(sc);
 }
 
 size_t ValueObjectMemory::CalculateNumChildren(uint32_t max) {

--- a/source/Core/ValueObjectVariable.cpp
+++ b/source/Core/ValueObjectVariable.cpp
@@ -79,8 +79,12 @@ ConstString ValueObjectVariable::GetTypeName() {
 
 ConstString ValueObjectVariable::GetDisplayTypeName() {
   Type *var_type = m_variable_sp->GetType();
-  if (var_type)
-    return var_type->GetForwardCompilerType().GetDisplayTypeName(GetFrameSP());
+  if (var_type) {
+      const SymbolContext *sc = nullptr;
+      if (GetFrameSP())
+        sc = &GetFrameSP()->GetSymbolContext(lldb::eSymbolContextFunction);
+      return var_type->GetForwardCompilerType().GetDisplayTypeName(sc);
+  }
   return ConstString();
 }
 

--- a/source/DataFormatters/FormatManager.cpp
+++ b/source/DataFormatters/FormatManager.cpp
@@ -188,8 +188,11 @@ void FormatManager::GetPossibleMatches(
     entries.push_back(
         {type_name, reason, did_strip_ptr, did_strip_ref, did_strip_typedef});
 
-    lldb::StackFrameSP frame_sp = valobj.GetFrameSP();
-    ConstString display_type_name(compiler_type.GetDisplayTypeName(frame_sp));
+    const SymbolContext *sc = nullptr;
+    if (valobj.GetFrameSP())
+      sc = &valobj.GetFrameSP()->GetSymbolContext(eSymbolContextFunction);
+
+    ConstString display_type_name(compiler_type.GetDisplayTypeName(sc));
     if (display_type_name != type_name)
       entries.push_back({display_type_name, reason, did_strip_ptr,
                          did_strip_ref, did_strip_typedef});

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1495,7 +1495,7 @@ bool SwiftLanguage::GetFunctionDisplayName(
   case Language::FunctionNameRepresentation::eNameWithNoArgs: {
     if (sc->function) {
       if (sc->function->GetLanguage() == eLanguageTypeSwift) {
-        if (ConstString cs = sc->function->GetDisplayName()) {
+        if (ConstString cs = sc->function->GetDisplayName(sc)) {
           s.Printf("%s", cs.AsCString());
           return true;
         }
@@ -1506,10 +1506,10 @@ bool SwiftLanguage::GetFunctionDisplayName(
   case Language::FunctionNameRepresentation::eNameWithArgs: {
     if (sc->function) {
       if (sc->function->GetLanguage() == eLanguageTypeSwift) {
-        if (const char *cstr = sc->function->GetDisplayName().AsCString()) {
+        if (const char *cstr =
+                sc->function->GetDisplayName(sc).AsCString()) {
           ExecutionContextScope *exe_scope =
               exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL;
-
           const InlineFunctionInfo *inline_info = NULL;
           VariableListSP variable_list_sp;
           bool get_function_vars = true;

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -321,9 +321,9 @@ ConstString CompilerType::GetTypeName() const {
 }
 
 ConstString
-CompilerType::GetDisplayTypeName(lldb::StackFrameSP frame_sp) const {
+CompilerType::GetDisplayTypeName(const SymbolContext *sc) const {
   if (IsValid()) {
-    return m_type_system->GetDisplayTypeName(m_type, frame_sp);
+    return m_type_system->GetDisplayTypeName(m_type, sc);
   }
   return ConstString();
 }

--- a/source/Symbol/Function.cpp
+++ b/source/Symbol/Function.cpp
@@ -431,10 +431,10 @@ bool Function::IsTopLevelFunction() {
   return result;
 }
 
-ConstString Function::GetDisplayName() const {
+ConstString Function::GetDisplayName(const SymbolContext *sc) const {
   if (!m_mangled)
     return GetName();
-  return m_mangled.GetDisplayDemangledName(GetLanguage());
+  return m_mangled.GetDisplayDemangledName(GetLanguage(), sc);
 }
 
 CompilerDeclContext Function::GetDeclContext() {
@@ -608,16 +608,17 @@ lldb::LanguageType Function::GetLanguage() const {
     return lldb::eLanguageTypeUnknown;
 }
 
-ConstString Function::GetName() const {
+ConstString Function::GetName(const SymbolContext *sc) const {
   LanguageType language = lldb::eLanguageTypeUnknown;
   if (m_comp_unit)
     language = m_comp_unit->GetLanguage();
-  return m_mangled.GetName(language);
+  return m_mangled.GetName(language, Mangled::ePreferDemangled, sc);
 }
 
-ConstString Function::GetNameNoArguments() const {
+ConstString Function::GetNameNoArguments(const SymbolContext *sc) const {
   LanguageType language = lldb::eLanguageTypeUnknown;
   if (m_comp_unit)
     language = m_comp_unit->GetLanguage();
-  return m_mangled.GetName(language, Mangled::ePreferDemangledWithoutArguments);
+  return m_mangled.GetName(language, Mangled::ePreferDemangledWithoutArguments,
+                           sc);
 }

--- a/source/Symbol/SymbolContext.cpp
+++ b/source/Symbol/SymbolContext.cpp
@@ -90,7 +90,7 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
                                     const Address &addr, bool show_fullpaths,
                                     bool show_module, bool show_inlined_frames,
                                     bool show_function_arguments,
-                                    bool show_function_name) const {
+                                    bool show_function_name) {
   bool dumped_something = false;
   if (show_module && module_sp) {
     if (show_fullpaths)
@@ -110,9 +110,9 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
     } else {
       ConstString name;
       if (!show_function_arguments)
-        name = function->GetNameNoArguments();
+        name = function->GetNameNoArguments(this);
       if (!name)
-        name = function->GetName();
+        name = function->GetName(this);
       if (name)
         name.Dump(s);
     }

--- a/source/Symbol/Symtab.cpp
+++ b/source/Symbol/Symtab.cpp
@@ -350,7 +350,10 @@ void Symtab::InitNameIndexes() {
 
       // Symbol name strings that didn't match a Mangled::ManglingScheme, are
       // stored in the demangled field.
-      entry.cstring = mangled.GetDemangledName(symbol->GetLanguage());
+      SymbolContext sc;
+      symbol->CalculateSymbolContext(&sc);
+      sc.module_sp = m_objfile->GetModule();
+      entry.cstring = mangled.GetDemangledName(symbol->GetLanguage(), &sc);
       if (entry.cstring) {
         m_name_to_index.Append(entry);
 

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -151,7 +151,7 @@ Status TypeSystem::IsCompatible() {
 }
 
 ConstString TypeSystem::GetDisplayTypeName(void *type,
-                                           lldb::StackFrameSP frame_sp) {
+                                           const SymbolContext *sc) {
   return GetTypeName(type);
 }
 


### PR DESCRIPTION
Since this information is now available in DWARF, LLDB can display the
correct names for archetypes when printing backtraces.

<rdar://problem/48259889>