### PR TITLE
repl: make the repl helper work on Windows

### DIFF
--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -24,5 +24,12 @@ target_link_libraries(repl_swift PRIVATE ${CMAKE_DL_LIBS})
 # swift symbol (corresponding to main). If we build the repl with debug info,
 # the debugger looks at the frame language (looking up the compile unit) and gets
 # confused.
-set_target_properties(repl_swift PROPERTIES
-    COMPILE_FLAGS "-g0")
+if(MSVC)
+  # disable inline function expansion so that we have a function that we can
+  # break upon
+  target_compile_options(repl_swift PRIVATE /Ob0)
+endif()
+if(NOT MSVC)
+  set_target_properties(repl_swift PROPERTIES
+      COMPILE_FLAGS "-g0")
+endif()

--- a/tools/repl/swift/main.c
+++ b/tools/repl/swift/main.c
@@ -19,6 +19,14 @@
 #include <dlfcn.h>
 #endif
 
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
+#include <stdio.h>
+
 #define REPL_MAIN _TF10repl_swift9repl_mainFT_Si
 
 #if !defined(__has_attribute)
@@ -32,7 +40,11 @@
 #endif
 
 SWIFT_REPL_NOOPT
-int REPL_MAIN() {
+int
+#if defined(_WIN32)
+__declspec(dllexport)
+#endif
+REPL_MAIN() {
   return 0;
 }
 
@@ -43,6 +55,10 @@ int main() {
   dlopen("@rpath/libswiftCore.dylib", RTLD_LAZY);
 #elif defined(__linux__)
   dlopen("libswiftCore.so", RTLD_LAZY);
+#elif defined(_WIN32)
+  HMODULE hModule = LoadLibraryW(L"swiftCore.dll");
+  if (hModule == NULL)
+    fprintf(stderr, "unable to load standard library: %lu\n", GetLastError());
 #endif
 
 #ifdef __APPLE__
@@ -77,6 +93,6 @@ int main() {
     }
   }
 #else
-  REPL_MAIN();
+  return REPL_MAIN();
 #endif
 }


### PR DESCRIPTION
Adjust the repl so that it emits the TEST_MAIN on Windows.  Add code to
actually load the standard library DLL.  Unfortunately, the standard
library interfaces are still unavailable to LLDB for some reason.