### PR TITLE
[Alias] Add 're' alias for register

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/register/register_command/TestRegisters.py
+++ b/packages/Python/lldbsuite/test/functionalities/register/register_command/TestRegisters.py
@@ -188,7 +188,8 @@ class RegisterCommandsTestCase(TestBase):
         elif not value.IsValid():
             return  # If register doesn't exist, skip this test
 
-        self.runCmd("register write " + register + " \'" + new_value + "\'")
+        # Also test the 're' alias.
+        self.runCmd("re write " + register + " \'" + new_value + "\'")
         self.expect(
             "register read " +
             register,

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -435,6 +435,11 @@ void CommandInterpreter::Initialize() {
     AddAlias("var", cmd_obj_sp);
     AddAlias("vo", cmd_obj_sp, "--object-description");
   }
+
+  cmd_obj_sp = GetCommandSPExact("register", false);
+  if (cmd_obj_sp) {
+    AddAlias("re", cmd_obj_sp);
+  }
 }
 
 void CommandInterpreter::Clear() {


### PR DESCRIPTION
This patch makes `re` an alias for `register`. Currently `re<TAB>` gives
you the choice between `register` and `reproducer`. Given that you use
`register` a lot more often, it should win for the common substring.

Differential revision: https://reviews.llvm.org/D61469

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@359927 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 39f7cfb4fed12f352b696e534972b8bcd333f10e)