### PR TITLE
Add a target.swift-extra-clang-flags setting for ClangImporter flags.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -196,6 +196,9 @@ public:
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(std::vector<std::string> ExtraArgs);
 
+  /// Add the target's swift-extra-clang-flags to the ClangImporter options.
+  void AddUserClangArgs(TargetProperties &props);
+
   llvm::StringRef GetPlatformSDKPath() const {
     return m_platform_sdk_path;
   }

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -145,6 +145,8 @@ public:
 
   FileSpecList GetSwiftModuleSearchPaths();
 
+  llvm::StringRef GetSwiftExtraClangFlags() const;
+
   bool GetSwiftCreateModuleContextsInParallel() const;
 
   bool GetEnableAutoImportClangModules() const;

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/Makefile
@@ -1,0 +1,7 @@
+LEVEL = ../../../../make
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules
+
+SWIFTFLAGS += -I$(SRCDIR)
+SWIFTFLAGS += -import-objc-header $(SRCDIR)/bridging-header.h

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -1,0 +1,59 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftExtraClangFlags(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+    
+    def setUp(self):
+        TestBase.setUp(self)
+
+    @skipUnlessDarwin
+    @swiftTest
+    @add_test_categories(["swiftpr"])
+    def test_sanity(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("frame var foo", "sanity check", substrs=['(Foo)'])
+        self.expect("expr FromOverlay(i: 23)", error=True)
+
+    @skipUnlessDarwin
+    @swiftTest
+    @add_test_categories(["swiftpr"])
+    def test_extra_clang_flags(self):
+        """
+        Test that a debug-only module map can be installed by injecting a
+        VFS overlay using target.swift-extra-clang-flags.
+        """
+        self.build()
+        # FIXME: this doesn't work if LLDB's build dir contains a space.
+        overlay = self.getBuildArtifact('overlay.yaml')
+        self.addTearDownHook(
+            lambda: self.runCmd("settings clear target.swift-extra-clang-flags"))
+        self.expect('settings set -- target.swift-extra-clang-flags '+
+                    '"-ivfsoverlay %s"' % overlay)
+        with open(overlay, 'w+') as f:
+            import os
+            f.write("""
+{
+  'version': 0,
+  'roots': [
+    { 'name': '"""+os.getcwd()+"""/nonmodular', 'type': 'directory',
+      'contents': [
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': '"""+os.path.join(os.getcwd(),
+                                                 'overlaid.map')+"""'
+        }
+      ]
+    }
+  ]
+}
+""")
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("frame var foo", "sanity check", substrs=['(Foo)'])
+        self.expect("expr FromOverlay(i: 23)", substrs=['(FromOverlay)', '23'])

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/bridging-header.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/bridging-header.h
@@ -1,0 +1,1 @@
+#import <nonmodular/a.h>

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/main.swift
@@ -1,0 +1,3 @@
+func use<T>(_ t: T) {}
+let foo = Foo()
+use(foo) // break here

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/nonmodular/a.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/nonmodular/a.h
@@ -1,0 +1,1 @@
+struct Foo {};

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/nonmodular/hidden.h
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/nonmodular/hidden.h
@@ -1,0 +1,1 @@
+struct FromOverlay { int i; };

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/overlaid.map
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/extra_clang_flags/overlaid.map
@@ -1,0 +1,4 @@
+module FromOverlay {
+  header "a.h"
+  header "hidden.h"
+}

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -3649,6 +3649,8 @@ static constexpr PropertyDefinition g_properties[] = {
     {"swift-module-search-paths", OptionValue::eTypeFileSpecList, false, 0,
      nullptr, {},
      "List of directories to be searched when locating modules for Swift."},
+    {"swift-extra-clang-flags", OptionValue::eTypeString, false, 0, nullptr, {},
+     "Additional -Xcc flags to be passed to the Swift ClangImporter."},
     {"auto-import-clang-modules", OptionValue::eTypeBoolean, false, true,
      nullptr, {},
      "Automatically load Clang modules referred to by the program."},
@@ -3796,6 +3798,7 @@ enum {
   ePropertyClangModuleSearchPaths,
   ePropertySwiftFrameworkSearchPaths,
   ePropertySwiftModuleSearchPaths,
+  ePropertySwiftExtraClangFlags,
   ePropertyAutoImportClangModules,
   ePropertyUseAllCompilerFlags,
   ePropertyAutoApplyFixIts,
@@ -4259,6 +4262,12 @@ FileSpecList TargetProperties::GetSwiftModuleSearchPaths() {
                                                                    idx);
   assert(option_value);
   return option_value->GetCurrentValue();
+}
+
+llvm::StringRef TargetProperties::GetSwiftExtraClangFlags() const {
+  const uint32_t idx = ePropertySwiftExtraClangFlags;
+  return m_collection_sp->GetPropertyAtIndexAsString(nullptr, idx,
+                                                     llvm::StringRef());
 }
 
 FileSpecList TargetProperties::GetClangModuleSearchPaths() {


### PR DESCRIPTION
This is intended as a power-user workaround for ClangImporter troubles
caused by non-modular system or 3rd-party headers that are outside of
the control of the user. See the TestSwiftExtraClangFlags for an
example installing a module map using a VFS overlay.

rdar://problem/51272979