### PR TITLE
Expression: correct relocation model for Windows

### DIFF
--- a/source/Expression/IRExecutionUnit.cpp
+++ b/source/Expression/IRExecutionUnit.cpp
@@ -277,23 +277,17 @@ void IRExecutionUnit::GetRunnableInfo(Status &error, lldb::addr_t &func_addr,
     log->Printf("Module being sent to JIT: \n%s", s.c_str());
   }
 
-  llvm::Triple triple(m_module->getTargetTriple());
-  llvm::Reloc::Model relocModel;
-
-  if (triple.isOSBinFormatELF()) {
-    relocModel = llvm::Reloc::Static;
-  } else {
-    relocModel = llvm::Reloc::PIC_;
-  }
-
   m_module_up->getContext().setInlineAsmDiagnosticHandler(ReportInlineAsmError,
                                                           &error);
 
   llvm::EngineBuilder builder(std::move(m_module_up));
+  llvm::Triple triple(m_module->getTargetTriple());
 
   builder.setEngineKind(llvm::EngineKind::JIT)
       .setErrorStr(&error_string)
-      .setRelocationModel(relocModel)
+      .setRelocationModel(triple.isOSBinFormatMachO()
+                              ? llvm::Reloc::PIC_
+                              : llvm::Reloc::Static)
       .setMCJITMemoryManager(
           std::unique_ptr<MemoryManager>(new MemoryManager(*this)))
       .setOptLevel(llvm::CodeGenOpt::Less);


### PR DESCRIPTION
The Windows Code Generation model cannot generation code with the PIC relocation
model - all code is implicitly position independent due to the DLL load slide
that occurs if it is not loaded at the preferred base address.  Invert the
condition and inline the single use of the variable.  This should also aid the
WASM target.  This significantly improves the state of the (swift) repl on
Windows (and should aid in expression evaluation on Windows).

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@361443 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 3b0388e3746bc88193da27092e837cb099188d29)