### PR TITLE
Actaully lock accesses to OptionValueFileSpecList objects

### DIFF
--- a/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -42,6 +42,7 @@ public:
                      VarSetOperationType = eVarSetOperationAssign) = delete;
 
   bool Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value.Clear();
     m_value_was_set = false;
     return true;
@@ -56,22 +57,22 @@ public:
   //---------------------------------------------------------------------
 
   FileSpecList GetCurrentValue() const {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     return m_current_value;
   }
 
   void SetCurrentValue(const FileSpecList &value) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = value;
   }
 
   void AppendCurrentValue(const FileSpec &value) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value.Append(value);
   }
 
 protected:
-  mutable std::mutex m_mutex;
+  mutable std::recursive_mutex m_mutex;
   FileSpecList m_current_value;
 };
 

--- a/source/Interpreter/OptionValueFileSpecLIst.cpp
+++ b/source/Interpreter/OptionValueFileSpecLIst.cpp
@@ -17,6 +17,7 @@ using namespace lldb_private;
 
 void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
                                         Stream &strm, uint32_t dump_mask) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (dump_mask & eDumpOptionType)
     strm.Printf("(%s)", GetTypeAsCString());
   if (dump_mask & eDumpOptionValue) {
@@ -43,6 +44,7 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
 
 Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
                                                    VarSetOperationType op) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   Status error;
   Args args(value.str());
   const size_t argc = args.GetArgumentCount();
@@ -163,6 +165,6 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
 }
 
 lldb::OptionValueSP OptionValueFileSpecList::DeepCopy() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   return OptionValueSP(new OptionValueFileSpecList(m_current_value));
 }


### PR DESCRIPTION
The patch in r359029 missed a few accessors and mutators. This patch
also changes the lock to a recursive one as OptionValueFileSpecList::Clear()
can be invoked from some of the other methods.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@361440 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 780aa8859164962b08181a02c1d9bab4f3cc5c79)