### PR TITLE
Check the result of creating a node from __next_ in the std::list for…

### DIFF
--- a/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -384,7 +384,7 @@ lldb::ValueObjectSP ListFrontEnd::GetChildAtIndex(size_t idx) {
   if (current_sp->GetName() == g_next) {
     ProcessSP process_sp(current_sp->GetProcessSP());
     if (!process_sp)
-      return nullptr;
+      return lldb::ValueObjectSP();
 
     // if we grabbed the __next_ pointer, then the child is one pointer deep-er
     lldb::addr_t addr = current_sp->GetParent()->GetPointerValue();
@@ -392,6 +392,8 @@ lldb::ValueObjectSP ListFrontEnd::GetChildAtIndex(size_t idx) {
     ExecutionContext exe_ctx(process_sp);
     current_sp =
         CreateValueObjectFromAddress("__value_", addr, exe_ctx, m_element_type);
+    if (!current_sp)
+      return lldb::ValueObjectSP();
   }
 
   // we need to copy current_sp into a new object otherwise we will end up with


### PR DESCRIPTION
…matter.

There's a single report of a crash coming from this current_sp being NULL.  I don't
have a repro case, and I couldn't get it to happen by hand-corrupting a list.  We
always get an error instead.  So I don't have a test case.  But checking for null
is clearly right here.

<rdar://problem/48503320>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355957 91177308-0d34-0410-b5e6-96231b3b80d8