### PR TITLE
Unify random timeouts throughout LLDB and make them configurable.

### DIFF
--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -67,36 +67,22 @@ public:
   ~ProcessProperties() override;
 
   bool GetDisableMemoryCache() const;
-
   uint64_t GetMemoryCacheLineSize() const;
-
   Args GetExtraStartupCommands() const;
-
   void SetExtraStartupCommands(const Args &args);
-
   FileSpec GetPythonOSPluginPath() const;
-
   void SetPythonOSPluginPath(const FileSpec &file);
-
   bool GetIgnoreBreakpointsInExpressions() const;
-
   void SetIgnoreBreakpointsInExpressions(bool ignore);
-
   bool GetUnwindOnErrorInExpressions() const;
-
   void SetUnwindOnErrorInExpressions(bool ignore);
-
   bool GetStopOnSharedLibraryEvents() const;
-
   void SetStopOnSharedLibraryEvents(bool stop);
-
   bool GetDetachKeepsStopped() const;
-
   void SetDetachKeepsStopped(bool keep_stopped);
-
   bool GetWarningsOptimization() const;
-
   bool GetStopOnExec() const;
+  std::chrono::seconds GetUtilityExpressionTimeout() const;
 
 protected:
   static void OptionValueChangedCallback(void *baton,

--- a/source/Plugins/InstrumentationRuntime/ASan/ASanRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/ASan/ASanRuntime.cpp
@@ -71,7 +71,6 @@ bool AddressSanitizerRuntime::CheckIfRuntimeIsValid(
   return symbol != nullptr;
 }
 
-static constexpr std::chrono::seconds g_retrieve_report_data_function_timeout(2);
 const char *address_sanitizer_retrieve_report_data_prefix = R"(
 extern "C"
 {
@@ -126,7 +125,7 @@ StructuredData::ObjectSP AddressSanitizerRuntime::RetrieveReportData() {
   options.SetTryAllThreads(true);
   options.SetStopOthers(true);
   options.SetIgnoreBreakpoints(true);
-  options.SetTimeout(g_retrieve_report_data_function_timeout);
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(address_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);

--- a/source/Plugins/InstrumentationRuntime/TSan/TSanRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/TSan/TSanRuntime.cpp
@@ -60,8 +60,6 @@ lldb::InstrumentationRuntimeType ThreadSanitizerRuntime::GetTypeStatic() {
 
 ThreadSanitizerRuntime::~ThreadSanitizerRuntime() { Deactivate(); }
 
-static constexpr std::chrono::seconds g_retrieve_data_function_timeout(2);
-
 const char *thread_sanitizer_retrieve_report_data_prefix = R"(
 extern "C"
 {
@@ -324,7 +322,7 @@ ThreadSanitizerRuntime::RetrieveReportData(ExecutionContextRef exe_ctx_ref) {
   options.SetTryAllThreads(true);
   options.SetStopOthers(true);
   options.SetIgnoreBreakpoints(true);
-  options.SetTimeout(g_retrieve_data_function_timeout);
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(thread_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);

--- a/source/Plugins/InstrumentationRuntime/UBSan/UBSanRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/UBSan/UBSanRuntime.cpp
@@ -131,7 +131,7 @@ StructuredData::ObjectSP UndefinedBehaviorSanitizerRuntime::RetrieveReportData(
   options.SetTryAllThreads(true);
   options.SetStopOthers(true);
   options.SetIgnoreBreakpoints(true);
-  options.SetTimeout(std::chrono::seconds(2));
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(ub_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);

--- a/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -569,7 +569,7 @@ ValueObjectSP ItaniumABILanguageRuntime::GetExceptionObjectForThread(
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
   options.SetStopOthers(true);
-  options.SetTimeout(std::chrono::milliseconds(500));
+  options.SetTimeout(m_process->GetUtilityExpressionTimeout());
   options.SetTryAllThreads(false);
   thread_sp->CalculateExecutionContext(exe_ctx);
 

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -45,8 +45,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static constexpr std::chrono::seconds g_po_function_timeout(15);
-
 AppleObjCRuntime::~AppleObjCRuntime() {}
 
 AppleObjCRuntime::AppleObjCRuntime(Process *process)
@@ -171,7 +169,7 @@ bool AppleObjCRuntime::GetObjectDescription(Stream &strm, Value &value,
   options.SetTryAllThreads(true);
   options.SetStopOthers(true);
   options.SetIgnoreBreakpoints(true);
-  options.SetTimeout(g_po_function_timeout);
+  options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetIsForUtilityExpr(true);
 
   ExpressionResults results = m_print_object_caller_up->ExecuteFunction(

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -70,9 +70,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-// 2 second timeout when running utility functions
-static constexpr std::chrono::seconds g_utility_function_timeout(2);
-
 static const char *g_get_dynamic_class_info_name =
     "__lldb_apple_objc_v2_get_dynamic_class_info";
 // Testing using the new C++11 raw string literals. If this breaks GCC then we
@@ -1419,7 +1416,7 @@ AppleObjCRuntimeV2::UpdateISAToDescriptorMapDynamic(
     options.SetTryAllThreads(false);
     options.SetStopOthers(true);
     options.SetIgnoreBreakpoints(true);
-    options.SetTimeout(g_utility_function_timeout);
+    options.SetTimeout(process->GetUtilityExpressionTimeout());
     options.SetIsForUtilityExpr(true);
 
     Value return_value;
@@ -1670,7 +1667,7 @@ AppleObjCRuntimeV2::UpdateISAToDescriptorMapSharedCache() {
     options.SetTryAllThreads(false);
     options.SetStopOthers(true);
     options.SetIgnoreBreakpoints(true);
-    options.SetTimeout(g_utility_function_timeout);
+    options.SetTimeout(process->GetUtilityExpressionTimeout());
     options.SetIsForUtilityExpr(true);
 
     Value return_value;

--- a/source/Plugins/MemoryHistory/asan/MemoryHistoryASan.cpp
+++ b/source/Plugins/MemoryHistory/asan/MemoryHistoryASan.cpp
@@ -148,8 +148,6 @@ static void CreateHistoryThreadFromValueObject(ProcessSP process_sp,
   result.push_back(new_thread_sp);
 }
 
-static constexpr std::chrono::seconds g_get_stack_function_timeout(2);
-
 HistoryThreads MemoryHistoryASan::GetHistoryThreads(lldb::addr_t address) {
   HistoryThreads result;
 
@@ -177,7 +175,7 @@ HistoryThreads MemoryHistoryASan::GetHistoryThreads(lldb::addr_t address) {
   options.SetTryAllThreads(true);
   options.SetStopOthers(true);
   options.SetIgnoreBreakpoints(true);
-  options.SetTimeout(g_get_stack_function_timeout);
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(memory_history_asan_command_prefix);
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);

--- a/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -916,7 +916,7 @@ Status PlatformPOSIX::EvaluateLibdlExpression(
   expr_options.SetLanguage(eLanguageTypeC_plus_plus);
   expr_options.SetTrapExceptions(false); // dlopen can't throw exceptions, so
                                          // don't do the work to trap them.
-  expr_options.SetTimeout(std::chrono::seconds(2));
+  expr_options.SetTimeout(process->GetUtilityExpressionTimeout());
 
   Status expr_error;
   ExpressionResults result =
@@ -1241,7 +1241,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   options.SetUnwindOnError(true);
   options.SetTrapExceptions(false); // dlopen can't throw exceptions, so
                                     // don't do the work to trap them.
-  options.SetTimeout(std::chrono::seconds(2));
+  options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetIsForUtilityExpr(true);
 
   Value return_value;

--- a/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
+++ b/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
@@ -60,7 +60,7 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
       options.SetIgnoreBreakpoints(true);
       options.SetTryAllThreads(true);
       options.SetDebug(false);
-      options.SetTimeout(std::chrono::milliseconds(500));
+      options.SetTimeout(process->GetUtilityExpressionTimeout());
       options.SetTrapExceptions(false);
 
       addr_t prot_arg;
@@ -148,7 +148,7 @@ bool lldb_private::InferiorCallMunmap(Process *process, addr_t addr,
       options.SetIgnoreBreakpoints(true);
       options.SetTryAllThreads(true);
       options.SetDebug(false);
-      options.SetTimeout(std::chrono::milliseconds(500));
+      options.SetTimeout(process->GetUtilityExpressionTimeout());
       options.SetTrapExceptions(false);
 
       AddressRange munmap_range;
@@ -197,7 +197,7 @@ bool lldb_private::InferiorCall(Process *process, const Address *address,
   options.SetIgnoreBreakpoints(true);
   options.SetTryAllThreads(true);
   options.SetDebug(false);
-  options.SetTimeout(std::chrono::milliseconds(500));
+  options.SetTimeout(process->GetUtilityExpressionTimeout());
   options.SetTrapExceptions(trap_exceptions);
 
   ClangASTContext *clang_ast_context =

--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -111,7 +111,13 @@ void DumpProcessGDBRemotePacketHistory(void *p, const char *path) {
 namespace {
 
 static constexpr PropertyDefinition g_properties[] = {
-    {"packet-timeout", OptionValue::eTypeUInt64, true, 1, NULL, {},
+    {"packet-timeout", OptionValue::eTypeUInt64, true, 1
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+      + 4
+#endif
+#endif
+      , NULL, {},
      "Specify the default packet timeout in seconds."},
     {"target-definition-file", OptionValue::eTypeFileSpec, true, 0, NULL, {},
      "The file that provides the description for remote target registers."}};

--- a/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
+++ b/source/Plugins/SystemRuntime/MacOSX/AppleGetItemInfoHandler.cpp
@@ -333,7 +333,7 @@ AppleGetItemInfoHandler::GetItemInfo(Thread &thread, uint64_t item,
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
   options.SetStopOthers(true);
-  options.SetTimeout(std::chrono::milliseconds(500));
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetTryAllThreads(false);
   options.SetIsForUtilityExpr(true);
   thread.CalculateExecutionContext(exe_ctx);

--- a/source/Plugins/SystemRuntime/MacOSX/AppleGetPendingItemsHandler.cpp
+++ b/source/Plugins/SystemRuntime/MacOSX/AppleGetPendingItemsHandler.cpp
@@ -342,7 +342,7 @@ AppleGetPendingItemsHandler::GetPendingItems(Thread &thread, addr_t queue,
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
   options.SetStopOthers(true);
-  options.SetTimeout(std::chrono::milliseconds(500));
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetTryAllThreads(false);
   options.SetIsForUtilityExpr(true);
   thread.CalculateExecutionContext(exe_ctx);

--- a/source/Plugins/SystemRuntime/MacOSX/AppleGetQueuesHandler.cpp
+++ b/source/Plugins/SystemRuntime/MacOSX/AppleGetQueuesHandler.cpp
@@ -347,7 +347,7 @@ AppleGetQueuesHandler::GetCurrentQueues(Thread &thread, addr_t page_to_free,
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
   options.SetStopOthers(true);
-  options.SetTimeout(std::chrono::milliseconds(500));
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetTryAllThreads(false);
   options.SetIsForUtilityExpr(true);
   thread.CalculateExecutionContext(exe_ctx);

--- a/source/Plugins/SystemRuntime/MacOSX/AppleGetThreadItemInfoHandler.cpp
+++ b/source/Plugins/SystemRuntime/MacOSX/AppleGetThreadItemInfoHandler.cpp
@@ -344,7 +344,7 @@ AppleGetThreadItemInfoHandler::GetThreadItemInfo(Thread &thread,
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
   options.SetStopOthers(true);
-  options.SetTimeout(std::chrono::milliseconds(500));
+  options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetTryAllThreads(false);
   options.SetIsForUtilityExpr(true);
   thread.CalculateExecutionContext(exe_ctx);

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -144,7 +144,11 @@ static constexpr PropertyDefinition g_properties[] = {
          "stepping and variable availability may not behave as expected."},
     {"stop-on-exec", OptionValue::eTypeBoolean, true, true,
      nullptr, {},
-     "If true, stop when a shared library is loaded or unloaded."}};
+     "If true, stop when a shared library is loaded or unloaded."},
+    {"utility-expression-timeout", OptionValue::eTypeUInt64, false, 15,
+     nullptr, {},
+     "The time in seconds to wait for LLDB-internal utility expressions."}
+};
 
 enum {
   ePropertyDisableMemCache,
@@ -156,7 +160,8 @@ enum {
   ePropertyDetachKeepsStopped,
   ePropertyMemCacheLineSize,
   ePropertyWarningOptimization,
-  ePropertyStopOnExec
+  ePropertyStopOnExec,
+  ePropertyUtilityExpressionTimeout,
 };
 
 ProcessProperties::ProcessProperties(lldb_private::Process *process)
@@ -277,6 +282,13 @@ bool ProcessProperties::GetStopOnExec() const {
   const uint32_t idx = ePropertyStopOnExec;
   return m_collection_sp->GetPropertyAtIndexAsBoolean(
       nullptr, idx, g_properties[idx].default_uint_value != 0);
+}
+  
+std::chrono::seconds ProcessProperties::GetUtilityExpressionTimeout() const {
+  const uint32_t idx = ePropertyUtilityExpressionTimeout;
+  uint64_t value = m_collection_sp->GetPropertyAtIndexAsUInt64(
+     nullptr, idx, g_properties[idx].default_uint_value);
+  return std::chrono::seconds(value);
 }
 
 void ProcessInstanceInfo::Dump(Stream &s, Platform *platform) const {
@@ -3940,10 +3952,10 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
     bool receipt_received = false;
     if (PrivateStateThreadIsValid()) {
       while (!receipt_received) {
-        // Check for a receipt for 2 seconds and then check if the private
+        // Check for a receipt for n seconds and then check if the private
         // state thread is still around.
         receipt_received =
-            event_receipt_sp->WaitForEventReceived(std::chrono::seconds(2));
+          event_receipt_sp->WaitForEventReceived(GetUtilityExpressionTimeout());
         if (!receipt_received) {
           // Check if the private state thread is still around. If it isn't
           // then we are done waiting
@@ -5246,7 +5258,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
         }
 
         got_event =
-            listener_sp->GetEvent(event_sp, std::chrono::milliseconds(500));
+            listener_sp->GetEvent(event_sp, GetUtilityExpressionTimeout());
         if (!got_event) {
           if (log)
             log->Printf("Process::RunThreadPlan(): didn't get any event after "
@@ -5477,7 +5489,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
               log->PutCString("Process::RunThreadPlan(): Halt succeeded.");
 
             got_event =
-                listener_sp->GetEvent(event_sp, std::chrono::milliseconds(500));
+                listener_sp->GetEvent(event_sp, GetUtilityExpressionTimeout());
 
             if (got_event) {
               stop_state =


### PR DESCRIPTION
Since these timeouts guard against catastrophic error in debugserver,
I also increased all of them to the maximum value among them.

The motivation for this test was the observation that an asanified
LLDB would often exhibit seemingly random test failures that could be
traced back to debugserver packets getting out of sync. With this path
applied I can no longer reproduce the one particular failure mode that
I was investigating.

rdar://problem/49441261

Differential Revision: https://reviews.llvm.org/D60340

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@357829 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 555e11a99fa590bdd39ba50941fb2eeb509c1e2b)

 Conflicts:
	source/Target/Process.cpp