### PR TITLE
ExpressionParser: adjust for SVN r363183

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -85,6 +85,12 @@ void SwiftPersistentExpressionState::RemovePersistentVariable(
   }
 }
 
+llvm::Optional<CompilerType>
+SwiftPersistentExpressionState::GetCompilerTypeFromPersistentDecl(
+    ConstString type_name) {
+  return llvm::None;
+}
+
 bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(
     swift::Decl *lhs_decl, swift::Decl *rhs_decl) {
   swift::DeclKind lhs_kind = lhs_decl->getKind();

--- a/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -91,6 +91,9 @@ public:
 
   void RemovePersistentVariable(lldb::ExpressionVariableSP variable) override;
 
+  llvm::Optional<CompilerType>
+  GetCompilerTypeFromPersistentDecl(ConstString type_name) override;
+
   void RegisterSwiftPersistentDecl(swift::ValueDecl *value_decl);
 
   void RegisterSwiftPersistentDeclAlias(swift::ValueDecl *value_decl,


### PR DESCRIPTION
A new pure virtual method has been added to `ExpressionVariable`.  Adjust for
that.