### PR TITLE
Hide runtime support values such as clang's __vla_expr from frame var…

### DIFF
--- a/include/lldb/Target/CPPLanguageRuntime.h
+++ b/include/lldb/Target/CPPLanguageRuntime.h
@@ -64,6 +64,7 @@ public:
   lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
                                                   bool stop_others);
 
+  bool IsRuntimeSupportValue(ValueObject &valobj) override;
 protected:
   //------------------------------------------------------------------
   // Classes that inherit from CPPLanguageRuntime can see and modify these

--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -163,6 +163,8 @@ public:
     return false;
   }
 
+  /// Identify whether a value is a language implementation detaul
+  /// that should be hidden from the user interface by default.
   virtual bool IsRuntimeSupportValue(ValueObject &valobj) { return false; }
 
   virtual void ModulesDidLoad(const ModuleList &module_list) {}

--- a/include/lldb/Target/ObjCLanguageRuntime.h
+++ b/include/lldb/Target/ObjCLanguageRuntime.h
@@ -292,6 +292,11 @@ public:
   bool GetTypeBitSize(const CompilerType &compiler_type,
                       uint64_t &size) override;
 
+  /// Check whether the name is "self" or "_cmd" and should show up in
+  /// "frame variable".
+  static bool IsWhitelistedRuntimeValue(ConstString name);
+  bool IsRuntimeSupportValue(ValueObject &valobj) override;
+
 protected:
   //------------------------------------------------------------------
   // Classes that inherit from ObjCLanguageRuntime can see and modify these

--- a/packages/Python/lldbsuite/test/lang/c/vla/TestVLA.py
+++ b/packages/Python/lldbsuite/test/lang/c/vla/TestVLA.py
@@ -23,7 +23,8 @@ class TestVLA(TestBase):
         var_opts.SetIncludeRuntimeSupportValues(False)
         var_opts.SetUseDynamic(lldb.eDynamicCanRunTarget)
         all_locals = self.frame().GetVariables(var_opts)
-        self.assertEqual(len(all_locals), 1)
+        for value in all_locals:
+            self.assertFalse("vla_expr" in value.name)
 
         def test(a, array):
             for i in range(a):

--- a/packages/Python/lldbsuite/test/lang/c/vla/TestVLA.py
+++ b/packages/Python/lldbsuite/test/lang/c/vla/TestVLA.py
@@ -8,8 +8,8 @@ class TestVLA(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    @decorators.skipIf(compiler="clang", compiler_version=['<', '8.0'])
-    def test_vla(self):
+    @skipIf(compiler="clang", compiler_version=['<', '8.0'])
+    def test_variable_list(self):
         self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec('main.c'))

--- a/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/Makefile
+++ b/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+
+OBJCXX_SOURCES := main.mm
+LDFLAGS = $(CFLAGS) -lobjc -framework Foundation
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/TestObjCXXHideRuntimeValues.py
+++ b/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/TestObjCXXHideRuntimeValues.py
@@ -1,0 +1,47 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestObjCXXHideRuntimeSupportValues(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    def test_hide_runtime_support_values(self):
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.mm'))
+
+        var_opts = lldb.SBVariablesOptions()
+        var_opts.SetIncludeArguments(True)
+        var_opts.SetIncludeLocals(True)
+        var_opts.SetInScopeOnly(True)
+        var_opts.SetIncludeStatics(False)
+        var_opts.SetIncludeRuntimeSupportValues(False)
+        var_opts.SetUseDynamic(lldb.eDynamicCanRunTarget)
+        values = self.frame().GetVariables(var_opts)
+
+        def shows_var(name):
+            for value in values:
+                if value.name == name:
+                    return True
+            return False
+        # ObjC method.
+        values = self.frame().GetVariables(var_opts)
+        self.assertFalse(shows_var("this"))
+        self.assertTrue(shows_var("self"))
+        self.assertTrue(shows_var("_cmd"))
+        self.assertTrue(shows_var("c"))
+
+        process.Continue()
+        # C++ method.
+        values = self.frame().GetVariables(var_opts)
+        self.assertTrue(shows_var("this"))
+        self.assertFalse(shows_var("self"))
+        self.assertFalse(shows_var("_cmd"))

--- a/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/TestObjCXXHideRuntimeValues.py
+++ b/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/TestObjCXXHideRuntimeValues.py
@@ -13,6 +13,10 @@ class TestObjCXXHideRuntimeSupportValues(TestBase):
     def setUp(self):
         TestBase.setUp(self)
 
+    @skipIfFreeBSD
+    @skipIfLinux
+    @skipIfWindows
+    @skipIfNetBSD
     def test_hide_runtime_support_values(self):
         self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(

--- a/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/main.mm
+++ b/packages/Python/lldbsuite/test/lang/objcxx/hide-runtime-values/main.mm
@@ -1,0 +1,28 @@
+#import <Foundation/Foundation.h>
+
+void baz() {}
+
+struct MyClass {
+  void bar() {
+    baz(); // break here
+  }
+};
+
+@interface MyObject : NSObject {}
+- (void)foo;
+@end
+
+@implementation MyObject
+- (void)foo {
+  MyClass c;
+  c.bar(); // break here
+}
+@end
+
+int main (int argc, char const *argv[]) {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    id obj = [MyObject new];
+    [obj foo];
+    [pool release];
+    return 0;
+}

--- a/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -66,6 +66,8 @@ class TestSwiftHideRuntimeSupport(TestBase):
         for value in values:
             if '_0_0' in value.name:
                 found = True
+            if '$' in value.name:
+                found = True
         self.assertFalse(found, "found the thing I was not expecting")
 
         var_opts.SetIncludeRuntimeSupportValues(True)

--- a/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/main.swift
@@ -2,16 +2,18 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
+func use(_ t: T) {}
+
 func foo<T>(_ x: T) -> () {
-  print(x)
-  return print("break here")
+  use("(\x)")
+  use("break here")
 }
 
 foo(193627)

--- a/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/hide_runtimesupport/main.swift
@@ -9,10 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-func use(_ t: T) {}
+func use<T>(_ t: T) {}
 
 func foo<T>(_ x: T) -> () {
-  use("(\x)")
+  use("\(x)")
   use("break here")
 }
 

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -32,6 +32,7 @@
 #include "lldb/Symbol/Declaration.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/Type.h"
+#include "lldb/Symbol/Variable.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/LanguageRuntime.h"
@@ -1809,6 +1810,9 @@ bool ValueObject::IsRuntimeSupportValue() {
       runtime = process->GetObjCLanguageRuntime();
     if (runtime)
       return runtime->IsRuntimeSupportValue(*this);
+    // If there is no language runtime, trust the compiler to mark all
+    // runtime support variables as artificial.
+    return GetVariable() && GetVariable()->IsArtificial();
   }
   return false;
 }

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -4299,9 +4299,11 @@ ClangASTContext::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
   if (qual_type->isAnyPointerType()) {
     if (qual_type->isObjCObjectPointerType())
       return lldb::eLanguageTypeObjC;
+    if (qual_type->getPointeeCXXRecordDecl())
+      return lldb::eLanguageTypeC_plus_plus;
 
     clang::QualType pointee_type(qual_type->getPointeeType());
-    if (pointee_type->getPointeeCXXRecordDecl() != nullptr)
+    if (pointee_type->getPointeeCXXRecordDecl())
       return lldb::eLanguageTypeC_plus_plus;
     if (pointee_type->isObjCObjectOrInterfaceType())
       return lldb::eLanguageTypeObjC;

--- a/source/Target/CPPLanguageRuntime.cpp
+++ b/source/Target/CPPLanguageRuntime.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Target/CPPLanguageRuntime.h"
+#include "lldb/Target/ObjCLanguageRuntime.h"
 
 #include <string.h>
 
@@ -16,6 +17,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include "lldb/Symbol/Block.h"
+#include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
 
 #include "lldb/Core/PluginManager.h"
@@ -32,13 +34,29 @@
 using namespace lldb;
 using namespace lldb_private;
 
-//----------------------------------------------------------------------
+static ConstString g_this = ConstString("this");
+
 // Destructor
-//----------------------------------------------------------------------
 CPPLanguageRuntime::~CPPLanguageRuntime() {}
 
 CPPLanguageRuntime::CPPLanguageRuntime(Process *process)
     : LanguageRuntime(process) {}
+
+bool CPPLanguageRuntime::IsRuntimeSupportValue(ValueObject &valobj) {
+  // All runtime support values have to be marked as artificial by the
+  // compiler. But not all artificial variables should be hidden from
+  // the user.
+  if (!valobj.GetVariable())
+    return false;
+  if (!valobj.GetVariable()->IsArtificial())
+    return false;
+
+  // Whitelist "this" and since there is no ObjC++ runtime, any ObjC names.
+  ConstString name = valobj.GetName();
+  if (name == g_this)
+    return false;
+  return !ObjCLanguageRuntime::IsWhitelistedRuntimeValue(name);
+}
 
 bool CPPLanguageRuntime::GetObjectDescription(Stream &str,
                                               ValueObject &object) {
@@ -320,7 +338,7 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
   StackFrameSP frame = thread.GetStackFrameAtIndex(0);
 
   if (frame) {
-    ValueObjectSP value_sp = frame->FindVariable(ConstString("this"));
+    ValueObjectSP value_sp = frame->FindVariable(g_this);
 
     CPPLanguageRuntime::LibCppStdFunctionCallableInfo callable_info =
         FindLibCppStdFunctionCallableInfo(value_sp);

--- a/source/Target/ObjCLanguageRuntime.cpp
+++ b/source/Target/ObjCLanguageRuntime.cpp
@@ -16,6 +16,7 @@
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/TypeList.h"
+#include "lldb/Symbol/Variable.h"
 #include "lldb/Target/ObjCLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/Log.h"
@@ -38,6 +39,25 @@ ObjCLanguageRuntime::ObjCLanguageRuntime(Process *process)
       m_isa_to_descriptor(), m_hash_to_isa_map(), m_type_size_cache(),
       m_isa_to_descriptor_stop_id(UINT32_MAX), m_complete_class_cache(),
       m_negative_complete_class_cache() {}
+
+bool ObjCLanguageRuntime::IsWhitelistedRuntimeValue(ConstString name) {
+  static ConstString g_self = ConstString("self");
+  static ConstString g_cmd = ConstString("_cmd");
+  return name == g_self || name == g_cmd;
+}
+
+bool ObjCLanguageRuntime::IsRuntimeSupportValue(ValueObject &valobj) {
+  // All runtime support values have to be marked as artificial by the
+  // compiler. But not all artificial variables should be hidden from
+  // the user.
+  if (!valobj.GetVariable())
+    return false;
+  if (!valobj.GetVariable()->IsArtificial())
+    return false;
+
+  // Whitelist "self" and "_cmd".
+  return !IsWhitelistedRuntimeValue(valobj.GetName());
+}
 
 bool ObjCLanguageRuntime::AddClass(ObjCISA isa,
                                    const ClassDescriptorSP &descriptor_sp,


### PR DESCRIPTION
…iable

by respecting the "artificial" attribute on variables. Function
arguments that are artificial and useful to end-users are being
whitelisted by the language runtime.

<rdar://problem/45322477>

Differential Revision: https://reviews.llvm.org/D61451

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359841 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit ec5a68ab06bd96a74246d57cffa3abeb4a4c7e6d)