### PR TITLE
[SwiftASTContext] Make sure search opts and clang importer are initia…

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/packages/Python/lldbsuite/test/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+import pexpect
+import os
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestSwiftREPLCompletion(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+
+    @skipUnlessDarwin
+    def test_repl_completion(self):
+        prompt = "Welcome to"
+        child = pexpect.spawn('%s --repl' % (lldbtest_config.lldbExec))
+        # Assign to make sure the sessions are killed during teardown
+        self.child = child
+        # Send a <TAB> and make sure we don't crash.
+        child.sendline("import Foundation\t")
+        child.expect("2>")

--- a/packages/Python/lldbsuite/test/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/packages/Python/lldbsuite/test/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -17,5 +17,7 @@ class TestSwiftREPLCompletion(TestBase):
         # Assign to make sure the sessions are killed during teardown
         self.child = child
         # Send a <TAB> and make sure we don't crash.
-        child.sendline("import Foundation\t")
+        child.sendline("import Foundatio\t")
         child.expect("2>")
+        child.sendline("print(NSString(\"patatino\"))")
+        child.expect("patatino")

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -877,16 +877,8 @@ SwiftASTContext::SwiftASTContext(const SwiftASTContext &rhs)
   InitializeSearchPathOptions(module_search_paths, framework_search_paths);
   GetClangImporterOptions();
 
-  swift::ASTContext *lhs_ast = GetASTContext();
-  swift::ASTContext *rhs_ast =
-      const_cast<SwiftASTContext &>(rhs).GetASTContext();
-
-  // As this is a copy constructor, make sure we copy the search path
-  // opts and clang importer options from RHS to LHS.
-  assert(lhs_ast && "Invalid LHS ASTContext");
-  assert(rhs_ast && "Invalid RHS ASTContext");
-  lhs_ast->SearchPathOpts = rhs_ast->SearchPathOpts;
-
+  // As this is a copy constructor, make sure we copy the clang importer
+  // options from RHS to LHS.
   GetCompilerInvocation().getClangImporterOptions() =
       rhs.m_compiler_invocation_ap->getClangImporterOptions();
 }


### PR DESCRIPTION
…lized.

Some codepaths, e.g. CompleteCode, try to grab a SwiftASTContext without
these initialized and crash later with an assertion (or, even worse, in release
mode, segfaults when trying to access these fields).

<rdar://problem/50875178>