### PR TITLE
cherry-pick : [NativePDB] Don't fail on import modules.

### DIFF
--- a/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.cpp
+++ b/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.cpp
@@ -124,11 +124,20 @@ CompilandIndexItem &CompileUnitIndex::GetOrCreateCompiland(uint16_t modi) {
   uint16_t stream = descriptor.getModuleStreamIndex();
   std::unique_ptr<llvm::msf::MappedBlockStream> stream_data =
       m_index.pdb().createIndexedStream(stream);
+
+
+  std::unique_ptr<CompilandIndexItem>& cci = result.first->second;
+
+  if (!stream_data) {
+    llvm::pdb::ModuleDebugStreamRef debug_stream(descriptor, nullptr);
+    cci = llvm::make_unique<CompilandIndexItem>(PdbCompilandId{ modi }, debug_stream, std::move(descriptor));
+    return *cci;
+  }
+
   llvm::pdb::ModuleDebugStreamRef debug_stream(descriptor,
                                                std::move(stream_data));
-  cantFail(debug_stream.reload());
 
-  std::unique_ptr<CompilandIndexItem> &cci = result.first->second;
+  cantFail(debug_stream.reload());
 
   cci = llvm::make_unique<CompilandIndexItem>(
       PdbCompilandId{modi}, std::move(debug_stream), std::move(descriptor));


### PR DESCRIPTION
A recent patch to LLD started emitting information about import modules.
These are represented as compile units in the PDB, but with no
additional debug info.  This was confusing the native pdb reader, who
expected that the debug info stream be present.

This should fix failing tests on the Windows bots.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@357513 91177308-0d34-0410-b5e6-96231b3b80d8