### PR TITLE
[CommandInterpreter] Fix SkipAppInitFiles setter

### DIFF
--- a/include/lldb/Interpreter/CommandInterpreter.h
+++ b/include/lldb/Interpreter/CommandInterpreter.h
@@ -412,7 +412,7 @@ public:
   }
 
   void SkipAppInitFiles(bool skip_app_init_files) {
-    m_skip_app_init_files = m_skip_lldbinit_files;
+    m_skip_app_init_files = skip_app_init_files;
   }
 
   bool GetSynchronous();


### PR DESCRIPTION
The SkipAppInitFiles setter was ignoring its import argument.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@361316 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 0e686d48bcbafea34197e3faf44f9eefe67810ba)