### PR TITLE
Fix flakyness in TestCommandScriptImmediateOutput

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/command_script_immediate_output/TestCommandScriptImmediateOutput.py
+++ b/packages/Python/lldbsuite/test/functionalities/command_script_immediate_output/TestCommandScriptImmediateOutput.py
@@ -31,7 +31,9 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
     @skipIfDarwin
     def test_command_script_immediate_output_console(self):
         """Test that LLDB correctly allows scripted commands to set immediate output to the console."""
+        prompt = "\(lldb\) "
         self.launch(timeout=10)
+        self.expect(prompt)
 
         script = os.path.join(self.getSourceDir(), 'custom_command.py')
         prompt = "\(lldb\) "
@@ -44,7 +46,7 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
             'mycommand',
             patterns='this is a test string, just a test string')
         self.sendline('command script delete mycommand', patterns=[prompt])
-        self.quit(gracefully=False)
+        self.quit()
 
     @skipIfRemote  # test not remote-ready llvm.org/pr24813
     @expectedFailureAll(
@@ -54,7 +56,9 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
     @skipIfDarwin
     def test_command_script_immediate_output_file(self):
         """Test that LLDB correctly allows scripted commands to set immediate output to a file."""
+        prompt = "\(lldb\) "
         self.launch(timeout=10)
+        self.expect(prompt)
 
         test_files = {self.getBuildArtifact('read.txt'): 'r',
                       self.getBuildArtifact('write.txt'): 'w',
@@ -71,7 +75,6 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
                 init.write(starter_string)
 
         script = os.path.join(self.getSourceDir(), 'custom_command.py')
-        prompt = "\(lldb\) "
 
         self.sendline('command script import %s' % script, patterns=[prompt])
 
@@ -85,7 +88,7 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
 
         self.sendline('command script delete mywrite', patterns=[prompt])
 
-        self.quit(gracefully=False)
+        self.quit()
 
         for path, mode in test_files.items():
             with open(path, 'r') as result:
@@ -96,4 +99,3 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
                         result.readline(), write_string + mode + '\n')
 
             self.assertTrue(os.path.isfile(path))
-            os.remove(path)

--- a/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -51,7 +51,7 @@ else:
             TestBase.setUp(self)
 
         def launchArgs(self):
-            pass
+            return ""
 
         def launch(self, timeout=None):
             if timeout is None:


### PR DESCRIPTION
I'm not sure why this surfaced at this particular point, but
TestCommandScriptImmediateOutput (a pexpect test) had a synchronization
issue, where the (lldb) promts it was expecting were getting out of
sync. This happened for two reasons:
- it did not expect the initial (lldb) prompt we print at startup
- launchArgs() returned None, which resulted in an extra "target create
  None" command being issued to lldb (and an extra unhandled prompt
  being printed).

Resolving these two issues seems to fix (or at least, improve) the test.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@357459 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 8909047b1a7e66ea1ecb99e8127a7fca469dedce)