### PR TITLE
Finish renaming CompileUnit -> Unit

### DIFF
--- a/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.cpp
+++ b/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.cpp
@@ -74,8 +74,8 @@ void AppleDWARFIndex::GetGlobalVariables(const DWARFUnit &cu,
     return;
 
   DWARFMappedHash::DIEInfoArray hash_data;
-  if (m_apple_names_up->AppendAllDIEsInRange(
-          cu.GetOffset(), cu.GetNextCompileUnitOffset(), hash_data))
+  if (m_apple_names_up->AppendAllDIEsInRange(cu.GetOffset(),
+                                             cu.GetNextUnitOffset(), hash_data))
     DWARFMappedHash::ExtractDIEArray(hash_data, offsets);
 }
 

--- a/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFCompileUnit.cpp
@@ -52,8 +52,7 @@ llvm::Expected<DWARFUnitSP> DWARFCompileUnit::extract(
     cu_sp->m_addr_size = debug_info.GetU8(offset_ptr);
   }
 
-  bool length_OK =
-      debug_info.ValidOffset(cu_sp->GetNextCompileUnitOffset() - 1);
+  bool length_OK = debug_info.ValidOffset(cu_sp->GetNextUnitOffset() - 1);
   bool version_OK = SymbolFileDWARF::SupportedVersion(cu_sp->m_version);
   bool abbr_offset_OK =
       dwarf2Data->get_debug_abbrev_data().ValidOffset(abbr_offset);
@@ -85,7 +84,7 @@ void DWARFCompileUnit::Dump(Stream *s) const {
             "abbr_offset = 0x%8.8x, addr_size = 0x%2.2x (next CU at "
             "{0x%8.8x})\n",
             m_offset, m_length, m_version, GetAbbrevOffset(), m_addr_size,
-            GetNextCompileUnitOffset());
+            GetNextUnitOffset());
 }
 
 uint32_t DWARFCompileUnit::GetHeaderByteSize() const {

--- a/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -154,7 +154,7 @@ DWARFDIE::LookupDeepestBlock(lldb::addr_t file_addr) const {
         if (cu->ContainsDIEOffset(block_die->GetOffset()))
           return DWARFDIE(cu, block_die);
         else
-          return DWARFDIE(dwarf->DebugInfo()->GetCompileUnit(
+          return DWARFDIE(dwarf->DebugInfo()->GetUnit(
                               DIERef(cu->GetOffset(), block_die->GetOffset())),
                           block_die);
       }

--- a/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDebugInfo.h
@@ -39,12 +39,11 @@ public:
   explicit DWARFDebugInfo(lldb_private::DWARFContext &context);
   void SetDwarfData(SymbolFileDWARF *dwarf2Data);
 
-  size_t GetNumCompileUnits();
-  DWARFUnit *GetCompileUnitAtIndex(lldb::user_id_t idx);
-  DWARFUnit *GetCompileUnitAtOffset(dw_offset_t cu_offset,
-                                    uint32_t *idx_ptr = NULL);
-  DWARFUnit *GetCompileUnitContainingDIEOffset(dw_offset_t die_offset);
-  DWARFUnit *GetCompileUnit(const DIERef &die_ref);
+  size_t GetNumUnits();
+  DWARFUnit *GetUnitAtIndex(lldb::user_id_t idx);
+  DWARFUnit *GetUnitAtOffset(dw_offset_t cu_offset, uint32_t *idx_ptr = NULL);
+  DWARFUnit *GetUnitContainingDIEOffset(dw_offset_t die_offset);
+  DWARFUnit *GetUnit(const DIERef &die_ref);
   DWARFDIE GetDIEForDIEOffset(dw_offset_t die_offset);
   DWARFDIE GetDIE(const DIERef &die_ref);
 
@@ -58,24 +57,24 @@ public:
   llvm::Expected<DWARFDebugAranges &> GetCompileUnitAranges();
 
 protected:
-  static bool OffsetLessThanCompileUnitOffset(dw_offset_t offset,
-                                              const DWARFUnitSP &cu_sp);
+  static bool OffsetLessThanUnitOffset(dw_offset_t offset,
+                                       const DWARFUnitSP &cu_sp);
 
-  typedef std::vector<DWARFUnitSP> CompileUnitColl;
+  typedef std::vector<DWARFUnitSP> UnitColl;
 
   // Member variables
   SymbolFileDWARF *m_dwarf2Data;
   lldb_private::DWARFContext &m_context;
-  CompileUnitColl m_compile_units;
+  UnitColl m_units;
   std::unique_ptr<DWARFDebugAranges>
       m_cu_aranges_up; // A quick address to compile unit table
 
 private:
   // All parsing needs to be done partially any managed by this class as
   // accessors are called.
-  void ParseCompileUnitHeadersIfNeeded();
+  void ParseUnitHeadersIfNeeded();
 
-  uint32_t FindCompileUnitIndex(dw_offset_t offset);
+  uint32_t FindUnitIndex(dw_offset_t offset);
 
   DISALLOW_COPY_AND_ASSIGN(DWARFDebugInfo);
 };

--- a/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -209,7 +209,7 @@ bool DWARFDebugInfoEntry::Extract(const DWARFUnit *cu,
   const DWARFDataExtractor &debug_info_data = cu->GetData();
   //    const DWARFDataExtractor& debug_str_data =
   //    dwarf2Data->get_debug_str_data();
-  const uint32_t cu_end_offset = cu->GetNextCompileUnitOffset();
+  const uint32_t cu_end_offset = cu->GetNextUnitOffset();
   lldb::offset_t offset = *offset_ptr;
   //  if (offset >= cu_end_offset)
   //      Log::Status("DIE at offset 0x%8.8x is beyond the end of the current

--- a/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -58,7 +58,7 @@ void DWARFUnit::ExtractUnitDIEIfNeeded() {
   const DWARFDataExtractor &data = GetData();
   DWARFFormValue::FixedFormSizes fixed_form_sizes =
       DWARFFormValue::GetFixedFormSizesForAddressSize(GetAddressByteSize());
-  if (offset < GetNextCompileUnitOffset() &&
+  if (offset < GetNextUnitOffset() &&
       m_first_die.FastExtract(data, this, fixed_form_sizes, &offset)) {
     AddUnitDIE(m_first_die);
     return;
@@ -151,7 +151,7 @@ void DWARFUnit::ExtractDIEsRWLocked() {
   // Set the offset to that of the first DIE and calculate the start of the
   // next compilation unit header.
   lldb::offset_t offset = GetFirstDIEOffset();
-  lldb::offset_t next_cu_offset = GetNextCompileUnitOffset();
+  lldb::offset_t next_cu_offset = GetNextUnitOffset();
 
   DWARFDebugInfoEntry die;
 
@@ -366,7 +366,7 @@ size_t DWARFUnit::AppendDIEsWithTag(const dw_tag_t tag,
   return dies.size() - old_size;
 }
 
-dw_offset_t DWARFUnit::GetNextCompileUnitOffset() const {
+dw_offset_t DWARFUnit::GetNextUnitOffset() const {
   return m_offset + GetLengthByteSize() + GetLength();
 }
 

--- a/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -84,12 +84,12 @@ public:
 
   bool ContainsDIEOffset(dw_offset_t die_offset) const {
     return die_offset >= GetFirstDIEOffset() &&
-           die_offset < GetNextCompileUnitOffset();
+           die_offset < GetNextUnitOffset();
   }
   dw_offset_t GetFirstDIEOffset() const {
     return m_offset + GetHeaderByteSize();
   }
-  dw_offset_t GetNextCompileUnitOffset() const;
+  dw_offset_t GetNextUnitOffset() const;
   // Size of the CU data (without initial length and without header).
   size_t GetDebugInfoSize() const;
   // Size of the CU data incl. header but without initial length.

--- a/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -55,7 +55,7 @@ DIERef DebugNamesDWARFIndex::ToDIERef(const DebugNames::Entry &entry) {
   if (!cu_offset)
     return DIERef();
 
-  DWARFUnit *cu = m_debug_info.GetCompileUnitAtOffset(*cu_offset);
+  DWARFUnit *cu = m_debug_info.GetUnitAtOffset(*cu_offset);
   if (!cu)
     return DIERef();
 
@@ -164,7 +164,7 @@ void DebugNamesDWARFIndex::GetCompleteObjCClass(ConstString class_name,
     if (!ref)
       continue;
 
-    DWARFUnit *cu = m_debug_info.GetCompileUnitAtOffset(ref.cu_offset);
+    DWARFUnit *cu = m_debug_info.GetUnitAtOffset(ref.cu_offset);
     if (!cu || !cu->Supports_DW_AT_APPLE_objc_complete_type()) {
       incomplete_types.push_back(ref);
       continue;

--- a/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -32,9 +32,9 @@ void ManualDWARFIndex::Index() {
   Timer scoped_timer(func_cat, "%p", static_cast<void *>(&debug_info));
 
   std::vector<DWARFUnit *> units_to_index;
-  units_to_index.reserve(debug_info.GetNumCompileUnits());
-  for (size_t U = 0; U < debug_info.GetNumCompileUnits(); ++U) {
-    DWARFUnit *unit = debug_info.GetCompileUnitAtIndex(U);
+  units_to_index.reserve(debug_info.GetNumUnits());
+  for (size_t U = 0; U < debug_info.GetNumUnits(); ++U) {
+    DWARFUnit *unit = debug_info.GetUnitAtIndex(U);
     if (unit && m_units_to_avoid.count(unit->GetOffset()) == 0)
       units_to_index.push_back(unit);
   }
@@ -43,8 +43,8 @@ void ManualDWARFIndex::Index() {
 
   std::vector<IndexSet> sets(units_to_index.size());
 
-  // Keep memory down by clearing DIEs for any compile units if indexing
-  // caused us to load the compile unit's DIEs.
+  // Keep memory down by clearing DIEs for any units if indexing
+  // caused us to load the unit's DIEs.
   std::vector<llvm::Optional<DWARFUnit::ScopedExtractDIEs>> clear_cu_dies(
       units_to_index.size());
   auto parser_fn = [&](size_t cu_idx) {
@@ -55,22 +55,24 @@ void ManualDWARFIndex::Index() {
     clear_cu_dies[cu_idx] = units_to_index[cu_idx]->ExtractDIEsScoped();
   };
 
-  // Create a task runner that extracts dies for each DWARF compile unit in a
+  // Create a task runner that extracts dies for each DWARF unit in a
   // separate thread
-  // First figure out which compile units didn't have their DIEs already
+  // First figure out which units didn't have their DIEs already
   // parsed and remember this.  If no DIEs were parsed prior to this index
   // function call, we are going to want to clear the CU dies after we are
   // done indexing to make sure we don't pull in all DWARF dies, but we need
-  // to wait until all compile units have been indexed in case a DIE in one
-  // compile unit refers to another and the indexes accesses those DIEs.
-  //----------------------------------------------------------------------
+  // to wait until all units have been indexed in case a DIE in one
+  // unit refers to another and the indexes accesses those DIEs.
+#if 0
+  // This call can deadlock because we are sometimes holding the module lock.
+  TaskMapOverInt(0, units_to_index.size(), extract_fn);
+#else
   for (int i=0; i<units_to_index.size(); ++i) {
      extract_fn(i);
   }
-  // This call can deadlock because we are sometimes holding the module lock.
-  //TaskMapOverInt(0, units_to_index.size(), extract_fn);
+#endif
 
-  // Now create a task runner that can index each DWARF compile unit in a
+  // Now create a task runner that can index each DWARF unit in a
   // separate thread so we can index quickly.
 
   TaskMapOverInt(0, units_to_index.size(), parser_fn);
@@ -100,7 +102,7 @@ void ManualDWARFIndex::IndexUnit(DWARFUnit &unit, IndexSet &set) {
 
   if (log) {
     m_module.LogMessage(
-        log, "ManualDWARFIndex::IndexUnit for compile unit at .debug_info[0x%8.8x]",
+        log, "ManualDWARFIndex::IndexUnit for unit at .debug_info[0x%8.8x]",
         unit.GetOffset());
   }
 
@@ -218,7 +220,7 @@ void ManualDWARFIndex::IndexUnitImpl(
                 //   if (block_data) {
                 //     uint32_t block_length = form_value.Unsigned();
                 //     if (block_length == 1 +
-                //     attributes.CompileUnitAtIndex(i)->GetAddressByteSize()) {
+                //     attributes.UnitAtIndex(i)->GetAddressByteSize()) {
                 //       if (block_data[0] == DW_OP_addr)
                 //         add_die = true;
                 //     }

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -306,13 +306,13 @@ size_t SymbolFileDWARF::GetTypes(SymbolContextScope *sc_scope,
     if (dwarf_cu == 0)
       return 0;
     GetTypes(dwarf_cu->DIE(), dwarf_cu->GetOffset(),
-             dwarf_cu->GetNextCompileUnitOffset(), type_mask, type_set);
+             dwarf_cu->GetNextUnitOffset(), type_mask, type_set);
   } else {
     DWARFDebugInfo *info = DebugInfo();
     if (info) {
-      const size_t num_cus = info->GetNumCompileUnits();
+      const size_t num_cus = info->GetNumUnits();
       for (size_t cu_idx = 0; cu_idx < num_cus; ++cu_idx) {
-        dwarf_cu = info->GetCompileUnitAtIndex(cu_idx);
+        dwarf_cu = info->GetUnitAtIndex(cu_idx);
         if (dwarf_cu) {
           GetTypes(dwarf_cu->DIE(), 0, UINT32_MAX, type_mask, type_set);
         }
@@ -695,7 +695,7 @@ SymbolFileDWARF::GetDWARFCompileUnit(lldb_private::CompileUnit *comp_unit) {
   DWARFDebugInfo *info = DebugInfo();
   if (info) {
     // The compile unit ID is the index of the DWARF unit.
-    DWARFUnit *dwarf_cu = info->GetCompileUnitAtIndex(comp_unit->GetID());
+    DWARFUnit *dwarf_cu = info->GetUnitAtIndex(comp_unit->GetID());
     if (dwarf_cu && dwarf_cu->GetUserData() == NULL)
       dwarf_cu->SetUserData(comp_unit);
     return dwarf_cu;
@@ -799,7 +799,7 @@ lldb::CompUnitSP SymbolFileDWARF::ParseCompileUnit(DWARFUnit *dwarf_cu,
 uint32_t SymbolFileDWARF::GetNumCompileUnits() {
   DWARFDebugInfo *info = DebugInfo();
   if (info)
-    return info->GetNumCompileUnits();
+    return info->GetNumUnits();
   return 0;
 }
 
@@ -808,7 +808,7 @@ CompUnitSP SymbolFileDWARF::ParseCompileUnitAtIndex(uint32_t cu_idx) {
   CompUnitSP cu_sp;
   DWARFDebugInfo *info = DebugInfo();
   if (info) {
-    DWARFUnit *dwarf_cu = info->GetCompileUnitAtIndex(cu_idx);
+    DWARFUnit *dwarf_cu = info->GetUnitAtIndex(cu_idx);
     if (dwarf_cu)
       cu_sp = ParseCompileUnit(dwarf_cu, cu_idx);
   }
@@ -1595,7 +1595,7 @@ void SymbolFileDWARF::UpdateExternalModuleListIfNeeded() {
 
   const uint32_t num_compile_units = GetNumCompileUnits();
   for (uint32_t cu_idx = 0; cu_idx < num_compile_units; ++cu_idx) {
-    DWARFUnit *dwarf_cu = debug_info->GetCompileUnitAtIndex(cu_idx);
+    DWARFUnit *dwarf_cu = debug_info->GetUnitAtIndex(cu_idx);
 
     const DWARFBaseDIE die = dwarf_cu->GetUnitDIEOnly();
     if (die && !die.HasChildren()) {
@@ -1759,8 +1759,7 @@ uint32_t SymbolFileDWARF::ResolveSymbolContext(const Address &so_addr,
         }
       } else {
         uint32_t cu_idx = DW_INVALID_INDEX;
-        DWARFUnit *dwarf_cu =
-            debug_info->GetCompileUnitAtOffset(cu_offset, &cu_idx);
+        DWARFUnit *dwarf_cu = debug_info->GetUnitAtOffset(cu_offset, &cu_idx);
         if (dwarf_cu) {
           sc.comp_unit = GetCompUnitForDWARFCompUnit(dwarf_cu, cu_idx);
           if (sc.comp_unit) {
@@ -1860,8 +1859,7 @@ uint32_t SymbolFileDWARF::ResolveSymbolContext(const FileSpec &file_spec,
       uint32_t cu_idx;
       DWARFUnit *dwarf_cu = NULL;
 
-      for (cu_idx = 0;
-           (dwarf_cu = debug_info->GetCompileUnitAtIndex(cu_idx)) != NULL;
+      for (cu_idx = 0; (dwarf_cu = debug_info->GetUnitAtIndex(cu_idx)) != NULL;
            ++cu_idx) {
         CompileUnit *dc_cu = GetCompUnitForDWARFCompUnit(dwarf_cu, cu_idx);
         const bool full_match = (bool)file_spec.GetDirectory();
@@ -2350,10 +2348,10 @@ void SymbolFileDWARF::GetMangledNamesForFunction(
   DWARFDebugInfo *info = DebugInfo();
   uint32_t num_comp_units = 0;
   if (info)
-    num_comp_units = info->GetNumCompileUnits();
+    num_comp_units = info->GetNumUnits();
 
   for (uint32_t i = 0; i < num_comp_units; i++) {
-    DWARFUnit *cu = info->GetCompileUnitAtIndex(i);
+    DWARFUnit *cu = info->GetUnitAtIndex(i);
     if (cu == nullptr)
       continue;
 
@@ -2696,7 +2694,7 @@ bool SymbolFileDWARF::Supports_DW_AT_APPLE_objc_complete_type(
       DWARFDebugInfo *debug_info = DebugInfo();
       const uint32_t num_compile_units = GetNumCompileUnits();
       for (uint32_t cu_idx = 0; cu_idx < num_compile_units; ++cu_idx) {
-        DWARFUnit *dwarf_cu = debug_info->GetCompileUnitAtIndex(cu_idx);
+        DWARFUnit *dwarf_cu = debug_info->GetUnitAtIndex(cu_idx);
         if (dwarf_cu != cu &&
             dwarf_cu->Supports_DW_AT_APPLE_objc_complete_type()) {
           m_supports_DW_AT_APPLE_objc_complete_type = eLazyBoolYes;
@@ -3250,7 +3248,7 @@ size_t SymbolFileDWARF::ParseVariablesForContext(const SymbolContext &sc) {
         return num_variables;
       }
     } else if (sc.comp_unit) {
-      DWARFUnit *dwarf_cu = info->GetCompileUnitAtIndex(sc.comp_unit->GetID());
+      DWARFUnit *dwarf_cu = info->GetUnitAtIndex(sc.comp_unit->GetID());
 
       if (dwarf_cu == NULL)
         return 0;

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
@@ -56,7 +56,7 @@ SymbolFileDWARFDwo::ParseCompileUnit(DWARFUnit *dwarf_cu,
 DWARFUnit *SymbolFileDWARFDwo::GetCompileUnit() {
   // Only dwo files with 1 compile unit is supported
   if (GetNumCompileUnits() == 1)
-    return DebugInfo()->GetCompileUnitAtIndex(0);
+    return DebugInfo()->GetUnitAtIndex(0);
   else
     return nullptr;
 }


### PR DESCRIPTION
I believe this patch was dropped from upstream-with-swift in one of the merges. Cherry-picking it back in. 
```
D42892 changed a lot of code to use superclass DWARFUnit instead of its
subclass DWARFCompileUnit.

Finish this change more thoroughly for any *CompileUnit* -> *Unit* names.
Later patch will introduce DWARFTypeUnit which needs to be sometimes different
from DWARFCompileUnit and it would be confusing without this renaming.

Differential Revision: https://reviews.llvm.org/D61501

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360443 91177308-0d34-0410-b5e6-96231b3b80d8
```