### PR TITLE
[CMake] Re-add ExpressionSourceCode.cpp to CMake

### DIFF
--- a/source/Expression/CMakeLists.txt
+++ b/source/Expression/CMakeLists.txt
@@ -6,6 +6,7 @@ add_lldb_library(lldbExpression
   DiagnosticManager.cpp
   DWARFExpression.cpp
   Expression.cpp
+  ExpressionSourceCode.cpp
   ExpressionVariable.cpp
   FunctionCaller.cpp
   IRDynamicChecks.cpp


### PR DESCRIPTION
This file got removed from llvm.org but remains in swift-lldb. It looks
like this got dropped during a merge but it is needed to build
upstream-with-swift.

cc @dcci @jimingham @JDevlieghere @adrian-prantl @compnerd 