### PR TITLE
[SwiftASTContext] The DWARFImporter is not a Clang module loader.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3089,7 +3089,7 @@ swift::ClangImporter *SwiftASTContext::GetClangImporter() {
       if (dwarf_importer_ap) {
         m_dwarf_importer = dwarf_importer_ap.get();
         m_ast_context_ap->addModuleLoader(std::move(dwarf_importer_ap),
-                                          is_clang);
+                                          !is_clang);
       }
     }
   }


### PR DESCRIPTION
<rdar://problem/49856499>