### PR TITLE
DWARF/NFC: Centralize DIERef conversions

### DIFF
--- a/source/Plugins/SymbolFile/DWARF/HashedNameToDIE.cpp
+++ b/source/Plugins/SymbolFile/DWARF/HashedNameToDIE.cpp
@@ -13,8 +13,7 @@ void DWARFMappedHash::ExtractDIEArray(const DIEInfoArray &die_info_array,
                                       DIEArray &die_offsets) {
   const size_t count = die_info_array.size();
   for (size_t i = 0; i < count; ++i)
-    die_offsets.emplace_back(die_info_array[i].cu_offset,
-                             die_info_array[i].offset);
+    die_offsets.emplace_back(die_info_array[i]);
 }
 
 void DWARFMappedHash::ExtractDIEArray(const DIEInfoArray &die_info_array,
@@ -33,8 +32,7 @@ void DWARFMappedHash::ExtractDIEArray(const DIEInfoArray &die_info_array,
               tag == DW_TAG_structure_type || tag == DW_TAG_class_type;
       }
       if (tag_matches)
-        die_offsets.emplace_back(die_info_array[i].cu_offset,
-                                 die_info_array[i].offset);
+        die_offsets.emplace_back(die_info_array[i]);
     }
   }
 }
@@ -58,8 +56,7 @@ void DWARFMappedHash::ExtractDIEArray(const DIEInfoArray &die_info_array,
               tag == DW_TAG_structure_type || tag == DW_TAG_class_type;
       }
       if (tag_matches)
-        die_offsets.emplace_back(die_info_array[i].cu_offset,
-                                 die_info_array[i].offset);
+        die_offsets.emplace_back(die_info_array[i]);
     }
   }
 }
@@ -77,8 +74,7 @@ void DWARFMappedHash::ExtractClassOrStructDIEArray(
           // We found the one true definition for this class, so only return
           // that
           die_offsets.clear();
-          die_offsets.emplace_back(die_info_array[i].cu_offset,
-                                   die_info_array[i].offset);
+          die_offsets.emplace_back(die_info_array[i]);
           return;
         } else {
           // Put the one true definition as the first entry so it matches first
@@ -86,8 +82,7 @@ void DWARFMappedHash::ExtractClassOrStructDIEArray(
                               die_info_array[i].offset);
         }
       } else {
-        die_offsets.emplace_back(die_info_array[i].cu_offset,
-                                 die_info_array[i].offset);
+        die_offsets.emplace_back(die_info_array[i]);
       }
     }
   }
@@ -99,8 +94,7 @@ void DWARFMappedHash::ExtractTypesFromDIEArray(
   const size_t count = die_info_array.size();
   for (size_t i = 0; i < count; ++i) {
     if ((die_info_array[i].type_flags & type_flag_mask) == type_flag_value)
-      die_offsets.emplace_back(die_info_array[i].cu_offset,
-                               die_info_array[i].offset);
+      die_offsets.emplace_back(die_info_array[i]);
   }
 }
 

--- a/source/Plugins/SymbolFile/DWARF/HashedNameToDIE.h
+++ b/source/Plugins/SymbolFile/DWARF/HashedNameToDIE.h
@@ -63,6 +63,8 @@ public:
     DIEInfo();
     DIEInfo(dw_offset_t c, dw_offset_t o, dw_tag_t t, uint32_t f, uint32_t h,
             uint64_t s = UINT64_MAX);
+
+    explicit operator DIERef() const { return {cu_offset, offset}; }
   };
 
   struct Atom {

--- a/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -250,6 +250,7 @@ void ManualDWARFIndex::IndexUnitImpl(
       }
     }
 
+    DIERef ref(cu_offset, die.GetOffset());
     switch (tag) {
     case DW_TAG_inlined_subroutine:
     case DW_TAG_subprogram:
@@ -263,38 +264,30 @@ void ManualDWARFIndex::IndexUnitImpl(
             ConstString objc_fullname_no_category_name(
                 objc_method.GetFullNameWithoutCategory(true));
             ConstString objc_class_name_no_category(objc_method.GetClassName());
-            set.function_fullnames.Insert(ConstString(name),
-                                          DIERef(cu_offset, die.GetOffset()));
+            set.function_fullnames.Insert(ConstString(name), ref);
             if (objc_class_name_with_category)
-              set.objc_class_selectors.Insert(
-                  objc_class_name_with_category,
-                  DIERef(cu_offset, die.GetOffset()));
+              set.objc_class_selectors.Insert(objc_class_name_with_category,
+                                              ref);
             if (objc_class_name_no_category &&
                 objc_class_name_no_category != objc_class_name_with_category)
-              set.objc_class_selectors.Insert(
-                  objc_class_name_no_category,
-                  DIERef(cu_offset, die.GetOffset()));
+              set.objc_class_selectors.Insert(objc_class_name_no_category, ref);
             if (objc_selector_name)
-              set.function_selectors.Insert(objc_selector_name,
-                                            DIERef(cu_offset, die.GetOffset()));
+              set.function_selectors.Insert(objc_selector_name, ref);
             if (objc_fullname_no_category_name)
               set.function_fullnames.Insert(objc_fullname_no_category_name,
-                                            DIERef(cu_offset, die.GetOffset()));
+                                            ref);
           }
           // If we have a mangled name, then the DW_AT_name attribute is
           // usually the method name without the class or any parameters
           bool is_method = DWARFDIE(&unit, &die).IsMethod();
 
           if (is_method)
-            set.function_methods.Insert(ConstString(name),
-                                        DIERef(cu_offset, die.GetOffset()));
+            set.function_methods.Insert(ConstString(name), ref);
           else
-            set.function_basenames.Insert(ConstString(name),
-                                          DIERef(cu_offset, die.GetOffset()));
+            set.function_basenames.Insert(ConstString(name), ref);
 
           if (!is_method && !mangled_cstr && !objc_method.IsValid(true))
-            set.function_fullnames.Insert(ConstString(name),
-                                          DIERef(cu_offset, die.GetOffset()));
+            set.function_fullnames.Insert(ConstString(name), ref);
         }
         if (mangled_cstr) {
           // Make sure our mangled name isn't the same string table entry as
@@ -304,8 +297,7 @@ void ManualDWARFIndex::IndexUnitImpl(
           if (name && name != mangled_cstr &&
               ((mangled_cstr[0] == '_') ||
                (::strcmp(name, mangled_cstr) != 0))) {
-            set.function_fullnames.Insert(ConstString(mangled_cstr),
-                                          DIERef(cu_offset, die.GetOffset()));
+            set.function_fullnames.Insert(ConstString(mangled_cstr), ref);
           }
         }
       }
@@ -323,22 +315,19 @@ void ManualDWARFIndex::IndexUnitImpl(
     case DW_TAG_union_type:
     case DW_TAG_unspecified_type:
       if (name && !is_declaration)
-        set.types.Insert(ConstString(name), DIERef(cu_offset, die.GetOffset()));
+        set.types.Insert(ConstString(name), ref);
       if (mangled_cstr && !is_declaration)
-        set.types.Insert(ConstString(mangled_cstr),
-                         DIERef(cu_offset, die.GetOffset()));
+        set.types.Insert(ConstString(mangled_cstr), ref);
       break;
 
     case DW_TAG_namespace:
       if (name)
-        set.namespaces.Insert(ConstString(name),
-                              DIERef(cu_offset, die.GetOffset()));
+        set.namespaces.Insert(ConstString(name), ref);
       break;
 
     case DW_TAG_variable:
       if (name && has_location_or_const_value && is_global_or_static_variable) {
-        set.globals.Insert(ConstString(name),
-                           DIERef(cu_offset, die.GetOffset()));
+        set.globals.Insert(ConstString(name), ref);
         // Be sure to include variables by their mangled and demangled names if
         // they have any since a variable can have a basename "i", a mangled
         // named "_ZN12_GLOBAL__N_11iE" and a demangled mangled name
@@ -350,8 +339,7 @@ void ManualDWARFIndex::IndexUnitImpl(
         // entries
         if (mangled_cstr && name != mangled_cstr &&
             ((mangled_cstr[0] == '_') || (::strcmp(name, mangled_cstr) != 0))) {
-          set.globals.Insert(ConstString(mangled_cstr),
-                             DIERef(cu_offset, die.GetOffset()));
+          set.globals.Insert(ConstString(mangled_cstr), ref);
         }
       }
       break;


### PR DESCRIPTION
This didn't merge cleanly into upstream-with-swift, cherry-picking it to stable to make future merges easier.

```
apple and manual indexing code were creating a DIERef in a bunch of
places. Though the code itself is not much, it is also easy to simplify
by factoring out the DIERef creation. In HashedNameToDIE I create a
conversion operator from DIEInfo to DIERef, and in ManualDWARFIndex I
just create the DIERef in a global variable up-front.

This also reduces the diff in follow-up patches which change how DIERefs
are constructed.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360669 91177308-0d34-0410-b5e6-96231b3b80d8
```