### PR TITLE
[Test] Be less stingent about whitespace in SwiftREPL tests

### DIFF
--- a/lit/SwiftREPL/Basic.test
+++ b/lit/SwiftREPL/Basic.test
@@ -1,7 +1,7 @@
 // Basic sanity checking of the REPL.
 
 // RUN: %lldb --repl --repl-language swift | FileCheck %s --check-prefix=SWIFT
-// SWIFT: Welcome to {{.*}} Swift
+// SWIFT: Welcome to {{.*}}Swift
 
 // RUN: %lldb --repl --repl-language c++ 2>&1 | FileCheck %s --check-prefix=CPP
 // CPP: error: couldn't find a REPL for c++
@@ -11,6 +11,6 @@
 // INVALID: error: Unrecognized language name: "patatino"
 
 // RUN: echo '2 + 3' | %lldb --repl | FileCheck %s --check-prefix=INT
-// INT: Welcome to {{.*}} Swift
+// INT: Welcome to {{.*}}Swift
 // INT-NEXT: Type :help
 // INT-NEXT: $R0: Int = 5

--- a/lit/SwiftREPL/CFString.test
+++ b/lit/SwiftREPL/CFString.test
@@ -2,7 +2,7 @@
 // REQUIRES: system-darwin
 
 // RUN: %lldb --repl < %s | FileCheck %s
-// CHECK: Welcome to {{.*}} Swift
+// CHECK: Welcome to {{.*}}Swift
 
 import Foundation
 

--- a/lit/SwiftREPL/ComputedProperties.test
+++ b/lit/SwiftREPL/ComputedProperties.test
@@ -2,16 +2,16 @@
 
 // RUN: %lldb --repl < %s | FileCheck %s
 
-var x : Int { 
-  get { 
-    return 0 
-  } 
-  set { 
-    0 
-  } 
+var x : Int {
+  get {
+    return 0
+  }
+  set {
+    0
+  }
 }
 
-// CHECK: Welcome to {{.*}} Swift
+// CHECK: Welcome to {{.*}}Swift
 // CHECK: Type :help
 // CHECK: {{x}}: Int
 

--- a/lit/SwiftREPL/CrashArgs.test
+++ b/lit/SwiftREPL/CrashArgs.test
@@ -1,4 +1,4 @@
 // Make sure we don't crash if we pass args to the repl.
 
 // RUN: %lldb --repl="-some-argument" | FileCheck %s --check-prefix=SWIFT
-// SWIFT: Welcome to {{.*}} Swift
+// SWIFT: Welcome to {{.*}}Swift

--- a/lit/SwiftREPL/UninitVariables.test
+++ b/lit/SwiftREPL/UninitVariables.test
@@ -3,9 +3,9 @@
 // RUN: %lldb --repl < %s | FileCheck %s
 
 var x : Int
-// CHECK: Welcome to {{.*}} Swift
+// CHECK: Welcome to {{.*}}Swift
 // CHECK: Type :help
 // CHECK: {{x}}: Int = 0
 x = 42
-x 
+x
 // CHECK: {{R0}}: Int = 42


### PR DESCRIPTION
Be more permissive when it comes to whitespace. Currently, if the regex
matches nothing, we still expect two spaces.