### PR TITLE
[FileSystem] Fix regression in FileSystem::Resolve

### DIFF
--- a/source/Host/common/FileSystem.cpp
+++ b/source/Host/common/FileSystem.cpp
@@ -241,17 +241,21 @@ void FileSystem::Resolve(SmallVectorImpl<char> &path) {
   if (path.empty())
     return;
 
-  // Resolve tilde.
-  SmallString<128> original_path(path.begin(), path.end());
+  // Resolve tilde in path.
+  SmallString<128> resolved(path.begin(), path.end());
   StandardTildeExpressionResolver Resolver;
-  Resolver.ResolveFullPath(original_path, path);
+  Resolver.ResolveFullPath(llvm::StringRef(path.begin(), path.size()),
+                           resolved);
 
   // Try making the path absolute if it exists.
-  SmallString<128> absolute_path(path.begin(), path.end());
-  MakeAbsolute(path);
-  if (!Exists(path)) {
-    path.clear();
-    path.append(original_path.begin(), original_path.end());
+  SmallString<128> absolute(resolved.begin(), resolved.end());
+  MakeAbsolute(absolute);
+
+  path.clear();
+  if (Exists(absolute)) {
+    path.append(absolute.begin(), absolute.end());
+  } else {
+    path.append(resolved.begin(), resolved.end());
   }
 }
 


### PR DESCRIPTION
When I moved the resolve code from FileSpec to the FileSystem class, I
introduced a regression. If you compare the two implementations, you'll
notice that if the path doesn't exist, we should only reverse the
effects of makeAbsolute, not the effects of tilde expansion.

As a result, the logic to create the ~/.lldb directory broke, because we
would resolve the path before creating it. Because the directory didn't
exist yet, we'd call create_directories on the unresolved path, which
failed.

Differential revision: https://reviews.llvm.org/D62219

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@361321 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 7d9cd080ff1e443ead918444c13eae3f12fe64e4)