### PR TITLE
Fix for ambiguous lookup in expressions between local variable and namespace

### DIFF
--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_cpp_and_c/Makefile
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_cpp_and_c/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../make
+
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_cpp_and_c/TestNamespaceLocalVarSameNameCppAndC.py
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_cpp_and_c/TestNamespaceLocalVarSameNameCppAndC.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestNamespaceLocalVarSameNameCppAndC(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    @add_test_categories(["gmodules"])
+    def test_namespace_local_var_same_name_cpp_and_c(self):
+        self.build()
+
+        (self.target, self.process, _, bkpt) = lldbutil.run_to_source_breakpoint(self, '// break here',
+                lldb.SBFileSpec("main.cpp", False))
+
+        self.expect("expr error",
+                substrs=['(int) $0 = 1'])
+
+        lldbutil.continue_to_breakpoint(self.process, bkpt)
+
+        self.expect("expr error",
+                substrs=['(int) $1 = 1'])

--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_cpp_and_c/main.cpp
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_cpp_and_c/main.cpp
@@ -1,0 +1,21 @@
+namespace error {
+  int x;
+}
+
+struct A {
+  void foo() {
+    int error=1;
+
+    return; // break here
+  }
+};
+
+int main() {
+ int error=1;
+
+ A a;
+
+ a.foo();
+
+ return 0; // break here
+}

--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/Makefile
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../make
+OBJCXX_SOURCES := main.mm util.mm
+include $(LEVEL)/Makefile.rules
+
+LDFLAGS += -framework Foundation

--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/TestNamespaceLocalVarSameNameObjC.py
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/TestNamespaceLocalVarSameNameObjC.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestNamespaceLocalVarSameNameObjC(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    @add_test_categories(["gmodules"])
+    def test_namespace_local_var_same_name_obj_c(self):
+        self.build()
+
+        (self.target, self.process, _, bkpt) = lldbutil.run_to_source_breakpoint(self, '// break here',
+                lldb.SBFileSpec("util.mm", False))
+
+        self.expect("expr error",
+                substrs=['(NSError *) $0 ='])
+
+        lldbutil.continue_to_breakpoint(self.process, bkpt)
+
+        self.expect("expr error",
+                substrs=['(NSError *) $1 ='])

--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/main.mm
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/main.mm
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+@interface Util : NSObject
++ (void)debugPrintErrorStatic;
+- (void)debugPrintError;
+@end
+
+int main(int argc, const char * argv[]) {
+  [Util debugPrintErrorStatic];
+
+  Util *u = [[Util alloc] init];
+
+  [u debugPrintError];
+
+  return 0;
+}
+

--- a/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/util.mm
+++ b/packages/Python/lldbsuite/test/expression_command/namespace_local_var_same_name_obj_c/util.mm
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+namespace error {
+int blah;
+}
+
+@interface Util : NSObject
++ (void)debugPrintErrorStatic;
+- (void)debugPrintError;
+@end
+
+@implementation Util
++ (void)debugPrintErrorStatic {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:-1 userInfo:nil];
+  NSLog(@"xxx, error = %@", error); // break here
+}
+
+- (void)debugPrintError {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:-1 userInfo:nil];
+  NSLog(@"xxx, error = %@", error); // break here
+}
+@end


### PR DESCRIPTION
Summary:
In an Objective-C context a local variable and namespace can cause an ambiguous name lookup when used in an expression. The solution involves mimicking the existing C++ solution which is to add local using declarations for local variables. This causes a different type of lookup to be used which eliminates the namespace during acceptable results filtering.

Differential Revision: https://reviews.llvm.org/D59960

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359921 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit f235e7581bb43fb891483f3bd51e4e35a83421ac)