### PR TITLE
[Commands] Remove unused link against swift libraries

### DIFF
--- a/source/Commands/CMakeLists.txt
+++ b/source/Commands/CMakeLists.txt
@@ -31,8 +31,6 @@ add_lldb_library(lldbCommands
   CommandObjectLanguage.cpp
 
   LINK_LIBS
-    swiftAST
-    swiftIDE
     lldbBase
     lldbBreakpoint
     lldbCore

--- a/source/Commands/CommandObjectExpression.cpp
+++ b/source/Commands/CommandObjectExpression.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/Identifier.h"
-#include "swift/AST/Module.h"
-#include "swift/IDE/REPLCodeCompletion.h"
-#include "swift/IDE/Utils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"


### PR DESCRIPTION
It doesn't look like lldbCommands actually uses swiftAST or swiftIDE.

cc @compnerd @dcci @JDevlieghere 