### PR TITLE
Pass /bigobj for SBReproducer.cpp with MSVC

### DIFF
--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -103,6 +103,10 @@ add_lldb_library(liblldb SHARED
     Support
   )
 
+if (MSVC)
+  set_source_files_properties(SBReproducer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
 if(lldb_python_wrapper)
   add_dependencies(liblldb swig_wrapper)
 


### PR DESCRIPTION
/BIGOBJ is used to bypass certain COFF file format
limitations and is used with, unsurprisingly, very big
object files.  This file has grown large enough that it
needs this flag in order to compile successfully.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@355559 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e6aef474e2c0ce41e29d91555be81270d7f4804a)