### PR TITLE
Avoid using RemoteAST for incomplete types.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -36,6 +36,8 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         shutil.rmtree(include)
 
     @swiftTest
+    # This test needs a working Remote Mirrors implementation.
+    @skipIf(oslist=['linux', 'windows'])
     def test_dwarf_importer(self):
         lldb.SBDebugger.MemoryPressureDetected()
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
@@ -51,6 +53,10 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
                                 target.FindFirstGlobalVariable("point"),
                                 typename="Point", num_children=2)
         self.expect("fr v point", substrs=["x = 1", "y = 2"])
+        self.expect("fr v point", substrs=["x = 1", "y = 2"])
+        self.expect("fr v pureSwiftStruct", substrs=["pure swift"])
+        self.expect("fr v swiftStructCMember",
+                    substrs=["swift struct c member"])
         logfile = open(log, "r")
         for line in logfile:
             self.assertFalse("missing required module" in line)

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/main.swift
@@ -5,5 +5,22 @@ func use<T>(_ t: T) {}
 let pureSwift = 42
 let point = Point(x: 1, y: 2)
 let enumerator = yellow
+
+struct SwiftStruct {
+  let name = "pure swift"
+}
+
+let pureSwiftStruct = SwiftStruct()
+
+struct SwiftStructCMember {
+  let point = Point(x: 3, y: 4)
+  let name = "swift struct c member"
+}
+
+let swiftStructCMember = SwiftStructCMember()
+
 use(pureSwift) // break here
 use(point)
+use(enumerator)
+use(pureSwiftStruct)
+use(swiftStructCMember)


### PR DESCRIPTION
This allows reading the pure Swift parts of a struct containing Swift
and C members, even if the C module couldn't be imported.