### PR TITLE
Fix a stack-smasher in PlatformMacOSX::GetSDKDirectory()

### DIFF
--- a/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -168,7 +168,7 @@ ConstString PlatformMacOSX::GetSDKDirectory(lldb_private::Target &target) {
       std::string default_xcode_sdk;
       FileSpec fspec;
       uint32_t versions[2];
-      if (objfile->GetSDKVersion(versions, sizeof(versions))) {
+      if (objfile->GetSDKVersion(versions, 2)) {
         fspec = HostInfo::GetShlibDir();
         if (fspec) {
           std::string path;


### PR DESCRIPTION
GetSDKVersion expects the number of version fields not their byte size
and will happily overwrite later contents of the stack.

Differential Revision: https://reviews.llvm.org/D61218

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359471 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit c456f699be5ce88e42fa0938329bc36b94ea0f18)