### PR TITLE
[lldb] [test] Skip lldb-mi test if LLDB_DISABLE_PYTHON is used

### DIFF
--- a/lit/helper/toolchain.py
+++ b/lit/helper/toolchain.py
@@ -52,7 +52,8 @@ def use_lldb_substitutions(config):
 
     llvm_config.add_tool_substitutions(primary_tools,
                                        [config.lldb_tools_dir])
-    if lldbmi.was_resolved:
+    # lldb-mi always fails without Python support
+    if lldbmi.was_resolved and not config.lldb_disable_python:
         config.available_features.add('lldb-mi')
 
 def _use_msvc_substitutions(config):

--- a/lit/tools/lldb-mi/lit.local.cfg
+++ b/lit/tools/lldb-mi/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "lldb-mi" in config.available_features:
+    config.unsupported = True


### PR DESCRIPTION
Skip running lldb-mi tests when Python support is disabled.  This causes
lldb-mi to unconditionally fail, and therefore all the relevant tests
fail as well.

Differential Revision: https://reviews.llvm.org/D58000

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@353700 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 26e4fcb287152f873c00b18075053f99c9a833eb)