### PR TITLE
Allow LLDB repl to properly handle redefinition of expressions. 

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -543,7 +543,8 @@ public:
      auto sl = decl->getLoc();
      if (!sl.isValid())
        return 0;
-     if (m_source_manager.getDisplayNameForLoc(sl) != "repl.swift")
+     if (m_source_manager.getDisplayNameForLoc(sl) !=
+         SwiftREPL::GetSourceFileBasename())
        return 0;
      std::pair<unsigned, unsigned> line_col =
          m_source_manager.getLineAndColumn(sl);

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -482,16 +482,18 @@ public:
     return !persistent_decl_results.empty();
   }
 
-  virtual void finishLookup(const swift::DeclContext *dc,
-                            swift::NLOptions options,
-                            llvm::SmallVectorImpl<swift::ValueDecl *> &decls) {
+  void finishLookupInNominals(
+      const swift::DeclContext *dc,
+      llvm::ArrayRef<swift::NominalTypeDecl *> typeDecls, swift::DeclName Name,
+      swift::NLOptions options,
+      llvm::SmallVectorImpl<swift::ValueDecl *> &decls) override {
     // Return if empty or there is no ambiguity.
     if (decls.size() <= 1)
       return;
 
-    // If a name lookup returns multiple declarations from REPL, we should
-    // prefer the latest one. We leave declarations that are defined outside of
-    // REPL as is. e.g.,
+    // If a name lookup in a nominal returns multiple declarations from REPL, we
+    // should prefer the latest one. We leave declarations that are defined
+    // outside of REPL as is. e.g.,
     //
     //  1> struct Foo {}
     //  2> extension Foo { func f() -> Int { return 1 } }
@@ -517,7 +519,7 @@ public:
         llvm::raw_string_ostream ss(s);
         decl->dump(ss);
         ss.flush();
-        m_log->Printf("[LLDBREPLNameLookup::finishLookup] (%s) %s.",
+        m_log->Printf("[LLDBREPLNameLookup::finishLookupInNominals] (%s) %s.",
                       should_remove ? "Removing" : "Keeping", s.c_str());
       }
       return should_remove;

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -422,8 +422,10 @@ class LLDBREPLNameLookup : public LLDBNameLookup {
 public:
   LLDBREPLNameLookup(swift::SourceFile &source_file,
                      SwiftExpressionParser::SILVariableMap &variable_map,
-                     SymbolContext &sc, ExecutionContextScope &exe_scope)
-      : LLDBNameLookup(source_file, variable_map, sc, exe_scope) {}
+                     SymbolContext &sc, ExecutionContextScope &exe_scope,
+                     swift::SourceManager &sm)
+      : LLDBNameLookup(source_file, variable_map, sc, exe_scope),
+        m_source_manager(sm) {}
 
   virtual ~LLDBREPLNameLookup() {}
 
@@ -480,8 +482,70 @@ public:
     return !persistent_decl_results.empty();
   }
 
+  virtual void finishLookup(const swift::DeclContext *dc,
+                            swift::NLOptions options,
+                            llvm::SmallVectorImpl<swift::ValueDecl *> &decls) {
+    // Return if empty or there is no ambiguity.
+    if (decls.size() <= 1)
+      return;
+
+    // If a name lookup returns multiple declarations from REPL, we should
+    // prefer the latest one. We leave declarations that are defined outside of
+    // REPL as is. e.g.,
+    //
+    //  1> struct Foo {}
+    //  2> extension Foo { func f() -> Int { return 1 } }
+    //  3> extension Foo { func f() -> Int { return 2 } }
+    //  4> Foo().f()
+    //
+    // The name lookup for `f` in the expression `Foo().f()` will return both
+    // the declarations of `f()`. We should prune the declaration at line 2.
+    // Otherwise, we will get ambiguous use of 'f()` error.
+    //
+    unsigned latest_repl_line = 0;
+    for (const auto* decl : decls) {
+      unsigned decl_line = GetREPLLineNumber(decl);
+      if (decl_line > latest_repl_line)
+        latest_repl_line = decl_line;
+    }
+
+    auto is_old_repl_line = [&](const swift::ValueDecl *decl) {
+      unsigned decl_line = GetREPLLineNumber(decl);
+      bool should_remove = (decl_line != 0) && (decl_line < latest_repl_line);
+      if (m_log) {
+        std::string s;
+        llvm::raw_string_ostream ss(s);
+        decl->dump(ss);
+        ss.flush();
+        m_log->Printf("[LLDBREPLNameLookup::finishLookup] (%s) %s.",
+                      should_remove ? "Removing" : "Keeping", s.c_str());
+      }
+      return should_remove;
+    };
+
+    // Filter out any thing that was defined in an earlier repl line.
+    decls.erase(std::remove_if(decls.begin(), decls.end(), is_old_repl_line));
+  }
+
   virtual swift::Identifier getPreferredPrivateDiscriminator() {
     return swift::Identifier();
+  }
+
+ protected:
+  swift::SourceManager& m_source_manager;
+
+ private:
+   /// Returns the line number if this was defined on a repl line.
+   /// If this is not defined on a REPL line returns 0.
+   unsigned GetREPLLineNumber(const swift::Decl *decl) {
+     auto sl = decl->getLoc();
+     if (!sl.isValid())
+       return 0;
+     if (m_source_manager.getDisplayNameForLoc(sl) != "repl.swift")
+       return 0;
+     std::pair<unsigned, unsigned> line_col =
+         m_source_manager.getLineAndColumn(sl);
+     return line_col.first;
   }
 };
 }; // END Anonymous namespace
@@ -1287,8 +1351,9 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
 
   LLDBNameLookup *external_lookup;
   if (options.GetPlaygroundTransformEnabled() || options.GetREPLEnabled()) {
-    external_lookup = new LLDBREPLNameLookup(*source_file, variable_map, sc,
-                                             exe_scope);
+    external_lookup =
+        new LLDBREPLNameLookup(*source_file, variable_map, sc, exe_scope,
+                               swift_ast_context->GetSourceManager());
   } else {
     external_lookup = new LLDBExprNameLookup(*source_file, variable_map, sc,
                                              exe_scope);


### PR DESCRIPTION
Currently, lldb's REPL mode does not work well with extensions. Specifically, we cannot redefine an extension. Consider the following LLDB repl session:

```
Welcome to Swift version 5.0-dev (LLVM dcb9eb74a7, Clang 95cdf7c9af, Swift 56a798a3ea).
Type :help for assistance.
  1> struct Foo {}
  2> extension Foo { func f() -> Int { return 1 } }
  3> Foo().f()
$R0: Int = 1
  4> extension Foo { func f() -> Int { return 2 } }
  5> Foo().f()
error: repl.swift:5:1: error: ambiguous use of 'f()'
Foo().f()
^

repl.swift:2:22: note: found this candidate
extension Foo { func f() -> Int { return 1 } }
                     ^

repl.swift:4:22: note: found this candidate
extension Foo { func f() -> Int { return 2 } }
                     ^
```
As you can see redefining a function in an extension causes an ambiguous use diagnostic. This PR uses the additional hooks declared in https://github.com/apple/swift/pull/23031 to deal with redefinition of extensions. 

See the discussion on the [swift forum](https://forums.swift.org/t/lldb-repl-does-not-work-well-with-extensions/20057/15) for more context. 