### PR TITLE
[lldb] Fix out-of-bounds read after c3ea7c66fec021867e005ad1b02f3c7e8…

### DIFF
--- a/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
+++ b/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
@@ -736,7 +736,6 @@ bool x86AssemblyInspectionEngine::pc_rel_branch_or_jump_p (
   int opcode_size = 0;
 
   uint8_t b1 = m_cur_insn[0];
-  uint8_t b2 = m_cur_insn[1];
 
   switch (b1) {
     case 0x77: // JA/JNBE rel8
@@ -764,6 +763,7 @@ bool x86AssemblyInspectionEngine::pc_rel_branch_or_jump_p (
       break;
   }
   if (b1 == 0x0f && opcode_size == 0) {
+    uint8_t b2 = m_cur_insn[1];
     switch (b2) {
       case 0x87: // JA/JNBE rel16/rel32
       case 0x86: // JBE/JNA rel16/rel32


### PR DESCRIPTION
…0feaa85

"Add support for mid-function epilogues on x86 that end in a non-local jump."

Detected by asan.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@362510 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 6258b64ab04f786fa839e78b52d8879c689d7098)