### PR TITLE
[Target] Remove Process::GetObjCLanguageRuntime

### DIFF
--- a/include/lldb/Target/CPPLanguageRuntime.h
+++ b/include/lldb/Target/CPPLanguageRuntime.h
@@ -54,7 +54,7 @@ public:
     return lldb::eLanguageTypeC_plus_plus;
   }
 
-  static CPPLanguageRuntime *GetCPPLanguageRuntime(Process &process) {
+  static CPPLanguageRuntime *Get(Process &process) {
     return llvm::cast_or_null<CPPLanguageRuntime>(
         process.GetLanguageRuntime(lldb::eLanguageTypeC_plus_plus));
   }

--- a/include/lldb/Target/ObjCLanguageRuntime.h
+++ b/include/lldb/Target/ObjCLanguageRuntime.h
@@ -199,6 +199,11 @@ public:
     return runtime->isA(&ID);
   }
 
+  static ObjCLanguageRuntime *Get(Process &process) {
+    return llvm::cast_or_null<ObjCLanguageRuntime>(
+        process.GetLanguageRuntime(lldb::eLanguageTypeObjC));
+  }
+
   virtual TaggedPointerVendor *GetTaggedPointerVendor() { return nullptr; }
 
   typedef std::shared_ptr<EncodingToType> EncodingToTypeSP;

--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -2522,8 +2522,6 @@ public:
   LanguageRuntime *GetLanguageRuntime(lldb::LanguageType language,
                                       bool retry_if_null = true);
 
-  ObjCLanguageRuntime *GetObjCLanguageRuntime(bool retry_if_null = true);
-
   SwiftLanguageRuntime *GetSwiftLanguageRuntime(bool retry_if_null = true);
 
   bool IsPossibleDynamicValue(ValueObject &in_value);

--- a/include/lldb/lldb-forward.h
+++ b/include/lldb/lldb-forward.h
@@ -137,7 +137,6 @@ class ModuleSpec;
 class ModuleSpecList;
 class Mutex;
 struct NameSearchContext;
-class ObjCLanguageRuntime;
 class ObjCRuntimeSyntheticProvider;
 class ObjectContainer;
 class OptionGroup;

--- a/source/API/SBTarget.cpp
+++ b/source/API/SBTarget.cpp
@@ -1887,7 +1887,7 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
 
     if (process_sp) {
       ObjCLanguageRuntime *objc_language_runtime =
-          process_sp->GetObjCLanguageRuntime();
+          ObjCLanguageRuntime::Get(*process_sp);
 
       if (objc_language_runtime) {
         DeclVendor *objc_decl_vendor = objc_language_runtime->GetDeclVendor();
@@ -1957,7 +1957,7 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
 
     if (process_sp) {
       ObjCLanguageRuntime *objc_language_runtime =
-          process_sp->GetObjCLanguageRuntime();
+          ObjCLanguageRuntime::Get(*process_sp);
 
       if (objc_language_runtime) {
         DeclVendor *objc_decl_vendor = objc_language_runtime->GetDeclVendor();

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -344,7 +344,7 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
 
       if (process_sp) {
         ObjCLanguageRuntime *objc_language_runtime(
-            process_sp->GetObjCLanguageRuntime());
+            ObjCLanguageRuntime::Get(*process_sp));
 
         if (objc_language_runtime) {
           TypeSP complete_objc_class_type_sp =
@@ -1792,7 +1792,7 @@ bool ValueObject::IsRuntimeSupportValue() {
     LanguageRuntime *runtime =
         process->GetLanguageRuntime(GetObjectRuntimeLanguage());
     if (!runtime)
-      runtime = process->GetObjCLanguageRuntime();
+      runtime = ObjCLanguageRuntime::Get(*process);
     if (runtime)
       return runtime->IsRuntimeSupportValue(*this);
     // If there is no language runtime, trust the compiler to mark all
@@ -3500,4 +3500,3 @@ lldb::StackFrameSP ValueObjectManager::GetFrameSP() const {
     return m_root_valobj_sp->GetFrameSP();
   return lldb::StackFrameSP();
 }
-

--- a/source/Expression/IRDynamicChecks.cpp
+++ b/source/Expression/IRDynamicChecks.cpp
@@ -61,7 +61,7 @@ bool DynamicCheckerFunctions::Install(DiagnosticManager &diagnostic_manager,
 
   if (process) {
     ObjCLanguageRuntime *objc_language_runtime =
-        process->GetObjCLanguageRuntime();
+        ObjCLanguageRuntime::Get(*process);
 
     if (objc_language_runtime) {
       m_objc_object_check.reset(objc_language_runtime->CreateObjectChecker(

--- a/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -709,8 +709,9 @@ bool DynamicLoaderDarwin::AlwaysRelyOnEHUnwindInfo(SymbolContext &sym_ctx) {
   if (module_sp.get() == NULL)
     return false;
 
-  ObjCLanguageRuntime *objc_runtime = m_process->GetObjCLanguageRuntime();
-  return objc_runtime != NULL && objc_runtime->IsModuleObjCLibrary(module_sp);
+  ObjCLanguageRuntime *objc_runtime = ObjCLanguageRuntime::Get(*m_process);
+  return objc_runtime != nullptr &&
+         objc_runtime->IsModuleObjCLibrary(module_sp);
 }
 
 //----------------------------------------------------------------------

--- a/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -92,7 +92,7 @@ void ClangASTSource::InstallASTContext(clang::ASTContext &ast_context,
       if (!process)
         break;
 
-      ObjCLanguageRuntime *language_runtime(process->GetObjCLanguageRuntime());
+      ObjCLanguageRuntime *language_runtime(ObjCLanguageRuntime::Get(*process));
 
       if (!language_runtime)
         break;
@@ -479,7 +479,7 @@ clang::ObjCInterfaceDecl *ClangASTSource::GetCompleteObjCInterface(
   if (!process)
     return NULL;
 
-  ObjCLanguageRuntime *language_runtime(process->GetObjCLanguageRuntime());
+  ObjCLanguageRuntime *language_runtime(ObjCLanguageRuntime::Get(*process));
 
   if (!language_runtime)
     return NULL;
@@ -949,7 +949,7 @@ void ClangASTSource::FindExternalVisibleDecls(
           break;
 
         ObjCLanguageRuntime *language_runtime(
-            process->GetObjCLanguageRuntime());
+            ObjCLanguageRuntime::Get(*process));
 
         if (!language_runtime)
           break;
@@ -1400,7 +1400,7 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
     if (!process)
       break;
 
-    ObjCLanguageRuntime *language_runtime(process->GetObjCLanguageRuntime());
+    ObjCLanguageRuntime *language_runtime(ObjCLanguageRuntime::Get(*process));
 
     if (!language_runtime)
       break;
@@ -1592,7 +1592,7 @@ void ClangASTSource::FindObjCPropertyAndIvarDecls(NameSearchContext &context) {
     if (!process)
       return;
 
-    ObjCLanguageRuntime *language_runtime(process->GetObjCLanguageRuntime());
+    ObjCLanguageRuntime *language_runtime(ObjCLanguageRuntime::Get(*process));
 
     if (!language_runtime)
       return;

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -695,7 +695,7 @@ addr_t ClangExpressionDeclMap::GetSymbolAddress(Target &target,
   }
 
   if (symbol_load_addr == LLDB_INVALID_ADDRESS && process) {
-    ObjCLanguageRuntime *runtime = process->GetObjCLanguageRuntime();
+    ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process);
 
     if (runtime) {
       symbol_load_addr = runtime->LookupRuntimeSymbol(name);

--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -502,15 +502,15 @@ ClangExpressionParser::ClangExpressionParser(ExecutionContextScope *exe_scope,
   lang_opts.SpellChecking = false;
 
   if (process_sp && lang_opts.ObjC) {
-    if (process_sp->GetObjCLanguageRuntime()) {
-      if (process_sp->GetObjCLanguageRuntime()->GetRuntimeVersion() ==
+    if (auto *runtime = ObjCLanguageRuntime::Get(*process_sp)) {
+      if (runtime->GetRuntimeVersion() ==
           ObjCLanguageRuntime::ObjCRuntimeVersions::eAppleObjC_V2)
         lang_opts.ObjCRuntime.set(ObjCRuntime::MacOSX, VersionTuple(10, 7));
       else
         lang_opts.ObjCRuntime.set(ObjCRuntime::FragileMacOSX,
                                   VersionTuple(10, 7));
 
-      if (process_sp->GetObjCLanguageRuntime()->HasNewLiteralsAndIndexing())
+      if (runtime->HasNewLiteralsAndIndexing())
         lang_opts.DebuggerObjCLiteral = true;
     }
   }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1228,7 +1228,7 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
     lldb::ProcessSP process_sp(this_frame_sp->CalculateProcess());
     if (!process_sp)
       return false;
-    return !process_sp->GetObjCLanguageRuntime();
+    return !ObjCLanguageRuntime::Get(*process_sp);
   };
 
   swift::ASTContext *ast_context =

--- a/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -67,8 +67,7 @@ bool lldb_private::formatters::LibcxxFunctionSummaryProvider(
   if (process == nullptr)
     return false;
 
-  CPPLanguageRuntime *cpp_runtime =
-      CPPLanguageRuntime::GetCPPLanguageRuntime(*process);
+  CPPLanguageRuntime *cpp_runtime = CPPLanguageRuntime::Get(*process);
 
   if (!cpp_runtime)
     return false;

--- a/source/Plugins/Language/ObjC/CF.cpp
+++ b/source/Plugins/Language/ObjC/CF.cpp
@@ -50,7 +50,7 @@ bool lldb_private::formatters::CFBagSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -112,7 +112,7 @@ bool lldb_private::formatters::CFBitVectorSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -234,7 +234,7 @@ bool lldb_private::formatters::CFBinaryHeapSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;

--- a/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -45,7 +45,7 @@ bool lldb_private::formatters::NSBundleSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -93,7 +93,7 @@ bool lldb_private::formatters::NSTimeZoneSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -138,7 +138,7 @@ bool lldb_private::formatters::NSNotificationSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -183,7 +183,7 @@ bool lldb_private::formatters::NSMachPortSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -229,7 +229,7 @@ bool lldb_private::formatters::NSIndexSetSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -418,7 +418,7 @@ bool lldb_private::formatters::NSNumberSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -474,10 +474,9 @@ bool lldb_private::formatters::NSNumberSummaryProvider(
       return true;
     } else {
       Status error;
-      
-      AppleObjCRuntime *runtime =
-      llvm::dyn_cast_or_null<AppleObjCRuntime>(
-          process_sp->GetObjCLanguageRuntime());
+
+      AppleObjCRuntime *runtime = llvm::dyn_cast_or_null<AppleObjCRuntime>(
+          ObjCLanguageRuntime::Get(*process_sp));
 
       const bool new_format =
           (runtime && runtime->GetFoundationVersion() >= 1400);
@@ -669,7 +668,7 @@ bool lldb_private::formatters::NSURLSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -783,7 +782,7 @@ bool lldb_private::formatters::NSDateSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -850,7 +849,7 @@ bool lldb_private::formatters::NSDateSummaryProvider(
   // Accomodate for the __NSTaggedDate format introduced in Foundation 1600.
   if (class_name == g___NSTaggedDate) {
     auto *runtime = llvm::dyn_cast_or_null<AppleObjCRuntime>(
-        process_sp->GetObjCLanguageRuntime());
+        ObjCLanguageRuntime::Get(*process_sp));
     if (runtime && runtime->GetFoundationVersion() >= 1600)
       date_value = decodeTaggedTimeInterval(value_bits << 4);
   }
@@ -878,7 +877,7 @@ bool lldb_private::formatters::ObjCClassSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -937,7 +936,7 @@ bool lldb_private::formatters::NSDataSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -1037,7 +1036,7 @@ bool lldb_private::formatters::ObjCBooleanSummaryProvider(
     return false;
 
   if (AppleObjCRuntime *objc_runtime = llvm::dyn_cast_or_null<AppleObjCRuntime>(
-          process_sp->GetObjCLanguageRuntime())) {
+          ObjCLanguageRuntime::Get(*process_sp))) {
     lldb::addr_t cf_true = LLDB_INVALID_ADDRESS,
                  cf_false = LLDB_INVALID_ADDRESS;
     objc_runtime->GetValuesForGlobalCFBooleans(cf_true, cf_false);

--- a/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/source/Plugins/Language/ObjC/NSArray.cpp
@@ -344,7 +344,7 @@ bool lldb_private::formatters::NSArraySummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -797,7 +797,7 @@ lldb_private::formatters::NSArraySyntheticFrontEndCreator(
   if (!process_sp)
     return nullptr;
   AppleObjCRuntime *runtime = llvm::dyn_cast_or_null<AppleObjCRuntime>(
-      process_sp->GetObjCLanguageRuntime());
+      ObjCLanguageRuntime::Get(*process_sp));
   if (!runtime)
     return nullptr;
 

--- a/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -347,7 +347,7 @@ bool lldb_private::formatters::NSDictionarySummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime =  process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -437,8 +437,8 @@ lldb_private::formatters::NSDictionarySyntheticFrontEndCreator(
   lldb::ProcessSP process_sp(valobj_sp->GetProcessSP());
   if (!process_sp)
     return nullptr;
-  AppleObjCRuntime *runtime =
-      llvm::dyn_cast_or_null<AppleObjCRuntime>(process_sp->GetObjCLanguageRuntime());
+  AppleObjCRuntime *runtime = llvm::dyn_cast_or_null<AppleObjCRuntime>(
+      ObjCLanguageRuntime::Get(*process_sp));
   if (!runtime)
     return nullptr;
 

--- a/source/Plugins/Language/ObjC/NSError.cpp
+++ b/source/Plugins/Language/ObjC/NSError.cpp
@@ -187,7 +187,7 @@ lldb_private::formatters::NSErrorSyntheticFrontEndCreator(
   lldb::ProcessSP process_sp(valobj_sp->GetProcessSP());
   if (!process_sp)
     return nullptr;
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
   if (!runtime)
     return nullptr;
 

--- a/source/Plugins/Language/ObjC/NSException.cpp
+++ b/source/Plugins/Language/ObjC/NSException.cpp
@@ -179,7 +179,7 @@ lldb_private::formatters::NSExceptionSyntheticFrontEndCreator(
   lldb::ProcessSP process_sp(valobj_sp->GetProcessSP());
   if (!process_sp)
     return nullptr;
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
   if (!runtime)
     return nullptr;
 

--- a/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -68,7 +68,7 @@ public:
     if (!process_sp)
       return false;
 
-    ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+    ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
     if (!runtime)
       return false;

--- a/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/source/Plugins/Language/ObjC/NSSet.cpp
@@ -225,7 +225,7 @@ bool lldb_private::formatters::NSSetSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;
@@ -302,7 +302,7 @@ lldb_private::formatters::NSSetSyntheticFrontEndCreator(
   lldb::ProcessSP process_sp(valobj_sp->GetProcessSP());
   if (!process_sp)
     return nullptr;
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
   if (!runtime)
     return nullptr;
 

--- a/source/Plugins/Language/ObjC/NSString.cpp
+++ b/source/Plugins/Language/ObjC/NSString.cpp
@@ -59,7 +59,7 @@ bool lldb_private::formatters::NSStringSummaryProvider(
   if (!process_sp)
     return false;
 
-  ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+  ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
 
   if (!runtime)
     return false;

--- a/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -900,7 +900,7 @@ ObjCLanguage::GetPossibleFormattersMatches(ValueObject &valobj,
       lldb::ProcessSP process_sp = valobj.GetProcessSP();
       if (!process_sp)
         break;
-      ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+      ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
       if (runtime == nullptr)
         break;
       ObjCLanguageRuntime::ClassDescriptorSP objc_class_sp(
@@ -944,8 +944,7 @@ std::unique_ptr<Language::TypeScavenger> ObjCLanguage::GetTypeScavenger() {
 
       Process *process = exe_scope->CalculateProcess().get();
       if (process) {
-        const bool create_on_demand = false;
-        auto objc_runtime = process->GetObjCLanguageRuntime(create_on_demand);
+        auto objc_runtime = ObjCLanguageRuntime::Get(*process);
         if (objc_runtime) {
           auto decl_vendor = objc_runtime->GetDeclVendor();
           if (decl_vendor) {

--- a/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -160,7 +160,7 @@ bool lldb_private::formatters::swift::Measurement_SummaryProvider(
     return false;
 
   auto descriptor_sp(
-      process_sp->GetObjCLanguageRuntime()->GetClassDescriptor(*unit_sp));
+      ObjCLanguageRuntime::Get(*process_sp)->GetClassDescriptor(*unit_sp));
   if (!descriptor_sp)
     return false;
 
@@ -607,7 +607,7 @@ public:
       return false;
 
     ObjCLanguageRuntime *objc_runtime =
-        m_backend.GetProcessSP()->GetObjCLanguageRuntime();
+        ObjCLanguageRuntime::Get(*m_backend.GetProcessSP());
     if (!objc_runtime)
       return false;
 

--- a/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
+++ b/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
@@ -68,7 +68,7 @@ ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(size_t idx) {
           ProcessSP process_sp(m_backend.GetProcessSP());
           if (!process_sp)
             break;
-          ObjCLanguageRuntime *runtime = process_sp->GetObjCLanguageRuntime();
+          ObjCLanguageRuntime *runtime = ObjCLanguageRuntime::Get(*process_sp);
           if (!runtime)
             break;
           DeclVendor *vendor = runtime->GetDeclVendor();

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -823,7 +823,7 @@ SwiftLanguage::GetHardcodedSynthetics() {
             if (swift_runtime->IsTaggedPointer(ptr, valobj.GetCompilerType()))
               return nullptr;
             ObjCLanguageRuntime *objc_runtime =
-                process_sp->GetObjCLanguageRuntime();
+                ObjCLanguageRuntime::Get(*process_sp);
             if (!objc_runtime)
               return nullptr;
             ObjCLanguageRuntime::ClassDescriptorSP valobj_descriptor_sp =

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -42,6 +42,7 @@
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/ObjCLanguageRuntime.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
@@ -579,7 +580,7 @@ protected:
     }
 
     Process *process = m_exe_ctx.GetProcessPtr();
-    ObjCLanguageRuntime *objc_runtime = process->GetObjCLanguageRuntime();
+    ObjCLanguageRuntime *objc_runtime = ObjCLanguageRuntime::Get(*process);
     if (objc_runtime) {
       auto iterators_pair = objc_runtime->GetDescriptorIteratorPair();
       auto iterator = iterators_pair.first;
@@ -681,7 +682,7 @@ protected:
 
     Process *process = m_exe_ctx.GetProcessPtr();
     ExecutionContext exe_ctx(process);
-    ObjCLanguageRuntime *objc_runtime = process->GetObjCLanguageRuntime();
+    ObjCLanguageRuntime *objc_runtime = ObjCLanguageRuntime::Get(*process);
     if (objc_runtime) {
       ObjCLanguageRuntime::TaggedPointerVendor *tagged_ptr_vendor =
           objc_runtime->GetTaggedPointerVendor();

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -457,8 +457,9 @@ bool AppleObjCTrampolineHandler::AppleObjCVTables::InitializeVTableSymbols() {
     size_t num_modules = target_modules.GetSize();
     if (!m_objc_module_sp) {
       for (size_t i = 0; i < num_modules; i++) {
-        if (process_sp->GetObjCLanguageRuntime()->IsModuleObjCLibrary(
-                target_modules.GetModuleAtIndexUnlocked(i))) {
+        if (ObjCLanguageRuntime::Get(*process_sp)
+                ->IsModuleObjCLibrary(
+                    target_modules.GetModuleAtIndexUnlocked(i))) {
           m_objc_module_sp = target_modules.GetModuleAtIndexUnlocked(i);
           break;
         }
@@ -1036,8 +1037,8 @@ AppleObjCTrampolineHandler::GetStepThroughDispatchPlan(Thread &thread,
                     isa_addr, sel_addr);
       }
       ObjCLanguageRuntime *objc_runtime =
-          thread.GetProcess()->GetObjCLanguageRuntime();
-      assert(objc_runtime != NULL);
+          ObjCLanguageRuntime::Get(*thread.GetProcess());
+      assert(objc_runtime != nullptr);
 
       impl_addr = objc_runtime->LookupInMethodCache(isa_addr, sel_addr);
     }

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
@@ -176,8 +176,8 @@ bool AppleThreadPlanStepThroughObjCTrampoline::ShouldStop(Event *event_ptr) {
                   target_addr);
 
     ObjCLanguageRuntime *objc_runtime =
-        GetThread().GetProcess()->GetObjCLanguageRuntime();
-    assert(objc_runtime != NULL);
+        ObjCLanguageRuntime::Get(*GetThread().GetProcess());
+    assert(objc_runtime != nullptr);
     objc_runtime->AddToMethodCache(m_isa_addr, m_sel_addr, target_addr);
     if (log)
       log->Printf("Adding {isa-addr=0x%" PRIx64 ", sel-addr=0x%" PRIx64

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5108,7 +5108,7 @@ ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
       ExecutionContext exe_ctx(exe_scope);
       Process *process = exe_ctx.GetProcessPtr();
       if (process) {
-        ObjCLanguageRuntime *objc_runtime = process->GetObjCLanguageRuntime();
+        ObjCLanguageRuntime *objc_runtime = ObjCLanguageRuntime::Get(*process);
         if (objc_runtime) {
           uint64_t bit_size = 0;
           if (objc_runtime->GetTypeBitSize(
@@ -6915,7 +6915,7 @@ CompilerType ClangASTContext::GetChildCompilerTypeAtIndex(
                   process = exe_ctx->GetProcessPtr();
                 if (process) {
                   ObjCLanguageRuntime *objc_runtime =
-                      process->GetObjCLanguageRuntime();
+                      ObjCLanguageRuntime::Get(*process);
                   if (objc_runtime != nullptr) {
                     CompilerType parent_ast_type(getASTContext(),
                                                  parent_qual_type);

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -47,7 +47,6 @@
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/MemoryHistory.h"
 #include "lldb/Target/MemoryRegionInfo.h"
-#include "lldb/Target/ObjCLanguageRuntime.h"
 #include "lldb/Target/OperatingSystem.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
@@ -1899,13 +1898,6 @@ LanguageRuntime *Process::GetLanguageRuntime(lldb::LanguageType language,
     assert(runtime->GetLanguageType() == Language::GetPrimaryLanguage(language));
 
   return runtime;
-}
-
-ObjCLanguageRuntime *Process::GetObjCLanguageRuntime(bool retry_if_null) {
-  std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
-  LanguageRuntime *runtime =
-      GetLanguageRuntime(eLanguageTypeObjC, retry_if_null);
-  return llvm::cast_or_null<ObjCLanguageRuntime>(runtime);
 }
 
 SwiftLanguageRuntime *Process::GetSwiftLanguageRuntime(bool retry_if_null) {

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -209,7 +209,7 @@ FindSymbolForSwiftObject(Target &target, ConstString object,
 }
 
 AppleObjCRuntimeV2 *SwiftLanguageRuntime::GetObjCRuntime() {
-  if (auto objc_runtime = GetProcess()->GetObjCLanguageRuntime()) {
+  if (auto objc_runtime = ObjCLanguageRuntime::Get(*GetProcess())) {
     if (objc_runtime->GetPluginName() ==
         AppleObjCRuntimeV2::GetPluginNameStatic())
       return (AppleObjCRuntimeV2 *)objc_runtime;


### PR DESCRIPTION
Summary:
In an effort to make Process more language agnostic, I removed
GetCPPLanguageRuntime from Process. I'm following up now with an equivalent
change for ObjC.

Differential Revision: https://reviews.llvm.org/D63052

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@362981 91177308-0d34-0410-b5e6-96231b3b80d8

Please note that I modified this patch from its original state to support swift.