### PR TITLE
[lit] Fix the timeout.

### DIFF
--- a/lit/lit.cfg.py
+++ b/lit/lit.cfg.py
@@ -74,5 +74,11 @@ for i in ['module-cache-clang', 'module-cache-lldb']:
         print("Deleting module cache at %s."%cachedir)
         shutil.rmtree(cachedir)
 
-# Set a default  timeout of 10 minutes.
-lit_config.maxIndividualTestTime = 600
+# Set a default per-test timeout of 10 minutes. Setting a timeout per test
+# requires the psutil module and lit complains if the value is set but the
+# module can't be found.
+try:
+    import psutil  # noqa: F401
+    lit_config.maxIndividualTestTime = 600
+except ImportError:
+    pass

--- a/lit/lit.cfg.py
+++ b/lit/lit.cfg.py
@@ -73,3 +73,6 @@ for i in ['module-cache-clang', 'module-cache-lldb']:
     if os.path.isdir(cachedir):
         print("Deleting module cache at %s."%cachedir)
         shutil.rmtree(cachedir)
+
+# Set a default  timeout of 10 minutes.
+lit_config.maxIndividualTestTime = 600

--- a/lit/lit.site.cfg.py.in
+++ b/lit/lit.site.cfg.py.in
@@ -21,7 +21,6 @@ config.lldb_bitness = 64 if @LLDB_IS_64_BITS@ else 32
 config.lldb_disable_python = @LLDB_DISABLE_PYTHON@
 config.have_lldb_instr = @LLDB_TOOL_LLDB_INSTR_BUILD@
 config.have_lldb_vscode = @LLDB_TOOL_LLDB_VSCODE_BUILD@
-config.maxIndividualTestTime = 600
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
The timeout wasn't working because it's a property of the lit
configuration, not of the configuration in lit.site.cfg. This sets the
property for the correct object.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359492 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit febdfc325332e113c9b400e1fd943a13366a25f1)