### PR TITLE
[Batch mode] Merge pull request #1431 from davidungar/batch-mode-error-suppression-rdar-40167351

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2770,12 +2770,13 @@ public:
     m_ast_context.GetDiagnosticEngine().takeConsumers();
   }
 
-  virtual void handleDiagnostic(swift::SourceManager &source_mgr,
-                                swift::SourceLoc source_loc,
-                                swift::DiagnosticKind kind,
-                                llvm::StringRef formatString,
-                                llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
-                                const swift::DiagnosticInfo &info) {
+  virtual void
+  handleDiagnostic(swift::SourceManager &source_mgr,
+                   swift::SourceLoc source_loc, swift::DiagnosticKind kind,
+                   llvm::StringRef formatString,
+                   llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
+                   const swift::DiagnosticInfo &info,
+                   const swift::SourceLoc bufferIndirectlyCausingDiagnostic) {
     llvm::StringRef bufferName = "<anonymous>";
     unsigned bufferID = 0;
     std::pair<unsigned, unsigned> line_col = {0, 0};


### PR DESCRIPTION
Cherry pick:

In batch mode, any diagnostics located in non-primary files are suppressed, with the expectation that they will surface when the containing file is compiled as primary. Although this assumption should hold, it does not always. For example, certain inputs can interact with associated type inferencing to violate it.

This PR tracks the current primary input in the DiagnosticEngine, which passed it down to the DiagnosticConsumer. The FileSpecificDiagnosticConsumer uses this information to output the diagnostic into the appropriate primary's .dia file. It addresses rdar://49303574.

Needs: https://github.com/apple/swift/pull/23848
