### PR TITLE
[Batch mode] Cope with bugs that cause error suppression.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2733,7 +2733,7 @@ public:
                    llvm::StringRef formatString,
                    llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
                    const swift::DiagnosticInfo &info,
-                   const SourceLoc bufferIndirectlyCausingDiagnostic) {
+                   const swift::SourceLoc bufferIndirectlyCausingDiagnostic) {
     llvm::StringRef bufferName = "<anonymous>";
     unsigned bufferID = 0;
     std::pair<unsigned, unsigned> line_col = {0, 0};

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2727,13 +2727,13 @@ public:
     m_ast_context.GetDiagnosticEngine().takeConsumers();
   }
 
-  virtual void handleDiagnostic(swift::SourceManager &source_mgr,
-                                swift::SourceLoc source_loc,
-                                swift::DiagnosticKind kind,
-                                llvm::StringRef formatString,
-                                llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
-                                const swift::DiagnosticInfo &info,
-                                const SourceLoc defaultDiagnosticLoc) {
+  virtual void
+  handleDiagnostic(swift::SourceManager &source_mgr,
+                   swift::SourceLoc source_loc, swift::DiagnosticKind kind,
+                   llvm::StringRef formatString,
+                   llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
+                   const swift::DiagnosticInfo &info,
+                   const SourceLoc bufferIndirectlyCausingDiagnostic) {
     llvm::StringRef bufferName = "<anonymous>";
     unsigned bufferID = 0;
     std::pair<unsigned, unsigned> line_col = {0, 0};

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2732,7 +2732,8 @@ public:
                                 swift::DiagnosticKind kind,
                                 llvm::StringRef formatString,
                                 llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
-                                const swift::DiagnosticInfo &info) {
+                                const swift::DiagnosticInfo &info,
+                                StringRef currentPrimaryInput) {
     llvm::StringRef bufferName = "<anonymous>";
     unsigned bufferID = 0;
     std::pair<unsigned, unsigned> line_col = {0, 0};

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2733,7 +2733,7 @@ public:
                                 llvm::StringRef formatString,
                                 llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
                                 const swift::DiagnosticInfo &info,
-                                StringRef currentPrimaryInput) {
+                                const SourceLoc defaultDiagnosticLoc) {
     llvm::StringRef bufferName = "<anonymous>";
     unsigned bufferID = 0;
     std::pair<unsigned, unsigned> line_col = {0, 0};


### PR DESCRIPTION
Companion to https://github.com/apple/swift/pull/23735

In batch mode, any diagnostics located in non-primary files are suppressed, with the expectation that they will surface when the containing file is compiled as primary. Although this assumption should hold, it does not always. For example, certain inputs can interact with associated type inferencing to violate it.

This PR tracks the current primary input in the DiagnosticEngine, which passed it down to the DiagnosticConsumer. The FileSpecificDiagnosticConsumer uses this information to output the diagnostic into the appropriate primary's .dia file. It addresses rdar://49303574.