### PR TITLE
batch newly added module notifications

### DIFF
--- a/include/lldb/Core/ModuleList.h
+++ b/include/lldb/Core/ModuleList.h
@@ -99,14 +99,16 @@ public:
   public:
     virtual ~Notifier() = default;
 
-    virtual void ModuleAdded(const ModuleList &module_list,
-                             const lldb::ModuleSP &module_sp) = 0;
-    virtual void ModuleRemoved(const ModuleList &module_list,
-                               const lldb::ModuleSP &module_sp) = 0;
-    virtual void ModuleUpdated(const ModuleList &module_list,
-                               const lldb::ModuleSP &old_module_sp,
-                               const lldb::ModuleSP &new_module_sp) = 0;
-    virtual void WillClearList(const ModuleList &module_list) = 0;
+    virtual void NotifyModuleAdded(const ModuleList &module_list,
+                                   const lldb::ModuleSP &module_sp) = 0;
+    virtual void NotifyModuleRemoved(const ModuleList &module_list,
+                                     const lldb::ModuleSP &module_sp) = 0;
+    virtual void NotifyModuleUpdated(const ModuleList &module_list,
+                                     const lldb::ModuleSP &old_module_sp,
+                                     const lldb::ModuleSP &new_module_sp) = 0;
+    virtual void NotifyWillClearList(const ModuleList &module_list) = 0;
+
+    virtual void NotifyModulesRemoved(lldb_private::ModuleList &module_list) = 0;
   };
 
   //------------------------------------------------------------------
@@ -149,12 +151,20 @@ public:
   //------------------------------------------------------------------
   /// Append a module to the module list.
   ///
-  /// Appends the module to the collection.
-  ///
-  /// @param[in] module_sp
+  /// \param[in] module_sp
   ///     A shared pointer to a module to add to this collection.
+  ///
+  /// \param[in] notify
+  ///     If true, and a notifier function is set, the notifier function
+  ///     will be called.  Defaults to true.
+  ///
+  ///     When this ModuleList is the Target's ModuleList, the notifier 
+  ///     function is Target::ModulesDidLoad -- the call to 
+  ///     ModulesDidLoad may be deferred when adding multiple Modules 
+  ///     to the Target, but it must be called at the end, 
+  ///     before resuming execution.
   //------------------------------------------------------------------
-  void Append(const lldb::ModuleSP &module_sp);
+  void Append(const lldb::ModuleSP &module_sp, bool notify = true);
 
   //------------------------------------------------------------------
   /// Append a module to the module list and remove any equivalent modules.
@@ -168,7 +178,22 @@ public:
   //------------------------------------------------------------------
   void ReplaceEquivalent(const lldb::ModuleSP &module_sp);
 
-  bool AppendIfNeeded(const lldb::ModuleSP &module_sp);
+  //------------------------------------------------------------------
+  /// Append a module to the module list, if it is not already there.
+  ///
+  /// \param[in] module_sp
+  ///
+  /// \param[in] notify
+  ///     If true, and a notifier function is set, the notifier function
+  ///     will be called.  Defaults to true.
+  ///
+  ///     When this ModuleList is the Target's ModuleList, the notifier 
+  ///     function is Target::ModulesDidLoad -- the call to 
+  ///     ModulesDidLoad may be deferred when adding multiple Modules 
+  ///     to the Target, but it must be called at the end, 
+  ///     before resuming execution.
+  //------------------------------------------------------------------
+  bool AppendIfNeeded(const lldb::ModuleSP &module_sp, bool notify = true);
 
   void Append(const ModuleList &module_list);
 
@@ -484,7 +509,23 @@ public:
                             std::vector<Address> &output_local,
                             std::vector<Address> &output_extern);
 
-  bool Remove(const lldb::ModuleSP &module_sp);
+  //------------------------------------------------------------------
+  /// Remove a module from the module list.
+  ///
+  /// \param[in] module_sp
+  ///     A shared pointer to a module to remove from this collection.
+  ///
+  /// \param[in] notify
+  ///     If true, and a notifier function is set, the notifier function
+  ///     will be called.  Defaults to true.
+  ///
+  ///     When this ModuleList is the Target's ModuleList, the notifier 
+  ///     function is Target::ModulesDidUnload -- the call to 
+  ///     ModulesDidUnload may be deferred when removing multiple Modules 
+  ///     from the Target, but it must be called at the end, 
+  ///     before resuming execution.
+  //------------------------------------------------------------------
+  bool Remove(const lldb::ModuleSP &module_sp, bool notify = true);
 
   size_t Remove(ModuleList &module_list);
 

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -542,8 +542,42 @@ public:
 
   static void SetDefaultArchitecture(const ArchSpec &arch);
 
-  lldb::ModuleSP GetSharedModule(const ModuleSpec &module_spec,
-                                 Status *error_ptr = nullptr);
+  //------------------------------------------------------------------
+  /// Find a binary on the system and return its Module, 
+  /// or return an existing Module that is already in the Target.
+  ///
+  /// Given a ModuleSpec, find a binary satisifying that specification,
+  /// or identify a matching Module already present in the Target,
+  /// and return a shared pointer to it.
+  ///
+  /// \param[in] module_spec
+  ///     The criteria that must be matched for the binary being loaded.
+  ///     e.g. UUID, architecture, file path.
+  ///
+  /// \param[in] notify
+  ///     If notify is true, and the Module is new to this Target, 
+  ///     Target::ModulesDidLoad will be called.  
+  ///     If notify is false, it is assumed that the caller is adding 
+  ///     multiple Modules and will call ModulesDidLoad with the 
+  ///     full list at the end.
+  ///     ModulesDidLoad must be called when a Module/Modules have
+  ///     been added to the target, one way or the other.
+  ///
+  /// \param[out] error_ptr
+  ///     Optional argument, pointing to a Status object to fill in 
+  ///     with any results / messages while attempting to find/load
+  ///     this binary.  Many callers will be internal functions that
+  ///     will handle / summarize the failures in a custom way and
+  ///     don't use these messages.
+  ///
+  /// \return 
+  ///     An empty ModuleSP will be returned if no matching file
+  ///     was found.  If error_ptr was non-nullptr, an error message
+  ///     will likely be provided.
+  //------------------------------------------------------------------
+  lldb::ModuleSP GetOrCreateModule(const ModuleSpec &module_spec,
+                                   bool notify,
+                                   Status *error_ptr = nullptr);
 
   //----------------------------------------------------------------------
   // Settings accessors
@@ -1372,16 +1406,19 @@ protected:
   /// Implementing of ModuleList::Notifier.
   //------------------------------------------------------------------
 
-  void ModuleAdded(const ModuleList &module_list,
-                   const lldb::ModuleSP &module_sp) override;
+  void NotifyModuleAdded(const ModuleList &module_list,
+                         const lldb::ModuleSP &module_sp) override;
 
-  void ModuleRemoved(const ModuleList &module_list,
-                     const lldb::ModuleSP &module_sp) override;
+  void NotifyModuleRemoved(const ModuleList &module_list,
+                         const lldb::ModuleSP &module_sp) override;
 
-  void ModuleUpdated(const ModuleList &module_list,
-                     const lldb::ModuleSP &old_module_sp,
-                     const lldb::ModuleSP &new_module_sp) override;
-  void WillClearList(const ModuleList &module_list) override;
+  void NotifyModuleUpdated(const ModuleList &module_list,
+                           const lldb::ModuleSP &old_module_sp,
+                           const lldb::ModuleSP &new_module_sp) override;
+
+  void NotifyWillClearList(const ModuleList &module_list) override;
+
+  void NotifyModulesRemoved(lldb_private::ModuleList &module_list) override;
 
   class Arch {
   public:

--- a/packages/Python/lldbsuite/test/functionalities/target-new-solib-notifications/Makefile
+++ b/packages/Python/lldbsuite/test/functionalities/target-new-solib-notifications/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../make
+
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/packages/Python/lldbsuite/test/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -1,0 +1,114 @@
+"""
+Test how many times newly loaded binaries are notified;
+they should be delivered in batches instead of one-by-one.
+"""
+
+from __future__ import print_function
+
+
+import os
+import time
+import re
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class ModuleLoadedNotifysTestCase(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    # DyanmicLoaderDarwin should batch up notifications about
+    # newly added/removed libraries.  Other DynamicLoaders may
+    # not be written this way.
+    @skipUnlessDarwin
+
+    def setUp(self):
+        # Call super's setUp().
+        TestBase.setUp(self)
+        # Find the line number to break inside main().
+        self.line = line_number('main.cpp', '// breakpoint')
+
+    def test_launch_notifications(self):
+        """Test that lldb broadcasts newly loaded libraries in batches."""
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        self.dbg.SetAsync(False)
+
+        listener = self.dbg.GetListener()
+        listener.StartListeningForEventClass(
+            self.dbg,
+            lldb.SBTarget.GetBroadcasterClassName(),
+            lldb.SBTarget.eBroadcastBitModulesLoaded | lldb.SBTarget.eBroadcastBitModulesUnloaded)
+
+        # Create a target by the debugger.
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        # break on main
+        breakpoint = target.BreakpointCreateByName('main', 'a.out')
+
+        event = lldb.SBEvent()
+        # CreateTarget() generated modules-loaded events; consume them & toss
+        while listener.GetNextEvent(event):
+            True
+
+        error = lldb.SBError()
+        process = target.Launch(listener,
+                                None,      # argv
+                                None,      # envp
+                                None,      # stdin_path
+                                None,      # stdout_path
+                                None,      # stderr_path
+                                None,      # working directory
+                                0,         # launch flags
+                                False,     # Stop at entry
+                                error)     # error
+
+        self.assertTrue(
+            process.GetState() == lldb.eStateStopped,
+            PROCESS_STOPPED)
+
+        total_solibs_added = 0
+        total_solibs_removed = 0
+        total_modules_added_events = 0
+        total_modules_removed_events = 0
+        while listener.GetNextEvent(event):
+            if lldb.SBTarget.EventIsTargetEvent(event):
+                if event.GetType() == lldb.SBTarget.eBroadcastBitModulesLoaded:
+                    solib_count = lldb.SBTarget.GetNumModulesFromEvent(event)
+                    total_modules_added_events += 1
+                    total_solibs_added += solib_count
+                    if self.TraceOn():
+                        # print all of the binaries that have been added
+                        added_files = []
+                        i = 0
+                        while i < solib_count:
+                            module = lldb.SBTarget.GetModuleAtIndexFromEvent(i, event)
+                            added_files.append(module.GetFileSpec().GetFilename())
+                            i = i + 1
+                        print("Loaded files: %s" % (', '.join(added_files)))
+
+                if event.GetType() == lldb.SBTarget.eBroadcastBitModulesUnloaded:
+                    solib_count = lldb.SBTarget.GetNumModulesFromEvent(event)
+                    total_modules_removed_events += 1
+                    total_solibs_removed += solib_count
+                    if self.TraceOn():
+                        # print all of the binaries that have been removed
+                        removed_files = []
+                        i = 0
+                        while i < solib_count:
+                            module = lldb.SBTarget.GetModuleAtIndexFromEvent(i, event)
+                            removed_files.append(module.GetFileSpec().GetFilename())
+                            i = i + 1
+                        print("Unloaded files: %s" % (', '.join(removed_files)))
+        
+
+        # This is testing that we get back a small number of events with the loaded 
+        # binaries in batches.  Check that we got back more than 1 solib per event.  
+        # In practice on Darwin today, we get back two events for a do-nothing c 
+        # program: a.out and dyld, and then all the rest of the system libraries.
+
+        avg_solibs_added_per_event = int(float(total_solibs_added) / float(total_modules_added_events))
+        self.assertGreater(avg_solibs_added_per_event, 1)

--- a/packages/Python/lldbsuite/test/functionalities/target-new-solib-notifications/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/target-new-solib-notifications/main.cpp
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main ()
+{
+  puts("running"); // breakpoint here
+  return 0;
+}

--- a/source/API/SBTarget.cpp
+++ b/source/API/SBTarget.cpp
@@ -1616,7 +1616,7 @@ lldb::SBModule SBTarget::AddModule(const char *path, const char *triple,
     if (symfile)
       module_spec.GetSymbolFileSpec().SetFile(symfile, FileSpec::Style::native);
 
-    sb_module.SetSP(target_sp->GetSharedModule(module_spec));
+    sb_module.SetSP(target_sp->GetOrCreateModule(module_spec, true /* notify */));
   }
   return LLDB_RECORD_RESULT(sb_module);
 }
@@ -1628,7 +1628,8 @@ lldb::SBModule SBTarget::AddModule(const SBModuleSpec &module_spec) {
   lldb::SBModule sb_module;
   TargetSP target_sp(GetSP());
   if (target_sp)
-    sb_module.SetSP(target_sp->GetSharedModule(*module_spec.m_opaque_up));
+    sb_module.SetSP(target_sp->GetOrCreateModule(*module_spec.m_opaque_up, 
+                                                 true /* notify */));
   return LLDB_RECORD_RESULT(sb_module);
 }
 

--- a/source/Commands/CommandObjectTarget.cpp
+++ b/source/Commands/CommandObjectTarget.cpp
@@ -395,7 +395,8 @@ protected:
         debugger.GetTargetList().SetSelectedTarget(target_sp.get());
         if (must_set_platform_path) {
           ModuleSpec main_module_spec(file_spec);
-          ModuleSP module_sp = target_sp->GetSharedModule(main_module_spec);
+          ModuleSP module_sp = target_sp->GetOrCreateModule(main_module_spec,
+                                                          true /* notify */);
           if (module_sp)
             module_sp->SetPlatformFileSpec(remote_file);
         }
@@ -2613,7 +2614,8 @@ protected:
             module_spec.GetSymbolFileSpec() =
                 m_symbol_file.GetOptionValue().GetCurrentValue();
           if (Symbols::DownloadObjectAndSymbolFile(module_spec)) {
-            ModuleSP module_sp(target->GetSharedModule(module_spec));
+            ModuleSP module_sp(target->GetOrCreateModule(module_spec,
+                                                 true /* notify */));
             if (module_sp) {
               result.SetStatus(eReturnStatusSuccessFinishResult);
               return true;
@@ -2675,7 +2677,8 @@ protected:
             if (!module_spec.GetArchitecture().IsValid())
               module_spec.GetArchitecture() = target->GetArchitecture();
             Status error;
-            ModuleSP module_sp(target->GetSharedModule(module_spec, &error));
+            ModuleSP module_sp(target->GetOrCreateModule(module_spec, 
+                                            true /* notify */, &error));
             if (!module_sp) {
               const char *error_cstr = error.AsCString();
               if (error_cstr)

--- a/source/Core/DynamicLoader.cpp
+++ b/source/Core/DynamicLoader.cpp
@@ -96,7 +96,7 @@ ModuleSP DynamicLoader::GetTargetExecutable() {
       }
 
       if (!executable) {
-        executable = target.GetSharedModule(module_spec);
+        executable = target.GetOrCreateModule(module_spec, true /* notify */);
         if (executable.get() != target.GetExecutableModulePointer()) {
           // Don't load dependent images since we are in dyld where we will
           // know and find out about all images that are loaded
@@ -166,7 +166,8 @@ ModuleSP DynamicLoader::LoadModuleAtAddress(const FileSpec &file,
     return module_sp;
   }
 
-  if ((module_sp = target.GetSharedModule(module_spec))) {
+  if ((module_sp = target.GetOrCreateModule(module_spec, 
+                                            true /* notify */))) {
     UpdateLoadedSections(module_sp, link_map_addr, base_addr,
                          base_addr_is_offset);
     return module_sp;
@@ -202,7 +203,8 @@ ModuleSP DynamicLoader::LoadModuleAtAddress(const FileSpec &file,
         return module_sp;
       }
 
-      if ((module_sp = target.GetSharedModule(new_module_spec))) {
+      if ((module_sp = target.GetOrCreateModule(new_module_spec, 
+                                                true /* notify */))) {
         UpdateLoadedSections(module_sp, link_map_addr, base_addr, false);
         return module_sp;
       }

--- a/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -842,7 +842,7 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::LoadImageUsingMemoryModule(
       // the DebugSymbols framework with the UUID to find the binary via its
       // search methods.
       if (!m_module_sp) {
-        m_module_sp = target.GetSharedModule(module_spec);
+        m_module_sp = target.GetOrCreateModule(module_spec, true /* notify */);
       }
 
       if (IsKernel() && !m_module_sp) {

--- a/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
+++ b/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
@@ -199,7 +199,7 @@ ModuleSP DynamicLoaderHexagonDYLD::GetTargetExecutable() {
     return executable;
 
   // TODO: What case is this code used?
-  executable = target.GetSharedModule(module_spec);
+  executable = target.GetOrCreateModule(module_spec, true /* notify */);
   if (executable.get() != target.GetExecutableModulePointer()) {
     // Don't load dependent images since we are in dyld where we will know and
     // find out about all images that are loaded

--- a/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -122,7 +122,9 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
 
   if (!module_sp) {
     if (can_create) {
-      module_sp = target.GetSharedModule(module_spec);
+      // We'll call Target::ModulesDidLoad after all the modules have been
+      // added to the target, don't let it be called for every one.
+      module_sp = target.GetOrCreateModule(module_spec, false /* notify */);
       if (!module_sp || module_sp->GetObjectFile() == NULL)
         module_sp = m_process->ReadModuleFromMemory(image_info.file_spec,
                                                     image_info.address);
@@ -637,7 +639,8 @@ bool DynamicLoaderDarwin::AddModulesUsingImageInfos(
               module_spec.SetObjectOffset(objfile->GetFileOffset() +
                                           commpage_section->GetFileOffset());
               module_spec.SetObjectSize(objfile->GetByteSize());
-              commpage_image_module_sp = target.GetSharedModule(module_spec);
+              commpage_image_module_sp = target.GetOrCreateModule(module_spec, 
+                                                               true /* notify */);
               if (!commpage_image_module_sp ||
                   commpage_image_module_sp->GetObjectFile() == NULL) {
                 commpage_image_module_sp = m_process->ReadModuleFromMemory(

--- a/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -543,7 +543,8 @@ ModuleSP DynamicLoaderPOSIXDYLD::LoadInterpreterModule() {
   FileSpec file(info.GetName().GetCString());
   ModuleSpec module_spec(file, target.GetArchitecture());
 
-  if (ModuleSP module_sp = target.GetSharedModule(module_spec)) {
+  if (ModuleSP module_sp = target.GetOrCreateModule(module_spec, 
+                                                    true /* notify */)) {
     UpdateLoadedSections(module_sp, LLDB_INVALID_ADDRESS, m_interpreter_base,
                          false);
     return module_sp;

--- a/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -908,7 +908,8 @@ void ProcessWindows::OnDebuggerConnected(lldb::addr_t image_base) {
     FileSystem::Instance().Resolve(executable_file);
     ModuleSpec module_spec(executable_file);
     Status error;
-    module = GetTarget().GetSharedModule(module_spec, &error);
+    module = GetTarget().GetOrCreateModule(module_spec, 
+                                           true /* notify */, &error);
     if (!module) {
       return;
     }

--- a/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -244,7 +244,8 @@ Status ProcessElfCore::DoLoadCore() {
       exe_module_spec.GetFileSpec().SetFile(
           m_nt_file_entries[0].path.GetCString(), FileSpec::Style::native);
       if (exe_module_spec.GetFileSpec()) {
-        exe_module_sp = GetTarget().GetSharedModule(exe_module_spec);
+        exe_module_sp = GetTarget().GetOrCreateModule(exe_module_spec, 
+                                                      true /* notify */);
         if (exe_module_sp)
           GetTarget().SetExecutableModule(exe_module_sp, eLoadDependentsNo);
       }

--- a/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -358,8 +358,7 @@ void ProcessMinidump::ReadModuleList() {
     FileSystem::Instance().Resolve(file_spec);
     ModuleSpec module_spec(file_spec, uuid);
     Status error;
-    lldb::ModuleSP module_sp = GetTarget().GetSharedModule(module_spec, &error);
-    if (!module_sp || error.Fail()) {
+    lldb::ModuleSP module_sp = GetTarget().GetSharedModule(module_spec, true /* notify */, &error);
       // We failed to locate a matching local object file. Fortunately, the
       // minidump format encodes enough information about each module's memory
       // range to allow us to create placeholder modules.
@@ -377,7 +376,7 @@ void ProcessMinidump::ReadModuleList() {
           std::make_shared<PlaceholderModule>(module_spec);
       placeholder_module->CreateImageSection(module, GetTarget());
       module_sp = placeholder_module;
-      GetTarget().GetImages().Append(module_sp);
+      GetTarget().GetImages().Append(module_sp, true /* notify */);
     }
 
     if (log) {

--- a/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -358,7 +358,8 @@ void ProcessMinidump::ReadModuleList() {
     FileSystem::Instance().Resolve(file_spec);
     ModuleSpec module_spec(file_spec, uuid);
     Status error;
-    lldb::ModuleSP module_sp = GetTarget().GetSharedModule(module_spec, true /* notify */, &error);
+    lldb::ModuleSP module_sp = GetTarget().GetOrCreateModule(module_spec, true /* notify */, &error);
+    if (!module_sp || error.Fail()) {
       // We failed to locate a matching local object file. Fortunately, the
       // minidump format encodes enough information about each module's memory
       // range to allow us to create placeholder modules.

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -1462,7 +1462,8 @@ void Target::SetExecutableModule(ModuleSP &executable_sp,
                        "Target::SetExecutableModule (executable = '%s')",
                        executable_sp->GetFileSpec().GetPath().c_str());
 
-    m_images.Append(executable_sp); // The first image is our executable file
+    const bool notify = true;
+    m_images.Append(executable_sp, notify); // The first image is our executable file
 
     // If we haven't set an architecture yet, reset our architecture based on
     // what we found in the executable module.
@@ -1490,6 +1491,7 @@ void Target::SetExecutableModule(ModuleSP &executable_sp,
     }
 
     if (executable_objfile && load_dependents) {
+      ModuleList added_modules;
       executable_objfile->GetDependentModules(dependent_files);
       for (uint32_t i = 0; i < dependent_files.GetSize(); i++) {
         FileSpec dependent_file_spec(
@@ -1502,13 +1504,16 @@ void Target::SetExecutableModule(ModuleSP &executable_sp,
           platform_dependent_file_spec = dependent_file_spec;
 
         ModuleSpec module_spec(platform_dependent_file_spec, m_arch.GetSpec());
-        ModuleSP image_module_sp(GetSharedModule(module_spec));
+        ModuleSP image_module_sp(GetOrCreateModule(module_spec, 
+                                 false /* notify */));
         if (image_module_sp) {
+          added_modules.AppendIfNeeded (image_module_sp, false);
           ObjectFile *objfile = image_module_sp->GetObjectFile();
           if (objfile)
             objfile->GetDependentModules(dependent_files);
         }
       }
+      ModulesDidLoad(added_modules);
     }
   }
 }
@@ -1626,20 +1631,19 @@ bool Target::MergeArchitecture(const ArchSpec &arch_spec) {
   return false;
 }
 
-void Target::WillClearList(const ModuleList &module_list) {}
+void Target::NotifyWillClearList(const ModuleList &module_list) {}
 
-void Target::ModuleAdded(const ModuleList &module_list,
+void Target::NotifyModuleAdded(const ModuleList &module_list,
                          const ModuleSP &module_sp) {
   // A module is being added to this target for the first time
   if (m_valid) {
     ModuleList my_module_list;
     my_module_list.Append(module_sp);
-    LoadScriptingResourceForModule(module_sp, this);
     ModulesDidLoad(my_module_list);
   }
 }
 
-void Target::ModuleRemoved(const ModuleList &module_list,
+void Target::NotifyModuleRemoved(const ModuleList &module_list,
                            const ModuleSP &module_sp) {
   // A module is being removed from this target.
   if (m_valid) {
@@ -1649,7 +1653,7 @@ void Target::ModuleRemoved(const ModuleList &module_list,
   }
 }
 
-void Target::ModuleUpdated(const ModuleList &module_list,
+void Target::NotifyModuleUpdated(const ModuleList &module_list,
                            const ModuleSP &old_module_sp,
                            const ModuleSP &new_module_sp) {
   // A module is replacing an already added module
@@ -1661,8 +1665,20 @@ void Target::ModuleUpdated(const ModuleList &module_list,
   }
 }
 
+void Target::NotifyModulesRemoved(lldb_private::ModuleList &module_list) {
+  ModulesDidUnload (module_list, false);
+}
+
+
 void Target::ModulesDidLoad(ModuleList &module_list) {
   if (m_valid && module_list.GetSize()) {
+
+    const ModuleList &modules = GetImages();
+    const size_t num_images = modules.GetSize();
+    for (size_t idx = 0; idx < num_images; ++idx) {
+      ModuleSP module_sp(modules.GetModuleAtIndex(idx));
+      LoadScriptingResourceForModule(module_sp, this);
+    }
     m_breakpoint_list.UpdateBreakpoints(module_list, true, false);
     m_internal_breakpoint_list.UpdateBreakpoints(module_list, true, false);
     if (m_process_sp) {
@@ -2024,8 +2040,8 @@ bool Target::ReadPointerFromMemory(const Address &addr, bool prefer_file_cache,
   return false;
 }
 
-ModuleSP Target::GetSharedModule(const ModuleSpec &module_spec,
-                                 Status *error_ptr) {
+ModuleSP Target::GetOrCreateModule(const ModuleSpec &module_spec, bool notify,
+                                   Status *error_ptr) {
   ModuleSP module_sp;
 
   Status error;
@@ -2158,8 +2174,9 @@ ModuleSP Target::GetSharedModule(const ModuleSpec &module_spec,
           Module *old_module_ptr = old_module_sp.get();
           old_module_sp.reset();
           ModuleList::RemoveSharedModuleIfOrphaned(old_module_ptr);
-        } else
-          m_images.Append(module_sp);
+        } else {
+          m_images.Append(module_sp, notify);
+        }
       } else
         module_sp.reset();
     }


### PR DESCRIPTION
   Rename Target::GetSharedModule to Target::GetOrCreateModule.
    
    Add a flag to control whether the ModulesDidLoad notification is
    called when a module is added.  If the notifications are disabled,
    the caller must call ModulesDidLoad after adding all the new modules,
    but postponing this notification until they're all batched up can
    allow for better efficiency than notifying one-by-one.
    
    Change the name of the ModuleList notifier functions that a subclass
    can implement to start with 'Notify' to make it clear what they are.
    Add a NotifyModulesRemoved.
    
    Add header documentation for the changed/updated methods.
    
    Added defaulted-value 'notify' argument to ModuleList Append,
    AppendIfNeeded, and Remove because callers working with a local
    ModuleList don't have an obvious idea of what notify means in this
    context.  When the ModuleList is a part of the Target class, the
    notify behavior matters.
    
    DynamicLoaderDarwin has been updated so that libraries being
    added/removed are correctly batched up before notifications are
    sent.  Added the TestModuleLoadedNotifys.py test to run on
    Darwin to test this.
    
    <rdar://problem/48293064>
    
    Differential Revision: https://reviews.llvm.org/D60172
