### PR TITLE
build: use the correct variable

### DIFF
--- a/unittests/tools/CMakeLists.txt
+++ b/unittests/tools/CMakeLists.txt
@@ -1,3 +1,3 @@
-if(LLDB_TOOL_LLDB_SERVER_BUILD)
+if(LLDB_CAN_USE_LLDB_SERVER)
   add_subdirectory(lldb-server)
 endif()


### PR DESCRIPTION
Adjust the variable that controls whether the unit tests use `lldb-server`.
This should repair the default build on Windows.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360695 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit b5a8abd57f23e2f621d5ceb0f64f1bb8f9579c3f)