### PR TITLE
repl: correct linking against `libdl`

### DIFF
--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -7,10 +7,10 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Linux" )
   # Set the correct rpath to locate libswiftCore
   if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "ppc64le")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-        -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-powerpc64le/lib${LLVM_LIBDIR_SUFFIX}/swift/linux/powerpc64le -Wl,-ldl")
+        -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-powerpc64le/lib${LLVM_LIBDIR_SUFFIX}/swift/linux/powerpc64le")
   else()
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} \
-        -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-x86_64/lib${LLVM_LIBDIR_SUFFIX}/swift/linux -Wl,-ldl")
+        -Wl,-rpath,${CMAKE_BINARY_DIR}/../swift-linux-x86_64/lib${LLVM_LIBDIR_SUFFIX}/swift/linux")
   endif()
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib/swift/linux:${CMAKE_INSTALL_RPATH}")
 endif()
@@ -18,6 +18,7 @@ endif()
 add_lldb_tool(repl_swift
   main.c
   )
+target_link_libraries(repl_swift PRIVATE ${CMAKE_DL_LIBS})
 
 # The dummy repl executable is a C program, but we always look for a mangled
 # swift symbol (corresponding to main). If we build the repl with debug info,


### PR DESCRIPTION
Not all targets link against libdl.  NetBSD is one such target.  Use
`CMAKE_DL_LIBS` which will correctly specify the spelling as well as
configure the value as appropriate for the target.