### PR TITLE
Make lldb-mi optional and change how we deal with missing tools in lit

### DIFF
--- a/lit/CMakeLists.txt
+++ b/lit/CMakeLists.txt
@@ -35,8 +35,6 @@ endif()
 # the value is not canonicalized within LLVM
 llvm_canonicalize_cmake_booleans(
   LLDB_DISABLE_PYTHON
-  LLDB_TOOL_LLDB_INSTR_BUILD
-  LLDB_TOOL_LLDB_VSCODE_BUILD
   LLVM_ENABLE_ZLIB
   LLDB_IS_64_BITS)
 

--- a/lit/lit.site.cfg.py.in
+++ b/lit/lit.site.cfg.py.in
@@ -19,8 +19,6 @@ config.have_zlib = @LLVM_ENABLE_ZLIB@
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.lldb_bitness = 64 if @LLDB_IS_64_BITS@ else 32
 config.lldb_disable_python = @LLDB_DISABLE_PYTHON@
-config.have_lldb_instr = @LLDB_TOOL_LLDB_INSTR_BUILD@
-config.have_lldb_vscode = @LLDB_TOOL_LLDB_VSCODE_BUILD@
 config.maxIndividualTestTime = 600
 
 # Support substitution of the tools and libs dirs with user parameters. This is

--- a/lit/tools/lldb-instr/lit.local.cfg
+++ b/lit/tools/lldb-instr/lit.local.cfg
@@ -1,4 +1,2 @@
-import sys
-  
-if not config.have_lldb_instr:
+if not "lldb-instr" in config.available_features:
     config.unsupported = True

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_subdirectory(argdumper)
 add_subdirectory(driver)
 add_subdirectory(intel-features)
-add_subdirectory(lldb-mi)
 
 # We want lldb-test to be built only when it's needed,
 # i.e. if a target requires it as dependency. The typical
@@ -9,6 +8,7 @@ add_subdirectory(lldb-mi)
 add_subdirectory(lldb-test EXCLUDE_FROM_ALL)
 
 add_lldb_tool_subdirectory(lldb-instr)
+add_lldb_tool_subdirectory(lldb-mi)
 add_lldb_tool_subdirectory(lldb-vscode)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")


### PR DESCRIPTION
We don't need the variables in lit, we can use the capabilities to check
if the utility exists.

Differential revision: https://reviews.llvm.org/D61533

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359926 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 097a7f74695bbd3a3256b391ab054d9bb37e06ce)