### PR TITLE
 Avoid a possible nullptr dereference. 

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -45,6 +45,13 @@ class TestSwiftGlobals(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        # Target variables. This is not actually expected to work, but
+        # also shouldn't crash.
+        g_counter = target.EvaluateExpression("g_counter")
+        self.assertTrue(
+            g_counter.IsValid(),
+            "g_counter returned a valid value object.")
+
         # Set the breakpoints
         outer_bkpt = target.BreakpointCreateBySourceRegex(
             'Set top_level breakpoint here', self.main_source_spec)

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -946,7 +946,7 @@ public:
     if (lang == lldb::eLanguageTypeSwift)
       // We already acquired the lock in the SwiftUserExpression.
       type_system =
-          target_sp->GetScratchSwiftASTContext(type_system_error, *frame_sp)
+          target_sp->GetScratchSwiftASTContext(type_system_error, *exe_scope)
               .get();
     else
       type_system = target_sp->GetScratchTypeSystemForLanguage(
@@ -963,7 +963,7 @@ public:
     PersistentExpressionState *persistent_state;
     if (lang == lldb::eLanguageTypeSwift)
       persistent_state =
-        target_sp->GetSwiftPersistentExpressionState(*frame_sp);
+        target_sp->GetSwiftPersistentExpressionState(*exe_scope);
     else
       persistent_state = type_system->GetPersistentExpressionState();
 


### PR DESCRIPTION
Contrary to frame_sp, exe_ctx is actually checked for nullptr beforehand.

rdar://problem/47134858