### PR TITLE
[Args] Handle backticks to prevent crash.

### DIFF
--- a/source/Utility/Args.cpp
+++ b/source/Utility/Args.cpp
@@ -722,14 +722,15 @@ std::string Args::EscapeLLDBCommandArgument(const std::string &arg,
   case '\0':
     chars_to_escape = " \t\\'\"`";
     break;
-  case '\'':
-    chars_to_escape = "";
-    break;
   case '"':
     chars_to_escape = "$\"`\\";
     break;
+  case '`':
+  case '\'':
+    return arg;
   default:
     assert(false && "Unhandled quote character");
+    return arg;
   }
 
   std::string res;

--- a/unittests/Utility/ArgsTest.cpp
+++ b/unittests/Utility/ArgsTest.cpp
@@ -188,3 +188,29 @@ TEST(ArgsTest, GetArgumentArrayRef) {
   EXPECT_STREQ("foo", ref[0]);
   EXPECT_STREQ("bar", ref[1]);
 }
+
+TEST(ArgsTest, EscapeLLDBCommandArgument) {
+  const std::string foo = "foo'";
+  EXPECT_EQ("foo\\'", Args::EscapeLLDBCommandArgument(foo, '\0'));
+  EXPECT_EQ("foo'", Args::EscapeLLDBCommandArgument(foo, '\''));
+  EXPECT_EQ("foo'", Args::EscapeLLDBCommandArgument(foo, '`'));
+  EXPECT_EQ("foo'", Args::EscapeLLDBCommandArgument(foo, '"'));
+
+  const std::string bar = "bar\"";
+  EXPECT_EQ("bar\\\"", Args::EscapeLLDBCommandArgument(bar, '\0'));
+  EXPECT_EQ("bar\"", Args::EscapeLLDBCommandArgument(bar, '\''));
+  EXPECT_EQ("bar\"", Args::EscapeLLDBCommandArgument(bar, '`'));
+  EXPECT_EQ("bar\\\"", Args::EscapeLLDBCommandArgument(bar, '"'));
+
+  const std::string baz = "baz`";
+  EXPECT_EQ("baz\\`", Args::EscapeLLDBCommandArgument(baz, '\0'));
+  EXPECT_EQ("baz`", Args::EscapeLLDBCommandArgument(baz, '\''));
+  EXPECT_EQ("baz`", Args::EscapeLLDBCommandArgument(baz, '`'));
+  EXPECT_EQ("baz\\`", Args::EscapeLLDBCommandArgument(baz, '"'));
+
+  const std::string quux = "quux\t";
+  EXPECT_EQ("quux\\\t", Args::EscapeLLDBCommandArgument(quux, '\0'));
+  EXPECT_EQ("quux\t", Args::EscapeLLDBCommandArgument(quux, '\''));
+  EXPECT_EQ("quux\t", Args::EscapeLLDBCommandArgument(quux, '`'));
+  EXPECT_EQ("quux\t", Args::EscapeLLDBCommandArgument(quux, '"'));
+}


### PR DESCRIPTION
Currently LLDB crashes when autocompleting a command that ends with a
backtick because the quote character wasn't handled. This fixes that and
adds a unit test for this function.

Differential revision: https://reviews.llvm.org/D59779

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@356927 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d28b1d4585a356d0bffdb4eb7e9816b2a8e7b5aa)