### PR TITLE
[5.1][Tests] Adjust error message for failing member lookup test

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/main.swift
@@ -10,7 +10,7 @@ extension Measurement where UnitType == UnitAngle {
   }
 
   func f() {
-    return //%self.expect('p self.radians', substrs=['is not convertible to'], error=True)
+    return //%self.expect('p self.radians', substrs=["property 'radians' requires the types 'UnitType' and 'UnitAngle' be equivalent"], error=True)
   }
 }
 


### PR DESCRIPTION
Align test error message with https://github.com/apple/swift/pull/25111
which improves diagnostics related to generic requirements.

This has already been committed to `stable`, I'm cherry-picking to `5.1`.

(cherry picked from commit bbe2050866b430cfa6524212198d24f125dc13c7)