### PR TITLE
[ExpressionParser] Fix typo in SwiftPersistentExpressionState

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -33,7 +33,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 SwiftPersistentExpressionState::SwiftPersistentExpressionState()
-    : lldb_private::PersistentExpressionState(LLVMCastKind::eKindClang),
+    : lldb_private::PersistentExpressionState(LLVMCastKind::eKindSwift),
       m_next_persistent_variable_id(0), m_next_persistent_error_id(0) {}
 
 ExpressionVariableSP SwiftPersistentExpressionState::CreatePersistentVariable(

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -73,7 +73,7 @@ public:
   // llvm casting support
   //------------------------------------------------------------------
   static bool classof(const PersistentExpressionState *pv) {
-    return pv->getKind() == PersistentExpressionState::eKindClang;
+    return pv->getKind() == PersistentExpressionState::eKindSwift;
   }
 
   lldb::ExpressionVariableSP


### PR DESCRIPTION
cc @dcci @JDevlieghere @compnerd 