### PR TITLE
[crashlog] Use loads() instead of readPlistFromString() for python 3.

### DIFF
--- a/examples/python/crashlog.py
+++ b/examples/python/crashlog.py
@@ -43,6 +43,12 @@ import sys
 import time
 import uuid
 
+def read_plist(s):
+    if sys.version_info.major == 3:
+        return plistlib.loads(s)
+    else:
+        return plistlib.readPlistFromString(s)
+
 try:
     # Just try for LLDB in case PYTHONPATH is already correctly setup
     import lldb
@@ -282,7 +288,7 @@ class CrashLog(symbolication.Symbolicator):
                 s = subprocess.check_output(dsym_for_uuid_command, shell=True)
                 if s:
                     try:
-                        plist_root = plistlib.readPlistFromString(s)
+                        plist_root = read_plist(s)
                     except:
                         print(("Got exception: ", sys.exc_info()[1], " handling dsymForUUID output: \n", s))
                         raise


### PR DESCRIPTION
<rdar://problem/50903413>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@361087 91177308-0d34-0410-b5e6-96231b3b80d8