### PR TITLE
When disassembling Aarch64 target and vendor Apple, set the cpu to

### DIFF
--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -1021,6 +1021,7 @@
 		6DEC6F391BD66D750091ABA6 /* TaskPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6DEC6F381BD66D750091ABA6 /* TaskPool.cpp */; };
 		23CB15421D66DA9300EDDDE1 /* TaskPoolTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2321F9451BDD346100BA9A93 /* TaskPoolTest.cpp */; };
 		2689007413353E1A00698AC0 /* Terminal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 268DA873130095ED00C9483A /* Terminal.cpp */; };
+		AFEABBF72230BF840097046F /* TestArm64Disassembly.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AFEABBF62230BF840097046F /* TestArm64Disassembly.cpp */; };
 		4CEC86A4204738C5009B37B1 /* TestArm64InstEmulation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4CEC86A3204738C5009B37B1 /* TestArm64InstEmulation.cpp */; };
 		AF7F97682141FA4500795BC0 /* TestArmv7Disassembly.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AF7F97662141FA3800795BC0 /* TestArmv7Disassembly.cpp */; };
 		23CB15401D66DA9300EDDDE1 /* TestClangASTContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 23CB150C1D66CF5600EDDDE1 /* TestClangASTContext.cpp */; };
@@ -3238,6 +3239,7 @@
 		2321F9451BDD346100BA9A93 /* TaskPoolTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TaskPoolTest.cpp; sourceTree = "<group>"; };
 		268DA873130095ED00C9483A /* Terminal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Terminal.cpp; sourceTree = "<group>"; };
 		268DA871130095D000C9483A /* Terminal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Terminal.h; path = include/lldb/Host/Terminal.h; sourceTree = "<group>"; };
+		AFEABBF62230BF840097046F /* TestArm64Disassembly.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestArm64Disassembly.cpp; path = unittests/Disassembler/TestArm64Disassembly.cpp; sourceTree = SOURCE_ROOT; };
 		4CEC86A3204738C5009B37B1 /* TestArm64InstEmulation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestArm64InstEmulation.cpp; path = UnwindAssembly/ARM64/TestArm64InstEmulation.cpp; sourceTree = "<group>"; };
 		AF7F97662141FA3800795BC0 /* TestArmv7Disassembly.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestArmv7Disassembly.cpp; path = unittests/Disassembler/TestArmv7Disassembly.cpp; sourceTree = SOURCE_ROOT; };
 		23CB150C1D66CF5600EDDDE1 /* TestClangASTContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestClangASTContext.cpp; sourceTree = "<group>"; };
@@ -7107,6 +7109,7 @@
 		AF7F97652141FA2100795BC0 /* Disassembler */ = {
 			isa = PBXGroup;
 			children = (
+				AFEABBF62230BF840097046F /* TestArm64Disassembly.cpp */,
 				AF7F97662141FA3800795BC0 /* TestArmv7Disassembly.cpp */,
 			);
 			name = Disassembler;
@@ -8170,6 +8173,7 @@
 				9A3D43D91F3151C400EB767C /* StatusTest.cpp in Sources */,
 				23CB15341D66DA9300EDDDE1 /* CPlusPlusLanguageTest.cpp in Sources */,
 				9A2057381F3B8E7E00F6C293 /* FileSystemTest.cpp in Sources */,
+				AFEABBF72230BF840097046F /* TestArm64Disassembly.cpp in Sources */,
 				9A2057201F3B8D2500F6C293 /* UnixSignalsTest.cpp in Sources */,
 				2668A2EE20AF417D00D94111 /* PathMappingListTest.cpp in Sources */,
 				AFAFD80A1E57E1B90017A14F /* ModuleCacheTest.cpp in Sources */,

--- a/source/Plugins/Disassembler/llvm/DisassemblerLLVMC.cpp
+++ b/source/Plugins/Disassembler/llvm/DisassemblerLLVMC.cpp
@@ -1196,6 +1196,11 @@ DisassemblerLLVMC::DisassemblerLLVMC(const ArchSpec &arch,
   if (triple.getArch() == llvm::Triple::aarch64)
     features_str += "+v8.2a";
 
+  if (triple.getArch() == llvm::Triple::aarch64
+      && triple.getVendor() == llvm::Triple::Apple) {
+    cpu = "apple-latest";
+  }
+
   // We use m_disasm_up.get() to tell whether we are valid or not, so if this
   // isn't good for some reason, we won't be valid and FindPlugin will fail and
   // we won't get used.

--- a/unittests/Disassembler/CMakeLists.txt
+++ b/unittests/Disassembler/CMakeLists.txt
@@ -1,5 +1,6 @@
 if("ARM" IN_LIST LLVM_TARGETS_TO_BUILD)
   add_lldb_unittest(DisassemblerTests
+    TestArm64Disassembly.cpp
     TestArmv7Disassembly.cpp
     LINK_LIBS
       lldbCore

--- a/unittests/Disassembler/TestArm64Disassembly.cpp
+++ b/unittests/Disassembler/TestArm64Disassembly.cpp
@@ -1,0 +1,80 @@
+//===-- TestArm64Disassembly.cpp ------------------------------------*- C++
+//-*-===//
+
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "lldb/Core/Address.h"
+#include "lldb/Core/Disassembler.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "lldb/Target/ExecutionContext.h"
+
+#include "Plugins/Disassembler/llvm/DisassemblerLLVMC.h"
+#include "llvm/Support/TargetSelect.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+class TestArm64Disassembly : public testing::Test {
+public:
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
+  //  virtual void SetUp() override { }
+  //  virtual void TearDown() override { }
+
+protected:
+};
+
+void TestArm64Disassembly::SetUpTestCase() {
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllDisassemblers();
+  DisassemblerLLVMC::Initialize();
+}
+
+void TestArm64Disassembly::TearDownTestCase() {
+  DisassemblerLLVMC::Terminate();
+}
+
+TEST_F(TestArm64Disassembly, TestArmv81Instruction) {
+  ArchSpec arch("arm64-apple-ios");
+
+  const unsigned num_of_instructions = 2;
+  uint8_t data[] = {
+      0xff, 0x43, 0x00, 0xd1, // 0xd10043ff :  sub    sp, sp, #0x10
+      0x62, 0x7c, 0xa1, 0xc8, // 0xc8a17c62 :  cas    x1, x2, [x3] (cas defined in ARM v8.1 & newer)
+  };
+
+  DisassemblerSP disass_sp;
+  Address start_addr(0x100);
+  disass_sp = Disassembler::DisassembleBytes(arch, nullptr, nullptr, start_addr,
+                                 &data, sizeof (data), num_of_instructions, false);
+
+  // If we failed to get a disassembler, we can assume it is because
+  // the llvm we linked against was not built with the ARM target,
+  // and we should skip these tests without marking anything as failing.
+
+  if (disass_sp) {
+    const InstructionList inst_list (disass_sp->GetInstructionList());
+    EXPECT_EQ (num_of_instructions, inst_list.GetSize());
+
+    InstructionSP inst_sp;
+    const char *mnemonic;
+    ExecutionContext exe_ctx (nullptr, nullptr, nullptr);
+    inst_sp = inst_list.GetInstructionAtIndex (0);
+    mnemonic = inst_sp->GetMnemonic(&exe_ctx);
+    ASSERT_STREQ ("sub", mnemonic);
+
+    inst_sp = inst_list.GetInstructionAtIndex (1);
+    mnemonic = inst_sp->GetMnemonic(&exe_ctx);
+    ASSERT_STREQ ("cas", mnemonic);
+  }
+}


### PR DESCRIPTION
When disassembling Aarch64 target and vendor Apple, set the cpu to
"apple-latest" which llvm uses to indicate the newest supported ISA.
Add a unit test; I'm only testing an armv8.1 instruction in this
unit test which would already be disassembled correctly because we
set the disassembler to ARM v8.2 mode, but it ensures that nothing
has been broken by adding this cpu spec.

<rdar://problem/38714781> 



git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355578 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 53e897c22fc698872154f5feb61434e9302a9019)