### PR TITLE
allow users to specify an extra import search path in the environment

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2589,6 +2589,10 @@ swift::SearchPathOptions &SwiftASTContext::GetSearchPathOptions() {
       search_path_opts.ImportSearchPaths.emplace_back(repl_modules_dir);
     }
 
+    // Allow users to specify an extra import search path in the environment.
+    if (auto *import_search_path = getenv("SWIFT_IMPORT_SEARCH_PATH")) {
+      search_path_opts.ImportSearchPaths.emplace_back(import_search_path);
+    }
   }
 
   return search_path_opts;


### PR DESCRIPTION
This will allow the package installation feature (https://github.com/google/swift-jupyter/pull/45) to put the swiftmodule files in a temporary directory so that installations in different sessions don't clash with each other.