### PR TITLE
[API] Add SBReproducer to LLDB.h

### DIFF
--- a/include/lldb/API/LLDB.h
+++ b/include/lldb/API/LLDB.h
@@ -48,6 +48,7 @@
 #include "lldb/API/SBProcessInfo.h"
 #include "lldb/API/SBQueue.h"
 #include "lldb/API/SBQueueItem.h"
+#include "lldb/API/SBReproducer.h"
 #include "lldb/API/SBSection.h"
 #include "lldb/API/SBSourceManager.h"
 #include "lldb/API/SBStream.h"


### PR DESCRIPTION
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@357424 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 90743f29dfc9c0f0210dd9e8a9e9d1426d73e7f8)