### PR TITLE
[lldb] UNXFAIL part of TestExprCompletion on swift-lldb.

### DIFF
--- a/packages/Python/lldbsuite/test/expression_command/completion/TestExprCompletion.py
+++ b/packages/Python/lldbsuite/test/expression_command/completion/TestExprCompletion.py
@@ -195,7 +195,6 @@ class CommandLineExprCompletionTestCase(TestBase):
         self.complete_exactly('expr some_expr.Self(). FooNoArgs',
                               'expr some_expr.Self(). FooNoArgsBar()')
 
-    @expectedFailureAll(bugnumber="rdar://47370292")
     def test_expr_completion_with_descriptions(self):
         self.build()
         self.main_source = "main.cpp"


### PR DESCRIPTION
<rdar://problem/47370292>