### PR TITLE
Windows: define `ComputeSwiftDirectory` for Windows

### DIFF
--- a/include/lldb/Host/windows/HostInfoWindows.h
+++ b/include/lldb/Host/windows/HostInfoWindows.h
@@ -36,6 +36,7 @@ public:
   static FileSpec GetProgramFileSpec();
   static FileSpec GetDefaultShell();
 
+  static bool ComputeSwiftDirectory(FileSpec &);
   static bool GetEnvironmentVar(const std::string &var_name, std::string &var);
 
 private:

--- a/source/Host/windows/HostInfoWindows.cpp
+++ b/source/Host/windows/HostInfoWindows.cpp
@@ -107,6 +107,16 @@ FileSpec HostInfoWindows::GetDefaultShell() {
   return FileSpec("C:\\Windows\\system32\\cmd.exe");
 }
 
+bool HostInfoWindows::ComputeSwiftDirectory(FileSpec &file_spec) {
+  if (!ComputeSupportExeDirectory(file_spec))
+    return false;
+
+  file_spec.RemoveLastPathComponent();  // drop `/bin`
+  file_spec.AppendPathComponent("lib");
+  file_spec.AppendPathComponent("swift");
+  return true;
+}
+
 bool HostInfoWindows::GetEnvironmentVar(const std::string &var_name,
                                         std::string &var) {
   std::wstring wvar_name;


### PR DESCRIPTION
Assume that the Windows layout is relatively similar to that on Linux.
`lldb.dll` is located in the `bin` directory rather than `lib` and the
`ComputeSupportExeDirectory` provides a `FileSpec` that is off by a
level.  Using `ComputeSupportExeDirectory` with `..\lib\swift` gives us
the actual location of the resource dir when lldb is installed into a
toolchain (as per the MSIs from
https://compnerd.visualstudio.com/windows-swift).