### PR TITLE
[Initialization] Clean up SystemInitializerCommon

### DIFF
--- a/source/API/SystemInitializerFull.cpp
+++ b/source/API/SystemInitializerFull.cpp
@@ -44,7 +44,10 @@
 #include "Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h"
 #include "Plugins/DynamicLoader/Static/DynamicLoaderStatic.h"
 #include "Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.h"
+#include "Plugins/Instruction/ARM/EmulateInstructionARM.h"
 #include "Plugins/Instruction/ARM64/EmulateInstructionARM64.h"
+#include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
+#include "Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h"
 #include "Plugins/Instruction/PPC64/EmulateInstructionPPC64.h"
 #include "Plugins/InstrumentationRuntime/ASan/ASanRuntime.h"
 #include "Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.h"
@@ -228,8 +231,13 @@ llvm::Error SystemInitializerFull::Initialize() {
   SymbolFileSymtab::Initialize();
   UnwindAssemblyInstEmulation::Initialize();
   UnwindAssembly_x86::Initialize();
+
+  EmulateInstructionARM::Initialize();
   EmulateInstructionARM64::Initialize();
+  EmulateInstructionMIPS::Initialize();
+  EmulateInstructionMIPS64::Initialize();
   EmulateInstructionPPC64::Initialize();
+
   SymbolFileDWARFDebugMap::Initialize();
   ItaniumABILanguageRuntime::Initialize();
   AppleObjCRuntimeV2::Initialize();
@@ -335,8 +343,13 @@ void SystemInitializerFull::Terminate() {
   SymbolFileSymtab::Terminate();
   UnwindAssembly_x86::Terminate();
   UnwindAssemblyInstEmulation::Terminate();
+
+  EmulateInstructionARM::Terminate();
   EmulateInstructionARM64::Terminate();
+  EmulateInstructionMIPS::Terminate();
+  EmulateInstructionMIPS64::Terminate();
   EmulateInstructionPPC64::Terminate();
+
   SymbolFileDWARFDebugMap::Terminate();
   ItaniumABILanguageRuntime::Terminate();
   AppleObjCRuntimeV2::Terminate();

--- a/source/API/SystemInitializerFull.cpp
+++ b/source/API/SystemInitializerFull.cpp
@@ -60,6 +60,8 @@
 #include "Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h"
 #include "Plugins/LanguageRuntime/RenderScript/RenderScriptRuntime/RenderScriptRuntime.h"
 #include "Plugins/MemoryHistory/asan/MemoryHistoryASan.h"
+#include "Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h"
+#include "Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h"
 #include "Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h"
 #include "Plugins/ObjectFile/ELF/ObjectFileELF.h"
 #include "Plugins/ObjectFile/Mach-O/ObjectFileMachO.h"
@@ -152,6 +154,9 @@ llvm::Error SystemInitializerFull::Initialize() {
   ObjectFileELF::Initialize();
   ObjectFileMachO::Initialize();
   ObjectFilePECOFF::Initialize();
+
+  ObjectContainerBSDArchive::Initialize();
+  ObjectContainerUniversalMachO::Initialize();
 
   ScriptInterpreterNone::Initialize();
 
@@ -392,6 +397,9 @@ void SystemInitializerFull::Terminate() {
   ObjectFileELF::Terminate();
   ObjectFileMachO::Terminate();
   ObjectFilePECOFF::Terminate();
+
+  ObjectContainerBSDArchive::Terminate();
+  ObjectContainerUniversalMachO::Terminate();
 
   // Now shutdown the common parts, in reverse order.
   SystemInitializerCommon::Terminate();

--- a/source/Initialization/CMakeLists.txt
+++ b/source/Initialization/CMakeLists.txt
@@ -14,9 +14,6 @@ add_lldb_library(lldbInitialization
   LINK_LIBS
     lldbCore
     lldbHost
-    lldbPluginInstructionARM
-    lldbPluginInstructionMIPS
-    lldbPluginInstructionMIPS64
     lldbPluginProcessGDBRemote
     ${EXTRA_PLUGINS}
     ${LLDB_SYSTEM_LIBS}

--- a/source/Initialization/CMakeLists.txt
+++ b/source/Initialization/CMakeLists.txt
@@ -17,8 +17,6 @@ add_lldb_library(lldbInitialization
     lldbPluginInstructionARM
     lldbPluginInstructionMIPS
     lldbPluginInstructionMIPS64
-    lldbPluginObjectContainerBSDArchive
-    lldbPluginObjectContainerMachOArchive
     lldbPluginProcessGDBRemote
     ${EXTRA_PLUGINS}
     ${LLDB_SYSTEM_LIBS}

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -11,8 +11,6 @@
 #include "Plugins/Instruction/ARM/EmulateInstructionARM.h"
 #include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
 #include "Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h"
-#include "Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h"
-#include "Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.h"
 #include "Plugins/Process/gdb-remote/ProcessGDBRemoteLog.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
@@ -95,17 +93,9 @@ llvm::Error SystemInitializerCommon::Initialize() {
 
   process_gdb_remote::ProcessGDBRemoteLog::Initialize();
 
-  // Initialize plug-ins
-  ObjectContainerBSDArchive::Initialize();
-
   EmulateInstructionARM::Initialize();
   EmulateInstructionMIPS::Initialize();
   EmulateInstructionMIPS64::Initialize();
-
-  //----------------------------------------------------------------------
-  // Apple/Darwin hosted plugins
-  //----------------------------------------------------------------------
-  ObjectContainerUniversalMachO::Initialize();
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
   ProcessPOSIXLog::Initialize();
@@ -120,14 +110,10 @@ llvm::Error SystemInitializerCommon::Initialize() {
 void SystemInitializerCommon::Terminate() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
-  ObjectContainerBSDArchive::Terminate();
-
 
   EmulateInstructionARM::Terminate();
   EmulateInstructionMIPS::Terminate();
   EmulateInstructionMIPS64::Terminate();
-
-  ObjectContainerUniversalMachO::Terminate();
 
 #if defined(_MSC_VER)
   ProcessWindowsLog::Terminate();

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -17,7 +17,6 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
-#include "lldb/Symbol/ClangASTContext.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Reproducer.h"
 #include "lldb/Utility/Timer.h"
@@ -97,8 +96,6 @@ llvm::Error SystemInitializerCommon::Initialize() {
   process_gdb_remote::ProcessGDBRemoteLog::Initialize();
 
   // Initialize plug-ins
-  ClangASTContext::Initialize();
-
   ObjectContainerBSDArchive::Initialize();
 
   EmulateInstructionARM::Initialize();
@@ -125,7 +122,6 @@ void SystemInitializerCommon::Terminate() {
   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
   ObjectContainerBSDArchive::Terminate();
 
-  ClangASTContext::Terminate();
 
   EmulateInstructionARM::Terminate();
   EmulateInstructionMIPS::Terminate();

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -8,9 +8,6 @@
 
 #include "lldb/Initialization/SystemInitializerCommon.h"
 
-#include "Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOSXDYLD.h"
-#include "Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.h"
-#include "Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.h"
 #include "Plugins/Instruction/ARM/EmulateInstructionARM.h"
 #include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
 #include "Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h"

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -8,9 +8,6 @@
 
 #include "lldb/Initialization/SystemInitializerCommon.h"
 
-#include "Plugins/Instruction/ARM/EmulateInstructionARM.h"
-#include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
-#include "Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h"
 #include "Plugins/Process/gdb-remote/ProcessGDBRemoteLog.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
@@ -93,10 +90,6 @@ llvm::Error SystemInitializerCommon::Initialize() {
 
   process_gdb_remote::ProcessGDBRemoteLog::Initialize();
 
-  EmulateInstructionARM::Initialize();
-  EmulateInstructionMIPS::Initialize();
-  EmulateInstructionMIPS64::Initialize();
-
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
   ProcessPOSIXLog::Initialize();
 #endif
@@ -110,10 +103,6 @@ llvm::Error SystemInitializerCommon::Initialize() {
 void SystemInitializerCommon::Terminate() {
   static Timer::Category func_cat(LLVM_PRETTY_FUNCTION);
   Timer scoped_timer(func_cat, LLVM_PRETTY_FUNCTION);
-
-  EmulateInstructionARM::Terminate();
-  EmulateInstructionMIPS::Terminate();
-  EmulateInstructionMIPS64::Terminate();
 
 #if defined(_WIN32)
   ProcessWindowsLog::Terminate();

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -23,7 +23,7 @@
 #include "Plugins/Process/POSIX/ProcessPOSIXLog.h"
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #include "Plugins/Process/Windows/Common/ProcessWindowsLog.h"
 #include "lldb/Host/windows/windows.h"
 #endif
@@ -40,7 +40,7 @@ SystemInitializerCommon::SystemInitializerCommon() {}
 SystemInitializerCommon::~SystemInitializerCommon() {}
 
 llvm::Error SystemInitializerCommon::Initialize() {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   const char *disable_crash_dialog_var = getenv("LLDB_DISABLE_CRASH_DIALOG");
   if (disable_crash_dialog_var &&
       llvm::StringRef(disable_crash_dialog_var).equals_lower("true")) {
@@ -100,7 +100,7 @@ llvm::Error SystemInitializerCommon::Initialize() {
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
   ProcessPOSIXLog::Initialize();
 #endif
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   ProcessWindowsLog::Initialize();
 #endif
 
@@ -115,7 +115,7 @@ void SystemInitializerCommon::Terminate() {
   EmulateInstructionMIPS::Terminate();
   EmulateInstructionMIPS64::Terminate();
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   ProcessWindowsLog::Terminate();
 #endif
 

--- a/tools/lldb-server/CMakeLists.txt
+++ b/tools/lldb-server/CMakeLists.txt
@@ -68,6 +68,9 @@ add_lldb_tool(lldb-server
       lldbHost
       lldbInitialization
       ${LLDB_PLUGINS}
+      lldbPluginInstructionARM
+      lldbPluginInstructionMIPS
+      lldbPluginInstructionMIPS64
       ${LLDB_SYSTEM_LIBS}
 
     LINK_COMPONENTS

--- a/tools/lldb-server/CMakeLists.txt
+++ b/tools/lldb-server/CMakeLists.txt
@@ -67,7 +67,6 @@ add_lldb_tool(lldb-server
       lldbCore
       lldbHost
       lldbInitialization
-      lldbInterpreter
       ${LLDB_PLUGINS}
       ${LLDB_SYSTEM_LIBS}
 

--- a/tools/lldb-server/SystemInitializerLLGS.cpp
+++ b/tools/lldb-server/SystemInitializerLLGS.cpp
@@ -19,6 +19,23 @@ using HostObjectFile = ObjectFilePECOFF;
 using HostObjectFile = ObjectFileELF;
 #endif
 
+#if defined(__arm__) || defined(__arm) || defined(_ARM) || defined(_M_ARM)
+#define LLDB_TARGET_ARM
+#include "Plugins/Instruction/ARM/EmulateInstructionARM.h"
+#endif
+
+#if defined(__mips__) || defined(mips) || defined(__mips) ||                   \
+    defined(__MIPS__) || defined(_M_MIPS)
+#define LLDB_TARGET_MIPS
+#include "Plugins/Instruction/MIPS/EmulateInstructionMIPS.h"
+#endif
+
+#if defined(__mips64__) || defined(mips64) || defined(__mips64) ||             \
+    defined(__MIPS64__) || defined(_M_MIPS64)
+#define LLDB_TARGET_MIPS64
+#include "Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.h"
+#endif
+
 using namespace lldb_private;
 
 llvm::Error SystemInitializerLLGS::Initialize() {
@@ -27,10 +44,31 @@ llvm::Error SystemInitializerLLGS::Initialize() {
 
   HostObjectFile::Initialize();
 
+#if defined(LLDB_TARGET_ARM)
+  EmulateInstructionARM::Initialize();
+#endif
+#if defined(LLDB_TARGET_MIPS)
+  EmulateInstructionMIPS::Initialize();
+#endif
+#if defined(LLDB_TARGET_MIPS64)
+  EmulateInstructionMIPS64::Initialize();
+#endif
+
   return llvm::Error::success();
 }
 
 void SystemInitializerLLGS::Terminate() {
   HostObjectFile::Terminate();
+
+#if defined(LLDB_TARGET_ARM)
+  EmulateInstructionARM::Terminate();
+#endif
+#if defined(LLDB_TARGET_MIPS)
+  EmulateInstructionMIPS::Terminate();
+#endif
+#if defined(LLDB_TARGET_MIPS64)
+  EmulateInstructionMIPS64::Terminate();
+#endif
+
   SystemInitializerCommon::Terminate();
 }


### PR DESCRIPTION
There are a decent number of things in SystemInitializerCommon that don't need to be there. Most of this should be delegated to SystemInitializerFull or SystemInitializerLLGS.

This PR consists of 2 commits I wrote and 4 commits that @compnerd wrote. This should make SystemInitializerCommon.cpp close to or the same as the version on llvm.org.