### PR TITLE
Add a small check to PlatformDarwin::LoadScriptingResourceForModule

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -71,8 +71,6 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResources(
     // precisely that. Ideally, we should have a per-platform list of
     // extensions (".exe", ".app", ".dSYM", ".framework") which should be
     // stripped while leaving "this.binary.file" as-is.
-    ScriptInterpreter *script_interpreter =
-        target->GetDebugger().GetCommandInterpreter().GetScriptInterpreter();
 
     FileSpec module_spec = module.GetFileSpec();
 
@@ -84,7 +82,10 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResources(
           ObjectFile *objfile = symfile->GetObjectFile();
           if (objfile) {
             FileSpec symfile_spec(objfile->GetFileSpec());
-            if (symfile_spec && FileSystem::Instance().Exists(symfile_spec)) {
+            if (symfile_spec && 
+                FileSystem::Instance().Exists(symfile_spec) && 
+                strcasestr (symfile_spec.GetPath().c_str(), 
+                        ".dSYM/Contents/Resources/DWARF") != nullptr) {
               while (module_spec.GetFilename()) {
                 std::string module_basename(
                     module_spec.GetFilename().GetCString());
@@ -106,6 +107,8 @@ FileSpecList PlatformDarwin::LocateExecutableScriptingResources(
                              ' ', '_');
                 std::replace(module_basename.begin(), module_basename.end(),
                              '-', '_');
+                ScriptInterpreter *script_interpreter =
+                  target->GetDebugger().GetCommandInterpreter().GetScriptInterpreter();
                 if (script_interpreter &&
                     script_interpreter->IsReservedWord(
                         module_basename.c_str())) {


### PR DESCRIPTION
Add a small check to PlatformDarwin::LoadScriptingResourceForModule
which reads the python files in a dSYM bundle, to check that the
SymbolFile is actually a dSYM bundle filepath; delay any fetching
of the ScriptInterpreter until after we've done that check.

When debugging a binary without a dSYM on darwin systems, the
SymbolFile we fetch is actually the ObjectFile -- so we would do
an unnecessary trip into Python land and stat around the filesystem
looking for a python file to read in.  There's no reason to do any
of this unless the SymbolFile's file path includes the .dSYM bundle
telltale path components.

<rdar://problem/50065315> 


git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@358938 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 11331029bcca42047f70953e7a990c27bd3f78fd)