### PR TITLE
[Reproducers] Fix lifetime issue

### DIFF
--- a/include/lldb/Utility/Reproducer.h
+++ b/include/lldb/Utility/Reproducer.h
@@ -121,6 +121,8 @@ public:
   Create(FileSpec filename);
 
   template <typename T> void Record(const T &t, bool newline = false) {
+    if (!m_record)
+      return;
     m_os << t;
     if (newline)
       m_os << '\n';

--- a/source/Utility/Reproducer.cpp
+++ b/source/Utility/Reproducer.cpp
@@ -259,8 +259,6 @@ void CommandProvider::Keep() {
     return;
   yaml::Output yout(os);
   yout << files;
-
-  m_data_recorders.clear();
 }
 
 void CommandProvider::Discard() { m_data_recorders.clear(); }


### PR DESCRIPTION
Deallocating the data recorder in during the ::Keep() operation causes
problems down the line when exiting the debugger. The command
interpreter still holds a pointer to the now deallocated object and has
no way to know it no longer exists. This is exactly what the m_record
flag was meant for, although it wasn't hooked up properly either.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@358916 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit da4b1b75f4d35861bea1abc13dbed8fe9174205e)