### PR TITLE
[Swift] Set the ParseableInterfaceModuleLoader's prebuilt module cache path

### DIFF
--- a/scripts/check-ast-context.py
+++ b/scripts/check-ast-context.py
@@ -419,7 +419,8 @@ def main():
         'GetPluginVersion',
         'HasFatalErrors',
         'GetFatalErrors',
-        'PrintDiagnostics'
+        'PrintDiagnostics',
+        'GetASTContext'
     ]
 
     for method in methods:


### PR DESCRIPTION
It's now being set to `<resource dir>/<platform>/prebuilt-modules` to match its default value in the Swift compiler.

Resolves rdar://problem/47611329