### PR TITLE
Support resilient values

### DIFF
--- a/include/lldb/Core/ValueObjectConstResult.h
+++ b/include/lldb/Core/ValueObjectConstResult.h
@@ -124,6 +124,7 @@ protected:
   uint64_t m_byte_size;
 
   ValueObjectConstResultImpl m_impl;
+  bool m_is_swift_fixed_value_buffer;
 
 private:
   friend class ValueObjectConstResultImpl;

--- a/include/lldb/Expression/ExpressionVariable.h
+++ b/include/lldb/Expression/ExpressionVariable.h
@@ -104,8 +104,9 @@ public:
                                 ///than the location
     EVUnknownType = 1 << 7, ///< This is a symbol of unknown type, and the type
                             ///must be resolved after parsing is complete
-    EVBareRegister = 1 << 8 ///< This variable is a direct reference to $pc or
-                            ///some other entity.
+    EVBareRegister = 1 << 8, ///< This variable is a direct reference to $pc or
+                             ///some other entity.
+    EVIsSwiftFixedBuffer = 1 << 9 ///< A Swift global in a fixed-size buffer.
   };
 
   typedef uint16_t FlagType;

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -395,6 +395,8 @@ public:
 
   const swift::irgen::FixedTypeInfo *GetSwiftFixedTypeInfo(void *type);
 
+  bool IsFixedSize(CompilerType compiler_type);
+
   DWARFASTParser *GetDWARFParser() override;
 
   //----------------------------------------------------------------------

--- a/include/lldb/Symbol/Type.h
+++ b/include/lldb/Symbol/Type.h
@@ -209,6 +209,17 @@ public:
     m_flags.is_complete_objc_class = is_complete_objc_class;
   }
 
+  /// \return whether this is a Swift fixed-size buffer. Resilient variables in
+  /// fixed-size buffers may be indirect depending on the runtime size of the
+  /// type. This is more a property of the value than of its type.
+  bool IsSwiftFixedValueBuffer() const {
+    return m_flags.is_swift_fixed_value_buffer;
+  }
+
+  void SetSwiftFixedValueBuffer(bool is_swift_fixed_value_buffer) {
+    m_flags.is_swift_fixed_value_buffer = is_swift_fixed_value_buffer;
+  }
+
 protected:
   ConstString m_name;
   SymbolFile *m_symbol_file;
@@ -230,6 +241,7 @@ protected:
     ResolveState compiler_type_resolve_state : 2;
 #endif
     bool is_complete_objc_class : 1;
+    bool is_swift_fixed_value_buffer : 1;
   } m_flags;
 
   Type *GetEncodingType();

--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -113,6 +113,10 @@ public:
     return addr;
   }
 
+  /// \return whether the dynamic value stored in a Swift fixed buffer
+  /// fits into that buffer or is indirect and allocated on the heap.
+  virtual bool IsStoredInlineInBuffer(CompilerType type) { return true; }
+
   virtual void SetExceptionBreakpoints() {}
 
   virtual void ClearExceptionBreakpoints() {}

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -39,6 +39,7 @@ template <unsigned PointerSize> struct RuntimeTarget;
 
 namespace reflection {
 template <typename T> class ReflectionContext;
+class TypeInfo;
 }
 
 namespace remoteAST {
@@ -279,6 +280,13 @@ public:
   FixupPointerValue(lldb::addr_t addr, CompilerType type) override;
   virtual lldb::addr_t FixupAddress(lldb::addr_t addr, CompilerType type,
                                     Status &error) override;
+
+  /// Ask Remote Mirrors for the type info about a Swift type.
+  const swift::reflection::TypeInfo *GetTypeInfo(CompilerType type);
+  virtual bool IsStoredInlineInBuffer(CompilerType type) override;
+
+  /// Ask Remote Mirrors for the size of a Swift type.
+  llvm::Optional<uint64_t> GetBitSize(CompilerType type);
 
   bool IsRuntimeSupportValue(ValueObject &valobj) override;
 

--- a/lit/SwiftREPL/FoundationTypes.test
+++ b/lit/SwiftREPL/FoundationTypes.test
@@ -35,3 +35,9 @@ let n = Notification(name: Notification.Name("abc"), object: Double(42.0), userI
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
+n
+
+// CHECK:      {{.*R.*}}: Notification = {
+// CHECK-NEXT:   name = "abc"
+// CHECK-NEXT:   object = 42

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/Makefile
@@ -1,40 +1,37 @@
 LEVEL = ../../../make
 
 EXE=
-override MAKE_DSYM=NO
+all: libmod.a.dylib libmod.b.dylib main.a main.b
 
 include $(LEVEL)/Makefile.rules
 
-MACOSX_DEPLOYMENT_TARGET ?= 10.10
-SWIFT_TRIPLE ?= -target x86_64-apple-macosx$(MACOSX_DEPLOYMENT_TARGET)
-
-SWIFTFLAGS += -enable-library-evolution $(SWIFT_TRIPLE)
-
-all: libmod.a.dylib libmod.b.dylib main.a main.b
-
 libmod.%.dylib: mod.%.swift
 	ln -sf $< mod.swift
-	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib
-ifneq "$(CODESIGN)" ""
-	$(CODESIGN) -s - "$@"
-endif
-	mv mod.swiftdoc mod.$*.swiftdoc
+	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_NAME=mod \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+	mv libmod.dylib $@
+	mv libmod.dylib.dSYM $@.dSYM || true
 	mv mod.swiftmodule mod.$*.swiftmodule
-	rm mod.swift
+	mv mod.o mod.$*.o
+	rm mod.swift mod.partial.swiftmodule
 
 main.%: main.swift
 	ln -sf libmod.$*.dylib libmod.dylib
 	ln -sf libmod.$*.dylib.dSYM libmod.dylib.dSYM
 	ln -sf mod.$*.swiftdoc mod.swiftdoc
 	ln -sf mod.$*.swiftmodule mod.swiftmodule
-	$(SWIFTC) $(SWIFTFLAGS) $< -o main -L$(shell pwd) -I$(shell pwd) -lmod
-ifneq "$(CODESIGN)" ""
-	$(CODESIGN) -s - main
-endif
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/exe.mk all
 	mv main main.$*
-	mv main.dSYM main.$*.dSYM
-	rm libmod.dylib libmod.dylib.dSYM mod.swiftdoc mod.swiftmodule
+	mv main.dSYM main.$*.dSYM || true
+	rm -rf libmod.dylib libmod.dylib.dSYM mod.swiftdoc mod.swiftmodule
+
+$(DSYM):
+	echo "Already built by exe.mk"
 
 clean::
-	rm -rf main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift
-
+	rm -rf main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift *.o

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/dylib.mk
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+DYLIB_ONLY := YES
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+SWIFTFLAGS_EXTRAS = -I$(shell pwd) -enable-library-evolution
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/exe.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/exe.mk
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+EXE := main
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(shell pwd)
+LD_EXTRAS = -lmod -L$(shell pwd)
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/main.swift
@@ -12,12 +12,31 @@
 import mod
 
 func main() {
+  initGlobal()
   let s = S()
   let a = fA(s)
   print(s.a) // break here
   print(a)
 }
 
-let global = S()
-print(global.a) // break here
-main()
+fileprivate class Message { fileprivate var s = "world" }
+fileprivate struct NotBitwiseTakable {
+  fileprivate weak var msg : Message?
+}
+private struct FixedContainer {
+  var s = S()
+}
+private struct NestedFixedContainer {
+  var s = FixedContainer()
+}
+
+private var g_main_msg = Message()
+private var g_main_b = NotBitwiseTakable()
+private var g_main_s = S()
+private var g_main_t = (S(), S())
+private var g_main_nested_t = ((1, S()), 2)
+private var g_main_c = FixedContainer()
+private var g_main_nested_c = NestedFixedContainer()
+g_main_b.msg = g_main_msg
+print(g_main_s.a + g_main_t.0.a + g_main_c.s.a)
+main() // break here

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/mod.a.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/mod.a.swift
@@ -12,12 +12,32 @@
 
 public struct S {
   public var a = 1
-  public var s1 = "i"
-  public var s2 = "am"
-  public var s3 = "large"
-  public var s4 = "!"
+  fileprivate var s1 = "i"
+  fileprivate var s2 = "am"
+  fileprivate var s3 = "large"
+  fileprivate var s4 = "!"
 
   public init() {}
+}
+
+fileprivate class Message { fileprivate var s = "hello" }
+fileprivate struct NotBitwiseTakable {
+  fileprivate weak var msg : Message?
+}
+
+fileprivate struct FixedContainer {
+    var s = S()
+}
+
+fileprivate var g_msg = Message()
+fileprivate var g_b = NotBitwiseTakable()
+fileprivate var g_s = S()
+fileprivate var g_t = (S(), S())
+fileprivate var g_c = FixedContainer()
+
+public func initGlobal() -> Int {
+  g_b.msg = g_msg
+  return g_s.a + g_t.0.a + g_c.s.a
 }
 
 public func fA(_ x: S) -> Int {

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/mod.b.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/mod.b.swift
@@ -17,6 +17,26 @@ public struct S {
   public init() {}
 }
 
+fileprivate class Message { fileprivate var s = "hello" }
+fileprivate struct NotBitwiseTakable {
+  fileprivate weak var msg : Message?
+}
+
+fileprivate struct FixedContainer {
+    var s = S()
+}
+
+fileprivate var g_msg = Message()
+fileprivate var g_b = NotBitwiseTakable()
+fileprivate var g_s = S()
+fileprivate var g_t = (S(), S())
+fileprivate var g_c = FixedContainer()
+
+public func initGlobal() -> Int {
+  g_b.msg = g_msg
+  return g_s.a + g_t.0.a + g_c.s.a
+}
+
 public func fA(_ x: S) -> Int {
   return x.b - 1
 }

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -29,10 +29,10 @@
 # Uncomment line below for debugging shell commands
 # SHELL = /bin/sh -x
 
-SRCDIR := $(shell dirname $(firstword $(MAKEFILE_LIST)))/
+SRCDIR := $(shell dirname $(firstword $(MAKEFILE_LIST)))
 BUILDDIR := $(shell pwd)
-THIS_FILE_DIR := $(shell dirname $(lastword $(MAKEFILE_LIST)))/
-LLDB_BASE_DIR := $(THIS_FILE_DIR)../../../../../
+THIS_FILE_DIR := $(shell dirname $(lastword $(MAKEFILE_LIST)))
+LLDB_BASE_DIR := $(THIS_FILE_DIR)/../../../../../
 
 #----------------------------------------------------------------------
 # If OS is not defined, use 'uname -s' to determine the OS name.
@@ -307,7 +307,7 @@ else
 	CFLAGS += $(ARCHFLAG)$(ARCH) $(FRAMEWORK_INCLUDES) -I$(LLDB_BASE_DIR)include
 endif
 
-CFLAGS += -I$(SRCDIR) -include $(THIS_FILE_DIR)test_common.h -I$(THIS_FILE_DIR)
+CFLAGS += -I$(SRCDIR) -include $(THIS_FILE_DIR)/test_common.h -I$(THIS_FILE_DIR)
 CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS)
 SWIFTFLAGS += $(TRIPLE_SWIFTFLAGS)
 SWIFTFLAGS += $(SWIFTFLAGS_EXTRAS)
@@ -653,6 +653,7 @@ MODULENAME=$(shell basename $(EXE) .out)
 else
 EXE = $(DYLIB_FILENAME)
 MODULENAME=$(DYLIB_NAME)
+SWIFT_FEFLAGS += -parse-as-library
 endif
 
 VPATHSOURCES=$(patsubst %,$(VPATH)/%,$(SWIFT_SOURCES))
@@ -692,7 +693,7 @@ $(MODULENAME).swiftmodule: $(OBJECTS) $(DYLIB_OBJECTS)
 	$(SWIFT_FE) $(SWIFT_FEFLAGS) -merge-modules \
 	  -emit-module $(patsubst %.swift,%.partial.swiftmodule,$(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)) \
 	  -emit-parseable-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface \
-	  -parse-as-library -sil-merge-partial-modules \
+	  -sil-merge-partial-modules \
 	  -disable-diagnostic-passes -disable-sil-perf-optzns \
 	  -module-name $(MODULENAME) \
 	  -o $(BUILDDIR)/$@

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1476,7 +1476,14 @@ SymbolFileDWARFDebugMap::GetASTData(lldb::LanguageType language) {
     } else {
       // Try to load the specified file.
       FileSpec file_spec(symbol->GetName().GetCString());
-      if (FileSystem::Instance().Exists(file_spec)) {
+      bool exists = FileSystem::Instance().Exists(file_spec);
+      if (!exists)
+        if (file_spec.GetDirectory().IsEmpty() && m_obj_file) {
+          // For relative paths, search next to the binary.
+          file_spec.GetDirectory() = m_obj_file->GetFileSpec().GetDirectory();
+          exists = FileSystem::Instance().Exists(file_spec);
+        }
+      if (exists) {
         // We found the source data for the AST data blob.
         // Read it in and add it to our return vector.
         std::shared_ptr<DataBufferLLVM> data_buf_sp 

--- a/source/Symbol/Type.cpp
+++ b/source/Symbol/Type.cpp
@@ -126,6 +126,7 @@ Type::Type(lldb::user_id_t uid, SymbolFile *symbol_file,
   m_flags.compiler_type_resolve_state =
       (compiler_type ? compiler_type_resolve_state : eResolveStateUnresolved);
   m_flags.is_complete_objc_class = false;
+  m_flags.is_swift_fixed_value_buffer = false;
 }
 
 Type::Type()


### PR DESCRIPTION
Specifically LLDB now calls into Remote Mirrors to determine whether a
resilient value that is stored in a fixed-size buffer is stored inline
or not.
    
rdar://problem/48018240