### PR TITLE
Set a CXXRecordDecl to not be passed in registers if DW_CC_pass_by_reference when loading from DWARF

### DIFF
--- a/packages/Python/lldbsuite/test/expression_command/argument_passing_restrictions/Makefile
+++ b/packages/Python/lldbsuite/test/expression_command/argument_passing_restrictions/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../make
+
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/expression_command/argument_passing_restrictions/TestArgumentPassingRestrictions.py
+++ b/packages/Python/lldbsuite/test/expression_command/argument_passing_restrictions/TestArgumentPassingRestrictions.py
@@ -1,0 +1,32 @@
+"""
+This is a test to ensure that both lldb is reconstructing the right
+calling convention for a CXXRecordDecl as represented by:
+
+   DW_CC_pass_by_reference
+   DW_CC_pass_by_value
+
+and to also make sure that the ASTImporter is copying over this
+setting when importing the CXXRecordDecl via setArgPassingRestrictions.
+"""
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestArgumentPassingRestrictions(TestBase):
+
+  mydir = TestBase.compute_mydir(__file__)
+
+  def test_argument_passing_restrictions(self):
+    self.build()
+
+    lldbutil.run_to_source_breakpoint(self, '// break here',
+            lldb.SBFileSpec("main.cpp"))
+
+    self.expect("expr returnPassByRef()",
+            substrs=['(PassByRef)', '= 11223344'])
+
+    self.expect("expr takePassByRef(p)",
+            substrs=['(int)', '= 42'])

--- a/packages/Python/lldbsuite/test/expression_command/argument_passing_restrictions/main.cpp
+++ b/packages/Python/lldbsuite/test/expression_command/argument_passing_restrictions/main.cpp
@@ -1,0 +1,19 @@
+// This structure has a non-trivial copy constructor so
+// it needs to be passed by reference.
+struct PassByRef {
+  PassByRef() = default;
+  PassByRef(const PassByRef &p){x = p.x;};
+
+  int x = 11223344;
+};
+
+PassByRef returnPassByRef() { return PassByRef(); }
+int takePassByRef(PassByRef p) {
+    return p.x;
+}
+
+int main() {
+    PassByRef p = returnPassByRef();
+    p.x = 42;
+    return takePassByRef(p); // break here
+}

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -960,6 +960,14 @@ TypeSP DWARFASTParserClang::ParseTypeFromDWARF(const SymbolContext &sc,
           }
         }
 
+        if (calling_convention == llvm::dwarf::DW_CC_pass_by_reference) {
+          clang::CXXRecordDecl *record_decl =
+              m_ast.GetAsCXXRecordDecl(clang_type.GetOpaqueQualType());
+          if (record_decl)
+            record_decl->setArgPassingRestrictions(
+                clang::RecordDecl::APK_CannotPassInRegs);
+        }
+
       } break;
 
       case DW_TAG_enumeration_type: {


### PR DESCRIPTION
Summary:
This will fix a bug where during expression parsing we are not setting a CXXRecordDecl to not be passed in registers and the resulting code generation is wrong.
The DWARF attribute DW_CC_pass_by_reference tells us that we should not be passing in registers i.e. RAA_Indirect.
This change depends this clang change which fixes the fact that the ASTImporter does not copy RecordDeclBits for CXXRecordDecl: https://reviews.llvm.org/D61140

Differential Revision: https://reviews.llvm.org/D61146

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359732 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 4285f7f8db7300c72712db5cf08bd071ea3bf90a)