### PR TITLE
[dotest.py] Remove swiftpr category

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/multilang_category/TestMultilangFormatterCategories.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/multilang_category/TestMultilangFormatterCategories.py
@@ -17,7 +17,6 @@ class TestMultilangFormatterCategories(TestBase):
 
     @swiftTest
     @skipUnlessDarwin
-    @add_test_categories(["swiftpr"])
     def test_multilang_formatter_categories(self):
         """Test that formatter categories can work for multiple languages"""
         self.build()

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -27,7 +27,6 @@ class TestSwiftTypeAliasFormatters(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/packages/Python/lldbsuite/test/lang/swift/address_of/TestSwiftAddressOf.py
@@ -49,7 +49,6 @@ class TestSwiftAddressOf(lldbtest.TestBase):
 
         
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_any_type(self):
         """Test the Any type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -28,7 +28,6 @@ class TestSwiftAnyObjectType(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_any_object_type(self):
         """Test the AnyObject type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/packages/Python/lldbsuite/test/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -28,7 +28,6 @@ class TestSwiftArchetypeResolution(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
+++ b/packages/Python/lldbsuite/test/lang/swift/backwards_compatibility/simple/TestSwiftBackwardsCompatibilitySimple.py
@@ -24,7 +24,6 @@ class TestSwiftBackwardsCompatibilitySimple(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(compiler="swiftc", compiler_version=['<', '5.0'])
-    @add_test_categories(["swiftpr", "swift-history"])
     def test_simple(self):
         if 'SWIFTC' in os.environ:
             compiler = os.environ['SWIFTC']

--- a/packages/Python/lldbsuite/test/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/packages/Python/lldbsuite/test/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -25,7 +25,6 @@ class SwiftPartialBreakTest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_partial_break(self):
         """Tests that we can break on a partial name of a Swift function"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/packages/Python/lldbsuite/test/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -29,7 +29,6 @@ class TestSwiftBridgedMetatype(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_bridged_metatype(self):
         """Test the formatting of bridged Swift metatypes"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/packages/Python/lldbsuite/test/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -24,7 +24,6 @@ class TestSwiftBacktracePrinting(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_backtrace_printing(self):
         """Test printing Swift backtrace"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -28,7 +28,6 @@ class TestSwiftBridgingHeaderHeadermap(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -30,7 +30,6 @@ class TestSwiftDedupMacros(TestBase):
     # is observed, try to collect a crashlog before disabling this test.
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def testSwiftDebugMacros(self):
         """This tests that configuration macros get uniqued when building the
         scratch ast context. Note that "-D MACRO" options with a space

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -27,7 +27,6 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         """
         This testcase causes the scratch context to get destroyed by a

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -27,7 +27,6 @@ class TestSwiftHeadermapConflict(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -27,7 +27,6 @@ class TestSwiftIncludeConflict(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -27,7 +27,6 @@ class TestSwiftMacroConflict(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -27,7 +27,6 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -27,7 +27,6 @@ class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         self.build()
         exe_name = "a.out"

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -27,7 +27,6 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         # To ensure we hit the rebuild problem remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -26,7 +26,6 @@ class TestSwiftRemoteASTImport(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def testSwiftRemoteASTImport(self):
         """This tests that RemoteAST querying the dynamic type of a variable
         doesn't import any modules into a module SwiftASTContext that

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -27,14 +27,12 @@ class TestSwiftRewriteClangPaths(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     @skipIf(debug_info=no_match(["dsym"]))
     def testWithRemap(self):
         self.dotest(True)
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     @skipIf(debug_info=no_match(["dsym"]))
     def testWithoutRemap(self):
         self.dotest(False)

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -27,7 +27,6 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         self.build()
         exe_name = "a.out"

--- a/packages/Python/lldbsuite/test/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
+++ b/packages/Python/lldbsuite/test/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
@@ -27,7 +27,6 @@ class TestSwiftDebugPrefixMap(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(['swiftpr'])
     def test_debug_prefix_map(self):
         self.do_test()
 

--- a/packages/Python/lldbsuite/test/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/packages/Python/lldbsuite/test/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -26,7 +26,6 @@ class TestSwiftDeploymentTarget(TestBase):
     @skipUnlessDarwin
     @skipIf(macos_version=["<", "10.11"])
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_deployment_target(self):
         self.build()
 
@@ -38,7 +37,6 @@ class TestSwiftDeploymentTarget(TestBase):
     @skipUnlessDarwin
     @skipIf(macos_version=["<", "10.11"])
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_deployment_target_dlopen(self):
         self.build()
         # Create the target

--- a/packages/Python/lldbsuite/test/lang/swift/expression/access_control/TestExpressionAccessControl.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/access_control/TestExpressionAccessControl.py
@@ -42,7 +42,6 @@ class TestSwiftExpressionAccessControl(TestBase):
         self.assertTrue(answer == expected_result, report_str)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_expression_access_control(self):
         """Make sure expressions ignore access control"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -41,7 +41,6 @@ class TestExpressionsInSwiftMethodsFromObjC(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_expressions_from_objc(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -40,7 +40,6 @@ class TestExpressionsInSwiftMethodsPureSwift(TestBase):
         self.assertTrue(answer == expected_result, report_str)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -36,7 +36,6 @@ class TestExclusivitySuppression(TestBase):
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_basic_exclusivity_suppression(self):
         """Test that exclusively owned values can still be accessed"""
 
@@ -57,7 +56,6 @@ class TestExclusivitySuppression(TestBase):
     # (5) Evaluating w.s.i again to check that finishing the nested expression
     #     did not prematurely re-enable exclusivity checks.
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_exclusivity_suppression_for_concurrent_expressions(self):
         """Test that exclusivity suppression works with concurrent expressions"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -31,14 +31,12 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
 
     @skipIfLinux # <rdar://problem/30783388> test crashing sometimes when run on linux
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_generic_expressions(self):
         """Test expressions in generic contexts"""
         self.build()
         self.do_test()
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_ivars_in_generic_expressions(self):
         """Test ivar access through expressions in generic contexts"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -27,7 +27,6 @@ class TestSwiftExpressionObjCContext(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         self.build()
         exe_name = "a.out"

--- a/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -19,7 +19,6 @@ class TestOptionalAmbiguity(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_sample_rename_this(self):
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")

--- a/packages/Python/lldbsuite/test/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -25,7 +25,6 @@ class TestSwiftExpressionScopes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -43,7 +43,6 @@ class TestSimpleSwiftExpressions(TestBase):
         self.assertTrue(answer == expected_result, report_str)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/file_private/TestFilePrivate.py
+++ b/packages/Python/lldbsuite/test/lang/swift/file_private/TestFilePrivate.py
@@ -46,7 +46,6 @@ class TestFilePrivate(TestBase):
         self.assertTrue(answer == expected_result, report_str)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test(self):
         """Test that we find the right file-local private decls using the discriminator"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/fixits/TestSwiftFixIts.py
+++ b/packages/Python/lldbsuite/test/lang/swift/fixits/TestSwiftFixIts.py
@@ -24,7 +24,6 @@ class TestSwiftFixIts(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_fixits(self):
         """Test applying fixits to expressions"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/packages/Python/lldbsuite/test/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -24,7 +24,6 @@ class SwiftGetValueAsUnsignedAPITest(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_get_value_as_unsigned_sbapi(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -19,7 +19,6 @@ class TestSwiftHashedContainerEnum(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_any_object_type(self):
         """Test combinations of hashed swift containers with enums"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -29,7 +29,6 @@ class TestSwiftCGImportedTypes(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_cg_imported_types(self):
         """Test that we are able to deal with C-imported types from CoreGraphics"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/packages/Python/lldbsuite/test/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -25,7 +25,6 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_instancepointerset_sp(self):
         """Test that we correctly track instance pointers in ValueObjectPrinter"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/let_int/TestSwiftLetInt.py
+++ b/packages/Python/lldbsuite/test/lang/swift/let_int/TestSwiftLetInt.py
@@ -28,7 +28,6 @@ class TestSwiftLetIntSupport(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_let_int(self):
         """Test that a 'let' Int is formatted properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/metatype/TestSwiftMetatype.py
+++ b/packages/Python/lldbsuite/test/lang/swift/metatype/TestSwiftMetatype.py
@@ -28,7 +28,6 @@ class TestSwiftMetatype(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -30,7 +30,6 @@ class TestSwiftModuleSearchPaths(TestBase):
 
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_module_search_paths(self):
         """
         Tests that we can import modules located using

--- a/packages/Python/lldbsuite/test/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -28,7 +28,6 @@ class TestSwiftMultipayloadEnum(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/nested_arrays/TestSwiftNestedArray.py
+++ b/packages/Python/lldbsuite/test/lang/swift/nested_arrays/TestSwiftNestedArray.py
@@ -42,7 +42,6 @@ class TestSwiftNestedArray(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_nested_array(self):
         """Test Arrays of Arrays in Swift"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/packages/Python/lldbsuite/test/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -35,7 +35,6 @@ class TestSwiftAtObjCIvars(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_at_objc_ivars(self):
         """Test ObjC instance variables"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/packages/Python/lldbsuite/test/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -25,7 +25,6 @@ class TestSwiftOneCaseEnum(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/path_with_colons/TestSwiftPathWithColons.py
+++ b/packages/Python/lldbsuite/test/lang/swift/path_with_colons/TestSwiftPathWithColons.py
@@ -31,7 +31,6 @@ class TestSwiftPathWithColon(TestBase):
     @skipUnlessDarwin
     @skipIfiOSSimulator
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_path_with_colon(self):
         """Test that LLDB correctly handles paths with colons"""
         self.do_test()

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds/TestPlaygrounds.py
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds/TestPlaygrounds.py
@@ -43,7 +43,6 @@ class TestSwiftPlaygrounds(TestBase):
         debug_info=decorators.no_match("dsym"),
         bugnumber="This test only builds one way",
         macos_version=["<", "10.11"])
-    @add_test_categories(["swiftpr"])
     def test_cross_module_extension(self):
         """Test that playgrounds work"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/packages/Python/lldbsuite/test/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -28,7 +28,6 @@ class TestSwiftTypeLookup(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -28,7 +28,6 @@ class TestSwiftRangeType(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -29,7 +29,6 @@ class TestSwiftReferenceStorageTypes(TestBase):
 
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/repl_in_c/TestSwiftReplInC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/repl_in_c/TestSwiftReplInC.py
@@ -19,7 +19,6 @@ class TestSwiftReplInC(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_repl_in_c(self):
         self.build()
         lldbutil.run_to_name_breakpoint(self, "main")

--- a/packages/Python/lldbsuite/test/lang/swift/tuple/TestSwiftTuple.py
+++ b/packages/Python/lldbsuite/test/lang/swift/tuple/TestSwiftTuple.py
@@ -28,7 +28,6 @@ class TestSwiftTuple(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/unit-tests/TestSwiftUnitTests.py
+++ b/packages/Python/lldbsuite/test/lang/swift/unit-tests/TestSwiftUnitTests.py
@@ -21,7 +21,6 @@ class TestSwiftUnitTests(TestBase):
     @swiftTest
     # The creation of the .xctest framework messes with the AST search path.
     @skipIf(debug_info=no_match("dsym"))
-    @add_test_categories(["swiftpr"])
     def test_cross_module_extension(self):
         """Test that XCTest-based unit tests work"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/array/TestSwiftArrayType.py
@@ -31,7 +31,6 @@ class TestSwiftArrayType(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(bugnumber='rdar://30663811', oslist=['linux'])
-    @add_test_categories(["swiftpr"])
     def test_array(self):
         """Check formatting for Swift.Array<T>"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bool/TestSwiftBool.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bool/TestSwiftBool.py
@@ -25,7 +25,6 @@ class TestSwiftBool(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_bool(self):
         """Test that we can inspect various Swift bools"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -32,7 +32,6 @@ class TestSwiftBridgedStringVariables(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_bridged_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -25,7 +25,6 @@ class TestBulkyEnumVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -26,7 +26,6 @@ class TestSwiftCoreGraphicsTypes(TestBase):
 
     @swiftTest
     @skipUnlessDarwin
-    @add_test_categories(["swiftpr"])
     def test_swift_coregraphics_types(self):
         """Test that we are able to properly format basic CG types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -25,7 +25,6 @@ class TestSwiftClassTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_class_types(self):
         """Test swift Class types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -29,7 +29,6 @@ class TestDictionaryNSObjectAnyObject(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_dictionary_nsobject_any_object(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary<NSObject,AnyObject>"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -92,7 +92,6 @@ class TestSwiftStdlibDictionary(TestBase):
 
     @swiftTest
     # @skipIfLinux  # bugs.swift.org/SR-844
-    @add_test_categories(["swiftpr"])
     def test_swift_stdlib_dictionary(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/enums/TestEnumVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/enums/TestEnumVariables.py
@@ -25,7 +25,6 @@ class TestEnumVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/func/TestFunctionVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/func/TestFunctionVariables.py
@@ -25,7 +25,6 @@ class TestFunctionVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_function_variables(self):
         """Tests that function type variables display correctly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -25,7 +25,6 @@ class TestSwiftGlobals(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
@@ -25,7 +25,6 @@ class TestInOutVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_in_out_variables(self):
         """Test that @inout variables display reasonably"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -26,7 +26,6 @@ class TestSwiftObjCOptionalType(TestBase):
 
     @swiftTest
     @skipUnlessDarwin
-    @add_test_categories(["swiftpr"])
     def test_swift_objc_optional_type(self):
         """Check formatting for T? and T! when T is an ObjC type"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -25,7 +25,6 @@ class TestSwiftOptionalType(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_optional_type(self):
         """Check formatting for T? and T!"""
         self.do_check_consistency()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -24,7 +24,6 @@ class TestSwiftProtocolTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_protocol_types(self):
         """Test support for protocol types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -28,7 +28,6 @@ class TestSwiftStdlibSet(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -28,7 +28,6 @@ class TestSwiftStaticStringVariables(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_static_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -31,7 +31,6 @@ class TestSwiftStringVariables(TestBase):
         TestBase.setUp(self)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/swift/TestSwiftTypes.py
@@ -25,7 +25,6 @@ class TestSwiftTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -24,7 +24,6 @@ class TestSwiftTupleTypes(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_tuple_types(self):
         """Test support for tuple types"""
         self.build()

--- a/packages/Python/lldbsuite/test/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
@@ -25,7 +25,6 @@ class TestSwiftValueOfOptionalType(TestBase):
     mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @add_test_categories(["swiftpr"])
     def test_swift_value_optional_type(self):
         """Check that trying to read an optional's numeric value doesn't crash LLDB"""
         self.build()

--- a/packages/Python/lldbsuite/test/repl/import-dispatch/TestREPLImportDispatch.py
+++ b/packages/Python/lldbsuite/test/repl/import-dispatch/TestREPLImportDispatch.py
@@ -24,7 +24,6 @@ class TestREPLImportDispatch(TestBase):
 
     @decorators.swiftTest
     @skipIf(debug_info=no_match(["dwarf"]))
-    @decorators.add_test_categories(["swiftpr"])
     def test(self):
         self.build()
         self.assertTrue(os.path.isfile(self.getBuildArtifact("a.out")))

--- a/packages/Python/lldbsuite/test/test_categories.py
+++ b/packages/Python/lldbsuite/test/test_categories.py
@@ -19,8 +19,6 @@ debug_info_categories = [
 ]
 
 all_categories = {
-    'swiftpr': 'Tests that may run as a part of Swift pull-request testing',
-    'swift-history': 'Tests that work even when compiled older versions of swiftc',
     'dataformatters': 'Tests related to the type command and the data formatters subsystem',
     'dwarf': 'Tests that can be run with DWARF debug information',
     'dwo': 'Tests that can be run with DWO debug information',

--- a/packages/Python/lldbsuite/test/test_result.py
+++ b/packages/Python/lldbsuite/test/test_result.py
@@ -134,18 +134,6 @@ class LLDBTestResult(unittest2.TextTestResult):
         """
         Gets all the categories for the currently running test method in test case
         """
-
-        # It isn't possible to reliably attach categories to inline tests
-        # because they all share the same instance method. Adding a category to
-        # one inline test causes all inline tests to be added to that category.
-        # This can result in an unpredictable set of tests being run when the
-        # multiprocess test runner is in use.
-        #
-        # To work around the problem, add all inline tests to the swiftpr
-        # category.
-        if any(['_InlineTest__' in field for field in dir(test)]):
-            return ['swiftpr']
-
         test_categories = []
         test_method = getattr(test, test._testMethodName)
         if test_method is not None and hasattr(test_method, "categories"):


### PR DESCRIPTION
Now that we use CMake for Swift PR testing, we have the lit filter  to
distinguish swift tests. The swift annotations are therefore no longer
necessary. This commit removes them.