### PR TITLE
Add parens to force the order of operations in an expression trying

### DIFF
--- a/source/Target/Memory.cpp
+++ b/source/Target/Memory.cpp
@@ -147,7 +147,7 @@ size_t MemoryCache::Read(addr_t addr, void *dst, size_t dst_len,
     }
     AddrRange chunk_range(pos->first, pos->second->GetByteSize());
     if (chunk_range.Contains(read_range)) {
-      memcpy(dst, pos->second->GetBytes() + addr - chunk_range.GetRangeBase(),
+      memcpy(dst, pos->second->GetBytes() + (addr - chunk_range.GetRangeBase()),
              dst_len);
       return dst_len;
     }


### PR DESCRIPTION
Add parens to force the order of operations in an expression trying
to do "databuffer + offset" so that we don't overflow the uint64_t's 
we're using for addresses when working with high addresses.

Found with clang's ubsan while doing darwin kernel debugging.

<rdar://problem/48728940> 



git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355761 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 9da7138a76c370a3cf534ff0ed12375df061d280)