### PR TITLE
[Breakpoint] Remove swift-specific bits from BreakpointResolverName

### DIFF
--- a/source/Breakpoint/BreakpointResolverName.cpp
+++ b/source/Breakpoint/BreakpointResolverName.cpp
@@ -241,25 +241,6 @@ void BreakpointResolverName::AddNameLookup(ConstString name,
     // those as well.
     Language::ForEach(add_variant_funcs);
   }
-
-  // we need to do this because we don't have a proper parser for Swift
-  // function name syntax
-  // so we try to ensure that if we autocomplete to something, we'll look for
-  // its mangled
-  // equivalent and use the mangled version as a lookup as well - to avoid
-  // overhead
-  // only do it for mangled names that start with _T - i.e. Swift mangled
-  // names!
-  ConstString counterpart;
-  if (name.GetMangledCounterpart(counterpart)) {
-    if (SwiftLanguageRuntime::IsSwiftMangledName(counterpart.GetCString())) {
-      Module::LookupInfo lookup;
-      lookup.SetName(counterpart);
-      lookup.SetLookupName(counterpart);
-      lookup.SetNameTypeMask(eFunctionNameTypeAuto);
-      m_lookups.push_back(lookup);
-    }
-  }
 }
 
 // FIXME: Right now we look at the module level, and call the module's

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -117,6 +117,22 @@ bool SwiftLanguage::IsTopLevelFunction(Function &function) {
   return false;
 }
 
+std::vector<ConstString>
+SwiftLanguage::GetMethodNameVariants(ConstString method_name) const {
+  std::vector<ConstString> variant_names;
+
+  // NOTE:  We need to do this because we don't have a proper parser for Swift
+  // function name syntax so we try to ensure that if we autocomplete to
+  // something, we'll look for its mangled equivalent and use the mangled
+  // version as a lookup as well.
+
+  ConstString counterpart;
+  if (method_name.GetMangledCounterpart(counterpart))
+    if (SwiftLanguageRuntime::IsSwiftMangledName(counterpart.GetCString()))
+      variant_names.emplace_back(counterpart);
+  return variant_names;
+}
+
 static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   if (!swift_category_sp)
     return;

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -34,6 +34,9 @@ public:
 
   bool IsTopLevelFunction(Function &function) override;
 
+  std::vector<ConstString>
+  GetMethodNameVariants(ConstString method_name) const override;
+
   virtual lldb::TypeCategoryImplSP GetFormatters() override;
 
   HardcodedFormatters::HardcodedSummaryFinder GetHardcodedSummaries() override;


### PR DESCRIPTION
On llvm.org I made Breakpoint language agnostic but in swift-lldb this small bit of language-specific support remained. This patch pulls that out into SwiftLanugage in hopes of making breakpoint truly language agnostic. 