### PR TITLE
[Swift] Update for removal of -enable-parseable-module-interface

### DIFF
--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -5,7 +5,7 @@
 // RUN: cp %S/Inputs/A.swift %t/AA.swift
 // RUN: %target-swiftc -module-name AA -emit-parseable-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
 // RUN: rm %t/AA.swift
-// RUN: %lldb --repl="-I%t -L%t -lAA -enable-parseable-module-interface" < %s | FileCheck %s
+// RUN: %lldb --repl="-I%t -L%t -lAA" < %s | FileCheck %s
 
 import AA
 

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/Makefile
@@ -3,7 +3,7 @@ LEVEL := ../../../make
 EXE := main
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC -Xlinker -rpath -Xlinker $(BUILDDIR)
-SWIFTFLAGS_EXTRAS = -enable-parseable-module-interface -I$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 
 # setup `all` to run each of the below before building the main executable

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
@@ -5,7 +5,7 @@ DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
 # Don't use the default swift flags, as we don't want -g for the libraries in
 # this test.
-SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface
+SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options
 
 # Don't include the wrapped .swiftmodule on Linux to make sure we actually use
 # the .swiftinterface. The issue here is that if the .swiftmodule is wrapped

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/Makefile
@@ -3,7 +3,7 @@ LEVEL := ../../../make
 EXE := main
 SWIFT_SOURCES := main.swift
 LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC
-SWIFTFLAGS_EXTRAS = -enable-parseable-module-interface -I$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 
 # setup `all` to run each of the below before building the main executable

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
@@ -7,7 +7,7 @@ DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
 # Don't use the default swift flags, as we don't want -g for the libraries in
 # this test.
-SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-parseable-module-interface -parse-as-library
+SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -parse-as-library
 
 # Don't include the wrapped .swiftmodule on Linux to make sure we use
 # the .swiftinterface. The issue here is that if the .swiftmodule is wrapped


### PR DESCRIPTION
This mode is on by default in swiftc now.