### PR TITLE
[5.1] Update the Playgrounds interface to conform with Swift

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/invalid_input/PlaygroundsRuntime.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/invalid_input/PlaygroundsRuntime.swift
@@ -26,46 +26,58 @@ struct SourceRange {
   }
 }
 
+struct ModuleFileIdentifier {
+  let moduleId : Int
+  let fileId : Int
+  var text : String {
+    return "[\(moduleId):\(fileId)]"
+  }
+}
+
 class LogRecord {
   let text : String
 
-  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object : Any, name : String, range : SourceRange) {
+  init(api : String, object : Any, name : String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object: Any, range : SourceRange) {
+  init(api : String, object: Any, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "['" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
   }
-  init(api: String, range : SourceRange) {
-    text = range.text + " " + api
+  init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
+    text = moduleFileId.text + " " + range.text + " " + api
   }
 }
 
 @_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
 @_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/last_line_assignment_log/PlaygroundsRuntime.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/last_line_assignment_log/PlaygroundsRuntime.swift
@@ -26,46 +26,58 @@ struct SourceRange {
   }
 }
 
+struct ModuleFileIdentifier {
+  let moduleId : Int
+  let fileId : Int
+  var text : String {
+    return "[\(moduleId):\(fileId)]"
+  }
+}
+
 class LogRecord {
   let text : String
 
-  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object : Any, name : String, range : SourceRange) {
+  init(api : String, object : Any, name : String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object: Any, range : SourceRange) {
+  init(api : String, object: Any, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "['" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
   }
-  init(api: String, range : SourceRange) {
-    text = range.text + " " + api
+  init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
+    text = moduleFileId.text + " " + range.text + " " + api
   }
 }
 
 @_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
 @_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/long_loops/PlaygroundsRuntime.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/long_loops/PlaygroundsRuntime.swift
@@ -26,46 +26,58 @@ struct SourceRange {
   }
 }
 
+struct ModuleFileIdentifier {
+  let moduleId : Int
+  let fileId : Int
+  var text : String {
+    return "[\(moduleId):\(fileId)]"
+  }
+}
+
 class LogRecord {
   let text : String
 
-  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object : Any, name : String, range : SourceRange) {
+  init(api : String, object : Any, name : String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object: Any, range : SourceRange) {
+  init(api : String, object: Any, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "['" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
   }
-  init(api: String, range : SourceRange) {
-    text = range.text + " " + api
+  init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
+    text = moduleFileId.text + " " + range.text + " " + api
   }
 }
 
 @_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
 @_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/old_playground/PlaygroundsRuntime.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/old_playground/PlaygroundsRuntime.swift
@@ -26,46 +26,58 @@ struct SourceRange {
   }
 }
 
+struct ModuleFileIdentifier {
+  let moduleId : Int
+  let fileId : Int
+  var text : String {
+    return "[\(moduleId):\(fileId)]"
+  }
+}
+
 class LogRecord {
   let text : String
 
-  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object : Any, name : String, range : SourceRange) {
+  init(api : String, object : Any, name : String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object: Any, range : SourceRange) {
+  init(api : String, object: Any, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "['" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
   }
-  init(api: String, range : SourceRange) {
-    text = range.text + " " + api
+  init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
+    text = moduleFileId.text + " " + range.text + " " + api
   }
 }
 
 @_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
 @_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/two_valid_inputs/PlaygroundsRuntime.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds-repl/two_valid_inputs/PlaygroundsRuntime.swift
@@ -26,46 +26,58 @@ struct SourceRange {
   }
 }
 
+struct ModuleFileIdentifier {
+  let moduleId : Int
+  let fileId : Int
+  var text : String {
+    return "[\(moduleId):\(fileId)]"
+  }
+}
+
 class LogRecord {
   let text : String
 
-  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object : Any, name : String, range : SourceRange) {
+  init(api : String, object : Any, name : String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object: Any, range : SourceRange) {
+  init(api : String, object: Any, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "['" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
   }
-  init(api: String, range : SourceRange) {
-    text = range.text + " " + api
+  init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
+    text = moduleFileId.text + " " + range.text + " " + api
   }
 }
 
 @_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
 @_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {

--- a/packages/Python/lldbsuite/test/lang/swift/playgrounds/PlaygroundsRuntime.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/playgrounds/PlaygroundsRuntime.swift
@@ -26,46 +26,58 @@ struct SourceRange {
   }
 }
 
+struct ModuleFileIdentifier {
+  let moduleId : Int
+  let fileId : Int
+  var text : String {
+    return "[\(moduleId):\(fileId)]"
+  }
+}
+
 class LogRecord {
   let text : String
 
-  init(api : String, object : Any, name : String, id : Int, range : SourceRange) {
+  init(api : String, object : Any, name : String, id : Int, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object : Any, name : String, range : SourceRange) {
+  init(api : String, object : Any, name : String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "[" + name + "='" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "[" + name + "='" + object_description + "']"
   }
-  init(api : String, object: Any, range : SourceRange) {
+  init(api : String, object: Any, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
     var object_description : String = ""
     print(object, terminator: "", to: &object_description)
-    text = range.text + " " + api + "['" + object_description + "']"
+    text = moduleFileId.text + " " + range.text + " " + api + "['" + object_description + "']"
   }
-  init(api: String, range : SourceRange) {
-    text = range.text + " " + api
+  init(api: String, range : SourceRange, moduleFileId : ModuleFileIdentifier) {
+    text = moduleFileId.text + " " + range.text + " " + api
   }
 }
 
 @_silgen_name ("playground_logger_initialize") public func builtin_initialize() {
 }
 
-@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_hidden") public func builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_entry") public func builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_scope_exit") public func builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
-@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
-  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
+@_silgen_name ("playground_log_postprint") public func builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleId : Int, _ fileId : Int) -> AnyObject? {
+  let moduleFileId = ModuleFileIdentifier(moduleId:moduleId, fileId:fileId)
+  return LogRecord(api:"__builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec), moduleFileId:moduleFileId)
 }
 
 @_silgen_name ("DVTSendPlaygroundLogData") public func builtin_send_data(_ object:AnyObject?) {

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -76,10 +76,10 @@ void SwiftASTManipulator::WrapExpression(
   if (playground) {
     const char *playground_logger_declarations = R"(
 @_silgen_name ("playground_logger_initialize") func __builtin_logger_initialize ()
-@_silgen_name ("playground_log_hidden") func __builtin_log_with_id<T> (_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject
-@_silgen_name ("playground_log_scope_entry") func __builtin_log_scope_entry (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject
-@_silgen_name ("playground_log_scope_exit") func __builtin_log_scope_exit (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject
-@_silgen_name ("playground_log_postprint") func __builtin_postPrint (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject
+@_silgen_name ("playground_log_hidden") func __builtin_log_with_id<T> (_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name ("playground_log_scope_entry") func __builtin_log_scope_entry (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name ("playground_log_scope_exit") func __builtin_log_scope_exit (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
+@_silgen_name ("playground_log_postprint") func __builtin_postPrint (_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int, _ moduleID: Int, _ fileID: Int) -> AnyObject
 @_silgen_name ("DVTSendPlaygroundLogData") func __builtin_send_data (_ :  AnyObject!)
 __builtin_logger_initialize()
 )";


### PR DESCRIPTION
**Explanation**

The PCMacro and PlaygroundTransfom inside of Swift were updated with two
additional parameters: moduleID and fileID. This change updates the
relevant to LLDB code to conform with these changes.

**Scope**

The scope is contained to Playgrounds related logic.

**SR Issue**

No SR issue, but tracked via rdar://problem/48323713

**Risk**

Low risk. Updated interface to include additional `moduleID` and `fileID` parameters. 

**Testing**

Tests have been updated to work with the updated interface.

**Reviewers**

Will add once build/tests are validated after cherry-pick.