### PR TITLE
[CMake] Correctly reinstate LLDB_CAN_USE_LLDB_SERVER

### DIFF
--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -436,9 +436,9 @@ list(APPEND system_libs ${CMAKE_DL_LIBS})
 # Figure out if lldb could use lldb-server.  If so, then we'll
 # ensure we build lldb-server when an lldb target is being built.
 if (CMAKE_SYSTEM_NAME MATCHES "Android|Darwin|FreeBSD|Linux|NetBSD")
-  set(LLDB_CAN_USE_LLDB_SERVER 1 INTERNAL)
+  set(LLDB_CAN_USE_LLDB_SERVER 1)
 else()
-  set(LLDB_CAN_USE_LLDB_SERVER 0 INTERNAL)
+  set(LLDB_CAN_USE_LLDB_SERVER 0)
 endif()
 
 # Figure out if lldb could use debugserver.  If so, then we'll


### PR DESCRIPTION
r360631 introduced a "syntax error" which meant that cmake was still not
honoring the value of LLDB_CAN_USE_LLDB_SERVER variable. The correct
syntax for seting an internal cache variable is "set(VAR value CACHE
INTERNAL)", but the patch omitted the "CACHE" keyword. The "syntax
error" is in quotes because without the CACHE keyword this is still
valid syntax for setting the value of LLDB_CAN_USE_LLDB_SERVER to "1
INTERNAL".

There doesn't seem to be a need for this to be a cache variable so I'm
reverting this variable to a plain one, as it was before r360621.

This will hopefully fix the windows build.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360652 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit f45b0767a46f977cb1ad2fb82604dab491a47706)