### PR TITLE
[Target] Remove Process::GetSwiftLanguageRuntime

### DIFF
--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -2522,8 +2522,6 @@ public:
   LanguageRuntime *GetLanguageRuntime(lldb::LanguageType language,
                                       bool retry_if_null = true);
 
-  SwiftLanguageRuntime *GetSwiftLanguageRuntime(bool retry_if_null = true);
-
   bool IsPossibleDynamicValue(ValueObject &in_value);
 
   bool IsRunning() const;

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -87,6 +87,11 @@ public:
     return runtime->isA(&ID);
   }
 
+  static SwiftLanguageRuntime *Get(Process &process) {
+    return llvm::cast_or_null<SwiftLanguageRuntime>(
+        process.GetLanguageRuntime(lldb::eLanguageTypeSwift));
+  }
+
   //------------------------------------------------------------------
   // PluginInterface protocol
   //------------------------------------------------------------------

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -590,7 +590,7 @@ public:
           lldb::ProcessSP process_sp =
               map.GetBestExecutionContextScope()->CalculateProcess();
           SwiftLanguageRuntime *language_runtime =
-              process_sp->GetSwiftLanguageRuntime();
+              SwiftLanguageRuntime::Get(*process_sp);
           if (language_runtime && frame_sp)
             layout_type = language_runtime->DoArchetypeBindingForType(
                 *frame_sp, layout_type);
@@ -988,7 +988,7 @@ public:
 
     if (lang == lldb::eLanguageTypeSwift) {
       SwiftLanguageRuntime *language_runtime =
-          process_sp->GetSwiftLanguageRuntime();
+          SwiftLanguageRuntime::Get(*process_sp);
       if (language_runtime && frame_sp)
         m_type = language_runtime->DoArchetypeBindingForType(*frame_sp, m_type);
     }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -544,7 +544,7 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     return;
 
   SwiftLanguageRuntime *swift_runtime =
-      stack_frame_sp->GetThread()->GetProcess()->GetSwiftLanguageRuntime();
+      SwiftLanguageRuntime::Get(*stack_frame_sp->GetThread()->GetProcess());
   auto *stack_frame = stack_frame_sp.get();
   imported_self_type =
       swift_runtime->DoArchetypeBindingForType(*stack_frame,
@@ -743,7 +743,7 @@ static void RegisterAllVariables(
 
   if (stack_frame_sp) {
     language_runtime =
-        stack_frame_sp->GetThread()->GetProcess()->GetSwiftLanguageRuntime();
+        SwiftLanguageRuntime::Get(*stack_frame_sp->GetThread()->GetProcess());
     scope = stack_frame_sp.get();
   }
 
@@ -1042,9 +1042,8 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       if (swift_type->hasTypeParameter()) {
         if (stack_frame_sp && stack_frame_sp->GetThread() &&
             stack_frame_sp->GetThread()->GetProcess()) {
-          SwiftLanguageRuntime *swift_runtime = stack_frame_sp->GetThread()
-                                                    ->GetProcess()
-                                                    ->GetSwiftLanguageRuntime();
+          SwiftLanguageRuntime *swift_runtime = SwiftLanguageRuntime::Get(
+              *stack_frame_sp->GetThread()->GetProcess());
           if (swift_runtime) {
             actual_type = swift_runtime->DoArchetypeBindingForType(
                 *stack_frame_sp, actual_type);
@@ -1273,7 +1272,7 @@ ParseAndImport(SwiftASTContext *swift_ast_context, Expression &expr,
     lldb::ProcessSP process_sp(this_frame_sp->CalculateProcess());
     if (!process_sp)
       return false;
-    auto *runtime = process_sp->GetSwiftLanguageRuntime();
+    auto *runtime = SwiftLanguageRuntime::Get(*process_sp);
     return !runtime->IsABIStable();
     return true;
   };

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -56,7 +56,7 @@ static lldb::addr_t FixupResilientGlobal(lldb::addr_t var_addr,
                                          lldb::ProcessSP process_sp,
                                          Status &error) {
   if (process_sp)
-    if (auto *runtime = process_sp->GetSwiftLanguageRuntime()) {
+    if (auto *runtime = SwiftLanguageRuntime::Get(*process_sp)) {
       if (!runtime->IsStoredInlineInBuffer(compiler_type)) {
         if (var_addr != LLDB_INVALID_ADDRESS) {
           size_t ptr_size = process_sp->GetAddressByteSize();

--- a/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -61,7 +61,7 @@ SwiftUserExpression::~SwiftUserExpression() {}
 
 void SwiftUserExpression::WillStartExecuting() {
   if (auto process = m_jit_process_wp.lock()) {
-    if (auto *swift_runtime = process->GetSwiftLanguageRuntime())
+    if (auto *swift_runtime = SwiftLanguageRuntime::Get(*process))
       swift_runtime->WillStartExecutingUserExpression(
           m_runs_in_playground_or_repl);
     else
@@ -72,7 +72,7 @@ void SwiftUserExpression::WillStartExecuting() {
 
 void SwiftUserExpression::DidFinishExecuting() {
   if (auto process = m_jit_process_wp.lock()) {
-    if (auto swift_runtime = process->GetSwiftLanguageRuntime())
+    if (auto swift_runtime = SwiftLanguageRuntime::Get(*process))
       swift_runtime->DidFinishExecutingUserExpression(
           m_runs_in_playground_or_repl);
     else
@@ -85,7 +85,7 @@ static CompilerType GetConcreteType(ExecutionContext &exe_ctx,
   auto swift_type = GetSwiftType(type.GetOpaqueQualType());
   StreamString type_name;
   if (SwiftLanguageRuntime::GetAbstractTypeName(type_name, swift_type)) {
-    auto *runtime = exe_ctx.GetProcessRef().GetSwiftLanguageRuntime();
+    auto *runtime = SwiftLanguageRuntime::Get(exe_ctx.GetProcessRef());
     return runtime->GetConcreteType(frame, ConstString(type_name.GetString()));
   }
   return type;
@@ -526,7 +526,7 @@ lldb::ExpressionVariableSP SwiftUserExpression::GetResultAfterDematerialization(
           lldb::ProcessSP process_sp = exe_scope->CalculateProcess();
           if (process_sp) {
             SwiftLanguageRuntime *swift_runtime =
-                process_sp->GetSwiftLanguageRuntime();
+                SwiftLanguageRuntime::Get(*process_sp);
             if (swift_runtime)
               error_is_valid = swift_runtime->IsValidErrorValue(*val_sp.get());
           }

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -321,7 +321,8 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
     if (error.Fail() || argmetadata_ptr == LLDB_INVALID_ADDRESS)
       return nullptr;
 
-    SwiftLanguageRuntime *swift_runtime = process_sp->GetSwiftLanguageRuntime();
+    SwiftLanguageRuntime *swift_runtime =
+        SwiftLanguageRuntime::Get(*process_sp);
     if (!swift_runtime)
       return nullptr;
 
@@ -409,7 +410,7 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
       if (!process_sp)
         return nullptr;
       SwiftLanguageRuntime *swift_runtime =
-          process_sp->GetSwiftLanguageRuntime();
+          SwiftLanguageRuntime::Get(*process_sp);
       if (!swift_runtime)
         return nullptr;
       lldb::addr_t masked_storage_location =

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -450,7 +450,7 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
       auto scratch_ctx = scratch_ctx_reader.get();
       if (!scratch_ctx)
         return;
-      auto *runtime = m_process->GetSwiftLanguageRuntime();
+      auto *runtime = SwiftLanguageRuntime::Get(*m_process);
       if (!runtime)
         return;
       std::vector<SwiftASTContext::TupleElement> tuple_elements{
@@ -671,7 +671,7 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   if (!process_sp)
     return nullptr;
 
-  SwiftLanguageRuntime *swift_runtime = process_sp->GetSwiftLanguageRuntime();
+  SwiftLanguageRuntime *swift_runtime = SwiftLanguageRuntime::Get(*process_sp);
   if (!swift_runtime)
     return nullptr;
 

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -817,7 +817,7 @@ SwiftLanguage::GetHardcodedSynthetics() {
             AddressType address_type;
             lldb::addr_t ptr = valobj.GetPointerValue(&address_type);
             SwiftLanguageRuntime *swift_runtime =
-                process_sp->GetSwiftLanguageRuntime();
+                SwiftLanguageRuntime::Get(*process_sp);
             if (!swift_runtime)
               return nullptr;
             if (swift_runtime->IsTaggedPointer(ptr, valobj.GetCompilerType()))
@@ -862,7 +862,7 @@ SwiftLanguage::GetHardcodedSynthetics() {
             if (!process_sp)
               return nullptr;
             SwiftLanguageRuntime *swift_runtime =
-                process_sp->GetSwiftLanguageRuntime();
+                SwiftLanguageRuntime::Get(*process_sp);
             return swift_runtime->GetBridgedSyntheticChildProvider(valobj);
           }
           return nullptr;
@@ -897,7 +897,7 @@ std::vector<ConstString> SwiftLanguage::GetPossibleFormattersMatches(
       lldb::ProcessSP process_sp = valobj.GetProcessSP();
       if (!process_sp)
         break;
-      SwiftLanguageRuntime *runtime = process_sp->GetSwiftLanguageRuntime();
+      SwiftLanguageRuntime *runtime = SwiftLanguageRuntime::Get(*process_sp);
       if (runtime == nullptr)
         break;
       TypeAndOrName type_and_or_name;

--- a/source/Plugins/Language/Swift/SwiftMetatype.cpp
+++ b/source/Plugins/Language/Swift/SwiftMetatype.cpp
@@ -37,7 +37,7 @@ bool lldb_private::formatters::swift::SwiftMetatype_SummaryProvider(
       return true;
     }
   } else {
-    auto swift_runtime = valobj.GetProcessSP()->GetSwiftLanguageRuntime();
+    auto swift_runtime = SwiftLanguageRuntime::Get(*valobj.GetProcessSP());
     if (!swift_runtime)
       return false;
     SwiftLanguageRuntime::MetadataPromiseSP metadata_promise_sp =

--- a/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -65,7 +65,7 @@ ExtractSomeIfAny(ValueObject *optional,
 
   auto process_sp = optional->GetProcessSP();
   SwiftLanguageRuntime *swift_runtime =
-      process_sp ? process_sp->GetSwiftLanguageRuntime() : nullptr;
+      process_sp ? SwiftLanguageRuntime::Get(*process_sp) : nullptr;
 
   SwiftASTContext::NonTriviallyManagedReferenceStrategy strategy;
   if (SwiftASTContext::IsNonTriviallyManagedReferenceType(

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -53,7 +53,6 @@
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StopInfo.h"
 #include "lldb/Target/StructuredDataPlugin.h"
-#include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/SystemRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/TargetList.h"
@@ -1898,13 +1897,6 @@ LanguageRuntime *Process::GetLanguageRuntime(lldb::LanguageType language,
     assert(runtime->GetLanguageType() == Language::GetPrimaryLanguage(language));
 
   return runtime;
-}
-
-SwiftLanguageRuntime *Process::GetSwiftLanguageRuntime(bool retry_if_null) {
-  std::lock_guard<std::recursive_mutex> guard(m_language_runtimes_mutex);
-  LanguageRuntime *runtime =
-      GetLanguageRuntime(eLanguageTypeSwift, retry_if_null);
-  return llvm::cast_or_null<SwiftLanguageRuntime>(runtime);
 }
 
 bool Process::IsPossibleDynamicValue(ValueObject &in_value) {

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -3212,7 +3212,7 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   Target *target = frame_sp->CalculateTarget().get();
   ValueObjectSP error_valobj_sp;
 
-  auto *runtime = process_sp->GetSwiftLanguageRuntime();
+  auto *runtime = Get(*process_sp);
   if (!runtime)
     return error_valobj_sp;
 

--- a/source/Target/ThreadPlanCallFunction.cpp
+++ b/source/Target/ThreadPlanCallFunction.cpp
@@ -457,7 +457,7 @@ void ThreadPlanCallFunction::SetBreakpoints() {
     }
     if (GetExpressionLanguage() == eLanguageTypeSwift) {
       SwiftLanguageRuntime *swift_runtime =
-          process_sp->GetSwiftLanguageRuntime();
+          SwiftLanguageRuntime::Get(*process_sp);
       if (swift_runtime) {
         ConstString backstop_name = swift_runtime->GetErrorBackstopName();
         if (!backstop_name.IsEmpty()) {

--- a/source/Target/ThreadPlanStepInRange.cpp
+++ b/source/Target/ThreadPlanStepInRange.cpp
@@ -570,7 +570,7 @@ bool ThreadPlanStepInRange::DefaultShouldStopHereImpl(Flags &flags,
       if (mangled_name.GuessLanguage() == lldb::eLanguageTypeSwift) {
         ProcessSP process_sp(GetThread().GetProcess());
         SwiftLanguageRuntime *swift_runtime =
-            process_sp->GetSwiftLanguageRuntime();
+            SwiftLanguageRuntime::Get(*process_sp);
         if (swift_runtime) {
           std::vector<Address> interesting_addresses;
           swift_runtime->FindFunctionPointersInCall(*frame,

--- a/source/Target/ThreadPlanStepOut.cpp
+++ b/source/Target/ThreadPlanStepOut.cpp
@@ -180,7 +180,7 @@ ThreadPlanStepOut::ThreadPlanStepOut(
 
     if (stepping_from_swift) {
       SwiftLanguageRuntime *swift_runtime =
-          m_thread.GetProcess()->GetSwiftLanguageRuntime();
+          SwiftLanguageRuntime::Get(*m_thread.GetProcess());
       if (swift_runtime) {
         m_swift_error_return =
             swift_runtime->GetErrorReturnLocationBeforeReturn(frame_sp,
@@ -541,7 +541,7 @@ void ThreadPlanStepOut::CalculateReturnValue() {
   // First check if we have an error return address, and if that pointer
   // contains a valid error return, grab it:
   SwiftLanguageRuntime *swift_runtime =
-        m_thread.GetProcess()->GetSwiftLanguageRuntime();
+      SwiftLanguageRuntime::Get(*m_thread.GetProcess());
 
   if (swift_runtime) {
     // In some ABI's the error is in a memory location in the caller's frame


### PR DESCRIPTION
As a follow up to removing GetCPPLanguageRuntime and GetObjCLanguageRuntime, let's remove GetSwiftLanguageRuntime!

cc @compnerd @dcci @JDevlieghere @adrian-prantl 