### PR TITLE
[ExpressionParser] Remove line_offset parameter from UserExpression::Parse

### DIFF
--- a/include/lldb/Expression/ExpressionParser.h
+++ b/include/lldb/Expression/ExpressionParser.h
@@ -97,8 +97,7 @@ public:
   //------------------------------------------------------------------
   virtual unsigned Parse(DiagnosticManager &diagnostic_manager,
                          uint32_t first_line = 0,
-                         uint32_t last_line = UINT32_MAX,
-                         uint32_t line_offset = 0) = 0;
+                         uint32_t last_line = UINT32_MAX) = 0;
 
   //------------------------------------------------------------------
   /// Try to use the FixIts in the diagnostic_manager to rewrite the

--- a/include/lldb/Expression/UserExpression.h
+++ b/include/lldb/Expression/UserExpression.h
@@ -91,8 +91,7 @@ public:
   virtual bool Parse(DiagnosticManager &diagnostic_manager,
                      ExecutionContext &exe_ctx,
                      lldb_private::ExecutionPolicy execution_policy,
-                     bool keep_result_in_memory, bool generate_debug_info,
-                     uint32_t line_offset) = 0;
+                     bool keep_result_in_memory, bool generate_debug_info) = 0;
 
   //------------------------------------------------------------------
   /// Attempts to find possible command line completions for the given

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -345,8 +345,7 @@ public:
 
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
-                        uint32_t last_line = UINT32_MAX,
-                        uint32_t line_offset = 0);
+                        uint32_t last_line = UINT32_MAX);
 
   ConstString GetMangledTypeName(swift::TypeBase *);
 

--- a/source/Breakpoint/BreakpointLocation.cpp
+++ b/source/Breakpoint/BreakpointLocation.cpp
@@ -267,7 +267,7 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
 
     if (!m_user_expression_sp->Parse(diagnostics, exe_ctx,
                                      eExecutionPolicyOnlyWhenNeeded, true,
-                                     false, 0)) {
+                                     false)) {
       error.SetErrorStringWithFormat(
           "Couldn't parse conditional expression:\n%s",
           diagnostics.GetString().c_str());

--- a/source/Expression/UserExpression.cpp
+++ b/source/Expression/UserExpression.cpp
@@ -242,9 +242,9 @@ lldb::ExpressionResults UserExpression::Evaluate(
 
   DiagnosticManager diagnostic_manager;
 
-  bool parse_success = user_expression_sp->Parse(
-      diagnostic_manager, exe_ctx, execution_policy, keep_expression_in_memory,
-      generate_debug_info, 0);
+  bool parse_success =
+      user_expression_sp->Parse(diagnostic_manager, exe_ctx, execution_policy,
+                                keep_expression_in_memory, generate_debug_info);
 
   // Calculate the fixed expression always, since we need it for errors.
   std::string tmp_fixed_expression;
@@ -273,7 +273,7 @@ lldb::ExpressionResults UserExpression::Evaluate(
       DiagnosticManager fixed_diagnostic_manager;
       parse_success = fixed_expression_sp->Parse(
           fixed_diagnostic_manager, exe_ctx, execution_policy,
-          keep_expression_in_memory, generate_debug_info, 0);
+          keep_expression_in_memory, generate_debug_info);
       if (parse_success) {
         diagnostic_manager.Clear();
         user_expression_sp = fixed_expression_sp;

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -867,8 +867,7 @@ bool ClangExpressionParser::Complete(CompletionRequest &request, unsigned line,
 // to avoid clashes when merging from upstream.
 // End Swift only
 unsigned ClangExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
-                                      uint32_t first_line, uint32_t last_line,
-                                      uint32_t line_offset) {
+                                      uint32_t first_line, uint32_t last_line) {
   return ParseInternal(diagnostic_manager);
 }
 

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
@@ -76,8 +76,7 @@ public:
   ///     success.
   //------------------------------------------------------------------
   unsigned Parse(DiagnosticManager &diagnostic_manager, uint32_t first_line = 0,
-                 uint32_t last_line = UINT32_MAX,
-                 uint32_t line_offset = 0) override;
+                 uint32_t last_line = UINT32_MAX) override;
 
   bool RewriteExpression(DiagnosticManager &diagnostic_manager) override;
 

--- a/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -454,8 +454,7 @@ bool ClangUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                 ExecutionContext &exe_ctx,
                                 lldb_private::ExecutionPolicy execution_policy,
                                 bool keep_result_in_memory,
-                                bool generate_debug_info,
-                                uint32_t line_offset) {
+                                bool generate_debug_info) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
   if (!PrepareForParsing(diagnostic_manager, exe_ctx))

--- a/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -149,8 +149,7 @@ public:
   //------------------------------------------------------------------
   bool Parse(DiagnosticManager &diagnostic_manager, ExecutionContext &exe_ctx,
              lldb_private::ExecutionPolicy execution_policy,
-             bool keep_result_in_memory, bool generate_debug_info,
-             uint32_t line_offset = 0) override;
+             bool keep_result_in_memory, bool generate_debug_info) override;
 
   bool Complete(ExecutionContext &exe_ctx, CompletionRequest &request,
                 unsigned complete_pos) override;

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1427,8 +1427,7 @@ bool SwiftExpressionParser::Complete(CompletionRequest &request, unsigned line,
 }
 
 unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
-                                      uint32_t first_line, uint32_t last_line,
-                                      uint32_t line_offset) {
+                                      uint32_t first_line, uint32_t last_line) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
   SwiftExpressionParser::SILVariableMap variable_map;
@@ -1438,8 +1437,8 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   unsigned buffer_id = UINT32_MAX;
   auto DiagnoseSwiftASTContextError = [&]() {
     assert(swift_ast_ctx->HasErrors() && "error expected");
-    swift_ast_ctx->PrintDiagnostics(diagnostic_manager, buffer_id,
-                                          first_line, last_line, line_offset);
+    swift_ast_ctx->PrintDiagnostics(diagnostic_manager, buffer_id, first_line,
+                                    last_line);
   };
 
   // In the case of playgrounds, we turn all rewriting functionality off.

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -83,8 +83,7 @@ public:
   ///     success.
   //------------------------------------------------------------------
   unsigned Parse(DiagnosticManager &diagnostic_manager, uint32_t first_line = 0,
-                 uint32_t last_line = UINT32_MAX,
-                 uint32_t line_offset = 0) override;
+                 uint32_t last_line = UINT32_MAX) override;
 
   //------------------------------------------------------------------
   /// Ready an already-parsed expression for execution, possibly

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -342,8 +342,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                 ExecutionContext &exe_ctx,
                                 lldb_private::ExecutionPolicy execution_policy,
                                 bool keep_result_in_memory,
-                                bool generate_debug_info,
-                                uint32_t line_offset) {
+                                bool generate_debug_info) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_EXPRESSIONS));
 
   Status err;
@@ -441,7 +440,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
 
   unsigned error_code = m_parser->Parse(
       diagnostic_manager, first_body_line,
-      first_body_line + source_code->GetNumBodyLines(), line_offset);
+      first_body_line + source_code->GetNumBodyLines());
 
   if (error_code == 2) {
     m_fixed_text = m_expr_text;

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -112,8 +112,7 @@ public:
   //------------------------------------------------------------------
   bool Parse(DiagnosticManager &diagnostic_manager, ExecutionContext &exe_ctx,
              lldb_private::ExecutionPolicy execution_policy,
-             bool keep_result_in_memory, bool generate_debug_info,
-             uint32_t line_offset = 0) override;
+             bool keep_result_in_memory, bool generate_debug_info) override;
 
   ExpressionTypeSystemHelper *GetTypeSystemHelper() override {
     return &m_type_system_helper;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2845,8 +2845,7 @@ public:
 
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
-                        uint32_t last_line = UINT32_MAX,
-                        uint32_t line_offset = 0) {
+                        uint32_t last_line = UINT32_MAX) {
     bool added_one_diagnostic = false;
     for (const RawDiagnostic &diagnostic : m_diagnostics) {
       // We often make expressions and wrap them in some code.  When
@@ -2880,10 +2879,9 @@ public:
                 fixed_description.Printf(
                     "%s", diagnostic.description.substr(start_pos, match_pos)
                               .c_str());
-              fixed_description.Printf("%s:%u:",
-                                       diagnostic.bufferName.str().c_str(),
-                                       diagnostic.line - first_line +
-                                           line_offset + 1);
+              fixed_description.Printf(
+                  "%s:%u:", diagnostic.bufferName.str().c_str(),
+                  diagnostic.line - first_line + 1);
               start_pos = match_pos + match_len;
               match_pos =
                   diagnostic.description.find(match.GetString(), start_pos);
@@ -4678,8 +4676,7 @@ bool SwiftASTContext::SetColorizeDiagnostics(bool b) {
 
 void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                                        uint32_t bufferID, uint32_t first_line,
-                                       uint32_t last_line,
-                                       uint32_t line_offset) {
+                                       uint32_t last_line) {
   // If this is a fatal error, copy the error into the AST context's
   // fatal error field, and then put it to the stream, otherwise just
   // dump the diagnostics to the stream.
@@ -4706,8 +4703,8 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
 
     if (m_diagnostic_consumer_ap.get())
       static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
-          ->PrintDiagnostics(fatal_diagnostics, bufferID, first_line, last_line,
-                             line_offset);
+          ->PrintDiagnostics(fatal_diagnostics, bufferID, first_line,
+                             last_line);
     if (fatal_diagnostics.Diagnostics().size())
       m_fatal_errors.SetErrorString(fatal_diagnostics.GetString().data());
     else
@@ -4727,7 +4724,7 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
     if (m_diagnostic_consumer_ap.get())
       static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
           ->PrintDiagnostics(diagnostic_manager, bufferID, first_line,
-                             last_line, line_offset);
+                             last_line);
   }
 }
 


### PR DESCRIPTION
The parameter `line_offset` is set to 0 everywhere. It was being used to adjust swift diagnostic messages when they needed to be modified, but as-is it's basically unused.

This will also slightly reduce the diff between llvm.org/master and swift-lldb/stable, so that's nice.