### PR TITLE
[5.1] Support multiple runtime library import paths

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4744,9 +4744,14 @@ void SwiftASTContext::DumpConfiguration(Log *log) {
               m_ast_context_ap->SearchPathOpts.RuntimeResourcePath.c_str());
   log->Printf("  Runtime library path         : %s",
               m_ast_context_ap->SearchPathOpts.RuntimeLibraryPath.c_str());
-  log->Printf(
-      "  Runtime library import path  : %s",
-      m_ast_context_ap->SearchPathOpts.RuntimeLibraryImportPath.c_str());
+  
+  log->Printf("  Runtime library import paths : (%llu items)",
+              (unsigned long long)
+            m_ast_context_ap->SearchPathOpts.RuntimeLibraryImportPaths.size());
+  for (const auto &runtime_import_path :
+       m_ast_context_ap->SearchPathOpts.RuntimeLibraryImportPaths) {
+    log->Printf("    %s", runtime_import_path.c_str());
+  }
 
   log->Printf("  Framework search paths       : (%llu items)",
               (unsigned long long)


### PR DESCRIPTION
Cherry-pick of #1365 to swift-5.1-branch. Needs to be coordinated with apple/swift#23267.