### PR TITLE
 Fix a crash in option parsing.

### DIFF
--- a/lit/Driver/Inputs/process_attach_pid.in
+++ b/lit/Driver/Inputs/process_attach_pid.in
@@ -1,0 +1,1 @@
+process attach --pid

--- a/lit/Driver/TestProcessAttach.test
+++ b/lit/Driver/TestProcessAttach.test
@@ -1,0 +1,2 @@
+# RUN: %lldb -x -b -S %S/Inputs/process_attach_pid.in 2>&1 | FileCheck %s
+# CHECK: requires an argument

--- a/source/Interpreter/Options.cpp
+++ b/source/Interpreter/Options.cpp
@@ -1364,6 +1364,12 @@ llvm::Expected<Args> Options::Parse(const Args &args,
     int long_options_index = -1;
     val = OptionParser::Parse(argv.size(), &*argv.begin(), sstr.GetString(),
                               long_options, &long_options_index);
+
+    if ((size_t)OptionParser::GetOptionIndex() > argv.size()) {
+      error.SetErrorStringWithFormat("option requires an argument");
+      break;
+    }
+
     if (val == -1)
       break;
 


### PR DESCRIPTION
The call to getopt_long didn't handle the case where the *last* option
had an argument missing.

<rdar://problem/51231882>

Differential Revision: https://reviews.llvm.org/D63110

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@363101 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 2abc98b56446972e7460fdc69c54270c3a3d8edf)