### PR TITLE
[Target] Make Processes' GetLanguageRuntime methods non-virtual

### DIFF
--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -2538,8 +2538,7 @@ public:
 
   ObjCLanguageRuntime *GetObjCLanguageRuntime(bool retry_if_null = true);
 
-  virtual SwiftLanguageRuntime *
-  GetSwiftLanguageRuntime(bool retry_if_null = true);
+  SwiftLanguageRuntime *GetSwiftLanguageRuntime(bool retry_if_null = true);
 
   bool IsPossibleDynamicValue(ValueObject &in_value);
 

--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -2531,13 +2531,12 @@ public:
 
   OperatingSystem *GetOperatingSystem() { return m_os_up.get(); }
 
-  virtual LanguageRuntime *GetLanguageRuntime(lldb::LanguageType language,
-                                              bool retry_if_null = true);
+  LanguageRuntime *GetLanguageRuntime(lldb::LanguageType language,
+                                      bool retry_if_null = true);
 
-  virtual CPPLanguageRuntime *GetCPPLanguageRuntime(bool retry_if_null = true);
+  CPPLanguageRuntime *GetCPPLanguageRuntime(bool retry_if_null = true);
 
-  virtual ObjCLanguageRuntime *
-  GetObjCLanguageRuntime(bool retry_if_null = true);
+  ObjCLanguageRuntime *GetObjCLanguageRuntime(bool retry_if_null = true);
 
   virtual SwiftLanguageRuntime *
   GetSwiftLanguageRuntime(bool retry_if_null = true);


### PR DESCRIPTION
This is a cherry-pick of svn rL361673 plus a patch to adjust for swift.

cc @JDevlieghere @dcci @compnerd 