### PR TITLE
 [Target] Protect Processes' language runtimes map with a mutex 

### DIFF
--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -3107,6 +3107,7 @@ protected:
   bool m_should_detach; /// Should we detach if the process object goes away
                         /// with an explicit call to Kill or Detach?
   LanguageRuntimeCollection m_language_runtimes;
+  std::recursive_mutex m_language_runtimes_mutex;
   InstrumentationRuntimeCollection m_instrumentation_runtimes;
   std::unique_ptr<NextEventAction> m_next_event_action_up;
   std::vector<PreResumeCallbackAndBaton> m_pre_resume_actions;

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -879,7 +879,10 @@ void Process::Finalize() {
   m_image_tokens.clear();
   m_memory_cache.Clear();
   m_allocated_memory_cache.Clear();
-  m_language_runtimes.clear();
+  {
+    std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
+    m_language_runtimes.clear();
+  }
   m_instrumentation_runtimes.clear();
   m_next_event_action_up.reset();
   // Clear the last natural stop ID since it has a strong reference to this
@@ -1853,6 +1856,7 @@ LanguageRuntime *Process::GetLanguageRuntime(lldb::LanguageType language,
   if (m_finalizing)
     return nullptr;
 
+  std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
   LanguageRuntimeCollection::iterator pos;
   pos = m_language_runtimes.find(language);
   if (pos == m_language_runtimes.end() || (retry_if_null && !(*pos).second)) {
@@ -1866,9 +1870,7 @@ LanguageRuntime *Process::GetLanguageRuntime(lldb::LanguageType language,
 }
 
 CPPLanguageRuntime *Process::GetCPPLanguageRuntime(bool retry_if_null) {
-  if (!IsValid())
-    return NULL;
-
+  std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
   LanguageRuntime *runtime =
       GetLanguageRuntime(eLanguageTypeC_plus_plus, retry_if_null);
   if (runtime != nullptr &&
@@ -1878,9 +1880,7 @@ CPPLanguageRuntime *Process::GetCPPLanguageRuntime(bool retry_if_null) {
 }
 
 ObjCLanguageRuntime *Process::GetObjCLanguageRuntime(bool retry_if_null) {
-  if (!IsValid())
-    return NULL;
-
+  std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
   LanguageRuntime *runtime =
       GetLanguageRuntime(eLanguageTypeObjC, retry_if_null);
   if (runtime != nullptr && runtime->GetLanguageType() == eLanguageTypeObjC)
@@ -5952,7 +5952,10 @@ void Process::DidExec() {
   m_jit_loaders_up.reset();
   m_image_tokens.clear();
   m_allocated_memory_cache.Clear();
-  m_language_runtimes.clear();
+  {
+    std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
+    m_language_runtimes.clear();
+  }
   m_instrumentation_runtimes.clear();
   m_thread_list.DiscardThreadPlans();
   m_memory_cache.Clear(true);
@@ -6021,14 +6024,17 @@ void Process::ModulesDidLoad(ModuleList &module_list) {
   // Iterate over a copy of this language runtime list in case the language
   // runtime ModulesDidLoad somehow causes the language runtime to be
   // unloaded.
-  LanguageRuntimeCollection language_runtimes(m_language_runtimes);
-  for (const auto &pair : language_runtimes) {
-    // We must check language_runtime_sp to make sure it is not nullptr as we
-    // might cache the fact that we didn't have a language runtime for a
-    // language.
-    LanguageRuntimeSP language_runtime_sp = pair.second;
-    if (language_runtime_sp)
-      language_runtime_sp->ModulesDidLoad(module_list);
+  {
+    std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
+    LanguageRuntimeCollection language_runtimes(m_language_runtimes);
+    for (const auto &pair : language_runtimes) {
+      // We must check language_runtime_sp to make sure it is not nullptr as we
+      // might cache the fact that we didn't have a language runtime for a
+      // language.
+      LanguageRuntimeSP language_runtime_sp = pair.second;
+      if (language_runtime_sp)
+        language_runtime_sp->ModulesDidLoad(module_list);
+    }
   }
 
   // If we don't have an operating system plug-in, try to load one since

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -1889,9 +1889,7 @@ ObjCLanguageRuntime *Process::GetObjCLanguageRuntime(bool retry_if_null) {
 }
 
 SwiftLanguageRuntime *Process::GetSwiftLanguageRuntime(bool retry_if_null) {
-  if (!IsValid())
-    return NULL;
-
+  std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
   LanguageRuntime *runtime =
       GetLanguageRuntime(eLanguageTypeSwift, retry_if_null);
   if (runtime != NULL && runtime->GetLanguageType() == eLanguageTypeSwift)


### PR DESCRIPTION
[Process] Lock GetSwiftLanguageRuntime() as we do for the other langs.