### PR TITLE
[CMake] Simplify lldb-server handling

### DIFF
--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -433,14 +433,10 @@ endif()
 
 list(APPEND system_libs ${CMAKE_DL_LIBS})
 
-SET(SKIP_LLDB_SERVER_BUILD OFF CACHE BOOL "Skip building lldb-server")
-
 # Figure out if lldb could use lldb-server.  If so, then we'll
 # ensure we build lldb-server when an lldb target is being built.
-if (CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|FreeBSD|Linux|NetBSD")
-    set(LLDB_CAN_USE_LLDB_SERVER 1)
-else()
-    set(LLDB_CAN_USE_LLDB_SERVER 0)
+if (NOT CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|FreeBSD|Linux|NetBSD")
+  set(LLDB_TOOL_LLDB_SERVER_BUILD OFF)
 endif()
 
 # Figure out if lldb could use debugserver.  If so, then we'll

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(lldb-test EXCLUDE_FROM_ALL)
 
 add_lldb_tool_subdirectory(lldb-instr)
 add_lldb_tool_subdirectory(lldb-mi)
+add_lldb_tool_subdirectory(lldb-server)
 add_lldb_tool_subdirectory(lldb-vscode)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
@@ -16,11 +17,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
   add_subdirectory(debugserver)
 endif()
 
-if (LLDB_CAN_USE_LLDB_SERVER AND NOT SKIP_LLDB_SERVER_BUILD)
-  add_subdirectory(lldb-server)
-endif()
-
 # BEGIN Swift Mods
 add_subdirectory(repl/swift)
 # END Swift Mods
-

--- a/unittests/tools/CMakeLists.txt
+++ b/unittests/tools/CMakeLists.txt
@@ -1,8 +1,6 @@
-if(CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|Linux|NetBSD")
-  if ((CMAKE_SYSTEM_NAME MATCHES "Darwin" AND SKIP_TEST_DEBUGSERVER) OR (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND SKIP_LLDB_SERVER_BUILD))
-    # These tests are meant to test lldb-server/debugserver in isolation, and
-    # don't provide any value if run against a server copied from somewhere.
-  else()
-    add_subdirectory(lldb-server)
-  endif()
+if(LLDB_TOOL_LLDB_MI_BUILD)
+  add_subdirectory(lldb-mi)
+endif()
+if(LLDB_TOOL_LLDB_SERVER_BUILD)
+  add_subdirectory(lldb-server)
 endif()


### PR DESCRIPTION
We can piggyback off the existing add_lldb_tool_subdirectory to decide
whether or not lldb-server should be built.

Differential revision: https://reviews.llvm.org/D61872

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360621 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e2a0d76f51ce8ca5940c348fde5030e3f83c198d)