### PR TITLE
When deserializing breakpoints some options may not be present.

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/serialize/TestBreakpointSerialization.py
@@ -17,6 +17,7 @@ from lldbsuite.test import lldbutil
 class BreakpointSerialization(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     @add_test_categories(['pyapi'])
     def test_resolvers(self):
@@ -194,6 +195,11 @@ class BreakpointSerialization(TestBase):
         bkpt = self.orig_target.BreakpointCreateByName("blubby", lldb.eFunctionNameTypeAuto, empty_module_list, empty_cu_list)
         bkpt.SetIgnoreCount(10)
         bkpt.SetThreadName("grubby")
+        source_bps.Append(bkpt)
+
+        bkpt = self.orig_target.BreakpointCreateByName("blubby", lldb.eFunctionNameTypeAuto, empty_module_list, empty_cu_list)
+        bkpt.SetCondition("gonna remove this")
+        bkpt.SetCondition("")
         source_bps.Append(bkpt)
 
         bkpt = self.orig_target.BreakpointCreateByName("blubby", lldb.eFunctionNameTypeFull, empty_module_list,empty_cu_list)

--- a/source/Breakpoint/BreakpointOptions.cpp
+++ b/source/Breakpoint/BreakpointOptions.cpp
@@ -253,55 +253,50 @@ std::unique_ptr<BreakpointOptions> BreakpointOptions::CreateFromStructuredData(
 
   const char *key = GetKey(OptionNames::EnabledState);
   bool success;
-  if (key) {
+  if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsBoolean(key, enabled);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not a boolean.",
-                                   GetKey(OptionNames::EnabledState));
+      error.SetErrorStringWithFormat("%s key is not a boolean.", key);
       return nullptr;
     }
     set_options.Set(eEnabled);
   }
 
   key = GetKey(OptionNames::OneShotState);
-  if (key) {
+  if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsBoolean(key, one_shot);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not a boolean.",
-                                     GetKey(OptionNames::OneShotState));
+      error.SetErrorStringWithFormat("%s key is not a boolean.", key);
       return nullptr;
       }
       set_options.Set(eOneShot);
   }
   
   key = GetKey(OptionNames::AutoContinue);
-  if (key) {
+  if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsBoolean(key, auto_continue);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not a boolean.",
-                                     GetKey(OptionNames::AutoContinue));
+      error.SetErrorStringWithFormat("%s key is not a boolean.", key);
       return nullptr;
       }
       set_options.Set(eAutoContinue);
   }
   
   key = GetKey(OptionNames::IgnoreCount);
-  if (key) {
+  if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsInteger(key, ignore_count);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not an integer.",
-                                     GetKey(OptionNames::IgnoreCount));
+      error.SetErrorStringWithFormat("%s key is not an integer.", key);
       return nullptr;
     }
     set_options.Set(eIgnoreCount);
   }
 
   key = GetKey(OptionNames::ConditionText);
-  if (key) {
+  if (key && options_dict.HasKey(key)) {
     success = options_dict.GetValueForKeyAsString(key, condition_ref);
     if (!success) {
-      error.SetErrorStringWithFormat("%s key is not an string.",
-                                     GetKey(OptionNames::ConditionText));
+      error.SetErrorStringWithFormat("%s key is not an string.", key);
       return nullptr;
     }
     set_options.Set(eCondition);


### PR DESCRIPTION
The deserializer was not handling this case.  For now we just
accept the absent option, and set it to the breakpoint default.
This will be more important if/when I figure out how to serialize
the options set on breakpont locations.

<rdar://problem/48322664>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@354702 91177308-0d34-0410-b5e6-96231b3b80d8