### PR TITLE
[debugserver] Relax the codesigning identity check

### DIFF
--- a/tools/debugserver/source/CMakeLists.txt
+++ b/tools/debugserver/source/CMakeLists.txt
@@ -93,16 +93,14 @@ elseif(NOT LLDB_NO_DEBUGSERVER)
   # Default case: on Darwin we need the right code signing ID.
   # See lldb/docs/code-signing.txt for details.
   if(CMAKE_HOST_APPLE AND NOT LLVM_CODESIGNING_IDENTITY STREQUAL "lldb_codesign")
-    set(msg "Cannot code sign debugserver with identity '${LLVM_CODESIGNING_IDENTITY}'.")
-    if(system_debugserver)
-      message(WARNING "${msg} Will fall back to system's debugserver.")
-      set(use_system_debugserver ON)
-    else()
-      message(WARNING "${msg} debugserver will not be available.")
-    endif()
-  else()
-    set(build_and_sign_debugserver ON)
+    message(WARNING "Codesigning debugserver with identity ${LLVM_CODESIGNING_IDENTITY}. "
+                    "The usual setup uses the \"lldb_codesign\" identity created with "
+                    "scripts/macos-setup-codesign.sh. As a result your debugserver might "
+                    "not be able to attach to processes.\n"
+                    "Pass -DLLDB_CODESIGN_IDENTITY=lldb_codesign to use the development "
+                    "signing identity.")
   endif()
+  set(build_and_sign_debugserver ON)
 endif()
 
 # TODO: We don't use the $<TARGET_FILE:debugserver> generator expression here,


### PR DESCRIPTION
In an effort to help new LLDB developers, we added checks and messaging around
the selection of your codesigning identity on macOS. While helpful, it is not
actually correct. It's perfectly valid to codesign with an identity that is
not named lldb_codesign. Currently this fails the build.

This patch keeps a warning that informs developers how to setup lldb_codesign
and how to pass it to cmake, but it allows the build to proceed with a
different identity.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@358525 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 15fd2e284f5cb4f6a251c5627247cd4e6702785a)