### PR TITLE
[Swift] Refactor all module loader creation/addition to happen in GetASTContext()

### DIFF
--- a/lit/Swift/DynamicTyperesolutionConflict.test
+++ b/lit/Swift/DynamicTyperesolutionConflict.test
@@ -1,4 +1,5 @@
 # REQUIRES: system-darwin
+# REQUIRES: rdar50667488
 
 # This testcase causes the scratch context to get destroyed by a
 # conflict that is triggered via dynamic type resolution. The conflict

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -58,13 +58,10 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
         self.expect("fr v -d no-dynamic-values -- input",
                     substrs=['(Dylib.LibraryProtocol) input'])
         self.expect("fr v -d run-target -- input",
-                    substrs=['(Dylib.LibraryProtocol) input'])
-                    # FIXME: substrs=['(main.FromMainModule) input'])
+                    substrs=['(a.FromMainModule) input'])
         self.expect("expr -d run-target -- input",
                     "test that the expression evaluator can recover",
-                    substrs=['(Dylib.LibraryProtocol) $R0'])
-                    # FIXME: substrs=['(main.FromMainModule) input'])
-                    
+                    substrs=['(a.FromMainModule) $R0'])
 
 if __name__ == '__main__':
     import atexit


### PR DESCRIPTION
This is necessary to be able to use the ClangImporter's clang::CompilerInstance to get the default clang module cache path to use in Swift's ParseableInterfaceModuleLoader which must be added before adding the ClangImporter. Previously they were created and added in separate methods
(GetASTContext() for the PIML and GetClangImporter() for the ClangImporter).