### PR TITLE
Fix reversed arguments to ExprBodyContainsVar(...)

### DIFF
--- a/source/Expression/ExpressionSourceCode.cpp
+++ b/source/Expression/ExpressionSourceCode.cpp
@@ -210,7 +210,7 @@ static void AddLocalVariableDecls(const lldb::VariableListSP &var_list_sp,
     if (!var_name || var_name == ConstString(".block_descriptor"))
       continue;
 
-    if (!expr.empty() && !ExprBodyContainsVar(expr, var_name.GetStringRef()))
+    if (!expr.empty() && !ExprBodyContainsVar(var_name.GetStringRef(), expr))
       continue;
 
     if ((var_name == ConstString("self") || var_name == ConstString("_cmd")) &&


### PR DESCRIPTION
When making the change to fix ambiguous lookup in expressions betwee local vairables and namespaces there was a merge conflict:

https://github.com/apple/swift-lldb/pull/1536/files

the conflict was incorrectly resolved for ExprBodyContainsVar() whose arguments were switched in order at one point.