### PR TITLE
TestZMMRegister: use an integer division as intended

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/register/intel_avx/TestZMMRegister.py
+++ b/packages/Python/lldbsuite/test/functionalities/register/intel_avx/TestZMMRegister.py
@@ -62,7 +62,7 @@ class TestYMMRegister(TestBase):
         else:
             register_range = 8
         for i in range(register_range):
-            j = i - ((i / 8) * 8)
+            j = i - ((i // 8) * 8)
             self.runCmd("thread step-inst")
 
             register_byte = (byte_pattern1 | j)
@@ -104,7 +104,7 @@ class TestYMMRegister(TestBase):
         else:
             register_range = 8
         for i in range(register_range):
-            j = i - ((i / 8) * 8)
+            j = i - ((i // 8) * 8)
             self.runCmd("thread step-inst")
             self.runCmd("thread step-inst")
 


### PR DESCRIPTION
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359347 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit f29315ab9c0a5bb4e6eb4d1e7cb0ebbc41cdc200)