### PR TITLE
Disabling test in TestClassTemplateParameterPack.py until we do template lookup correctly

### DIFF
--- a/packages/Python/lldbsuite/test/lang/cpp/class-template-parameter-pack/TestClassTemplateParameterPack.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/class-template-parameter-pack/TestClassTemplateParameterPack.py
@@ -4,6 +4,4 @@ from lldbsuite.test import decorators
 lldbinline.MakeInlineTest(
     __file__, globals(), [
         decorators.expectedFailureAll(
-            compiler="gcc"),
-        decorators.expectedFailureAll(
-            bugnumber="rdar://47370292")])
+            compiler="gcc")])

--- a/packages/Python/lldbsuite/test/lang/cpp/class-template-parameter-pack/main.cpp
+++ b/packages/Python/lldbsuite/test/lang/cpp/class-template-parameter-pack/main.cpp
@@ -42,10 +42,12 @@ int main (int argc, char const *argv[])
     (void)C<int,16,32>().isSixteenThirtyTwo();
     (void)C<int,16>().isSixteenThirtyTwo();
     (void)(myC.member != 64);   //% self.expect("expression -- myC", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["64"])
-                                //% self.expect("expression -- C<int, 16>().isSixteenThirtyTwo()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["false"])
-                                //% self.expect("expression -- C<int, 16, 32>().isSixteenThirtyTwo()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["true"])
                                 //% self.expect("expression -- myLesserC.isSixteenThirtyTwo()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["false"])
                                 //% self.expect("expression -- myC.isSixteenThirtyTwo()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["true"])
+
+                                // Disabling until we do template lookup correctly: http://lists.llvm.org/pipermail/lldb-commits/Week-of-Mon-20180507/040689.html
+                                //#% self.expect("expression -- C<int, 16>().isSixteenThirtyTwo()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["false"])
+                                //#% self.expect("expression -- C<int, 16, 32>().isSixteenThirtyTwo()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["true"])
    
     D<int,int,bool> myD;
     D<int,int> myLesserD;
@@ -53,8 +55,10 @@ int main (int argc, char const *argv[])
     (void)D<int,int,bool>().isIntBool();
     (void)D<int,int>().isIntBool();
     return myD.member != 64;	//% self.expect("expression -- myD", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["64"])
-                                //% self.expect("expression -- D<int, int>().isIntBool()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["false"])
-                                //% self.expect("expression -- D<int, int, bool>().isIntBool()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["true"])
                                 //% self.expect("expression -- myLesserD.isIntBool()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["false"])
                                 //% self.expect("expression -- myD.isIntBool()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["true"])
+
+                                // See comment above.
+                                //#% self.expect("expression -- D<int, int>().isIntBool()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["false"])
+                                //#% self.expect("expression -- D<int, int, bool>().isIntBool()", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["true"])
 }


### PR DESCRIPTION
Summary:
Some tests currently only work because we are pulling all the local variables when we are evaluating an expression. This will soon
change and these test are working but for the wrong reasons. The details can be found in the discussion here:
http://lists.llvm.org/pipermail/lldb-commits/Week-of-Mon-20180507/040689.html

Differential Review:  https://reviews.llvm.org/D61266

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359699 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 3ce4f605628023708c30581f84467544b3187492)