### PR TITLE
 Avoid querying funciton debug info while building the symbol table.

### DIFF
--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -443,6 +443,9 @@ Mangled::GetDemangledName(lldb::LanguageType language,
         log->Printf("demangle swift: %s", mangled_name);
       std::string demangled(SwiftLanguageRuntime::DemangleSymbolAsString(
           mangled_name, false, sc));
+      // Don't cache the demangled name the function isn't available yet.
+      if (!sc || !sc->function)
+        return ConstString(demangled);
       if (!demangled.empty()) {
         m_demangled.SetStringWithMangledCounterpart(demangled,
 						    m_mangled);

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -702,21 +702,10 @@ void SwiftLanguageRuntime::GetGenericParameterNamesForFunction(
   SymbolContext &sc = const_cast<SymbolContext &>(const_sc);
 
   // While building the Symtab itself the symbol context is incomplete.
-  if (!sc.function && sc.module_sp && sc.symbol) {
-    SymbolContextList sc_list;
-    bool symbols_okay = false;
-    bool inlines_okay = false;
-    bool append = false;
-    size_t num_matches = sc.module_sp->FindFunctions(
-        sc.symbol->GetMangled().GetMangledName(), nullptr,
-        lldb::eFunctionNameTypeBase, inlines_okay, symbols_okay, append,
-        sc_list);
-    for (size_t idx = 0; idx < num_matches; idx++) {
-      sc_list.GetContextAtIndex(idx, sc);
-      if (sc.function)
-        break;
-    }
-  }
+  // Note that calling sc.module_sp->FindFunctions() here is too early and
+  // would mess up the loading process.
+  if (!sc.function && sc.module_sp && sc.symbol)
+    return;
 
   Block *block = sc.GetFunctionBlock();
   if (!block)


### PR DESCRIPTION
This fixes a testcase breakage introduced by 7eba1df14c04ce4ce812e5f0ab8f108899550001.

rdar://problem/48580111