### PR TITLE
Update com.apple.diagnosticd.diagnostic entitlement

### DIFF
--- a/tools/debugserver/source/debugserver-entitlements.plist
+++ b/tools/debugserver/source/debugserver-entitlements.plist
@@ -16,7 +16,7 @@
     <array>
         <string>debugserver</string>
     </array>
-    <key>com.apple.diagnosticd.diagnostic</key>
+    <key>com.apple.private.logging.diagnostic</key>
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>

--- a/tools/debugserver/source/debugserver-macosx-entitlements.plist
+++ b/tools/debugserver/source/debugserver-macosx-entitlements.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.diagnosticd.diagnostic</key>
+    <key>com.apple.private.logging.diagnostic</key>
     <true/>
     <key>com.apple.private.cs.debugger</key>
     <true/>

--- a/tools/lldb-server/Darwin/resources/lldb-server-entitlements.plist
+++ b/tools/lldb-server/Darwin/resources/lldb-server-entitlements.plist
@@ -18,7 +18,7 @@
     <array>
         <string>debugserver</string>
     </array>
-    <key>com.apple.diagnosticd.diagnostic</key>
+    <key>com.apple.private.logging.diagnostic</key>
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>

--- a/tools/lldb-server/Darwin/resources/lldb-server-macos-entitlements.plist
+++ b/tools/lldb-server/Darwin/resources/lldb-server-macos-entitlements.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.diagnosticd.diagnostic</key>
+    <key>com.apple.private.logging.diagnostic</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Update com.apple.diagnosticd.diagnostic entitlement
name to the newer com.apple.private.logging.diagnostic.

<rdar://problem/47183116> 


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355170 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 242f7cc7b40c00089b2192913fe6f664de7f6c48)