### PR TITLE
[DataFormatters] Switch to FindSymbolsMatchingRegExAndType() from FindFunctions() in FindLibCppStdFunctionCallableInfo()

### DIFF
--- a/source/Target/CPPLanguageRuntime.cpp
+++ b/source/Target/CPPLanguageRuntime.cpp
@@ -242,8 +242,8 @@ CPPLanguageRuntime::FindLibCppStdFunctionCallableInfo(
 
   SymbolContextList scl;
 
-  target.GetImages().FindFunctions(RegularExpression{func_to_match}, true, true,
-                                   true, scl);
+  target.GetImages().FindSymbolsMatchingRegExAndType(
+      RegularExpression{R"(^)" + func_to_match}, eSymbolTypeAny, scl, true);
 
   // Case 1,2 or 3
   if (scl.GetSize() >= 1) {


### PR DESCRIPTION
FindLibCppStdFunctionCallableInfo() currently uses FindFunctions() in order to find a lambdas operator()() but using FindSymbolsMatchingRegExAndType() is cheaper and if we also anchor the regex using ^ this adds some additional performance gains.

Differential Revision: https://reviews.llvm.org/D61759

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360599 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit a729f640b19ce8b8554f92ee32731913d19c981d)