### PR TITLE
Change the logging on ptrace(PT_KILL) in MachProcess::Kill to log

### DIFF
--- a/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -1290,9 +1290,11 @@ bool MachProcess::Kill(const struct timespec *timeout_abstime) {
   ::ptrace(PT_KILL, m_pid, 0, 0);
   DNBError err;
   err.SetErrorToErrno();
-  DNBLogThreadedIf(LOG_PROCESS, "MachProcess::Kill() DoSIGSTOP() ::ptrace "
-                                "(PT_KILL, pid=%u, 0, 0) => 0x%8.8x (%s)",
-                   m_pid, err.Status(), err.AsString());
+  if (DNBLogCheckLogBit(LOG_PROCESS) || err.Fail()) {
+    err.LogThreaded("MachProcess::Kill() DoSIGSTOP() ::ptrace "
+            "(PT_KILL, pid=%u, 0, 0) => 0x%8.8x (%s)",
+            m_pid, err.Status(), err.AsString());
+  }
   m_thread_actions = DNBThreadResumeActions(eStateRunning, 0);
   PrivateResume();
 


### PR DESCRIPTION
Change the logging on ptrace(PT_KILL) in MachProcess::Kill to log
if LOG_PROCESS is enabled or if there was an error making that call.

<rdar://problem/49036508> 


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@356626 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 9df5ddbd4e97a8c986b0c199eb4e6fc70e423050)