### PR TITLE
[Swift] The AST printer now qualifies type names more consistently

### DIFF
--- a/lit/Swift/DynamicTyperesolutionConflict.test
+++ b/lit/Swift/DynamicTyperesolutionConflict.test
@@ -25,5 +25,5 @@ p input
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: {{Swift}} error in fallback scratch context
 # CHECK: {{This}} error message is displayed only once.
-# CHECK: (LibraryProtocol) ${{R0}} =
-# CHECK: (LibraryProtocol) ${{R2}} =
+# CHECK: (Dylib.LibraryProtocol) ${{R0}} =
+# CHECK: (Dylib.LibraryProtocol) ${{R2}} =

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -75,20 +75,20 @@ class TestSwiftTypeAliasFormatters(TestBase):
         self.expect("frame variable f", substrs=['Foo) f = (value = 12)'])
         self.expect("frame variable b", substrs=['Bar) b = (value = 24)'])
 
-        self.runCmd('type summary add Foo -v -s "hello"')
+        self.runCmd('type summary add a.Foo -v -s "hello"')
         self.expect("frame variable f", substrs=['Foo) f = hello'])
         self.expect("frame variable b", substrs=['Bar) b = hello'])
 
-        self.runCmd('type summary add Bar -v -s "hi"')
+        self.runCmd('type summary add a.Bar -v -s "hi"')
         self.expect("frame variable f", substrs=['Foo) f = hello'])
         self.expect("frame variable b", substrs=['Bar) b = hi'])
 
-        self.runCmd("type summary delete Foo")
+        self.runCmd("type summary delete a.Foo")
         self.expect("frame variable f", substrs=['Foo) f = (value = 12)'])
         self.expect("frame variable b", substrs=['Bar) b = hi'])
 
-        self.runCmd("type summary delete Bar")
-        self.runCmd("type summary add -C no -v Foo -s hello")
+        self.runCmd("type summary delete a.Bar")
+        self.runCmd("type summary add -C no -v a.Foo -s hello")
         self.expect("frame variable f", substrs=['Foo) f = hello'])
         self.expect("frame variable b", substrs=['Bar) b = (value = 24)'])
 

--- a/packages/Python/lldbsuite/test/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -69,7 +69,7 @@ class TestSwiftAnyObjectType(TestBase):
             self,
             var_object,
             use_dynamic=False,
-            typename="AnyObject")
+            typename="Swift.AnyObject")
         lldbutil.check_variable(
             self,
             var_object,

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -56,13 +56,13 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
                                           lldb.SBFileSpec('Dylib.swift'))
         self.expect("bt", substrs=['Dylib.swift'])
         self.expect("fr v -d no-dynamic-values -- input",
-                    substrs=['(LibraryProtocol) input'])
+                    substrs=['(Dylib.LibraryProtocol) input'])
         self.expect("fr v -d run-target -- input",
-                    substrs=['(LibraryProtocol) input'])
+                    substrs=['(Dylib.LibraryProtocol) input'])
                     # FIXME: substrs=['(main.FromMainModule) input'])
         self.expect("expr -d run-target -- input",
                     "test that the expression evaluator can recover",
-                    substrs=['(LibraryProtocol) $R0'])
+                    substrs=['(Dylib.LibraryProtocol) $R0'])
                     # FIXME: substrs=['(main.FromMainModule) input'])
                     
 

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -41,7 +41,7 @@ class TestSwiftRemoteASTImport(TestBase):
                                           lldb.SBFileSpec('Library.swift'))
         # FIXME: Reversing the order of these two commands does not work!
         self.expect("expr -d no-dynamic-values -- input",
-                    substrs=['(LibraryProtocol) $R0'])
+                    substrs=['(Library.LibraryProtocol) $R0'])
         self.expect("expr -d run-target -- input",
                     substrs=['(a.FromMainModule) $R2'])
         

--- a/packages/Python/lldbsuite/test/lang/swift/metatype/TestSwiftMetatype.py
+++ b/packages/Python/lldbsuite/test/lang/swift/metatype/TestSwiftMetatype.py
@@ -47,7 +47,7 @@ class TestSwiftMetatype(TestBase):
         lldbutil.check_variable(self, var_c, False, "a.D")
         lldbutil.check_variable(self, var_f, False, "(Int) -> Int")
         lldbutil.check_variable(self, var_t, False, "(Int, Int, String)")
-        lldbutil.check_variable(self, var_p, False, "P")
+        lldbutil.check_variable(self, var_p, False, "a.P")
 
 if __name__ == '__main__':
     import atexit

--- a/packages/Python/lldbsuite/test/lang/swift/substituted_typealias/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/substituted_typealias/main.swift
@@ -15,7 +15,7 @@ func main() {
   let d = unsafeBitCast(5, to: Int.self)
   let x = unsafeBitCast(5, to: X.self)
   print("break here and do test") //%self.expect('frame variable d', substrs=['5'])
-  //%self.expect('frame variable x', substrs=['(X)', '5'])
+  //%self.expect('frame variable x', substrs=['.X)', '5'])
 }
 
 main()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -70,10 +70,10 @@ class TestSwiftObjCOptionalType(TestBase):
         """Check formatting for T? and T! when T is an ObjC type"""
         self.expect(
             "frame variable optColor_Some",
-            substrs=['(Color?) optColor_Some = 0x'])
+            substrs=['Color?) optColor_Some = 0x'])
         self.expect(
             "frame variable uoptColor_Some",
-            substrs=['(Color?) uoptColor_Some = 0x'])
+            substrs=['Color?) uoptColor_Some = 0x'])
 
         self.expect("frame variable optColor_None", substrs=['nil'])
         self.expect("frame variable uoptColor_None", substrs=['nil'])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -62,7 +62,7 @@ class TestSwiftProtocolTypes(TestBase):
         self.thread = threads[0]
 
         self.expect("frame variable --raw-output --show-types loc2d",
-                    substrs=['(PointUtils) loc2d =',
+                    substrs=['PointUtils) loc2d =',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
@@ -74,7 +74,7 @@ class TestSwiftProtocolTypes(TestBase):
                              'x = 1.25', 'y = 2.5'])
 
         self.expect("frame variable --raw-output --show-types loc3d",
-                    substrs=['(PointUtils) loc3d =',
+                    substrs=['PointUtils) loc3d =',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
@@ -90,7 +90,7 @@ class TestSwiftProtocolTypes(TestBase):
                 'z = 1.25'])
 
         self.expect("expression --raw-output --show-types -- loc2d",
-                    substrs=['(PointUtils) $R',
+                    substrs=['PointUtils) $R',
                              '(Builtin.RawPointer) payload_data_0 = 0x',
                              '(Builtin.RawPointer) payload_data_1 = 0x',
                              '(Builtin.RawPointer) payload_data_2 = 0x',
@@ -102,7 +102,7 @@ class TestSwiftProtocolTypes(TestBase):
                              'x = 1.25', 'y = 2.5'])
 
         self.expect("expression --raw-output --show-types -- loc3dCB",
-                    substrs=['(PointUtils & AnyObject) $R',
+                    substrs=['PointUtils & AnyObject) $R',
                              '(Builtin.RawPointer) instance = 0x',
                              '(Builtin.RawPointer) witness_table_PointUtils = 0x'])
 
@@ -110,7 +110,7 @@ class TestSwiftProtocolTypes(TestBase):
                     substrs=['Point3D) $R', 'x = 1.25', 'y = 2.5', 'z = 1.25'])
 
         self.expect("expression --raw-output --show-types -- loc3dSuper",
-                    substrs=['(a.PointSuperclass & PointUtils) $R',
+                    substrs=['(a.PointSuperclass & a.PointUtils) $R',
                              '(a.PointSuperclass) instance = 0x',
                              '(Swift.Int) superData = ',
                              '(Builtin.RawPointer) witness_table_PointUtils = 0x'])

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1187,9 +1187,11 @@ bool lldb_private::formatters::swift::GLKit_SummaryProvider(
 
   Process &process = *process_sp.get();
 
-  // Get the type name without the "simd.simd_" prefix.
+  // Get the type name without the "GLKit." prefix.
   ConstString full_type_name = valobj.GetTypeName();
   llvm::StringRef type_name = full_type_name.GetStringRef();
+  if (type_name.startswith("GLKit."))
+    type_name = type_name.drop_front(6);
 
   // Get the type of object this is.
   bool is_quaternion = type_name == "GLKQuaternion";


### PR DESCRIPTION
LLDB counterpart of apple/swift#22830.

This does have one breaking effect: formatters for protocols and typealiases will now have to match against the module name as well. Since this is consistent with structs and enums, this is probably worth it.