### PR TITLE
make lldb work with python3.6 and python3.7 at the same time

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -69,5 +69,11 @@ set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/lldb.py PROPERTIES GENER
 # Install the LLDB python module
 install(DIRECTORY ${SWIG_PYTHON_DIR} DESTINATION ${SWIG_INSTALL_DIR})
 
+# SWIFT_ENABLE_TENSORFLOW
+# The build might have generated some "python3.x" symlinks. See the comment in
+# "finishSwigPythonLLDB.py" for more information. Install them, if they exist.
+install(DIRECTORY "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python3.6" DESTINATION ${SWIG_INSTALL_DIR} OPTIONAL)
+install(DIRECTORY "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/python3.7" DESTINATION ${SWIG_INSTALL_DIR} OPTIONAL)
+
 # build Python modules
 add_subdirectory(Python/modules)


### PR DESCRIPTION
This will allow people to use our prebuilt toolchains (which are built with python3.6) even if they have python3.7.

In principle, this is something that we should be able to upstream to main lldb. But this is a slightly hacky temporary solution, so I think we should wait until we have a more proper implementation before doing that.