### PR TITLE
[Target] Remove unused method Process::PrintWarningCantLoadSwift

### DIFF
--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -536,7 +536,7 @@ public:
   //------------------------------------------------------------------
   /// Process warning types.
   //------------------------------------------------------------------
-  enum Warnings { eWarningsOptimization = 1, eWarningsCantLoadSwift };
+  enum Warnings { eWarningsOptimization = 1 };
 
   typedef Range<lldb::addr_t, lldb::addr_t> LoadRange;
   // We use a read/write lock to allow on or more clients to access the process
@@ -1588,21 +1588,6 @@ public:
   ///     pre-computed.
   //------------------------------------------------------------------
   void PrintWarningOptimization(const SymbolContext &sc);
-
-  //------------------------------------------------------------------
-  /// Print a user-visible warning about a module having Swift settings
-  /// incompatible with the current system
-  ///
-  /// Prints a async warning message to the user one time per Process for a
-  /// Module
-  /// whose Swift AST sections couldn't be loaded because they aren't buildable
-  /// on
-  /// the current machine.
-  ///
-  /// @param [in] module
-  ///     The affected Module.
-  //------------------------------------------------------------------
-  void PrintWarningCantLoadSwift(const Module &module);
 
   virtual bool GetProcessInfo(ProcessInstanceInfo &info);
 

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -6119,13 +6119,6 @@ void Process::PrintWarningOptimization(const SymbolContext &sc) {
   }
 }
 
-void Process::PrintWarningCantLoadSwift(const Module &module) {
-  PrintWarning(Process::Warnings::eWarningsCantLoadSwift, (void *)&module,
-               "%s had Swift information that isn't usable on the current "
-               "system; its internals will be unavailable.\n",
-               module.GetFileSpec().GetCString());
-}
-
 bool Process::GetProcessInfo(ProcessInstanceInfo &info) {
   info.Clear();
 


### PR DESCRIPTION
This appears to be unused.

cc @compnerd @JDevlieghere @dcci 