### PR TITLE
[Initialization] Remove swift initialization from SystemInitializerCommon

### DIFF
--- a/source/API/SystemInitializerFull.cpp
+++ b/source/API/SystemInitializerFull.cpp
@@ -113,6 +113,7 @@
 #endif
 
 #if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
+#include "Plugins/ExpressionParser/Swift/SwiftREPL.h"
 #include "Plugins/Language/Swift/SwiftLanguage.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #endif
@@ -131,6 +132,7 @@ static void SwiftInitialize() {
 #if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
   SwiftLanguage::Initialize();
   SwiftLanguageRuntime::Initialize();
+  SwiftREPL::Initialize();
 #endif
 }
 
@@ -138,6 +140,7 @@ static void SwiftTerminate() {
 #if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
   SwiftLanguage::Terminate();
   SwiftLanguageRuntime::Terminate();
+  SwiftREPL::Terminate();
 #endif
 }
 

--- a/source/Initialization/CMakeLists.txt
+++ b/source/Initialization/CMakeLists.txt
@@ -20,7 +20,6 @@ add_lldb_library(lldbInitialization
     lldbPluginObjectContainerBSDArchive
     lldbPluginObjectContainerMachOArchive
     lldbPluginProcessGDBRemote
-    lldbPluginExpressionParserSwift
     ${EXTRA_PLUGINS}
     ${LLDB_SYSTEM_LIBS}
   LINK_COMPONENTS

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -11,7 +11,6 @@
 #include "Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.h"
 #include "Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h"
 #include "Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.h"
-#include "Plugins/ExpressionParser/Swift/SwiftREPL.h"
 #include "Plugins/Instruction/ARM/EmulateInstructionARM.h"
 #include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
 #include "Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h"
@@ -103,8 +102,6 @@ llvm::Error SystemInitializerCommon::Initialize() {
   // Initialize plug-ins
   ClangASTContext::Initialize();
 
-  SwiftREPL::Initialize();
-
   ObjectContainerBSDArchive::Initialize();
 
   EmulateInstructionARM::Initialize();
@@ -132,8 +129,6 @@ void SystemInitializerCommon::Terminate() {
   ObjectContainerBSDArchive::Terminate();
 
   ClangASTContext::Terminate();
-
-  SwiftREPL::Terminate();
 
   EmulateInstructionARM::Terminate();
   EmulateInstructionMIPS::Terminate();

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -22,7 +22,6 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Symbol/ClangASTContext.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Reproducer.h"
 #include "lldb/Utility/Timer.h"
@@ -103,7 +102,6 @@ llvm::Error SystemInitializerCommon::Initialize() {
 
   // Initialize plug-ins
   ClangASTContext::Initialize();
-  SwiftASTContext::Initialize();
 
   SwiftREPL::Initialize();
 
@@ -134,7 +132,6 @@ void SystemInitializerCommon::Terminate() {
   ObjectContainerBSDArchive::Terminate();
 
   ClangASTContext::Terminate();
-  SwiftASTContext::Terminate();
 
   SwiftREPL::Terminate();
 


### PR DESCRIPTION
Swift initialization should occur in SystemInitializaterFull and not in the SystemInitializerCommon.
This PR has 3 changes:
 - I found that SwiftASTContext was being initialized in both Full and Common, which seems problematic. Removed the one in Common.
 - Moved SwiftREPL initialization from Common to Full.
 - Stopped linking lldbInitialization against the swift ExpressionParser plugin. This is good because it means lldb-server stops linking against it.