### PR TITLE
[5.1] Include swift::ParseableInterfaceModuleLoader header

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -45,6 +45,7 @@
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Driver/Util.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/ParseableInterfaceModuleLoader.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/Utils.h"
 #include "swift/IRGen/Linking.h"


### PR DESCRIPTION
This is a cherry-pick of #1328 onto swift-5.1-branch.