### PR TITLE
Pass the temporary clang module cache path to %target-swift[c].

### DIFF
--- a/lit/helper/toolchain.py
+++ b/lit/helper/toolchain.py
@@ -108,14 +108,18 @@ def use_support_substitutions(config):
     config.substitutions.append(('%target-shared-library-suffix', config.target_shared_library_suffix))
 
     # Swift support
-    swift_sdk = [' -sdk ', sdk_path] if platform.system() in ['Darwin'] else []
+    swift_args = ['-module-cache-path',
+                  os.path.join(os.path.dirname(config.lldb_libs_dir),
+                               'lldb-test-build.noindex',
+                               'module-cache-clang')]
+    if platform.system() in ['Darwin']:
+      swift_args += ['-sdk', sdk_path]
     tools = [
         ToolSubst(
-            '%target-swiftc', command=config.swiftc, extra_args=swift_sdk),
+            '%target-swiftc', command=config.swiftc, extra_args=swift_args),
         ToolSubst(
-            '%target-swift-frontend',
-            command=config.swiftc[:-1],
-            extra_args=['-frontend'] + swift_sdk)
+            '%target-swift-frontend', command=config.swiftc[:-1],
+            extra_args=(['-frontend'] + swift_args))
     ]
     llvm_config.add_tool_substitutions(tools)
 

--- a/lit/lit.cfg.py
+++ b/lit/lit.cfg.py
@@ -68,7 +68,7 @@ llvm_config.feature_config(
 # so doing it once per lit.py invocation is close enough.
 
 for i in ['module-cache-clang', 'module-cache-lldb']:
-    cachedir = os.path.join(config.lldb_libs_dir, '..',
+    cachedir = os.path.join(os.path.dirname(config.lldb_libs_dir),
                             'lldb-test-build.noindex', i)
     if os.path.isdir(cachedir):
         print("Deleting module cache at %s."%cachedir)


### PR DESCRIPTION
Avoiding the system module cache will make the tests more robust when
running in CI where the clang version number isn't necessarily bumped
every time the module format is changed.