### PR TITLE
 Make sure GetObjectDescription falls back to the Objective-C runtime.

### DIFF
--- a/include/lldb/Target/Language.h
+++ b/include/lldb/Target/Language.h
@@ -247,6 +247,9 @@ public:
 
   static bool LanguageIsC(lldb::LanguageType language);
 
+  /// Equivalent to \c LanguageIsC||LanguageIsObjC||LanguageIsCPlusPlus.
+  static bool LanguageIsCFamily(lldb::LanguageType language);
+
   static bool LanguageIsPascal(lldb::LanguageType language);
 
   // return the primary language, so if LanguageIsC(l), return eLanguageTypeC,

--- a/packages/Python/lldbsuite/test/lang/objcxx/cxx-bridged-po/Makefile
+++ b/packages/Python/lldbsuite/test/lang/objcxx/cxx-bridged-po/Makefile
@@ -1,0 +1,6 @@
+LEVEL = ../../../make
+
+OBJCXX_SOURCES := main.mm
+LDFLAGS = $(CFLAGS) -lobjc -framework CoreFoundation
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
+++ b/packages/Python/lldbsuite/test/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestObjCXXBridgedPO(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @skipUnlessDarwin
+    def test_bridged_type_po(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.mm'))
+        self.expect('po num',
+                    "did not get the Objective-C object description",
+                    substrs=['CFNumber', '0x', '42'])
+        pointer_val = str(self.frame().FindVariable('num').GetValue())
+        self.expect('po '+pointer_val,
+                    "did not get the Objective-C object description",
+                    substrs=['CFNumber', '0x', '42'])

--- a/packages/Python/lldbsuite/test/lang/objcxx/cxx-bridged-po/main.mm
+++ b/packages/Python/lldbsuite/test/lang/objcxx/cxx-bridged-po/main.mm
@@ -1,0 +1,12 @@
+#include <CoreFoundation/CoreFoundation.h>
+
+void stop() {}
+
+int main(int argc, char **argv)
+{
+  int value = 42;
+  CFNumberRef num;
+  num = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &value);
+  stop(); // break here
+  return 0;
+}

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -1193,17 +1193,11 @@ const char *ValueObject::GetObjectDescription() {
   if (const char *desc = get_object_description(native_language))
     return desc;
 
-  switch (native_language) {
-  case eLanguageTypeC:
-  case eLanguageTypeC_plus_plus:
-  case eLanguageTypeObjC:
-  case eLanguageTypeObjC_plus_plus:
-    // Try the Objective-C language runtime. This fallback is necessary
-    // for Objective-C++ and mixed Objective-C / C++ programs.
+  // Try the Objective-C language runtime. This fallback is necessary
+  // for Objective-C++ and mixed Objective-C / C++ programs.
+  if (Language::LanguageIsCFamily(native_language))
     return get_object_description(eLanguageTypeObjC);
-  default:
-    return nullptr;
-  }
+  return nullptr;
 }
 
 bool ValueObject::GetValueAsCString(const lldb_private::TypeFormatImpl &format,

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -1164,44 +1164,46 @@ std::pair<TypeValidatorResult, std::string> ValueObject::GetValidationStatus() {
 }
 
 const char *ValueObject::GetObjectDescription() {
-
   if (!UpdateValueIfNeeded(true))
-    return NULL;
+    return nullptr;
 
+  // Return cached value.
   if (!m_object_desc_str.empty())
     return m_object_desc_str.c_str();
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
   Process *process = exe_ctx.GetProcessPtr();
-  if (process == NULL)
-    return NULL;
+  if (!process)
+    return nullptr;
 
-  StreamString s;
-
-  LanguageType language = GetObjectRuntimeLanguage();
-  LanguageRuntime *runtime = process->GetLanguageRuntime(language);
-
-  if (runtime == NULL) {
-    // Aw, hell, if the things a pointer, or even just an integer, let's try
-    // ObjC anyway...
-    CompilerType compiler_type = GetCompilerType();
-    if (compiler_type) {
-      bool is_signed;
-      if (compiler_type.IsIntegerType(is_signed) ||
-          compiler_type.IsPointerType()) {
-        runtime = process->GetLanguageRuntime(eLanguageTypeObjC);
+  // Returns the object description produced by one language runtime.
+  auto get_object_description = [&](LanguageType language) -> const char * {
+    if (LanguageRuntime *runtime = process->GetLanguageRuntime(language)) {
+      StreamString s;
+      if (runtime->GetObjectDescription(s, *this)) {
+        m_object_desc_str.append(s.GetString());
+        return m_object_desc_str.c_str();
       }
     }
-  }
+    return nullptr;
+  };
 
-  if (runtime && runtime->GetObjectDescription(s, *this)) {
-    m_object_desc_str.append(s.GetString());
-  }
+  // Try the native language runtime first.
+  LanguageType native_language = GetObjectRuntimeLanguage();
+  if (const char *desc = get_object_description(native_language))
+    return desc;
 
-  if (m_object_desc_str.empty())
-    return NULL;
-  else
-    return m_object_desc_str.c_str();
+  switch (native_language) {
+  case eLanguageTypeC:
+  case eLanguageTypeC_plus_plus:
+  case eLanguageTypeObjC:
+  case eLanguageTypeObjC_plus_plus:
+    // Try the Objective-C language runtime. This fallback is necessary
+    // for Objective-C++ and mixed Objective-C / C++ programs.
+    return get_object_description(eLanguageTypeObjC);
+  default:
+    return nullptr;
+  }
 }
 
 bool ValueObject::GetValueAsCString(const lldb_private::TypeFormatImpl &format,

--- a/source/Target/Language.cpp
+++ b/source/Target/Language.cpp
@@ -273,6 +273,24 @@ bool Language::LanguageIsC(LanguageType language) {
   }
 }
 
+bool Language::LanguageIsCFamily(LanguageType language) {
+  switch (language) {
+  case eLanguageTypeC:
+  case eLanguageTypeC89:
+  case eLanguageTypeC99:
+  case eLanguageTypeC11:
+  case eLanguageTypeC_plus_plus:
+  case eLanguageTypeC_plus_plus_03:
+  case eLanguageTypeC_plus_plus_11:
+  case eLanguageTypeC_plus_plus_14:
+  case eLanguageTypeObjC_plus_plus:
+  case eLanguageTypeObjC:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool Language::LanguageIsPascal(LanguageType language) {
   switch (language) {
   case eLanguageTypePascal83:


### PR DESCRIPTION
This fixes an unintended regression introduced by
https://reviews.llvm.org/D61451 by making sure the Objective-C runtime
is also tried when the "correct" language runtime failed to return an
object description.

rdar://problem/50791055

Differential Revision: https://reviews.llvm.org/D62015

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@360929 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 109c11f1afcc6a82325aa1ab8d61ceef3e8fafcb)