### PR TITLE
 "Temporarily" disable some lldb-mi tests that are unreliable.

### DIFF
--- a/lit/tools/lldb-mi/exec/exec-continue.test
+++ b/lit/tools/lldb-mi/exec/exec-continue.test
@@ -1,3 +1,6 @@
+# REQUIRES: 50050012
+# swift-lldb: DISABLED because this test is unreliable.
+
 # RUN: %build %p/inputs/main.c --nodefaultlib -o %t
 # RUN: %lldbmi %t < %s | FileCheck %s
 

--- a/lit/tools/lldb-mi/exec/exec-step.test
+++ b/lit/tools/lldb-mi/exec/exec-step.test
@@ -1,3 +1,6 @@
+# REQUIRES: 50050012
+# swift-lldb: DISABLED because this test is unreliable.
+
 # RUN: %build %p/inputs/main.c --nodefaultlib -o %t
 # RUN: %lldbmi %t < %s | FileCheck %s
 


### PR DESCRIPTION
<rdar://problem/50050012>