### PR TITLE
Fix TestAppleSimulatorOSType.py with Xcode 10.2

### DIFF
--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -30,7 +30,9 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
             if not platform in runtime.lower():
                 continue
             for device in devices:
-                if device['availability'] != '(available)':
+                if 'availability' in device and device['availability'] != '(available)':
+                    continue
+                if 'isAvailable' in device and device['isAvailable'] != True:
                     continue
                 deviceUDID = device['udid']
                 break


### PR DESCRIPTION
It looks like the simctl tool shipped in Xcode10.2 changed the format of
its json output.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355644 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 5bbf64b8fd2b16d739e730537b3122ebb9aa16e5)