### PR TITLE
[DWARF] Fix Swift build after r361849

### DIFF
--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -298,7 +298,7 @@ Function *DWARFASTParserSwift::ParseFunctionFromDWARF(
   int call_file = 0;
   int call_line = 0;
   int call_column = 0;
-  DWARFExpression frame_base(die.GetCU());
+  DWARFExpression frame_base;
 
   if (die.Tag() != DW_TAG_subprogram)
     return NULL;


### PR DESCRIPTION
r361849 removed the one-argument constructor to DWARFExpression. In this
case, we can just switch to the default constructor, since the
constructed object is being used with GetDIENamesAndRanges, which has
been updated to fill in the CU itself.