### PR TITLE
[CMake] Emit LLDB.framework.dSYM

### DIFF
--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -14,6 +14,10 @@ if(NOT LLDB_DISABLE_PYTHON)
   set(lldb_python_wrapper ${lldb_scripts_dir}/LLDBWrapPython.cpp)
 endif()
 
+if(LLDB_BUILD_FRAMEWORK AND LLVM_EXTERNALIZE_DEBUGINFO)
+  set(LLVM_EXTERNALIZE_DEBUGINFO_EXTENSION framework.dSYM)
+endif()
+
 add_lldb_library(liblldb SHARED
   SBAddress.cpp
   SBAttachInfo.cpp


### PR DESCRIPTION
In order to avoid potential name collision with driver's lldb.dSYM

Summary:
Emit framework's dSYM bundle as LLDB.framework.dSYM instead of LLDB.dSYM, because the latter could conflict with the driver's lldb.dSYM when emitted in the same directory on case-insensitive file systems.
Requires https://reviews.llvm.org/D60862

Reviewers: friss, beanz, bogner

Subscribers: mgorny, lldb-commits, #lldb

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D60863

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@358686 91177308-0d34-0410-b5e6-96231b3b80d8