### PR TITLE
[Reproducers] Fix GDB remote flakiness during replay

### DIFF
--- a/lit/Reproducer/Functionalities/TestDataFormatter.test
+++ b/lit/Reproducer/Functionalities/TestDataFormatter.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-freebsd, system-linux
+# UNSUPPORTED: system-windows, system-freebsd
 
 # This tests that data formatters continue to work when replaying a reproducer.
 

--- a/lit/Reproducer/Functionalities/TestImageList.test
+++ b/lit/Reproducer/Functionalities/TestImageList.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-freebsd, system-linux
+# UNSUPPORTED: system-windows, system-freebsd
 
 # This tests that image list works when replaying. We arbitrarily assume
 # there's at least two entries and compare that they're identical.

--- a/lit/Reproducer/Functionalities/TestStepping.test
+++ b/lit/Reproducer/Functionalities/TestStepping.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-freebsd, system-linux
+# UNSUPPORTED: system-windows, system-freebsd
 
 # This tests that stepping continues to work when replaying a reproducer.
 

--- a/lit/Reproducer/TestGDBRemoteRepro.test
+++ b/lit/Reproducer/TestGDBRemoteRepro.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-freebsd, system-linux
+# UNSUPPORTED: system-windows, system-freebsd
 
 # This tests the replaying of GDB remote packets.
 #

--- a/lit/Reproducer/TestReuseDirectory.test
+++ b/lit/Reproducer/TestReuseDirectory.test
@@ -1,4 +1,4 @@
-# UNSUPPORTED: system-windows, system-freebsd, system-linux
+# UNSUPPORTED: system-windows, system-freebsd
 
 # Test that we can capture twice to the same directory without breaking the
 # reproducer functionality.


### PR DESCRIPTION
This fixes the flakiness of the GDB remote reproducer during replay. It
was caused by a combination sending one ACK to many from the replay
server and the code that "flushes" any queued GDB remote packets in
GDBRemoteCommunicationClient::HandshakeWithServer.

The spurious ACK was the result of combining both implicit and explicit
handling of ACKs in the replay server. The handshake consists of an ACK
followed by an QStartNoAckMode. As long as we haven't seen any
QStartNoAckMode, we were sending implicit acknowledgments. So the first
ACK got acknowledged twice, once implicitly, and once as part of the
replay.

The reason we didn't notice this was the code in HandshakeWithServer
that "waits for any responses that might have been queued up in the
remote GDB server and flush them all". A 10ms timeout is used to move on
when no packets are left. If the second ACK didn't make it within those
10ms, all packets were offset by one.