### PR TITLE
[Swift] Add a setting to control the Swift module loading mode

### DIFF
--- a/include/lldb/Core/ModuleList.h
+++ b/include/lldb/Core/ModuleList.h
@@ -81,6 +81,8 @@ public:
   bool GetUseDWARFImporter() const;
   FileSpec GetClangModulesCachePath() const;
   bool SetClangModulesCachePath(llvm::StringRef path);
+  SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
+  bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
   bool GetEnableExternalLookup() const;
 }; 
 

--- a/include/lldb/lldb-private-enumerations.h
+++ b/include/lldb/lldb-private-enumerations.h
@@ -210,6 +210,19 @@ typedef enum LanguageRuntimeDescriptionDisplayVerbosity {
 } LanguageRuntimeDescriptionDisplayVerbosity;
 
 //----------------------------------------------------------------------
+// Loading mode for Swift module files
+//----------------------------------------------------------------------
+typedef enum SwiftModuleLoadingMode {
+  eSwiftModuleLoadingModePreferSerialized, // Prefer loading via .swiftmodule,
+                                           // falling back to .swiftinterface
+  eSwiftModuleLoadingModePreferParseable,  // Prefer Loading via
+                                           // .swiftinterface, falling back to
+                                           // .swiftmodule
+  eSwiftModuleLoadingModeOnlySerialized,   // Load via .swiftmodule only
+  eSwiftModuleLoadingModeOnlyParseable,    // Load via .swiftinterface only
+} SwiftModuleLoadingMode;
+
+//----------------------------------------------------------------------
 // Loading modules from memory
 //----------------------------------------------------------------------
 typedef enum MemoryModuleLoadLevel {

--- a/lit/Driver/TestRepl.test
+++ b/lit/Driver/TestRepl.test
@@ -1,0 +1,7 @@
+# RUN: echo ':quit' | %lldb -x --repl -O 'expr 42' -S %S/Inputs/Print2.in -o 'expr 999999' -s %s 2>&1 | FileCheck %s
+# CHECK: {{w}}arning: commands specified to run after file load (via -o or -s) are ignored in REPL mode
+# CHECK: (int) $0 = 42
+# CHECK: (int) $1 = 2
+# CHECK-NOT: 999999
+
+expr 999999

--- a/lit/SwiftREPL/Inputs/A.swift
+++ b/lit/SwiftREPL/Inputs/A.swift
@@ -19,3 +19,8 @@ public struct MyPoint {
     return x*x + y*y
   }
 }
+
+public struct FromInterface {}
+public struct OtherType {}
+
+public let testValue = FromInterface()

--- a/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -1,0 +1,87 @@
+// This test checks that the value of the symbols.swift-module-loading-mode
+// setting is respected when loading Swift modules.
+
+// RUN: rm -rf %t && mkdir %t
+
+// Setup generates a dylib and .swiftinterface for A.swift as is, but generates
+// the .swiftmodule from a modified version a A.swift where the 'FromInterface'
+// type has been renamed to 'FromSerialized'. This means that the 'testValue'
+// variable will have a different type depending on whether the module was
+// loaded via the .swiftinterface or .swiftmodule.
+
+// RUN: mkdir %t/mcp
+// RUN: mkdir %t/lib
+// RUN: cp %S/Inputs/A.swift %t/AA.swift
+// RUN: %target-swiftc -module-name AA -emit-parseable-module-interface-path %t/lib/AA.swiftinterface -emit-library -o %t/lib/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: sed -e 's/FromInterface/FromSerialized/g' %t/AA.swift | %target-swiftc -module-name AA -emit-module -o %t/lib/AA.swiftmodule -
+// RUN: rm %t/AA.swift
+
+
+// This is the input provided to lldb. It intentionally assigns 'testValue' to
+// a variable of the incorrect type so we can tell via the produced diagnostic
+// whether the .swiftinterface or .swiftmodule was used.
+
+import AA
+
+let x: OtherType = testValue
+// NOT-LOADED: use of undeclared type 'OtherType'
+// FROM-INTERFACE: cannot convert value of type 'FromInterface' to specified type 'OtherType'
+// FROM-SERIALIZED: cannot convert value of type 'FromSerialized' to specified type 'OtherType'
+// INVALID: error: invalid enumeration value '{{.*}}', valid values are: {{.*}}
+
+
+// 1. Neither .swiftinterface or .swiftmodule present
+//
+// RUN: mv %t/lib %t/lib-backup
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-parseable" < %s 2>&1 | FileCheck %s -check-prefix=NOT-LOADED
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-serialized" < %s 2>&1 | FileCheck %s -check-prefix=NOT-LOADED
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-parseable" < %s 2>&1 | FileCheck %s -check-prefix=NOT-LOADED
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-serialized" < %s 2>&1 | FileCheck %s -check-prefix=NOT-LOADED
+
+// 2. .swiftinterface only
+//
+// RUN: mkdir %t/lib
+// RUN: cp %t/lib-backup/AA.swiftinterface %t/lib/
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-parseable" < %s 2>&1 | FileCheck %s -check-prefix=FROM-INTERFACE
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-serialized" < %s 2>&1 | FileCheck %s -check-prefix=FROM-INTERFACE
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-parseable" < %s 2>&1 | FileCheck %s -check-prefix=FROM-INTERFACE
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-serialized" < %s 2>&1 | FileCheck %s -check-prefix=NOT-LOADED
+
+// 3. .swiftinterface and .swiftmodule
+//
+// RUN: cp %t/lib-backup/AA.swiftmodule %t/lib/
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-parseable" < %s 2>&1 | FileCheck %s -check-prefix=FROM-INTERFACE
+// RUN: rm -rf %t/mcp/AA*
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-serialized" < %s 2>&1 | FileCheck %s -check-prefix=FROM-SERIALIZED
+// RUN: rm -rf %t/mcp/AA*
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-parseable" < %s 2>&1 | FileCheck %s -check-prefix=FROM-INTERFACE
+// RUN: rm -rf %t/mcp/AA*
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-serialized" < %s 2>&1 | FileCheck %s -check-prefix=FROM-SERIALIZED
+// RUN: rm -rf %t/mcp/AA*
+
+// 4. .swiftmodule only
+// RUN: rm %t/lib/AA.swiftinterface
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-parseable" < %s 2>&1 | FileCheck %s -check-prefix=FROM-SERIALIZED
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode prefer-serialized" < %s 2>&1 | FileCheck %s -check-prefix=FROM-SERIALIZED
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-parseable" < %s 2>&1 | FileCheck %s -check-prefix=NOT-LOADED
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode only-serialized" < %s 2>&1 | FileCheck %s -check-prefix=FROM-SERIALIZED
+
+// 5. Check invalid values are rejected
+// RUN: %lldb --repl="-I%t/lib -L%t/lib -lAA" -O "settings set symbols.clang-modules-cache-path %t/mcp" \
+// RUN:   -O "settings set symbols.swift-module-loading-mode garbage" < %s 2>&1 | FileCheck %s -check-prefix=INVALID

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2992,20 +2992,43 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
     std::string ModuleCachePath = GetClangImporterOptions().ModuleCachePath;
     StringRef PrebuiltModuleCachePath =
       GetCompilerInvocation().getFrontendOptions().PrebuiltModuleCachePath;
-    std::unique_ptr<swift::ModuleLoader> parseable_module_loader_ap(
-      swift::ParseableInterfaceModuleLoader::create(
-        *m_ast_context_ap, ModuleCachePath, PrebuiltModuleCachePath,
-        /*tracker=*/nullptr, swift::ModuleLoadingMode::PreferSerialized));
 
-    if (parseable_module_loader_ap) {
-      m_parseable_module_loader =
-      (swift::ParseableInterfaceModuleLoader *)parseable_module_loader_ap.get();
-      m_ast_context_ap->addModuleLoader(std::move(parseable_module_loader_ap));
+    auto props = ModuleList::GetGlobalModuleListProperties();
+    swift::ModuleLoadingMode loading_mode;
+    switch (props.GetSwiftModuleLoadingMode()) {
+      case eSwiftModuleLoadingModePreferSerialized:
+        loading_mode = swift::ModuleLoadingMode::PreferSerialized;
+        break;
+      case eSwiftModuleLoadingModePreferParseable:
+        loading_mode = swift::ModuleLoadingMode::PreferParseable;
+        break;
+      case eSwiftModuleLoadingModeOnlySerialized:
+        loading_mode = swift::ModuleLoadingMode::OnlySerialized;
+        break;
+      case eSwiftModuleLoadingModeOnlyParseable:
+        loading_mode = swift::ModuleLoadingMode::OnlyParseable;
+        break;
+    }
+
+    if (loading_mode != swift::ModuleLoadingMode::OnlySerialized) {
+      std::unique_ptr<swift::ModuleLoader> parseable_module_loader_ap(
+        swift::ParseableInterfaceModuleLoader::create(
+          *m_ast_context_ap, ModuleCachePath, PrebuiltModuleCachePath,
+          /*tracker=*/nullptr, loading_mode));
+
+      if (parseable_module_loader_ap) {
+        m_parseable_module_loader = (swift::ParseableInterfaceModuleLoader *)
+          parseable_module_loader_ap.get();
+        m_ast_context_ap->addModuleLoader(
+          std::move(parseable_module_loader_ap));
+      }
     }
 
     // Install the serialized module loader.
     std::unique_ptr<swift::ModuleLoader> serialized_module_loader_ap(
-        swift::SerializedModuleLoader::create(*m_ast_context_ap));
+        swift::SerializedModuleLoader::create(*m_ast_context_ap,
+                                              /*tracker=*/nullptr,
+                                              loading_mode));
 
     if (serialized_module_loader_ap) {
       m_serialized_module_loader =

--- a/tools/driver/Driver.cpp
+++ b/tools/driver/Driver.cpp
@@ -613,47 +613,55 @@ int Driver::MainLoop() {
   // are processed.
   WriteCommandsForSourcing(eCommandPlacementBeforeFile, commands_stream);
 
-  const size_t num_args = m_option_data.m_args.size();
-  if (num_args > 0) {
-    char arch_name[64];
-    if (lldb::SBDebugger::GetDefaultArchitecture(arch_name, sizeof(arch_name)))
-      commands_stream.Printf("target create --arch=%s %s", arch_name,
-                             EscapeString(m_option_data.m_args[0]).c_str());
-    else
-      commands_stream.Printf("target create %s",
-                             EscapeString(m_option_data.m_args[0]).c_str());
+  // If we're not in --repl mode, add the commands to process the file
+  // arguments, and the commands specified to run afterwards.
+  if (!m_option_data.m_repl) {
+    const size_t num_args = m_option_data.m_args.size();
+    if (num_args > 0) {
+      char arch_name[64];
+      if (lldb::SBDebugger::GetDefaultArchitecture(arch_name, sizeof(arch_name)))
+        commands_stream.Printf("target create --arch=%s %s", arch_name,
+                               EscapeString(m_option_data.m_args[0]).c_str());
+      else
+        commands_stream.Printf("target create %s",
+                               EscapeString(m_option_data.m_args[0]).c_str());
 
-    if (!m_option_data.m_core_file.empty()) {
-      commands_stream.Printf(" --core %s",
-                             EscapeString(m_option_data.m_core_file).c_str());
-    }
-    commands_stream.Printf("\n");
-
-    if (num_args > 1) {
-      commands_stream.Printf("settings set -- target.run-args ");
-      for (size_t arg_idx = 1; arg_idx < num_args; ++arg_idx)
-        commands_stream.Printf(
-            " %s", EscapeString(m_option_data.m_args[arg_idx]).c_str());
+      if (!m_option_data.m_core_file.empty()) {
+        commands_stream.Printf(" --core %s",
+                               EscapeString(m_option_data.m_core_file).c_str());
+      }
       commands_stream.Printf("\n");
+
+      if (num_args > 1) {
+        commands_stream.Printf("settings set -- target.run-args ");
+        for (size_t arg_idx = 1; arg_idx < num_args; ++arg_idx)
+          commands_stream.Printf(
+              " %s", EscapeString(m_option_data.m_args[arg_idx]).c_str());
+        commands_stream.Printf("\n");
+      }
+    } else if (!m_option_data.m_core_file.empty()) {
+      commands_stream.Printf("target create --core %s\n",
+                             EscapeString(m_option_data.m_core_file).c_str());
+    } else if (!m_option_data.m_process_name.empty()) {
+      commands_stream.Printf("process attach --name %s",
+                             EscapeString(m_option_data.m_process_name).c_str());
+
+      if (m_option_data.m_wait_for)
+        commands_stream.Printf(" --waitfor");
+
+      commands_stream.Printf("\n");
+
+    } else if (LLDB_INVALID_PROCESS_ID != m_option_data.m_process_pid) {
+      commands_stream.Printf("process attach --pid %" PRIu64 "\n",
+                             m_option_data.m_process_pid);
     }
-  } else if (!m_option_data.m_core_file.empty()) {
-    commands_stream.Printf("target create --core %s\n",
-                           EscapeString(m_option_data.m_core_file).c_str());
-  } else if (!m_option_data.m_process_name.empty()) {
-    commands_stream.Printf("process attach --name %s",
-                           EscapeString(m_option_data.m_process_name).c_str());
 
-    if (m_option_data.m_wait_for)
-      commands_stream.Printf(" --waitfor");
-
-    commands_stream.Printf("\n");
-
-  } else if (LLDB_INVALID_PROCESS_ID != m_option_data.m_process_pid) {
-    commands_stream.Printf("process attach --pid %" PRIu64 "\n",
-                           m_option_data.m_process_pid);
+    WriteCommandsForSourcing(eCommandPlacementAfterFile, commands_stream);
+  } else if (!m_option_data.m_after_file_commands.empty()) {
+    // We're in repl mode and after-file-load commands were specified.
+    WithColor::warning() << "commands specified to run after file load (via -o "
+      "or -s) are ignored in REPL mode.\n";
   }
-
-  WriteCommandsForSourcing(eCommandPlacementAfterFile, commands_stream);
 
   if (GetDebugMode()) {
     result.PutError(m_debugger.GetErrorFileHandle());
@@ -663,100 +671,101 @@ int Driver::MainLoop() {
   bool handle_events = true;
   bool spawn_thread = false;
 
-  if (m_option_data.m_repl) {
-    const char *repl_options = nullptr;
-    if (!m_option_data.m_repl_options.empty())
-      repl_options = m_option_data.m_repl_options.c_str();
-    SBError error(m_debugger.RunREPL(m_option_data.m_repl_lang, repl_options));
-    if (error.Fail()) {
-      const char *error_cstr = error.GetCString();
-      if ((error_cstr != nullptr) && (error_cstr[0] != 0))
-        WithColor::error() << error_cstr << '\n';
-      else
-        WithColor::error() << error.GetError() << '\n';
-    }
-  } else {
-    // Check if we have any data in the commands stream, and if so, save it to a
-    // temp file
-    // so we can then run the command interpreter using the file contents.
-    const char *commands_data = commands_stream.GetData();
-    const size_t commands_size = commands_stream.GetSize();
+  // Check if we have any data in the commands stream, and if so, save it to a
+  // temp file
+  // so we can then run the command interpreter using the file contents.
+  const char *commands_data = commands_stream.GetData();
+  const size_t commands_size = commands_stream.GetSize();
 
-    // The command file might have requested that we quit, this variable will
-    // track that.
-    bool quit_requested = false;
-    bool stopped_for_crash = false;
-    if ((commands_data != nullptr) && (commands_size != 0u)) {
-      int initial_commands_fds[2];
-      bool success = true;
-      FILE *commands_file = PrepareCommandsForSourcing(
-          commands_data, commands_size, initial_commands_fds);
-      if (commands_file != nullptr) {
-        m_debugger.SetInputFileHandle(commands_file, true);
+  // The command file might have requested that we quit, this variable will
+  // track that.
+  bool quit_requested = false;
+  bool stopped_for_crash = false;
+  if ((commands_data != nullptr) && (commands_size != 0u)) {
+    int initial_commands_fds[2];
+    bool success = true;
+    FILE *commands_file = PrepareCommandsForSourcing(
+        commands_data, commands_size, initial_commands_fds);
+    if (commands_file != nullptr) {
+      m_debugger.SetInputFileHandle(commands_file, true);
 
-        // Set the debugger into Sync mode when running the command file.
-        // Otherwise command files
-        // that run the target won't run in a sensible way.
-        bool old_async = m_debugger.GetAsync();
-        m_debugger.SetAsync(false);
-        int num_errors;
+      // Set the debugger into Sync mode when running the command file.
+      // Otherwise command files
+      // that run the target won't run in a sensible way.
+      bool old_async = m_debugger.GetAsync();
+      m_debugger.SetAsync(false);
+      int num_errors;
 
-        SBCommandInterpreterRunOptions options;
-        options.SetStopOnError(true);
-        if (m_option_data.m_batch)
-          options.SetStopOnCrash(true);
+      SBCommandInterpreterRunOptions options;
+      options.SetStopOnError(true);
+      if (m_option_data.m_batch)
+        options.SetStopOnCrash(true);
 
-        m_debugger.RunCommandInterpreter(handle_events, spawn_thread, options,
-                                         num_errors, quit_requested,
-                                         stopped_for_crash);
+      m_debugger.RunCommandInterpreter(handle_events, spawn_thread, options,
+                                       num_errors, quit_requested,
+                                       stopped_for_crash);
 
-        if (m_option_data.m_batch && stopped_for_crash &&
-            !m_option_data.m_after_crash_commands.empty()) {
-          int crash_command_fds[2];
-          SBStream crash_commands_stream;
-          WriteCommandsForSourcing(eCommandPlacementAfterCrash,
-                                   crash_commands_stream);
-          const char *crash_commands_data = crash_commands_stream.GetData();
-          const size_t crash_commands_size = crash_commands_stream.GetSize();
-          commands_file = PrepareCommandsForSourcing(
-              crash_commands_data, crash_commands_size, crash_command_fds);
-          if (commands_file != nullptr) {
-            bool local_quit_requested;
-            bool local_stopped_for_crash;
-            m_debugger.SetInputFileHandle(commands_file, true);
+      if (m_option_data.m_batch && stopped_for_crash &&
+          !m_option_data.m_after_crash_commands.empty()) {
+        int crash_command_fds[2];
+        SBStream crash_commands_stream;
+        WriteCommandsForSourcing(eCommandPlacementAfterCrash,
+                                 crash_commands_stream);
+        const char *crash_commands_data = crash_commands_stream.GetData();
+        const size_t crash_commands_size = crash_commands_stream.GetSize();
+        commands_file = PrepareCommandsForSourcing(
+            crash_commands_data, crash_commands_size, crash_command_fds);
+        if (commands_file != nullptr) {
+          bool local_quit_requested;
+          bool local_stopped_for_crash;
+          m_debugger.SetInputFileHandle(commands_file, true);
 
-            m_debugger.RunCommandInterpreter(
-                handle_events, spawn_thread, options, num_errors,
-                local_quit_requested, local_stopped_for_crash);
-            if (local_quit_requested)
-              quit_requested = true;
-          }
+          m_debugger.RunCommandInterpreter(
+              handle_events, spawn_thread, options, num_errors,
+              local_quit_requested, local_stopped_for_crash);
+          if (local_quit_requested)
+            quit_requested = true;
         }
-        m_debugger.SetAsync(old_async);
-      } else
-        success = false;
-
-      // Close any pipes that we still have ownership of
-      CleanupAfterCommandSourcing(initial_commands_fds);
-
-      // Something went wrong with command pipe
-      if (!success) {
-        exit(1);
       }
+      m_debugger.SetAsync(old_async);
+    } else
+      success = false;
+
+    // Close any pipes that we still have ownership of
+    CleanupAfterCommandSourcing(initial_commands_fds);
+
+    // Something went wrong with command pipe
+    if (!success) {
+      exit(1);
     }
+  }
 
-    // Now set the input file handle to STDIN and run the command
-    // interpreter again in interactive mode and let the debugger
-    // take ownership of stdin
+  // Now set the input file handle to STDIN and run the command
+  // interpreter again in interactive mode or repl mode and let the debugger
+  // take ownership of stdin
 
-    bool go_interactive = true;
-    if (quit_requested)
-      go_interactive = false;
-    else if (m_option_data.m_batch && !stopped_for_crash)
-      go_interactive = false;
+  bool go_interactive = true;
+  if (quit_requested)
+    go_interactive = false;
+  else if (m_option_data.m_batch && !stopped_for_crash)
+    go_interactive = false;
 
-    if (go_interactive) {
-      m_debugger.SetInputFileHandle(stdin, true);
+  if (go_interactive) {
+    m_debugger.SetInputFileHandle(stdin, true);
+
+    if (m_option_data.m_repl) {
+      const char *repl_options = nullptr;
+      if (!m_option_data.m_repl_options.empty())
+        repl_options = m_option_data.m_repl_options.c_str();
+      SBError error(m_debugger.RunREPL(m_option_data.m_repl_lang, repl_options));
+      if (error.Fail()) {
+        const char *error_cstr = error.GetCString();
+        if ((error_cstr != nullptr) && (error_cstr[0] != 0))
+          WithColor::error() << error_cstr << '\n';
+        else
+          WithColor::error() << error.GetError() << '\n';
+      }
+    } else {
       m_debugger.RunCommandInterpreter(handle_events, spawn_thread);
     }
   }
@@ -842,13 +851,16 @@ EXAMPLES:
 
     lldb -c /path/to/core
 
-  Command options can be combined with either mode and cause lldb to run the
+  Command options can be combined with these modes and cause lldb to run the
   specified commands before or after events, like loading the file or crashing,
   in the order provided on the command line.
 
     lldb -O 'settings set stop-disassembly-count 20' -o 'run' -o 'bt'
     lldb -S /source/before/file -s /source/after/file
     lldb -K /source/before/crash -k /source/after/crash
+
+  Note: In REPL mode no file is loaded, so commands specified to run after
+  loading the file (via -o or -s) will be ignored.
   )___";
   llvm::outs() << examples;
 }


### PR DESCRIPTION
This adds a new setting that controls the Swift module loading mode, equivalent to the SWIFT_FORCE_MODULE_LOADING environment variable supported by the Swift compiler:

- `settings set symbols.swift-module-loading-mode only-parseable`
Only load swift modules via .swiftinterface files
- `settings set symbols.swift-module-loading-mode only-serialized`
Only load swift modules via .swiftmodule files
- `settings set symbols.swift-module-loading-mode prefer-parseable`
Try to load via a .swiftinterface, but fall back to the .swiftmodule if that fails (e.g. if it doesn't exist)
- `settings set symbols.swift-module-loading-mode prefer-serialized`
Try to load via a .swiftmodule, but fall back to the .swiftinterface if that fails (e.g. if it doesn't exist). This is the default.

This patch also updates lldb's `--repl` mode to respect the `-O` option so that it's possible to change this setting before the Swift module loader is initialized when using the REPL.