### PR TITLE
Merge target and launch info environments

### DIFF
--- a/lit/Process/Inputs/env.cpp
+++ b/lit/Process/Inputs/env.cpp
@@ -1,0 +1,7 @@
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+  if (const char *env_p = std::getenv("FOO"))
+    std::cout << "FOO=" << env_p << '\n';
+}

--- a/lit/Process/TestEnvironment.test
+++ b/lit/Process/TestEnvironment.test
@@ -1,0 +1,7 @@
+The double quotes around "BAR" ensure we don't match the command.
+
+RUN: %clangxx -std=c++11 %p/Inputs/env.cpp -o %t
+RUN: %lldb %t -o 'process launch --environment FOO="BAR"' | FileCheck %s
+RUN: %lldb %t -o 'env FOO="BAR"' -o 'process launch' | FileCheck %s
+
+CHECK: FOO=BAR

--- a/source/Commands/CommandObjectProcess.cpp
+++ b/source/Commands/CommandObjectProcess.cpp
@@ -195,7 +195,10 @@ protected:
     if (target->GetDisableSTDIO())
       m_options.launch_info.GetFlags().Set(eLaunchFlagDisableSTDIO);
 
-    m_options.launch_info.GetEnvironment() = target->GetEnvironment();
+    // Merge the launch info environment with the target environment.
+    Environment target_env = target->GetEnvironment();
+    m_options.launch_info.GetEnvironment().insert(target_env.begin(),
+                                                  target_env.end());
 
     if (!target_settings_argv0.empty()) {
       m_options.launch_info.GetArguments().AppendArgument(


### PR DESCRIPTION
Before this change we were overriding the launch info environment with
the target environment. This meant that the environment variables passed
to `process launch --environment <>` were lost. Instead of replacing the
environment, we should merge them.

Differential revision: https://reviews.llvm.org/D61864

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360612 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 1467977362168cda2dc4cd75f65c50433621c90b)