### PR TITLE
 Add -fmodule-map-file= to RemapClangImporterOptions whitelist

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1380,6 +1380,7 @@ namespace {
 bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
   static StringRef options[] = {"-I",
                                 "-F",
+                                "-fmodule-map-file=",
                                 "-iquote",
                                 "-idirafter",
                                 "-iframeworkwithsysroot",


### PR DESCRIPTION
See discussion https://github.com/apple/swift-lldb/pull/1369

(cherry picked from commit 14b40731018c79df8b2e9c5fc30678aae0e320a2)