### PR TITLE
[CommandInterpreter] Accept blanks after `all` or [0-9]+ for bt.

### DIFF
--- a/lit/Commands/command-backtrace.test
+++ b/lit/Commands/command-backtrace.test
@@ -7,6 +7,6 @@ bt 1
 # CHECK: error: invalid target
 
 # Make sure this is not rejected by the parser as invalid syntax.
-# Blank characters after the '1' are important, as we're testing the parser.
+# Blank characters after the 'all' are important, as we're testing the parser.
 bt all       
 # CHECK: error: invalid target

--- a/lit/Commands/command-backtrace.test
+++ b/lit/Commands/command-backtrace.test
@@ -1,0 +1,12 @@
+# Check basic functionality of command bt.
+# RUN: %lldb -s %s 2>&1 | FileCheck %s
+
+# Make sure this is not rejected by the parser as invalid syntax.
+# Blank characters after the '1' are important, as we're testing the parser.
+bt 1      
+# CHECK: error: invalid target
+
+# Make sure this is not rejected by the parser as invalid syntax.
+# Blank characters after the '1' are important, as we're testing the parser.
+bt all       
+# CHECK: error: invalid target

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -762,12 +762,12 @@ void CommandInterpreter::LoadCommandDictionary() {
     // command if you wanted to backtrace three frames you would do "bt -c 3"
     // but the intention is to have this emulate the gdb "bt" command and so
     // now "bt 3" is the preferred form, in line with gdb.
-    if (bt_regex_cmd_up->AddRegexCommand("^([[:digit:]]+)\\s*$",
+    if (bt_regex_cmd_up->AddRegexCommand("^([[:digit:]]+)[[:space:]]*$",
                                          "thread backtrace -c %1") &&
-        bt_regex_cmd_up->AddRegexCommand("^-c ([[:digit:]]+)\\s*$",
+        bt_regex_cmd_up->AddRegexCommand("^-c ([[:digit:]]+)[[:space:]]*$",
                                          "thread backtrace -c %1") &&
-        bt_regex_cmd_up->AddRegexCommand("^all\\s*$", "thread backtrace all") &&
-        bt_regex_cmd_up->AddRegexCommand("^\\s*$", "thread backtrace")) {
+        bt_regex_cmd_up->AddRegexCommand("^all[[:space:]]*$", "thread backtrace all") &&
+        bt_regex_cmd_up->AddRegexCommand("^[[:space:]]*$", "thread backtrace")) {
       CommandObjectSP command_sp(bt_regex_cmd_up.release());
       m_command_dict[command_sp->GetCommandName()] = command_sp;
     }

--- a/source/Interpreter/CommandInterpreter.cpp
+++ b/source/Interpreter/CommandInterpreter.cpp
@@ -762,12 +762,12 @@ void CommandInterpreter::LoadCommandDictionary() {
     // command if you wanted to backtrace three frames you would do "bt -c 3"
     // but the intention is to have this emulate the gdb "bt" command and so
     // now "bt 3" is the preferred form, in line with gdb.
-    if (bt_regex_cmd_up->AddRegexCommand("^([[:digit:]]+)$",
+    if (bt_regex_cmd_up->AddRegexCommand("^([[:digit:]]+)\\s*$",
                                          "thread backtrace -c %1") &&
-        bt_regex_cmd_up->AddRegexCommand("^-c ([[:digit:]]+)$",
+        bt_regex_cmd_up->AddRegexCommand("^-c ([[:digit:]]+)\\s*$",
                                          "thread backtrace -c %1") &&
-        bt_regex_cmd_up->AddRegexCommand("^all$", "thread backtrace all") &&
-        bt_regex_cmd_up->AddRegexCommand("^$", "thread backtrace")) {
+        bt_regex_cmd_up->AddRegexCommand("^all\\s*$", "thread backtrace all") &&
+        bt_regex_cmd_up->AddRegexCommand("^\\s*$", "thread backtrace")) {
       CommandObjectSP command_sp(bt_regex_cmd_up.release());
       m_command_dict[command_sp->GetCommandName()] = command_sp;
     }


### PR DESCRIPTION
Previously "bt all    " would've failed as the regex didn't match
them.

<rdar://problem/50824935>