### PR TITLE
Disable temporarily SwiftREPL/BreakpointSimple.test, which failed in CI

### DIFF
--- a/lit/SwiftREPL/BreakpointSimple.test
+++ b/lit/SwiftREPL/BreakpointSimple.test
@@ -1,5 +1,8 @@
 // Test that we can set breakpoints in the REPL.
 
+// REQUIRES: rdar51709992
+// swift-lldb: DISABLED because this test failed on the package bot
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 func foo() -> Int {


### PR DESCRIPTION
... this should be re-enabled once this issue has been resolved.

Failure https://ci.swift.org/job/oss-swift-5.1-pr-test//1327/

rdar://51709992