### PR TITLE
[test] Enable library evolution for swiftinterface test libraries

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/TestSwiftInterfaceNoDebugInfo.py
@@ -30,12 +30,14 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfLinux # rdar://49662256
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()
         self.do_test()
 
     @swiftTest
+    @skipIfLinux # rdar://49662256
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_shared/libs/Makefile
@@ -5,7 +5,7 @@ DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
 # Don't use the default swift flags, as we don't want -g for the libraries in
 # this test.
-SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options
+SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -enable-library-evolution
 
 # Don't include the wrapped .swiftmodule on Linux to make sure we actually use
 # the .swiftinterface. The issue here is that if the .swiftmodule is wrapped

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -30,12 +30,14 @@ class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfLinux
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()
         self.do_test()
 
     @swiftTest
+    @skipIfLinux # rdar://49662256
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/swift_interface_static/libs/Makefile
@@ -7,7 +7,7 @@ DYLIB_SWIFT_SOURCES := libs/$(BASENAME).swift
 
 # Don't use the default swift flags, as we don't want -g for the libraries in
 # this test.
-SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -parse-as-library
+SWIFTFLAGS=-Onone -Xfrontend -serialize-debugging-options -parse-as-library -enable-library-evolution
 
 # Don't include the wrapped .swiftmodule on Linux to make sure we use
 # the .swiftinterface. The issue here is that if the .swiftmodule is wrapped


### PR DESCRIPTION
Since we've changed the behavior of interface printing for non-resilient
types, and since we're not supporting module interfaces for
non-resilient modules, enable library evolution for these libraries so
the tests that exercise information-hiding remain working.