### PR TITLE
[Commands] Stop hardcoding languages in CommandObjectType

### DIFF
--- a/source/Commands/CommandObjectType.cpp
+++ b/source/Commands/CommandObjectType.cpp
@@ -2843,18 +2843,11 @@ public:
       return m_cmd_help_long;
 
     StreamString stream;
-    // FIXME: hardcoding languages is not good
-    lldb::LanguageType languages[] = {eLanguageTypeObjC,
-                                      eLanguageTypeC_plus_plus,
-                                      eLanguageTypeSwift};
-
-    for (const auto lang_type : languages) {
-      if (auto language = Language::FindPlugin(lang_type)) {
-        if (const char *help = language->GetLanguageSpecificTypeLookupHelp()) {
-          stream.Printf("%s\n", help);
-        }
-      }
-    }
+    Language::ForEach([&](Language *lang) {
+      if (const char *help = lang->GetLanguageSpecificTypeLookupHelp())
+        stream.Printf("%s\n", help);
+      return true;
+    });
 
     m_cmd_help_long = stream.GetString();
     return m_cmd_help_long;
@@ -2894,10 +2887,10 @@ public:
 
     if ((is_global_search =
              (m_command_options.m_language == eLanguageTypeUnknown))) {
-      // FIXME: hardcoding languages is not good
-      languages.push_back(Language::FindPlugin(eLanguageTypeObjC));
-      languages.push_back(Language::FindPlugin(eLanguageTypeC_plus_plus));
-      languages.push_back(Language::FindPlugin(eLanguageTypeSwift));
+      Language::ForEach([&](Language *lang) {
+        languages.push_back(lang);
+        return true;
+      });
     } else {
       languages.push_back(Language::FindPlugin(m_command_options.m_language));
     }


### PR DESCRIPTION
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@362268 91177308-0d34-0410-b5e6-96231b3b80d8

Note: This patch has been modified to accommodate swift.

cc @compnerd @dcci @JDevlieghere 