### PR TITLE
Fix incorrect merge

### DIFF
--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -111,8 +111,6 @@ llvm::Error SystemInitializerCommon::Initialize() {
 
   SwiftREPL::Initialize();
 
-  ObjectContainerBSDArchive::Initialize();
-
   EmulateInstructionARM::Initialize();
   EmulateInstructionMIPS::Initialize();
   EmulateInstructionMIPS64::Initialize();


### PR DESCRIPTION
ObjectContainerBSDArchive initialization was moved, but that change
didn't get merged correctly so the build fails.

cc @dcci @compnerd @JDevlieghere @jimingham @adrian-prantl 