### PR TITLE
Implement ComputeSwiftResourceDirectory work on all platforms

### DIFF
--- a/include/lldb/Host/HostInfoBase.h
+++ b/include/lldb/Host/HostInfoBase.h
@@ -92,8 +92,6 @@ public:
   /// FileSpec is filled in.
   static FileSpec GetGlobalTempDir();
 
-  static FileSpec GetSwiftDir();
-
   //---------------------------------------------------------------------------
   /// If the triple does not specify the vendor, os, and environment parts, we
   /// "augment" these using information from the host and return the resulting
@@ -112,7 +110,6 @@ protected:
   static bool ComputeTempFileBaseDirectory(FileSpec &file_spec);
   static bool ComputeHeaderDirectory(FileSpec &file_spec);
   static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);
-  static bool ComputeSwiftDirectory(FileSpec &file_spec);
   static bool ComputeUserPluginsDirectory(FileSpec &file_spec);
 
   static void ComputeHostArchitectureSupport(ArchSpec &arch_32,

--- a/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -39,11 +39,6 @@ protected:
   static bool ComputeHeaderDirectory(FileSpec &file_spec);
   static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);
   static bool ComputeUserPluginsDirectory(FileSpec &file_spec);
-
-  /// Swift additions.
-  /// @{
-  static bool ComputeSwiftDirectory(FileSpec &file_spec);
-  /// @}
 };
 }
 

--- a/include/lldb/Host/posix/HostInfoPosix.h
+++ b/include/lldb/Host/posix/HostInfoPosix.h
@@ -36,7 +36,6 @@ protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);
   static bool ComputeSupportFileDirectory(FileSpec &file_spec);
   static bool ComputeHeaderDirectory(FileSpec &file_spec);
-  static bool ComputeSwiftDirectory(FileSpec &file_spec);
 };
 }
 

--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		492E8B021BA37DC80034B4D7 /* SwiftExpressionVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 492E8B001BA37DC80034B4D7 /* SwiftExpressionVariable.cpp */; };
 		948C86D41B97764D00F3CAC3 /* SwiftFormatters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 948C86C31B97763200F3CAC3 /* SwiftFormatters.cpp */; };
 		948C86D51B97764D00F3CAC3 /* SwiftHashedContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 948C86C51B97763200F3CAC3 /* SwiftHashedContainer.cpp */; };
+		AE0D16AD2273EC0E00533A74 /* SwiftHost.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE0D16A92273EBEA00533A74 /* SwiftHost.cpp */; };
 		942612F01B94D33200EF842E /* SwiftLanguage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 942612EE1B94D32900EF842E /* SwiftLanguage.cpp */; };
 		4C848E0B18D28C0C00EC6DD0 /* SwiftLanguageRuntime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C848E0A18D28C0C00EC6DD0 /* SwiftLanguageRuntime.cpp */; };
 		948C86D61B97764D00F3CAC3 /* SwiftMetatype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 948C86C91B97763200F3CAC3 /* SwiftMetatype.cpp */; };
@@ -1506,6 +1507,8 @@
 		495D98F31C18F52500B9774B /* SwiftForward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SwiftForward.h; path = include/lldb/Core/SwiftForward.h; sourceTree = "<group>"; };
 		948C86C51B97763200F3CAC3 /* SwiftHashedContainer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftHashedContainer.cpp; path = Language/Swift/SwiftHashedContainer.cpp; sourceTree = "<group>"; };
 		948C86C61B97763200F3CAC3 /* SwiftHashedContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SwiftHashedContainer.h; path = Language/Swift/SwiftHashedContainer.h; sourceTree = "<group>"; };
+		AE0D16A92273EBEA00533A74 /* SwiftHost.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftHost.cpp; path = ExpressionParser/Swift/SwiftHost.cpp; sourceTree = "<group>"; };
+		AE0D16AA2273EBEA00533A74 /* SwiftHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwiftHost.h; path = ExpressionParser/Swift/SwiftHost.h; sourceTree = "<group>"; };
 		942612EE1B94D32900EF842E /* SwiftLanguage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftLanguage.cpp; path = Language/Swift/SwiftLanguage.cpp; sourceTree = "<group>"; };
 		942612EF1B94D32900EF842E /* SwiftLanguage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SwiftLanguage.h; path = Language/Swift/SwiftLanguage.h; sourceTree = "<group>"; };
 		4C848E0A18D28C0C00EC6DD0 /* SwiftLanguageRuntime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = SwiftLanguageRuntime.cpp; path = source/Target/SwiftLanguageRuntime.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -6323,6 +6326,8 @@
 				4C848DFC18D2873500EC6DD0 /* SwiftASTManipulator.cpp */,
 				4C848DFA18D2871600EC6DD0 /* SwiftExpressionParser.h */,
 				4C848DFD18D2873500EC6DD0 /* SwiftExpressionParser.cpp */,
+				AE0D16A92273EBEA00533A74 /* SwiftHost.cpp */,
+				AE0D16AA2273EBEA00533A74 /* SwiftHost.h */,
 				4C848DFB18D2871600EC6DD0 /* SwiftSILManipulator.h */,
 				4C848DFE18D2873500EC6DD0 /* SwiftSILManipulator.cpp */,
 				492E8B011BA37DC80034B4D7 /* SwiftExpressionVariable.h */,
@@ -8627,6 +8632,7 @@
 				949EEDA31BA76577008C63CF /* Cocoa.cpp in Sources */,
 				AFD966BB217140B6006714AC /* SymbolFileNativePDB.cpp in Sources */,
 				AFCB1D59219CD4FD00730AD5 /* GDBRemoteCommunicationReplayServer.cpp in Sources */,
+				AE0D16AD2273EC0E00533A74 /* SwiftHost.cpp in Sources */,
 				3FDFE56C19AF9C44009756A7 /* HostProcessPosix.cpp in Sources */,
 				268900B413353E5000698AC0 /* RegisterContextMacOSXFrameBackchain.cpp in Sources */,
 				6B74D89B200696BB0074051B /* Environment.cpp in Sources */,

--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -172,6 +172,7 @@ endif()
 set(lib_dir "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX}")
 set(CLANG_RESOURCE_PATH "${LLDB_PATH_TO_SWIFT_BUILD}/lib${LLVM_LIBDIR_SUFFIX}/swift/clang")
 set(clang_headers_target ${CLANG_RESOURCE_PATH}/include)
+set(SWIFT_RESOURCE_PATH "${LLDB_PATH_TO_SWIFT_BUILD}/lib${LLVM_LIBDIR_SUFFIX}/swift")
 if(NOT LLDB_BUILT_STANDALONE)
   set(clang_headers_target clang-headers symlink_clang_headers)
 endif()
@@ -185,9 +186,22 @@ add_custom_command_target(
     ALL
     DEPENDS ${clang_headers_target})
 
+add_custom_command_target(
+    unused_var
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${SWIFT_RESOURCE_PATH}" "${lib_dir}/lldb/swift/"
+    OUTPUT "${lib_dir}/lldb/swift/"
+    VERBATIM
+    ALL
+    DEPENDS ${SWIFT_RESOURCE_PATH})
+
 install(
   CODE "file(MAKE_DIRECTORY ${lib_dir}/lldb)")
 
 install(
   DIRECTORY "${lib_dir}/lldb/clang"
   DESTINATION lib${LLVM_LIBDIR_SUFFIX}/lldb/)
+
+install(
+  DIRECTORY "${lib_dir}/lldb/swift"
+  DESTINATION lib${LLVM_LIBDIR_SUFFIX}/lldb/)
+

--- a/source/Host/common/HostInfoBase.cpp
+++ b/source/Host/common/HostInfoBase.cpp
@@ -57,7 +57,6 @@ struct HostInfoBaseFields {
   FileSpec m_lldb_so_dir;
   FileSpec m_lldb_support_exe_dir;
   FileSpec m_lldb_headers_dir;
-  FileSpec m_lldb_swift_resource_dir;
   FileSpec m_lldb_clang_resource_dir;
   FileSpec m_lldb_system_plugin_dir;
   FileSpec m_lldb_user_plugin_dir;
@@ -131,18 +130,6 @@ FileSpec HostInfoBase::GetSupportExeDir() {
     LLDB_LOG(log, "support exe dir -> `{0}`", g_fields->m_lldb_support_exe_dir);
   });
   return success ? g_fields->m_lldb_support_exe_dir : FileSpec();
-}
-
-FileSpec HostInfoBase::GetSwiftDir() {
-    static std::once_flag g_once_flag;
-    static bool success = false;
-    std::call_once(g_once_flag, []() {
-      success =
-          HostInfo::ComputeSwiftDirectory(g_fields->m_lldb_swift_resource_dir);
-      Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
-      LLDB_LOG(log, "swift dir -> '{0}'", g_fields->m_lldb_swift_resource_dir);
-    });
-    return success ? g_fields->m_lldb_swift_resource_dir : FileSpec();
 }
 
 FileSpec HostInfoBase::GetHeaderDir() {
@@ -329,12 +316,6 @@ bool HostInfoBase::ComputeHeaderDirectory(FileSpec &file_spec) {
 bool HostInfoBase::ComputeSystemPluginsDirectory(FileSpec &file_spec) {
   // TODO(zturner): Figure out how to compute the system plugins directory for
   // all platforms.
-  return false;
-}
-
-bool HostInfoBase::ComputeSwiftDirectory(FileSpec &file_spec) {
-  // TODO(zturner): Figure out how to compute the swift directory for all
-  // platforms.
   return false;
 }
 

--- a/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -282,24 +282,3 @@ void HostInfoMacOSX::ComputeHostArchitectureSupport(ArchSpec &arch_32,
     }
   }
 }
-
-// Swift additions.
-
-bool HostInfoMacOSX::ComputeSwiftDirectory(FileSpec &file_spec) {
-  FileSpec lldb_file_spec = GetShlibDir();
-  if (!lldb_file_spec)
-    return false;
-
-  std::string raw_path = lldb_file_spec.GetPath();
-  size_t framework_pos = raw_path.find("LLDB.framework");
-  if (framework_pos == std::string::npos)
-    return HostInfoPosix::ComputeSwiftDirectory(file_spec);
-
-  if (framework_pos != std::string::npos) {
-    framework_pos += strlen("LLDB.framework");
-    raw_path.resize(framework_pos);
-    raw_path.append("/Resources/Swift");
-  }
-  file_spec.SetFile(raw_path.c_str(), FileSpec::Style::native);
-  return true;
-}

--- a/source/Host/posix/HostInfoPosix.cpp
+++ b/source/Host/posix/HostInfoPosix.cpp
@@ -142,15 +142,6 @@ bool HostInfoPosix::ComputeHeaderDirectory(FileSpec &file_spec) {
   return true;
 }
 
-bool HostInfoPosix::ComputeSwiftDirectory(FileSpec &file_spec) {
-  if (FileSpec lldb_file_spec = GetShlibDir()) {
-    lldb_file_spec.AppendPathComponent("swift");
-    file_spec = lldb_file_spec;
-    return true;
-  }
-  return false;
-}
-
 bool HostInfoPosix::GetEnvironmentVar(const std::string &var_name,
                                       std::string &var) {
   if (const char *pvar = ::getenv(var_name.c_str())) {

--- a/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -6,6 +6,7 @@ add_lldb_library(lldbPluginExpressionParserSwift PLUGIN
   SwiftASTManipulator.cpp
   SwiftExpressionParser.cpp
   SwiftExpressionVariable.cpp
+  SwiftHost.cpp
   SwiftPersistentExpressionState.cpp
   SwiftREPL.cpp
   SwiftREPLMaterializer.cpp

--- a/source/Plugins/ExpressionParser/Swift/SwiftHost.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftHost.cpp
@@ -1,0 +1,102 @@
+//===-- SwiftHost.cpp -------------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftHost.h"
+
+#include "lldb/Host/Config.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Utility/FileSpec.h"
+#include "lldb/Utility/Log.h"
+
+#include <string>
+
+using namespace lldb_private;
+
+static bool VerifySwiftPath(const llvm::Twine &swift_path) {
+  if (FileSystem::Instance().IsDirectory(swift_path))
+    return true;
+  Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
+  if (log)
+    log->Printf("VerifySwiftPath(): "
+                "failed to stat swift resource directory at \"%s\"",
+                swift_path.str().c_str());
+  return false;
+}
+
+static bool DefaultComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
+                                                 FileSpec &file_spec,
+                                                 bool verify) {
+  if (!lldb_shlib_spec)
+    return false;
+  Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
+  std::string raw_path = lldb_shlib_spec.GetPath();
+  // Drop bin (windows) or lib
+  llvm::StringRef parent_path = llvm::sys::path::parent_path(raw_path);
+
+  static const llvm::StringRef kResourceDirSuffixes[] = {
+      "lib/swift",
+      "lib" LLDB_LIBDIR_SUFFIX "/lldb/swift",
+  };
+  for (const auto &Suffix : kResourceDirSuffixes) {
+    llvm::SmallString<256> swift_path(parent_path);
+    llvm::SmallString<32> relative_path(Suffix);
+    llvm::sys::path::append(swift_path, relative_path);
+    if (!verify || VerifySwiftPath(swift_path)) {
+      if (log)
+        log->Printf("DefaultComputeSwiftResourceDir: Setting SwiftResourceDir "
+                    "to \"%s\", verify = %s",
+                    swift_path.str().str().c_str(), verify ? "true" : "false");
+      file_spec.GetDirectory().SetString(swift_path);
+      FileSystem::Instance().Resolve(file_spec);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool lldb_private::ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
+                                                 FileSpec &file_spec,
+                                                 bool verify) {
+#if !defined(__APPLE__)
+  return DefaultComputeSwiftResourceDirectory(lldb_shlib_spec, file_spec,
+                                              verify);
+#else
+  if (!lldb_shlib_spec)
+    return false;
+
+  std::string raw_path = lldb_shlib_spec.GetPath();
+  size_t framework_pos = raw_path.find("LLDB.framework");
+  if (framework_pos == std::string::npos)
+    return DefaultComputeSwiftResourceDirectory(lldb_shlib_spec, file_spec,
+                                                verify);
+
+  framework_pos += strlen("LLDB.framework");
+  raw_path.resize(framework_pos);
+  raw_path.append("/Resources/Swift");
+  if (!verify || VerifySwiftPath(raw_path)) {
+    file_spec.GetDirectory().SetString(raw_path);
+    FileSystem::Instance().Resolve(file_spec);
+    return true;
+  }
+  return true;
+#endif // __APPLE__
+}
+
+FileSpec lldb_private::GetSwiftResourceDir() {
+  static std::once_flag g_once_flag;
+  static FileSpec g_swift_resource_dir;
+  std::call_once(g_once_flag, []() {
+    FileSpec lldb_file_spec = HostInfo::GetShlibDir();
+    ComputeSwiftResourceDirectory(lldb_file_spec, g_swift_resource_dir, true);
+    Log *log = lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_HOST);
+    LLDB_LOG(log, "swift dir -> '{0}'", g_swift_resource_dir);
+  });
+  return g_swift_resource_dir;
+}

--- a/source/Plugins/ExpressionParser/Swift/SwiftHost.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftHost.h
@@ -1,0 +1,24 @@
+//===-- SwiftHost.h ---------------------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PLUGINS_EXPRESSIONPARSER_SWIFT_SWIFTHOST_H
+#define LLDB_PLUGINS_EXPRESSIONPARSER_SWIFT_SWIFTHOST_H
+
+namespace lldb_private {
+
+class FileSpec;
+
+bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
+                                   FileSpec &file_spec, bool verify);
+
+FileSpec GetSwiftResourceDir();
+
+} // namespace lldb_private
+
+#endif

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -85,6 +85,7 @@
 
 #include "Plugins/ExpressionParser/Clang/ClangHost.h"
 #include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
+#include "Plugins/ExpressionParser/Swift/SwiftHost.h"
 #include "Plugins/ExpressionParser/Swift/SwiftUserExpression.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/DumpDataExtractor.h"
@@ -1069,7 +1070,7 @@ StringRef SwiftASTContext::GetResourceDir(const llvm::Triple &triple) {
 
   auto value =
       GetResourceDir(platform_sdk_path, swift_stdlib_os_dir,
-                     HostInfo::GetSwiftDir().GetPath(), GetXcodeContentsPath(),
+                     GetSwiftResourceDir().GetPath(), GetXcodeContentsPath(),
                      GetCurrentToolchainPath(), GetCurrentCLToolsPath());
   g_resource_dir_cache.insert({key, value});
   return g_resource_dir_cache[key];

--- a/unittests/Expression/CMakeLists.txt
+++ b/unittests/Expression/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_unittest(ExpressionTests
   ClangParserTest.cpp
+  SwiftParserTest.cpp
 
   LINK_LIBS
     lldbCore

--- a/unittests/Expression/SwiftParserTest.cpp
+++ b/unittests/Expression/SwiftParserTest.cpp
@@ -1,0 +1,69 @@
+//===-- SwiftParserTest.cpp --------------------------------------*- C++-*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/ExpressionParser/Swift/SwiftHost.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Utility/FileSpec.h"
+#include "lldb/lldb-defines.h"
+#include "gtest/gtest.h"
+
+using namespace lldb_private;
+
+namespace {
+struct SwiftHostTest : public testing::Test {
+  static void SetUpTestCase() {
+    FileSystem::Initialize();
+    HostInfo::Initialize();
+  }
+  static void TearDownTestCase() {
+    HostInfo::Terminate();
+    FileSystem::Terminate();
+  }
+};
+} // namespace
+
+static std::string
+ComputeSwiftResourceDirectoryHelper(std::string lldb_shlib_path,
+                                    bool verify = false) {
+  FileSpec swift_dir;
+  FileSpec lldb_shlib_spec(lldb_shlib_path);
+  ComputeSwiftResourceDirectory(lldb_shlib_spec, swift_dir, verify);
+  return swift_dir.GetPath();
+}
+
+TEST_F(SwiftHostTest, ComputeSwiftResourceDirectory) {
+#if !defined(_WIN32)
+  std::string path_to_liblldb = "/foo/bar/lib";
+  std::string path_to_swift_dir = "/foo/bar/lib/swift";
+#else
+  std::string path_to_liblldb = "C:\\foo\\bar\\bin";
+  std::string path_to_swift_dir = "C:\\foo\\bar\\lib\\swift";
+#endif
+  EXPECT_EQ(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
+            path_to_swift_dir);
+  EXPECT_NE(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
+            ComputeSwiftResourceDirectoryHelper(path_to_liblldb, true));
+  EXPECT_TRUE(ComputeSwiftResourceDirectoryHelper("").empty());
+}
+
+#if defined(__APPLE__)
+TEST_F(SwiftHostTest, MacOSX) {
+  // test for LLDB.framework
+  std::string path_to_liblldb = "/foo/bar/lib/LLDB.framework";
+  std::string path_to_swift_dir = "/foo/bar/lib/LLDB.framework/Resources/Swift";
+  EXPECT_EQ(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
+            path_to_swift_dir);
+  path_to_liblldb = "/foo/bar/lib/LLDB.framework/foo/bar";
+  path_to_swift_dir = "/foo/bar/lib/LLDB.framework/Resources/Swift";
+  EXPECT_EQ(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
+            path_to_swift_dir);
+}
+#endif


### PR DESCRIPTION
Implemented a new class SwiftHost taking care of Swift directory. Made ComputeSwiftResourceDirectory work for all platforms.
@xiaobai 