### PR TITLE
Pass explicit C++ version to test

### DIFF
--- a/lit/ExecControl/StopHook/stop-hook-threads.test
+++ b/lit/ExecControl/StopHook/stop-hook-threads.test
@@ -1,4 +1,4 @@
-# RUN: %clangxx %p/Inputs/stop-hook-threads.cpp -g -o %t
+# RUN: %clangxx -std=c++11 %p/Inputs/stop-hook-threads.cpp -g -o %t
 # RUN: %lldb -b -s %p/Inputs/stop-hook-threads-1.lldbinit -s %s -f %t \
 # RUN:     | FileCheck --check-prefix=CHECK --check-prefix=CHECK-NO-FILTER %s
 # RUN: %lldb -b -s %p/Inputs/stop-hook-threads-2.lldbinit -s %s -f %t \


### PR DESCRIPTION
stop-hook-threads.cpp uses C++11 features, so ask for C++11 explicitely.
This isn't broken on mainstream because clang defaults to a newer C++
version now, but it breaks if testing against an older compiler.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359349 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e5d2e62e50092bc5604054ff9f123359c4255fcc)