### PR TITLE
Cherry-pick changes for ComputeClangResourceDirectory on Windows

### DIFF
--- a/include/lldb/Host/HostInfoBase.h
+++ b/include/lldb/Host/HostInfoBase.h
@@ -101,6 +101,9 @@ public:
   //---------------------------------------------------------------------------
   static ArchSpec GetAugmentedArchSpec(llvm::StringRef triple);
 
+  static bool ComputePathRelativeToLibrary(FileSpec &file_spec,
+                                           llvm::StringRef dir);
+
 protected:
   static bool ComputeSharedLibraryDirectory(FileSpec &file_spec);
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);

--- a/include/lldb/Host/posix/HostInfoPosix.h
+++ b/include/lldb/Host/posix/HostInfoPosix.h
@@ -32,9 +32,6 @@ public:
 
   static bool GetEnvironmentVar(const std::string &var_name, std::string &var);
 
-  static bool ComputePathRelativeToLibrary(FileSpec &file_spec,
-                                           llvm::StringRef dir);
-
 protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);
   static bool ComputeSupportFileDirectory(FileSpec &file_spec);

--- a/lit/helper/build.py
+++ b/lit/helper/build.py
@@ -569,6 +569,8 @@ class MsvcBuilder(Builder):
         args.append('/c')
 
         args.append('/Fo' + obj)
+        if self.toolchain_type == 'clang-cl':
+            args.append('--')
         args.append(source)
 
         return ('compiling', [source], obj,

--- a/packages/Python/lldbsuite/test/functionalities/paths/TestPaths.py
+++ b/packages/Python/lldbsuite/test/functionalities/paths/TestPaths.py
@@ -25,21 +25,13 @@ class TestPaths(TestBase):
                           lldb.ePathTypePythonDir,
                           lldb.ePathTypeLLDBSystemPlugins,
                           lldb.ePathTypeLLDBUserPlugins,
-                          lldb.ePathTypeLLDBTempSystemDir]
+                          lldb.ePathTypeLLDBTempSystemDir,
+                          lldb.ePathTypeClangDir]
 
         for path_type in dir_path_types:
             f = lldb.SBHostOS.GetLLDBPath(path_type)
             # No directory path types should have the filename set
             self.assertTrue(f.GetFilename() is None)
-
-    # TODO: Merge into test_path when GetClangResourceDir is implemented on
-    # windows
-    @expectedFailureAll(oslist=["windows"])
-    @no_debug_info_test
-    def test_clang_dir_path(self):
-      '''Test to make sure clang dir is set correctly'''
-      clang_dir = lldb.SBHostOS.GetLLDBPath(lldb.ePathTypeClangDir)
-      self.assertFalse(clang_dir.GetDirectory() is None)
 
     @no_debug_info_test
     def test_directory_doesnt_end_with_slash(self):

--- a/packages/Python/lldbsuite/test/functionalities/paths/TestPaths.py
+++ b/packages/Python/lldbsuite/test/functionalities/paths/TestPaths.py
@@ -32,6 +32,15 @@ class TestPaths(TestBase):
             # No directory path types should have the filename set
             self.assertTrue(f.GetFilename() is None)
 
+    # TODO: Merge into test_path when GetClangResourceDir is implemented on
+    # windows
+    @expectedFailureAll(oslist=["windows"])
+    @no_debug_info_test
+    def test_clang_dir_path(self):
+      '''Test to make sure clang dir is set correctly'''
+      clang_dir = lldb.SBHostOS.GetLLDBPath(lldb.ePathTypeClangDir)
+      self.assertFalse(clang_dir.GetDirectory() is None)
+
     @no_debug_info_test
     def test_directory_doesnt_end_with_slash(self):
         current_directory_spec = lldb.SBFileSpec(os.path.curdir)

--- a/source/Host/common/FileSystem.cpp
+++ b/source/Host/common/FileSystem.cpp
@@ -264,7 +264,10 @@ void FileSystem::Resolve(FileSpec &file_spec) {
   Resolve(path);
 
   // Update the FileSpec with the resolved path.
-  file_spec.SetPath(path);
+  if (file_spec.GetFilename().IsEmpty())
+    file_spec.GetDirectory().SetString(path);
+  else
+    file_spec.SetPath(path);
   file_spec.SetIsResolved(true);
 }
 

--- a/source/Host/common/HostInfoBase.cpp
+++ b/source/Host/common/HostInfoBase.cpp
@@ -227,6 +227,38 @@ ArchSpec HostInfoBase::GetAugmentedArchSpec(llvm::StringRef triple) {
   return ArchSpec(normalized_triple);
 }
 
+bool HostInfoBase::ComputePathRelativeToLibrary(FileSpec &file_spec,
+                                                llvm::StringRef dir) {
+  Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
+
+  FileSpec lldb_file_spec = GetShlibDir();
+  if (!lldb_file_spec)
+    return false;
+
+  std::string raw_path = lldb_file_spec.GetPath();
+  if (log)
+    log->Printf("HostInfo::%s() attempting to "
+                "derive the path %s relative to liblldb install path: %s",
+                __FUNCTION__, dir.data(), raw_path.c_str());
+
+  // Drop bin (windows) or lib
+  llvm::StringRef parent_path = llvm::sys::path::parent_path(raw_path);
+  if (parent_path.empty()) {
+    if (log)
+      log->Printf("HostInfo::%s() failed to find liblldb within the shared "
+                  "lib path",
+                  __FUNCTION__);
+    return false;
+  }
+
+  raw_path = (parent_path + dir).str();
+  if (log)
+    log->Printf("HostInfo::%s() derived the path as: %s", __FUNCTION__,
+                raw_path.c_str());
+  file_spec.GetDirectory().SetString(raw_path);
+  return (bool)file_spec.GetDirectory();
+}
+
 bool HostInfoBase::ComputeSharedLibraryDirectory(FileSpec &file_spec) {
   // To get paths related to LLDB we get the path to the executable that
   // contains this function. On MacOSX this will be "LLDB.framework/.../LLDB".

--- a/source/Host/posix/HostInfoPosix.cpp
+++ b/source/Host/posix/HostInfoPosix.cpp
@@ -120,43 +120,6 @@ uint32_t HostInfoPosix::GetEffectiveGroupID() { return getegid(); }
 
 FileSpec HostInfoPosix::GetDefaultShell() { return FileSpec("/bin/sh"); }
 
-bool HostInfoPosix::ComputePathRelativeToLibrary(FileSpec &file_spec,
-                                                 llvm::StringRef dir) {
-  Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
-
-  FileSpec lldb_file_spec = GetShlibDir();
-  if (!lldb_file_spec)
-    return false;
-
-  std::string raw_path = lldb_file_spec.GetPath();
-  // drop library directory
-  llvm::StringRef parent_path = llvm::sys::path::parent_path(raw_path);
-
-  // Most Posix systems (e.g. Linux/*BSD) will attempt to replace a */lib with
-  // */bin as the base directory for helper exe programs.  This will fail if
-  // the /lib and /bin directories are rooted in entirely different trees.
-  if (log)
-    log->Printf("HostInfoPosix::ComputePathRelativeToLibrary() attempting to "
-                "derive the %s path from this path: %s",
-                dir.data(), raw_path.c_str());
-
-  if (!parent_path.empty()) {
-    // Now write in bin in place of lib.
-    raw_path = (parent_path + dir).str();
-
-    if (log)
-      log->Printf("Host::%s() derived the bin path as: %s", __FUNCTION__,
-                  raw_path.c_str());
-  } else {
-    if (log)
-      log->Printf("Host::%s() failed to find /lib/liblldb within the shared "
-                  "lib path, bailing on bin path construction",
-                  __FUNCTION__);
-  }
-  file_spec.GetDirectory().SetString(raw_path);
-  return (bool)file_spec.GetDirectory();
-}
-
 bool HostInfoPosix::ComputeSupportFileDirectory(FileSpec &file_spec) {
   FileSpec temp_file_spec;
 

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -53,9 +53,7 @@ static bool DefaultComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
 
   llvm::SmallString<256> clang_dir(parent_dir);
   llvm::SmallString<32> relative_path;
-  llvm::sys::path::append(relative_path,
-                          llvm::Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang",
-                          CLANG_VERSION_STRING);
+  llvm::sys::path::append(relative_path, "lib", "lldb", "clang");
 
   llvm::sys::path::append(clang_dir, relative_path);
   if (!verify || VerifyClangPath(clang_dir)) {

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -76,7 +76,7 @@ bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
     ++rev_it;
   }
 
-  // Posix-style of LLDB detected.
+  // We found a non-framework build of LLDB
   if (rev_it == r_end)
     return DefaultComputeClangResourceDirectory(lldb_shlib_spec, file_spec,
                                                 verify);

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -18,9 +18,6 @@
 
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
-#if !defined(_WIN32)
-#include "lldb/Host/posix/HostInfoPosix.h"
-#endif
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Log.h"
 
@@ -28,12 +25,6 @@
 
 using namespace lldb_private;
 
-#if defined(_WIN32)
-static bool ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
-                                          FileSpec &file_spec, bool verify) {
-  return false;
-}
-#else
 static bool VerifyClangPath(const llvm::Twine &clang_path) {
   if (FileSystem::Instance().IsDirectory(clang_path))
     return true;
@@ -65,7 +56,7 @@ static bool DefaultComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
     return true;
   }
 
-  return HostInfoPosix::ComputePathRelativeToLibrary(file_spec, relative_path);
+  return HostInfo::ComputePathRelativeToLibrary(file_spec, relative_path);
 }
 
 bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
@@ -139,7 +130,6 @@ bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
   return true;
 #endif // __APPLE__
 }
-#endif // _WIN32
 
 FileSpec lldb_private::GetClangResourceDir() {
   static FileSpec g_cached_resource_dir;

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -52,6 +52,7 @@ static bool DefaultComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
   llvm::sys::path::append(clang_dir, relative_path);
   if (!verify || VerifyClangPath(clang_dir)) {
     file_spec.GetDirectory().SetString(clang_dir);
+    FileSystem::Instance().Resolve(file_spec);
     return true;
   }
 

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -96,7 +96,7 @@ bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
                             "Developer/Toolchains/XcodeDefault.xctoolchain",
                             swift_clang_resource_dir);
     if (!verify || VerifyClangPath(clang_path)) {
-      file_spec.SetFile(clang_path.c_str(), FileSpec::Style::native);
+      file_spec.GetDirectory().SetString(clang_path.c_str());
       FileSystem::Instance().Resolve(file_spec);
       return true;
     }
@@ -111,7 +111,7 @@ bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
       raw_path.resize(parent - r_end);
       llvm::sys::path::append(clang_path, raw_path, swift_clang_resource_dir);
       if (!verify || VerifyClangPath(clang_path)) {
-        file_spec.SetFile(clang_path.c_str(), FileSpec::Style::native);
+        file_spec.GetDirectory().SetString(clang_path.c_str());
         FileSystem::Instance().Resolve(file_spec);
         return true;
       }
@@ -124,7 +124,7 @@ bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
 
   // Fall back to the Clang resource directory inside the framework.
   raw_path.append("LLDB.framework/Resources/Clang");
-  file_spec.SetFile(raw_path.c_str(), FileSpec::Style::native);
+  file_spec.GetDirectory().SetString(raw_path.c_str());
   FileSystem::Instance().Resolve(file_spec);
   return true;
 #endif // __APPLE__

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -29,19 +29,8 @@
 using namespace lldb_private;
 
 #if defined(_WIN32)
-static bool ComputeClangDirectory(FileSpec &file_spec) { return false; }
+static bool ComputeClangResourceDirectory(FileSpec &file_spec) { return false; }
 #else
-static bool DefaultComputeClangDirectory(FileSpec &file_spec) {
-  return HostInfoPosix::ComputePathRelativeToLibrary(
-      file_spec, "/lib/lldb/clang/");
-  return HostInfoPosix::ComputePathRelativeToLibrary(
-      file_spec, (llvm::Twine("/lib") + CLANG_LIBDIR_SUFFIX + "/clang/" +
-                  CLANG_VERSION_STRING)
-                     .str());
-}
-
-#if defined(__APPLE__)
-
 static bool VerifyClangPath(const llvm::Twine &clang_path) {
   if (FileSystem::Instance().IsDirectory(clang_path))
     return true;
@@ -53,8 +42,37 @@ static bool VerifyClangPath(const llvm::Twine &clang_path) {
   return false;
 }
 
-bool lldb_private::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
+///
+/// This will compute the clang resource directory assuming that clang was
+/// installed with the same prefix as lldb.
+///
+static bool DefaultComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
                                          FileSpec &file_spec, bool verify) {
+  std::string raw_path = lldb_shlib_spec.GetPath();
+  llvm::StringRef parent_dir = llvm::sys::path::parent_path(raw_path);
+
+  llvm::SmallString<256> clang_dir(parent_dir);
+  llvm::SmallString<32> relative_path;
+  llvm::sys::path::append(relative_path,
+                          llvm::Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang",
+                          CLANG_VERSION_STRING);
+
+  llvm::sys::path::append(clang_dir, relative_path);
+  if (!verify || VerifyClangPath(clang_dir)) {
+    file_spec.GetDirectory().SetString(clang_dir);
+    FileSystem::Instance().Resolve(file_spec);
+    return true;
+  }
+
+  return HostInfoPosix::ComputePathRelativeToLibrary(file_spec, relative_path);
+}
+
+bool lldb_private::ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
+                                         FileSpec &file_spec, bool verify) {
+#if !defined(__APPLE__)
+  return DefaultComputeClangResourceDirectory(lldb_shlib_spec, file_spec,
+                                              verify);
+#else
   std::string raw_path = lldb_shlib_spec.GetPath();
 
   auto rev_it = llvm::sys::path::rbegin(raw_path);
@@ -67,8 +85,10 @@ bool lldb_private::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
     ++rev_it;
   }
 
+  // Posix-style of LLDB detected.
   if (rev_it == r_end)
-    return DefaultComputeClangDirectory(file_spec);
+    return DefaultComputeClangResourceDirectory(lldb_shlib_spec, file_spec,
+                                                verify);
 
   // Inside Xcode and in Xcode toolchains LLDB is always in lockstep
   // with the Swift compiler, so it can reuse its Clang resource
@@ -116,27 +136,17 @@ bool lldb_private::ComputeClangDirectory(FileSpec &lldb_shlib_spec,
   file_spec.SetFile(raw_path.c_str(), FileSpec::Style::native);
   FileSystem::Instance().Resolve(file_spec);
   return true;
-}
-
-static bool ComputeClangDirectory(FileSpec &file_spec) {
-  if (FileSpec lldb_file_spec = HostInfo::GetShlibDir())
-    return ComputeClangDirectory(lldb_file_spec, file_spec, true);
-  return false;
-}
-#else  // __APPLE__
-
-// All non-Apple posix systems.
-static bool ComputeClangDirectory(FileSpec &file_spec) {
-  return DefaultComputeClangDirectory(file_spec);
-}
 #endif // __APPLE__
+}
 #endif // _WIN32
 
 FileSpec lldb_private::GetClangResourceDir() {
   static FileSpec g_cached_resource_dir;
   static llvm::once_flag g_once_flag;
   llvm::call_once(g_once_flag, []() {
-    ::ComputeClangDirectory(g_cached_resource_dir);
+    if (FileSpec lldb_file_spec = HostInfo::GetShlibDir())
+      ComputeClangResourceDirectory(lldb_file_spec, g_cached_resource_dir,
+                                    true);
     Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
     if (log)
       log->Printf("GetClangResourceDir() => '%s'",

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -29,7 +29,10 @@
 using namespace lldb_private;
 
 #if defined(_WIN32)
-static bool ComputeClangResourceDirectory(FileSpec &file_spec) { return false; }
+static bool ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
+                                          FileSpec &file_spec, bool verify) {
+  return false;
+}
 #else
 static bool VerifyClangPath(const llvm::Twine &clang_path) {
   if (FileSystem::Instance().IsDirectory(clang_path))

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.cpp
@@ -52,7 +52,6 @@ static bool DefaultComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
   llvm::sys::path::append(clang_dir, relative_path);
   if (!verify || VerifyClangPath(clang_dir)) {
     file_spec.GetDirectory().SetString(clang_dir);
-    FileSystem::Instance().Resolve(file_spec);
     return true;
   }
 

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.h
@@ -13,10 +13,8 @@ namespace lldb_private {
 
 class FileSpec;
 
-#if !defined(_WIN32)
 bool ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
                                    FileSpec &file_spec, bool verify);
-#endif
 
 FileSpec GetClangResourceDir();
 

--- a/source/Plugins/ExpressionParser/Clang/ClangHost.h
+++ b/source/Plugins/ExpressionParser/Clang/ClangHost.h
@@ -13,9 +13,9 @@ namespace lldb_private {
 
 class FileSpec;
 
-#if defined(__APPLE__)
-bool ComputeClangDirectory(FileSpec &lldb_shlib_spec, FileSpec &file_spec,
-                           bool verify);
+#if !defined(_WIN32)
+bool ComputeClangResourceDirectory(FileSpec &lldb_shlib_spec,
+                                   FileSpec &file_spec, bool verify);
 #endif
 
 FileSpec GetClangResourceDir();

--- a/unittests/Expression/ClangParserTest.cpp
+++ b/unittests/Expression/ClangParserTest.cpp
@@ -31,7 +31,6 @@ struct ClangHostTest : public testing::Test {
 };
 } // namespace
 
-#if !defined(_WIN32)
 static std::string ComputeClangResourceDir(std::string lldb_shlib_path,
                                            bool verify = false) {
   FileSpec clang_dir;
@@ -41,8 +40,13 @@ static std::string ComputeClangResourceDir(std::string lldb_shlib_path,
 }
 
 TEST_F(ClangHostTest, ComputeClangResourceDirectory) {
+#if !defined(_WIN32)
   std::string path_to_liblldb = "/foo/bar/lib/";
   std::string path_to_clang_dir = "/foo/bar/lib/clang/" CLANG_VERSION_STRING;
+#else
+  std::string path_to_liblldb = "C:\\foo\\bar\\lib";
+  std::string path_to_clang_dir = "C:\\foo\\bar\\lib\\clang\\" CLANG_VERSION_STRING;
+#endif
   EXPECT_EQ(ComputeClangResourceDir(path_to_liblldb), path_to_clang_dir);
 
   // The path doesn't really exist, so setting verify to true should make
@@ -91,4 +95,3 @@ TEST_F(ClangHostTest, MacOSX) {
             ComputeClangResourceDir(GetInputFilePath(xcode)));
 }
 #endif // __APPLE__
-#endif // !_WIN32

--- a/unittests/Expression/ClangParserTest.cpp
+++ b/unittests/Expression/ClangParserTest.cpp
@@ -42,10 +42,10 @@ static std::string ComputeClangResourceDir(std::string lldb_shlib_path,
 TEST_F(ClangHostTest, ComputeClangResourceDirectory) {
 #if !defined(_WIN32)
   std::string path_to_liblldb = "/foo/bar/lib/";
-  std::string path_to_clang_dir = "/foo/bar/lib/clang/" CLANG_VERSION_STRING;
+  std::string path_to_clang_dir = "/foo/bar/lib/lldb/clang";
 #else
   std::string path_to_liblldb = "C:\\foo\\bar\\lib";
-  std::string path_to_clang_dir = "C:\\foo\\bar\\lib\\clang\\" CLANG_VERSION_STRING;
+  std::string path_to_clang_dir = "C:\\foo\\bar\\lib\\lldb\\clang";
 #endif
   EXPECT_EQ(ComputeClangResourceDir(path_to_liblldb), path_to_clang_dir);
 


### PR DESCRIPTION
This is useful for having swift debugging on a Windows host, so I'd like to cherry-pick them into stable.

cc @compnerd @adrian-prantl 