### PR TITLE
[Swift] Test simple cases of @_implementationOnly import 

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/ReadMe.md
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/ReadMe.md
@@ -1,0 +1,11 @@
+These tests concern the experimental Swift feature `@_implementationOnly import`.\* Unlike a normal import, an `@_implementationOnly` import is guaranteed not to be part of a library's API or ABI, which means that client apps don't have to know about the import at all to use the library. However, the import *can* be used in the *implementation* of the library, so it's important for LLDB to handle the cases where the `@_implementationOnly` import is and isn't available when debugging.
+
+In a scenario with a client app, a library, and an implementation-only import that the library uses, there are three situations we care about:
+
+1. The library has no debug info, or just line tables. In this case, the implementation-only import is irrelevant; someone debugging the app can only use the public parts of the library.
+
+2. The library has debug info and the implementation-only import is available. In this case, the debugger should make everything available like it would with a normal import.
+
+3. The library has debug info, but the implementation-only import is not available (for whatever reason). In this case LLDB may still have to deal with internal parts of the library even though some types will not be available. (This is the least important case, but it'd be good to not crash or lie to users.)
+
+\* Hopefully someone will remember to edit this ReadMe before the feature goes public!

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -1,0 +1,21 @@
+LEVEL = ../../../../make
+
+EXE=a.out
+SWIFT_SOURCES=main.swift
+SWIFTFLAGS_EXTRAS= -I$(shell pwd)
+MODULENAME=main
+LD_EXTRAS=-L$(shell pwd) -lSomeLibrary
+
+all: SomeLibrary.swiftmodule a.out
+
+include $(LEVEL)/Makefile.rules
+
+SomeLibrary.swiftmodule: SomeLibrary.swift
+	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=$(shell basename $< .swift) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+
+clean::
+	rm -rf main *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/SomeLibrary.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/SomeLibrary.swift
@@ -1,0 +1,8 @@
+public struct TwoInts {
+  public var first: Int
+  public var second: Int
+  public init(_ first: Int, _ second: Int) {
+    self.first = first
+    self.second = second
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -1,0 +1,65 @@
+# TestMainExecutable.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test `@_implementationOnly import` in the main executable
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import time
+import unittest2
+
+class TestMainExecutable(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    
+    @swiftTest
+    def test_implementation_only_import_main_executable(self):
+        """Test `@_implementationOnly import` in the main executable"""
+        self.build()
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.TwoInts) value = (first = 2, second = 3)",
+            "(main.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}"])
+        self.expect("e value", substrs=["(SomeLibrary.TwoInts)", "= (first = 2, second = 3)"])
+        self.expect("e container", substrs=["(main.ContainsTwoInts)", "wrapped = (first = 2, second = 3)", "other = 10"])
+        self.expect("e TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
+    
+    @swiftTest
+    def test_implementation_only_import_main_executable_no_library_module(self):
+        """Test `@_implementationOnly import` in the main executable, after removing the library's swiftmodule"""
+        self.build()
+        os.remove(os.path.join(self.getBuildDir(), "SomeLibrary.swiftmodule"))
+        os.remove(os.path.join(self.getBuildDir(), "SomeLibrary.swiftinterface"))
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+
+        self.expect("fr var", substrs=[
+            "value = <could not resolve type>",
+            "container = (other = 10)"])
+        # FIXME: Ideally we would still show that 'value' exists but make it unusable somehow.
+        self.expect("e value", error=True, substrs=["error: use of unresolved identifier 'value'"])
+        # FIXME: The representation of 'container' is garbage because we've dropped a field.
+        # The compiler should keep track of this.
+        self.expect("e container", substrs=["(main.ContainsTwoInts)", "other = "])
+        # This one's probably unavoidable, though.
+        self.expect("e TwoInts(4, 5)", error=True, substrs=["error: use of unresolved identifier 'TwoInts'"])

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/dylib.mk
@@ -1,0 +1,8 @@
+LEVEL = ../../../../make
+DYLIB_ONLY := YES
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+# Disable debug info for the library.
+SWIFTFLAGS := -gnone
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/main.swift
@@ -1,0 +1,13 @@
+@_implementationOnly import SomeLibrary
+
+struct ContainsTwoInts {
+  var wrapped: TwoInts
+  var other: Int
+}
+
+func test(_ value: TwoInts) {
+  let container = ContainsTwoInts(wrapped: value, other: 10)
+  return // break here
+}
+
+test(TwoInts(2, 3))

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/Makefile
@@ -1,0 +1,21 @@
+LEVEL = ../../../../make
+
+EXE=a.out
+SWIFT_SOURCES=main.swift
+SWIFTFLAGS_EXTRAS= -I$(shell pwd)
+MODULENAME=main
+LD_EXTRAS=-L$(shell pwd) -lSomeLibrary
+
+all: SomeLibrary.swiftmodule a.out
+
+include $(LEVEL)/Makefile.rules
+
+SomeLibrary.swiftmodule: SomeLibrary.swift
+	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=$(shell basename $< .swift) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+
+clean::
+	rm -rf main *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/SomeLibrary.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/SomeLibrary.swift
@@ -1,0 +1,8 @@
+public struct TwoInts {
+  public var first: Int
+  public var second: Int
+  public init(_ first: Int, _ second: Int) {
+    self.first = first
+    self.second = second
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/TestMainExecutableResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/TestMainExecutableResilient.py
@@ -1,0 +1,65 @@
+# TestMainExecutableResilient.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test `@_implementationOnly import` in the main executable with a resilient library
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import time
+import unittest2
+
+class TestMainExecutable(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    
+    @swiftTest
+    def test_implementation_only_import_main_executable_resilient(self):
+        """Test `@_implementationOnly import` in the main executable with a resilient library"""
+        self.build()
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.TwoInts) value = (first = 2, second = 3)",
+            "(main.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}"])
+        self.expect("e value", substrs=["(SomeLibrary.TwoInts)", "= (first = 2, second = 3)"])
+        self.expect("e container", substrs=["(main.ContainsTwoInts)", "wrapped = (first = 2, second = 3)", "other = 10"])
+        self.expect("e TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
+    
+    @swiftTest
+    def test_implementation_only_import_main_executable_resilient_no_library_module(self):
+        """Test `@_implementationOnly import` in the main executable with a resilient library, after removing the library's swiftmodule"""
+        self.build()
+        os.remove(os.path.join(self.getBuildDir(), "SomeLibrary.swiftmodule"))
+        os.remove(os.path.join(self.getBuildDir(), "SomeLibrary.swiftinterface"))
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+
+        self.expect("fr var", substrs=[
+            "value = <could not resolve type>",
+            "(main.ContainsTwoInts) container = (other = 10)"])
+        # FIXME: Ideally we would still show that 'value' exists but make it unusable somehow.
+        self.expect("e value", error=True, substrs=["error: use of unresolved identifier 'value'"])
+        # FIXME: This representation of 'container' is garbage because we've dropped a field.
+        # The compiler should keep track of this.
+        self.expect("e container", substrs=["(main.ContainsTwoInts)", "other = "])
+        # This one's probably unavoidable, though.
+        self.expect("e TwoInts(4, 5)", error=True, substrs=["error: use of unresolved identifier 'TwoInts'"])

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/dylib.mk
@@ -1,0 +1,8 @@
+LEVEL = ../../../../make
+DYLIB_ONLY := YES
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+# Disable debug info for the library.
+SWIFTFLAGS := -gnone -enable-library-evolution
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable_resilient/main.swift
@@ -1,0 +1,13 @@
+@_implementationOnly import SomeLibrary
+
+struct ContainsTwoInts {
+  var wrapped: TwoInts
+  var other: Int
+}
+
+func test(_ value: TwoInts) {
+  let container = ContainsTwoInts(wrapped: value, other: 10)
+  return // break here
+}
+
+test(TwoInts(2, 3))

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -649,10 +649,10 @@ endif
 ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(DYLIB_NAME)" ""
-MODULENAME=$(shell basename $(EXE) .out)
+MODULENAME?=$(shell basename $(EXE) .out)
 else
 EXE = $(DYLIB_FILENAME)
-MODULENAME=$(DYLIB_NAME)
+MODULENAME?=$(DYLIB_NAME)
 SWIFT_FEFLAGS += -parse-as-library
 endif
 


### PR DESCRIPTION
More tests to come, but this gets the "don't crash" part in place, and help shake out a bug in the Swift implementation.

Builds on #1139, also depends on a small Swift change that isn't on GitHub yet (to not produce an error when an implementation-only import can't be loaded).