### PR TITLE
Add `-fmodule-map-file=` to RemapClangImporterOptions whitelist

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1410,6 +1410,7 @@ namespace {
 bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
   static StringRef options[] = {"-I",
                                 "-F",
+                                "-fmodule-map-file=",
                                 "-iquote",
                                 "-idirafter",
                                 "-iframeworkwithsysroot",


### PR DESCRIPTION
This flag was missed in the RemapClangImporterOptions whitelist. Let me know if I should instead create this PR against a different branch (stable/swift 5?) or if more information is needed.