### PR TITLE
Experiment with a larger packet timeout.

### DIFF
--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -111,10 +111,10 @@ void DumpProcessGDBRemotePacketHistory(void *p, const char *path) {
 namespace {
 
 static constexpr PropertyDefinition g_properties[] = {
-    {"packet-timeout", OptionValue::eTypeUInt64, true, 1
+    {"packet-timeout", OptionValue::eTypeUInt64, true, 5
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
-      + 4
+      * 2
 #endif
 #endif
       , NULL, {},


### PR DESCRIPTION
This is a follow-up to r357829 (https://reviews.llvm.org/D60340) to
see whether increasing the packet timeout for non-asan builds could
also positively affect the stability of non-asan bots.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@357954 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 7c1d5b1b71bbcd12a082fd9b1816a38e16eaa3c2)