### PR TITLE
[StackFrame] Prefer synthetic variable if asked.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/array_element/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/array_element/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/array_element/TestSwiftArrayElement.py
+++ b/packages/Python/lldbsuite/test/lang/swift/array_element/TestSwiftArrayElement.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/array_element/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/array_element/main.swift
@@ -1,0 +1,2 @@
+var patatino = [1,2,3,4]
+print(patatino) //%self.expect('frame variable -d run -- patatino[0]', substrs=['(Int)', '1'])

--- a/source/Target/StackFrame.cpp
+++ b/source/Target/StackFrame.cpp
@@ -868,6 +868,8 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
         } else if (valobj_sp->GetCompilerType().IsArrayType(
                        nullptr, nullptr, &is_incomplete_array)) {
           // BEGIN SWIFT MOD
+          // This is a workaround for value-providing synthetic
+          // children like the one used for Swift.Int.
           if (!no_synth_child) {
             ValueObjectSP synthetic = valobj_sp->GetSyntheticValue();
             if (synthetic)

--- a/source/Target/StackFrame.cpp
+++ b/source/Target/StackFrame.cpp
@@ -867,9 +867,16 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
           }
         } else if (valobj_sp->GetCompilerType().IsArrayType(
                        nullptr, nullptr, &is_incomplete_array)) {
-          // Pass false to dynamic_value here so we can tell the difference
-          // between no dynamic value and no member of this type...
-          child_valobj_sp = valobj_sp->GetChildAtIndex(child_index, true);
+          // BEGIN SWIFT MOD
+          if (!no_synth_child) {
+            ValueObjectSP synthetic = valobj_sp->GetSyntheticValue();
+            if (synthetic)
+              child_valobj_sp = synthetic->GetChildAtIndex(child_index, true);
+          }
+          if (!child_valobj_sp)
+            child_valobj_sp = valobj_sp->GetChildAtIndex(child_index, true);
+          // END SWIFT MOD
+
           if (!child_valobj_sp && (is_incomplete_array || !no_synth_child))
             child_valobj_sp =
                 valobj_sp->GetSyntheticArrayMember(child_index, true);


### PR DESCRIPTION
If a type has a synthetic we should give it preference.
I believe this works fine for most of the types anwyay,
but integers are "special", as lldb treats them both
as primitive types or structures depending on the code
path in the data formatters code. Eventually we should
just have a consistent reprensentation for integers and
floats (i.e. represent them for what they really are, structs).
But until that happens, we need to have this hack in place.

Fixes:
(lldb) frame var patatino[0]
(_ArrayBuffer<Int>) patatino[0] = {
  _storage = (rawValue = 4 values)
}

to print:
(lldb) frame var patatino[0]
(Int) [0] = 1

<rdar://problem/50705707>