### PR TITLE
When iterating over breakpoint site owners::ShouldStop, don't hold the list mutex

### DIFF
--- a/include/lldb/Breakpoint/BreakpointLocationCollection.h
+++ b/include/lldb/Breakpoint/BreakpointLocationCollection.h
@@ -22,6 +22,8 @@ public:
   BreakpointLocationCollection();
 
   ~BreakpointLocationCollection();
+  
+  BreakpointLocationCollection &operator=(const BreakpointLocationCollection &rhs);
 
   //------------------------------------------------------------------
   /// Add the breakpoint \a bp_loc_sp to the list.

--- a/include/lldb/Core/ModuleSpec.h
+++ b/include/lldb/Core/ModuleSpec.h
@@ -311,8 +311,10 @@ public:
 
   ModuleSpecList &operator=(const ModuleSpecList &rhs) {
     if (this != &rhs) {
-      std::lock_guard<std::recursive_mutex> lhs_guard(m_mutex);
-      std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_mutex);
+      std::lock(m_mutex, rhs.m_mutex);
+      std::lock_guard<std::recursive_mutex> lhs_guard(m_mutex, std::adopt_lock);
+      std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_mutex, 
+                                                      std::adopt_lock);
       m_specs = rhs.m_specs;
     }
     return *this;

--- a/include/lldb/Utility/StreamTee.h
+++ b/include/lldb/Utility/StreamTee.h
@@ -49,8 +49,11 @@ public:
   StreamTee &operator=(const StreamTee &rhs) {
     if (this != &rhs) {
       Stream::operator=(rhs);
-      std::lock_guard<std::recursive_mutex> lhs_locker(m_streams_mutex);
-      std::lock_guard<std::recursive_mutex> rhs_locker(rhs.m_streams_mutex);
+      std::lock(m_streams_mutex, rhs.m_streams_mutex);
+      std::lock_guard<std::recursive_mutex> lhs_locker(m_streams_mutex,
+                                                       std::adopt_lock);
+      std::lock_guard<std::recursive_mutex> rhs_locker(rhs.m_streams_mutex,
+                                                       std::adopt_lock);
       m_streams = rhs.m_streams;
     }
     return *this;

--- a/source/Breakpoint/BreakpointLocationCollection.cpp
+++ b/source/Breakpoint/BreakpointLocationCollection.cpp
@@ -181,17 +181,11 @@ void BreakpointLocationCollection::GetDescription(
 
 BreakpointLocationCollection &BreakpointLocationCollection::operator=(
     const BreakpointLocationCollection &rhs) {
-  // Same trick as in ModuleList to avoid lock inversion.
   if (this != &rhs) {
-    if (uintptr_t(this) > uintptr_t(&rhs)) {
-      std::lock_guard<std::mutex> lhs_guard(m_collection_mutex);
-      std::lock_guard<std::mutex> rhs_guard(rhs.m_collection_mutex);
+      std::lock(m_collection_mutex, rhs.m_collection_mutex);
+      std::lock_guard<std::mutex> lhs_guard(m_collection_mutex, std::adopt_lock);
+      std::lock_guard<std::mutex> rhs_guard(rhs.m_collection_mutex, std::adopt_lock);
       m_break_loc_collection = rhs.m_break_loc_collection;
-    } else {
-      std::lock_guard<std::mutex> lhs_guard(m_collection_mutex);
-      std::lock_guard<std::mutex> rhs_guard(rhs.m_collection_mutex);
-      m_break_loc_collection = rhs.m_break_loc_collection;
-    }
   }
   return *this;
 }

--- a/source/Breakpoint/BreakpointLocationCollection.cpp
+++ b/source/Breakpoint/BreakpointLocationCollection.cpp
@@ -178,3 +178,20 @@ void BreakpointLocationCollection::GetDescription(
     (*pos)->GetDescription(s, level);
   }
 }
+
+BreakpointLocationCollection &BreakpointLocationCollection::operator=(
+    const BreakpointLocationCollection &rhs) {
+  // Same trick as in ModuleList to avoid lock inversion.
+  if (this != &rhs) {
+    if (uintptr_t(this) > uintptr_t(&rhs)) {
+      std::lock_guard<std::mutex> lhs_guard(m_collection_mutex);
+      std::lock_guard<std::mutex> rhs_guard(rhs.m_collection_mutex);
+      m_break_loc_collection = rhs.m_break_loc_collection;
+    } else {
+      std::lock_guard<std::mutex> lhs_guard(m_collection_mutex);
+      std::lock_guard<std::mutex> rhs_guard(rhs.m_collection_mutex);
+      m_break_loc_collection = rhs.m_break_loc_collection;
+    }
+  }
+  return *this;
+}

--- a/source/Core/ModuleList.cpp
+++ b/source/Core/ModuleList.cpp
@@ -145,25 +145,12 @@ ModuleList::ModuleList(ModuleList::Notifier *notifier)
 
 const ModuleList &ModuleList::operator=(const ModuleList &rhs) {
   if (this != &rhs) {
-    // That's probably me nit-picking, but in theoretical situation:
-    //
-    // * that two threads A B and
-    // * two ModuleList's x y do opposite assignments ie.:
-    //
-    //  in thread A: | in thread B:
-    //    x = y;     |   y = x;
-    //
-    // This establishes correct(same) lock taking order and thus avoids
-    // priority inversion.
-    if (uintptr_t(this) > uintptr_t(&rhs)) {
-      std::lock_guard<std::recursive_mutex> lhs_guard(m_modules_mutex);
-      std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_modules_mutex);
-      m_modules = rhs.m_modules;
-    } else {
-      std::lock_guard<std::recursive_mutex> lhs_guard(m_modules_mutex);
-      std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_modules_mutex);
-      m_modules = rhs.m_modules;
-    }
+    std::lock(m_modules_mutex, rhs.m_modules_mutex);
+    std::lock_guard<std::recursive_mutex> lhs_guard(m_modules_mutex, 
+                                                    std::adopt_lock);
+    std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_modules_mutex, 
+                                                    std::adopt_lock);
+    m_modules = rhs.m_modules;
   }
   return *this;
 }

--- a/source/Target/SectionLoadList.cpp
+++ b/source/Target/SectionLoadList.cpp
@@ -27,8 +27,9 @@ SectionLoadList::SectionLoadList(const SectionLoadList &rhs)
 }
 
 void SectionLoadList::operator=(const SectionLoadList &rhs) {
-  std::lock_guard<std::recursive_mutex> lhs_guard(m_mutex);
-  std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_mutex);
+  std::lock(m_mutex, rhs.m_mutex);
+  std::lock_guard<std::recursive_mutex> lhs_guard(m_mutex, std::adopt_lock);
+  std::lock_guard<std::recursive_mutex> rhs_guard(rhs.m_mutex, std::adopt_lock);
   m_addr_to_sect = rhs.m_addr_to_sect;
   m_sect_to_addr = rhs.m_sect_to_addr;
 }

--- a/source/Target/ThreadList.cpp
+++ b/source/Target/ThreadList.cpp
@@ -37,8 +37,10 @@ const ThreadList &ThreadList::operator=(const ThreadList &rhs) {
   if (this != &rhs) {
     // Lock both mutexes to make sure neither side changes anyone on us while
     // the assignment occurs
-    std::lock_guard<std::recursive_mutex> guard(GetMutex());
-    std::lock_guard<std::recursive_mutex> rhs_guard(rhs.GetMutex());
+    std::lock(GetMutex(), rhs.GetMutex());
+    std::lock_guard<std::recursive_mutex> guard(GetMutex(), std::adopt_lock);
+    std::lock_guard<std::recursive_mutex> rhs_guard(rhs.GetMutex(), 
+                                                    std::adopt_lock);
 
     m_process = rhs.m_process;
     m_stop_id = rhs.m_stop_id;


### PR DESCRIPTION
The breakpoint site ShouldStop iterates over the list of owners calling ShouldStop, while holding the owner's list mutex.  If a ShouldStop call hits this same breakpoint on another thread we will deadlock against this mutex.  So copy the list and drop the lock and iterate over the copy to avoid the deadlock.

This patch also includes a fix-up for a bunch of our operator='s that were taking the pair of mutexes w/o worrying about priority inversion.