### PR TITLE
[Target] Move ObjCLanguageRuntime::LookupRuntimeSymbol into LanguageR…

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -185,6 +185,13 @@ public:
 
   static bool IsSymbolAnyRuntimeThunk(Symbol &symbol);
 
+  // Given the name of a runtime symbol (e.g. in Objective-C, an ivar offset
+  // symbol), try to determine from the runtime what the value of that symbol
+  // would be. Useful when the underlying binary is stripped.
+  virtual lldb::addr_t LookupRuntimeSymbol(ConstString name) {
+    return LLDB_INVALID_ADDRESS;
+  }
+
 protected:
   //------------------------------------------------------------------
   // Classes that inherit from LanguageRuntime can see and modify these

--- a/include/lldb/Target/ObjCLanguageRuntime.h
+++ b/include/lldb/Target/ObjCLanguageRuntime.h
@@ -264,13 +264,6 @@ public:
   virtual size_t GetByteOffsetForIvar(CompilerType &parent_qual_type,
                                       const char *ivar_name);
 
-  // Given the name of an Objective-C runtime symbol (e.g., ivar offset
-  // symbol), try to determine from the runtime what the value of that symbol
-  // would be. Useful when the underlying binary is stripped.
-  virtual lldb::addr_t LookupRuntimeSymbol(ConstString name) {
-    return LLDB_INVALID_ADDRESS;
-  }
-
   bool HasNewLiteralsAndIndexing() {
     if (m_has_new_literals_and_indexing == eLazyBoolCalculate) {
       if (CalculateHasNewLiteralsAndIndexing())

--- a/source/Expression/IRExecutionUnit.cpp
+++ b/source/Expression/IRExecutionUnit.cpp
@@ -24,7 +24,7 @@
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Target/ExecutionContext.h"
-#include "lldb/Target/ObjCLanguageRuntime.h"
+#include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/DataBufferHeap.h"
@@ -915,10 +915,8 @@ IRExecutionUnit::FindInRuntimes(const std::vector<SearchSpec> &specs,
     return LLDB_INVALID_ADDRESS;
   }
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
-
-  if (runtime) {
-    for (const SearchSpec &spec : specs) {
+  for (const SearchSpec &spec : specs) {
+    for (LanguageRuntime *runtime : process_sp->GetLanguageRuntimes()) {
       lldb::addr_t symbol_load_addr = runtime->LookupRuntimeSymbol(spec.name);
 
       if (symbol_load_addr != LLDB_INVALID_ADDRESS)


### PR DESCRIPTION
…untime

Summary:
LookupRuntimeSymbol seems like a general LanguageRuntime method.
Although no other language runtime currently implements this, there's no
reason another language runtime couldn't use this.

Additionally, this breaks IRExecutionUnit's dependency on
ObjCLanguageRuntime.

Reviewers: compnerd, labath, JDevlieghere, davide

Subscribers: lldb-commits

Differential Revision: https://reviews.llvm.org/D62795

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@362458 91177308-0d34-0410-b5e6-96231b3b80d8

cc @compnerd @JDevlieghere @dcci 