### PR TITLE
Upstream rpath-related test changes for Swift-in-Apple-OSs

### DIFF
--- a/lit/helper/toolchain.py
+++ b/lit/helper/toolchain.py
@@ -110,11 +110,14 @@ def use_support_substitutions(config):
                   os.path.join(os.path.dirname(config.lldb_libs_dir),
                                'lldb-test-build.noindex',
                                'module-cache-clang')]
+    swift_driver_args = []
     if platform.system() in ['Darwin']:
-      swift_args += ['-sdk', sdk_path]
+        swift_args += ['-sdk', sdk_path]
+        swift_driver_args += ['-toolchain-stdlib-rpath']
     tools = [
         ToolSubst(
-            '%target-swiftc', command=config.swiftc, extra_args=swift_args),
+            '%target-swiftc', command=config.swiftc,
+            extra_args=swift_args + swift_driver_args),
         ToolSubst(
             '%target-swift-frontend', command=config.swiftc[:-1],
             extra_args=(['-frontend'] + swift_args))

--- a/lldb.xcodeproj/project.pbxproj
+++ b/lldb.xcodeproj/project.pbxproj
@@ -10047,7 +10047,7 @@
 				OTHER_CFLAGS = "-Wparentheses";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -12171,7 +12171,7 @@
 				OTHER_CFLAGS = "-Wparentheses";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -12210,7 +12210,7 @@
 				OTHER_CFLAGS = "-Wparentheses";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -12244,7 +12244,7 @@
 				OTHER_CFLAGS = "-Wparentheses";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -12280,7 +12280,7 @@
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "-DXCODE_BUILD_ME";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -13545,7 +13545,7 @@
 				PYTHON_FRAMEWORK_PATH = /System/Library/Frameworks/Python.framework/;
 				PYTHON_VERSION_MAJOR = 2;
 				PYTHON_VERSION_MINOR = 7;
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -14484,7 +14484,7 @@
 				OTHER_CFLAGS = "-Wparentheses";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
@@ -15077,7 +15077,7 @@
 				OTHER_CFLAGS = "-Wparentheses";
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				REPL_SWIFT_RPATH = "@executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
+				REPL_SWIFT_RPATH = "/usr/lib/swift @executable_path/../../../../../Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx @executable_path/../../../../../../usr/lib/swift/macosx @executable_path/../../../../../../../usr/lib/swift/macosx @executable_path/LLDB.framework/Resources/Swift/macosx @executable_path/Swift/macosx";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
@@ -7,7 +7,8 @@ include $(LEVEL)/Makefile.rules
 
 a.out: main.swift libDylib.dylib
 	$(SWIFTC) -g -Onone $^ -lDylib -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I. \
-	  -Xcc -DDEBUG=1 -Xcc -DSPACE -Xcc -UNDEBUG
+	  -Xcc -DDEBUG=1 -Xcc -DSPACE -Xcc -UNDEBUG \
+	  -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
@@ -15,7 +16,8 @@ endif
 libDylib.dylib: dylib.swift
 	$(SWIFTC) -g -Onone $^ -emit-library -module-name Dylib -emit-module \
 	  -Xlinker -install_name -Xlinker @executable_path/$@ \
-	  -Xcc -DDEBUG=1 -Xcc -D -Xcc SPACE -Xcc -U -Xcc NDEBUG
+	  -Xcc -DDEBUG=1 -Xcc -D -Xcc SPACE -Xcc -U -Xcc NDEBUG \
+          -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/Makefile
@@ -13,7 +13,8 @@ ifneq "$(CODESIGN)" ""
 endif
 
 lib%.dylib: %.swift
-	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(shell basename $< .swift) $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h
+	$(SWIFTC) -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(shell basename $< .swift) $(SWIFTFLAGS) -emit-objc-header-path $(shell basename $< .swift).h \
+           -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/static_archive/Makefile
@@ -14,7 +14,8 @@ include $(LEVEL)/Makefile.rules
 a.out: main.o
 	$(SWIFTC) $(SWIFTFLAGS) $< -lFoo -lBar -L$(shell pwd) -o $@ \
 	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Foo.swiftmodule \
-	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Bar.swiftmodule
+	    -Xlinker -add_ast_path -Xlinker $(shell pwd)/Bar.swiftmodule \
+	    -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/debug_prefix_map/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/debug_prefix_map/Makefile
@@ -13,7 +13,7 @@ a.out: main.swift
 	# be able to find the source files.
 	mkdir $(BUILDDIR)/srcroot
 	cp $^ $(BUILDDIR)/srcroot
-	$(SWIFTC) srcroot/main.swift -debug-prefix-map $(BUILDDIR)=. -o $@ $(SWIFTFLAGS)
+	$(SWIFTC) srcroot/main.swift -debug-prefix-map $(BUILDDIR)=. -o $@ $(SWIFTFLAGS) -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/deployment_target/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/deployment_target/Makefile
@@ -7,7 +7,8 @@ include $(LEVEL)/Makefile.rules
 # This test only works on macOS 10.11+.
 
 a.out: main.swift libNewerTarget.dylib
-	$(SWIFTC) -target x86_64-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking
+	$(SWIFTC) -target x86_64-apple-macosx10.10 -g -Onone $^ -lNewerTarget -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I$(shell pwd) -Xfrontend -disable-target-os-checking \
+         -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
@@ -19,7 +20,8 @@ ifneq "$(CODESIGN)" ""
 endif
 
 lib%.dylib: %.swift
-	$(SWIFTC) -target x86_64-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@
+	$(SWIFTC) -target x86_64-apple-macosx10.11 -g -Onone $^ -emit-library -module-name $(shell basename $< .swift) -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ \
+	     -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/equality_operators/Makefile
@@ -10,8 +10,9 @@ all: libfooey.dylib three
 include $(LEVEL)/Makefile.rules
 
 libfooey.dylib: one.swift two.swift
-	$(SWIFTC) $(SWIFT_MODULE_CACHE_FLAGS) -g -Onone $^ -emit-library -module-name fooey -emit-module -Xlinker -install_name -Xlinker @executable_path/$@
-ifneq "$(CODESIGN)" ""#
+	$(SWIFTC) $(SWIFT_MODULE_CACHE_FLAGS) -g -Onone $^ -emit-library -module-name fooey -emit-module -Xlinker -install_name -Xlinker @executable_path/$@ \
+	  -toolchain-stdlib-rpath
+ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
 

--- a/packages/Python/lldbsuite/test/lang/swift/missing_sdk/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/missing_sdk/Makefile
@@ -10,7 +10,7 @@ fakesdk:
 SWIFTFLAGS := $(subst $(SDKROOT),$(shell pwd)/fakesdk,$(SWIFTFLAGS))
 
 a.out: $(SWIFT_SOURCES) fakesdk
-	$(SWIFTC) $< $(SWIFTFLAGS) -o "$(EXE)"
+	$(SWIFTC) $< $(SWIFTFLAGS) -o "$(EXE)" -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds/Makefile
@@ -15,8 +15,9 @@ include $(LEVEL)/Makefile.rules
 LD_EXTRAS=-lPlaygroundsRuntime -L$(shell pwd)
 
 libPlaygroundsRuntime.dylib: PlaygroundsRuntime.swift
-	$(SWIFTC) $(SWIFTFLAGS_NOLINK) -module-name PlaygroundsRuntime -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/$@ $<
-ifneq "$(CODESIGN)" ""#
+	$(SWIFTC) $(SWIFTFLAGS_NOLINK) -module-name PlaygroundsRuntime -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/$@ $< \
+	  -toolchain-stdlib-rpath
+ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
 

--- a/packages/Python/lldbsuite/test/lang/swift/resilience/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/resilience/Makefile
@@ -7,7 +7,7 @@ include $(LEVEL)/Makefile.rules
 
 libmod.%.dylib: mod.%.swift
 	ln -sf $< mod.swift
-	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
+	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -toolchain-stdlib-rpath -###
 	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=mod \

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -756,8 +756,9 @@ ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(OS)" "Darwin"
 DYLIB_SWIFT_FLAGS=  \
+	 -toolchain-stdlib-rpath \
 	 -Xlinker -dylib \
-         -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule \
+	 -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule \
 	 -Xlinker -install_name -Xlinker @executable_path/$(shell basename $@) \
 	 $(LD_EXTRAS)
 else

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -290,7 +290,7 @@ DEBUG_INFO_FLAG ?= -g
 CFLAGS ?= $(DEBUG_INFO_FLAG) -O0 -fno-builtin
 SWIFTFLAGS ?= $(DEBUG_INFO_FLAG) -Onone -Xfrontend -serialize-debugging-options
 
-STATIC_STDLIB = 
+STATIC_STDLIB =
 ifneq (,$(findstring arm,$(ARCH)))
 	STATIC_STDLIB = -static-stdlib
 endif
@@ -670,7 +670,7 @@ VPATHSOURCES=$(patsubst %,$(VPATH)/%,$(SWIFT_SOURCES))
 ifeq "$(OS)" "Darwin"
 $(EXE): $(MODULENAME).swiftmodule $(OBJECTS)
 	@echo "### Linking" $(EXE)
-	$(SWIFTC) $(STATIC_STDLIB) $(LD_EXTRAS) \
+	$(SWIFTC) -toolchain-stdlib-rpath $(STATIC_STDLIB) $(LD_EXTRAS) \
 	  $(patsubst $<,-Xlinker -add_ast_path -Xlinker $(BUILDDIR)/$<,$^) \
 	  $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
 ifneq "$(CODESIGN)" ""

--- a/packages/Python/lldbsuite/test/repl/cpp_exceptions/Makefile
+++ b/packages/Python/lldbsuite/test/repl/cpp_exceptions/Makefile
@@ -5,7 +5,8 @@ CURDIR = $(shell pwd)
 include $(LEVEL)/Makefile.rules
 
 a.out: main.swift libCppLib.dylib libWrapper.dylib
-	$(SWIFTC) $(SWIFTFLAGS) -Xlinker -rpath -Xlinker $(CURDIR) -I$(CURDIR) -lWrapper -L$(CURDIR) -o $@ $<
+	$(SWIFTC) $(SWIFTFLAGS) -Xlinker -rpath -Xlinker $(CURDIR) -I$(CURDIR) -lWrapper -L$(CURDIR) -o $@ $< \
+	    -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif
@@ -17,7 +18,8 @@ libCppLib.dylib: CppLib/CppLib.cpp
 	install_name_tool -id $@ $@
 
 libWrapper.dylib: wrapper.swift libCppLib.dylib
-	$(SWIFTC) $(SWIFTFLAGS) -emit-module -emit-library -module-link-name Wrapper -module-name Wrapper -o $@ -L$(CURDIR) -lCppLib -I$(SRCDIR)/CppLib -o $@ -Xlinker -install_name -Xlinker @executable_path/$@ $<
+	$(SWIFTC) $(SWIFTFLAGS) -emit-module -emit-library -module-link-name Wrapper -module-name Wrapper -o $@ -L$(CURDIR) -lCppLib -I$(SRCDIR)/CppLib -o $@ -Xlinker -install_name -Xlinker @executable_path/$@ $< \
+            -toolchain-stdlib-rpath
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif


### PR DESCRIPTION
Cherry-pick a bunch of changes that deal with the Swift stdlib and overlays living in /usr/lib/swift/, mostly from @adrian-prantl. These changes shipped in Apple Swift 5.0 but never made it back to open source. LLDB side of apple/swift#24787.

(not urgent at this point because we're so late with it)

rdar://problem/50748941
