### PR TITLE
 Clean up triple handling in SwiftASTContext (NFC)

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -116,7 +116,8 @@ public:
   //------------------------------------------------------------------
   // Constructors and destructors
   //------------------------------------------------------------------
-  SwiftASTContext(const char *triple = NULL, Target *target = NULL);
+  SwiftASTContext(std::string description, llvm::Triple triple,
+                  Target *target = nullptr);
 
   SwiftASTContext(const SwiftASTContext &rhs);
 
@@ -132,12 +133,14 @@ public:
   static ConstString GetPluginNameStatic();
 
   /// Create a SwiftASTContext from a Module.  This context is used
-  /// for frame variable ans uses ClangImporter options specific to
-  /// this lldb::Module.  The optional target is to create a
-  /// module-specific scract context.
+  /// for frame variable and uses ClangImporter options specific to
+  /// this lldb::Module.  The optional target is necessary when
+  /// creating a module-specific scratch context.  If \p fallback is
+  /// true, then a SwiftASTContextForExpressions is created.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
                                            Module &module,
-                                           Target *target = nullptr);
+                                           Target *target = nullptr,
+                                           bool fallback = false);
   /// Create a SwiftASTContext from a Target.  This context is global
   /// and used for the expression evaluator.
   static lldb::TypeSystemSP CreateInstance(lldb::LanguageType language,
@@ -151,10 +154,6 @@ public:
   static void Initialize();
 
   static void Terminate();
-
-  void SetDescription(const std::string &description) {
-    m_description = description;
-  }
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
@@ -296,9 +295,10 @@ public:
 
   swift::irgen::IRGenModule &GetIRGenModule();
 
-  std::string GetTriple() const;
+  llvm::Triple GetTriple() const;
 
-  bool SetTriple(std::string triple, lldb_private::Module *module = nullptr);
+  bool SetTriple(const llvm::Triple triple,
+                 lldb_private::Module *module = nullptr);
 
   uint32_t GetPointerBitAlignment();
 
@@ -904,7 +904,7 @@ protected:
 
 class SwiftASTContextForExpressions : public SwiftASTContext {
 public:
-  SwiftASTContextForExpressions(Target &target);
+  SwiftASTContextForExpressions(std::string description, Target &target);
 
   virtual ~SwiftASTContextForExpressions() {}
 

--- a/source/Core/Module.cpp
+++ b/source/Core/Module.cpp
@@ -1609,7 +1609,7 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
     if (SwiftASTContext *swift_ast = llvm::dyn_cast_or_null<SwiftASTContext>(
             m_type_system_map.GetTypeSystemForLanguage(eLanguageTypeSwift, this,
                                                        false)))
-      swift_ast->SetTriple(new_arch.GetTriple().str().c_str());
+      swift_ast->SetTriple(new_arch.GetTriple());
     return true;
   }
   return m_arch.IsCompatibleMatch(new_arch);

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -250,8 +250,8 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
   TypeSystem *type_system = target_sp->GetScratchTypeSystemForLanguage(
       nullptr, eLanguageTypeSwift, true, repl_options);
   if (!type_system) {
-    err.SetErrorString("Could not construct an expression"
-                       " context for the REPL.\n");
+    err.SetErrorString("Could not construct an expression "
+                       "context for the REPL.\n");
     return nullptr;
   }
 

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -2511,9 +2511,10 @@ SwiftASTContextReader Target::GetScratchSwiftASTContext(
     if (auto *global_scratch_ctx = llvm::cast_or_null<SwiftASTContext>(
             GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift, false)))
       DisplayFallbackSwiftContextErrors(global_scratch_ctx);
-    
+
+    bool fallback = true;
     auto typesystem_sp = SwiftASTContext::CreateInstance(
-        lldb::eLanguageTypeSwift, *lldb_module, this);
+        lldb::eLanguageTypeSwift, *lldb_module, this, fallback);
     auto *swift_ast_ctx = cast<SwiftASTContext>(typesystem_sp.get());
     m_scratch_typesystem_for_module.insert({idx, typesystem_sp});
     GetSwiftScratchContextLock().unlock();


### PR DESCRIPTION
This patch

- replaces all char* and std::string triples in public interfaces with
  llvm::Triple objects

- Avoids initializing module contexts with
  SwiftASTContextForExpression objects

- Fixes a bug in log description of regular SwiftASTContext objects

rdar://problem/50894825