### PR TITLE
[DataFormatters] Adjusting libc++ std::list formatter to act better with pointers and references and adding a test to cover a previous related fix

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/list/TestDataFormatterLibcxxList.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/list/TestDataFormatterLibcxxList.py
@@ -162,6 +162,10 @@ class LibcxxListDataFormatterTestCase(TestBase):
                              '[2] = ', '3',
                              '[3] = ', '4'])
 
+        ListPtr = self.frame().FindVariable("list_ptr")
+        self.assertTrue(ListPtr.GetChildAtIndex(
+            0).GetValueAsUnsigned(0) == 1, "[0] = 1")
+
         # check that MightHaveChildren() gets it right
         self.assertTrue(
             self.frame().FindVariable("numbers_list").MightHaveChildren(),

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/list/main.cpp
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/list/main.cpp
@@ -8,7 +8,8 @@ typedef std::list<std::string> string_list;
 int main()
 {
     int_list numbers_list;
-    
+    std::list<int>* list_ptr = &numbers_list;
+
     printf("// Set break point at this line.");
     (numbers_list.push_back(0x12345678));
     (numbers_list.push_back(0x11223344));

--- a/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -501,7 +501,8 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       cpp_category_sp,
       lldb_private::formatters::LibcxxStdListSyntheticFrontEndCreator,
       "libc++ std::list synthetic children",
-      ConstString("^std::__(ndk)?1::list<.+>(( )?&)?$"), stl_synth_flags, true);
+      ConstString("^std::__(ndk)?1::list<.+>(( )?&)?$"), stl_deref_flags,
+      true);
   AddCXXSynthetic(
       cpp_category_sp,
       lldb_private::formatters::LibcxxStdMapSyntheticFrontEndCreator,


### PR DESCRIPTION
Summary:
This previous fix https://github.com/llvm-mirror/lldb/commit/5469bda296c183d1b6bf74597c88c9ed667b3145 did not have a test since we did not have a reproducer.

This is related to how formatters deal with pointers and references. The added tests both the new behavior and covers the previous bug fix as well.

Differential Revision: https://reviews.llvm.org/D60588

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359118 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 65c885bf9a215d6b05432f5f138378eb96f0e730)