### PR TITLE
[Target] Generalize some behavior in Target::SymbolsDidLoad

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -160,6 +160,8 @@ public:
     return false;
   }
 
+  virtual void SymbolsDidLoad(const ModuleList &module_list) { return; }
+
   virtual lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
                                                           bool stop_others) = 0;
 

--- a/include/lldb/Target/ObjCLanguageRuntime.h
+++ b/include/lldb/Target/ObjCLanguageRuntime.h
@@ -282,7 +282,7 @@ public:
     return (m_has_new_literals_and_indexing == eLazyBoolYes);
   }
 
-  virtual void SymbolsDidLoad(const ModuleList &module_list) {
+  void SymbolsDidLoad(const ModuleList &module_list) override {
     m_negative_complete_class_cache.clear();
   }
 

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -47,7 +47,6 @@
 #include "lldb/Symbol/SymbolVendor.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/LanguageRuntime.h"
-#include "lldb/Target/ObjCLanguageRuntime.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/StackFrame.h"
@@ -1708,11 +1707,8 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
 void Target::SymbolsDidLoad(ModuleList &module_list) {
   if (m_valid && module_list.GetSize()) {
     if (m_process_sp) {
-      LanguageRuntime *runtime =
-          m_process_sp->GetLanguageRuntime(lldb::eLanguageTypeObjC);
-      if (runtime) {
-        ObjCLanguageRuntime *objc_runtime = (ObjCLanguageRuntime *)runtime;
-        objc_runtime->SymbolsDidLoad(module_list);
+      for (LanguageRuntime *runtime : m_process_sp->GetLanguageRuntimes()) {
+        runtime->SymbolsDidLoad(module_list);
       }
     }
 


### PR DESCRIPTION
Summary:
SymbolsDidLoad is currently only implemented for ObjCLanguageRuntime,
but that doesn't mean that it couldn't be useful for other Langauges. Although
this change seems like it's generalizing for the sake of purity, this removes
Target's dependency on ObjCLanguageRuntime.

Differential Revision: https://reviews.llvm.org/D62796

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@362461 91177308-0d34-0410-b5e6-96231b3b80d8

cc @compnerd @JDevlieghere @dcci 