### PR TITLE
Fix a bug in my change to ModulesDidLoad in r357955.

### DIFF
--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -1671,12 +1671,10 @@ void Target::NotifyModulesRemoved(lldb_private::ModuleList &module_list) {
 
 
 void Target::ModulesDidLoad(ModuleList &module_list) {
-  if (m_valid && module_list.GetSize()) {
-
-    const ModuleList &modules = GetImages();
-    const size_t num_images = modules.GetSize();
+  const size_t num_images = module_list.GetSize();
+  if (m_valid && num_images) {
     for (size_t idx = 0; idx < num_images; ++idx) {
-      ModuleSP module_sp(modules.GetModuleAtIndex(idx));
+      ModuleSP module_sp(module_list.GetModuleAtIndex(idx));
       LoadScriptingResourceForModule(module_sp, this);
     }
     m_breakpoint_list.UpdateBreakpoints(module_list, true, false);


### PR DESCRIPTION
Fix a bug in my change to ModulesDidLoad in r357955.
In the process of hoisting the LoadScriptingResourceForModule
out of Target::ModuleAdded and into Target::ModulesDidLoad,
I had ModulesDidLoad fetching the Target's entire image list
and look for scripting resources in those -- instead of only
looking for scripting resources in the modules that had
been added to the target's image list.

<rdar://problem/50065315> 



git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@358929 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit c76ff4289ac0a7920b3517b9e884179e85480143)