### PR TITLE
[SwiftASTContext] Library search paths should be consistent with the …

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3472,9 +3472,16 @@ bool SwiftASTContext::LoadOneImage(Process &process, FileSpec &link_lib_spec,
 
 static std::vector<std::string>
 GetLibrarySearchPaths(const swift::SearchPathOptions &search_path_opts) {
-  std::vector<std::string> paths(search_path_opts.LibrarySearchPaths.begin(),
-                                 search_path_opts.LibrarySearchPaths.end());
+  // The order in which we look up the libraries is important. The REPL
+  // dlopen()s libswiftCore, and gives precedence to the just built standard
+  // library instead of the one in the OS. When we type `import Foundation`,
+  // we want to make sure we end up loading the correct library, i.e. the
+  // one sitting next to the stdlib we just built, and then fall back to the
+  // one in the OS if that's not available.
+  std::vector<std::string> paths;
   paths.push_back(search_path_opts.RuntimeLibraryPath);
+  for (std::string path : search_path_opts.LibrarySearchPaths)
+    paths.push_back(path);
   return paths;
 }
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3479,7 +3479,8 @@ GetLibrarySearchPaths(const swift::SearchPathOptions &search_path_opts) {
   // one sitting next to the stdlib we just built, and then fall back to the
   // one in the OS if that's not available.
   std::vector<std::string> paths;
-  paths.push_back(search_path_opts.RuntimeLibraryPath);
+  if (!search_path_opts.RuntimeLibraryPath.empty())
+    paths.push_back(search_path_opts.RuntimeLibraryPath);
   for (std::string path : search_path_opts.LibrarySearchPaths)
     paths.push_back(path);
   return paths;


### PR DESCRIPTION
…ones in repl_swift.

The general idea behind the REPL is that of creating a dummy
target for lldb to attach to run swift expressions. The dummy target
dlopen()s libswiftCore, so that people don't have to type `import Swift`
when they open it. In order to find libswiftCore, the build system sets
a couple of @rpath, giving priority to the just built stdlib (if any)
and falling back to the OS standard library (in /usr/lib/swift).

Once the REPL has been launched, if somebody tries to import, e.g.
Foundation, lldb calls SwiftASTContext::LoadLibraryUsingPaths, which
asks GetLibrarySearchPaths() where to look. GetLibrarySearchPaths()
sets the first rpath to /usr/lib/swift and then falls back to the
stdlib just built.

In this tragedy of commons, lldb ends up loading two different
libSwiftCore which might be not compatible with each other. This
results in weird crashes, because in presence of symbols implemented
in multiple libraries, the one that's picked is undefined.

<rdar://problem/50022178>