### PR TITLE
Get the run locker before you ask if your thread is valid.

### DIFF
--- a/source/API/SBThread.cpp
+++ b/source/API/SBThread.cpp
@@ -1345,9 +1345,9 @@ SBThread SBThread::GetExtendedBacktraceThread(const char *type) {
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
   SBThread sb_origin_thread;
 
-  if (exe_ctx.HasThreadScope()) {
-    Process::StopLocker stop_locker;
-    if (stop_locker.TryLock(&exe_ctx.GetProcessPtr()->GetRunLock())) {
+  Process::StopLocker stop_locker;
+  if (stop_locker.TryLock(&exe_ctx.GetProcessPtr()->GetRunLock())) {
+    if (exe_ctx.HasThreadScope()) {
       ThreadSP real_thread(exe_ctx.GetThreadSP());
       if (real_thread) {
         ConstString type_const(type);


### PR DESCRIPTION
I have occasional crashes coming from SBThread::GetExtendedBacktraceThread.  The 
symptom is that we got true back from HasThreadScope - so we should have a valid
live thread, but then when we go to use the thread, it is not good anymore and we
crash.
I can't spot any obvious cause for this crash, but in looking for same I noticed
that in the current code we check that the thread is valid, THEN we take the stop 
locker.  We really should do that in the other order, and ensure that the process 
will stay stopped before we check our thread is still good.  That's what this patch does.

<rdar://problem/47478205>


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@357963 91177308-0d34-0410-b5e6-96231b3b80d8