### PR TITLE
[DataFormatters] Fix printing of objects spaning across type systems.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/packages/Python/lldbsuite/test/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -29,14 +29,12 @@ class TestObjCIVarDiscovery(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessDarwin
-    @expectedFailureAll(bugnumber="rdar://45929100")
     def test_nodbg(self):
         self.build()
         shutil.rmtree(self.getBuildArtifact("aTestFramework.framework.dSYM"))
         self.do_test(False)
 
     @skipUnlessDarwin
-    @expectedFailureAll(bugnumber="rdar://45929100")
     def test_dbg(self):
         self.build()
         self.do_test(True)
@@ -48,9 +46,6 @@ class TestObjCIVarDiscovery(TestBase):
 
     def do_test(self, dbg):
         """Test that we can correctly see ivars from the Objective-C runtime"""
-        if dbg:
-            self.runCmd("type category disable runtime-synthetics")
-
         # Launch the process, and do not stop at the entry point.
         envp = ['DYLD_FRAMEWORK_PATH=.']
         lldbutil.run_to_source_breakpoint(
@@ -90,8 +85,8 @@ class TestObjCIVarDiscovery(TestBase):
             myclass.GetChildMemberWithName("m_myclass_numbers"))
 
         self.assertTrue(
-            m_numbers.GetSummary() == '"3 values"',
-            "m_myclass_numbers != 3 values")
+            m_numbers.GetSummary() == '3 elements',
+            "m_myclass_numbers != 3 elements")
 
         m_subclass_ivar = mysubclass.GetChildMemberWithName("m_subclass_ivar")
         self.assertTrue(
@@ -102,14 +97,6 @@ class TestObjCIVarDiscovery(TestBase):
         self.assertTrue(
             m_mysubclass_s.GetSummary() == '"an NSString here"',
             'm_subclass_s != "an NSString here"')
-
-        m_mysubclass_r = mysubclass.GetChildMemberWithName("m_mysubclass_r")
-        self.assertTrue(
-            re.search(
-                '.*x=0[, ]+y=0.*width=30[, ]+height=40.*',
-                m_mysubclass_r.GetSummary()
-            ) is not None,
-            'm_subclass_r != origin=(x=0, y=0) size=(width=30, height=40)')
 
         swiftivar = obj.GetChildMemberWithName("swiftivar")
         self.assertTrue(

--- a/packages/Python/lldbsuite/test/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/packages/Python/lldbsuite/test/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -111,9 +111,3 @@ class TestObjCIVarDiscovery(TestBase):
         self.assertTrue(
             silly_url.GetSummary() == '"http://www.apple.com"',
             "url != apple.com")
-
-if __name__ == '__main__':
-    import atexit
-    lldb.SBDebugger.Initialize()
-    atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()

--- a/packages/Python/lldbsuite/test/lang/swift/objc_runtime_ivars/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/objc_runtime_ivars/main.swift
@@ -13,7 +13,7 @@ import aTestFramework
 
 class SwiftSubclass: MySubclass {
   var swiftivar: String = "Hey Swift!"
-  var silly: AnyObject = MySillyOtherClass()
+  var silly = MySillyOtherClass()
 }
 
 func main() {

--- a/source/Core/ValueObjectChild.cpp
+++ b/source/Core/ValueObjectChild.cpp
@@ -169,9 +169,17 @@ bool ValueObjectChild::UpdateValue() {
               m_value.SetValueType(Value::eValueTypeFileAddress);
           } break;
           case eAddressTypeLoad:
-            m_value.SetValueType(is_instance_ptr_base
-                                     ? Value::eValueTypeScalar
-                                     : Value::eValueTypeLoadAddress);
+            // BEGIN SWIFT MOD
+            // We need to detect when we cross TypeSystem boundaries,
+            // e.g. when we try to print Obj-C fields of a Swift object.
+            if (parent->GetCompilerType().GetTypeSystem()->getKind() ==
+                GetCompilerType().GetTypeSystem()->getKind())
+                m_value.SetValueType(is_instance_ptr_base
+                                    ? Value::eValueTypeScalar
+                                    : Value::eValueTypeLoadAddress);
+            else
+              m_value.SetValueType(Value::eValueTypeLoadAddress);
+            // END SWIFT MOD
             break;
           case eAddressTypeHost:
             m_value.SetValueType(Value::eValueTypeHostAddress);


### PR DESCRIPTION
Sometimes you have a swift class containing obj-C fields, and now
we print them correctly. Kudos to JimI for helping me a lot with
this patch.

<rdar://problem/45929100>