### PR TITLE
[Core] Remove unused link against swift libraries

### DIFF
--- a/source/Core/CMakeLists.txt
+++ b/source/Core/CMakeLists.txt
@@ -58,9 +58,6 @@ add_lldb_library(lldbCore
   ValueObjectVariable.cpp
 
   LINK_LIBS
-    swiftBasic
-    swiftFrontend
-    swiftSerialization
     clangAST
     lldbBreakpoint
     lldbDataFormatters

--- a/source/Core/Debugger.cpp
+++ b/source/Core/Debugger.cpp
@@ -11,7 +11,6 @@
 #include <map>
 #include <mutex>
 
-#include "swift/Basic/Version.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/FileSystem.h"

--- a/source/Core/Module.cpp
+++ b/source/Core/Module.cpp
@@ -55,9 +55,6 @@
 #include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "Plugins/Language/ObjC/ObjCLanguage.h"
 
-#include "swift/Basic/LangOptions.h"
-#include "swift/Frontend/Frontend.h"
-#include "swift/Serialization/Validation.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/FileSystem.h"


### PR DESCRIPTION
These aren't used by Core directly. Let's remove them!

cc @compnerd @JDevlieghere @dcci 