### PR TITLE
[Batch mode] Cherry-pick fix for error suppression

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2691,12 +2691,13 @@ public:
     m_ast_context.GetDiagnosticEngine().takeConsumers();
   }
 
-  virtual void handleDiagnostic(swift::SourceManager &source_mgr,
-                                swift::SourceLoc source_loc,
-                                swift::DiagnosticKind kind,
-                                llvm::StringRef formatString,
-                                llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
-                                const swift::DiagnosticInfo &info) {
+  virtual void
+  handleDiagnostic(swift::SourceManager &source_mgr,
+                   swift::SourceLoc source_loc, swift::DiagnosticKind kind,
+                   llvm::StringRef formatString,
+                   llvm::ArrayRef<swift::DiagnosticArgument> formatArgs,
+                   const swift::DiagnosticInfo &info,
+                   const swift::SourceLoc bufferIndirectlyCausingDiagnostic) {
     llvm::StringRef bufferName = "<anonymous>";
     unsigned bufferID = 0;
     std::pair<unsigned, unsigned> line_col = {0, 0};


### PR DESCRIPTION
Addresses rdar://49303574
Requires https://github.com/apple/swift/pull/23879

When compiler issues errors for nonprimaries that do not show up when that file is primary, batch mode never shows the user the specific error. This PR addresses that issue by passing the responsible primary into the `FileSpecificDiagnosticConsumer` so that it can place the error in the primary's .dia file.