### PR TITLE
Increase timeout in Symbols::DownloadObjectAndSymbolFile

### DIFF
--- a/source/Host/macosx/Symbols.cpp
+++ b/source/Host/macosx/Symbols.cpp
@@ -594,7 +594,7 @@ bool Symbols::DownloadObjectAndSymbolFile(ModuleSpec &module_spec,
             &signo,          // Signal int *
             &command_output, // Command output
             std::chrono::seconds(
-                30), // Large timeout to allow for long dsym download times
+               120), // Large timeout to allow for long dsym download times
             false);  // Don't run in a shell (we don't need shell expansion)
         if (error.Success() && exit_status == 0 && !command_output.empty()) {
           CFCData data(CFDataCreateWithBytesNoCopy(


### PR DESCRIPTION
Increase timeout in Symbols::DownloadObjectAndSymbolFile
from 30 seconds to 120 seconds.  We've seen cases where
this symbol lookup can exceed 30 seconds for people
working remotely.

<rdar://problem/48460476> 


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355169 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d9cf88b9c4d3b21eeefe3fd00eaf96e2f19ab74f)