### PR TITLE
[SwiftExpressionParser] Don't get an unbound version of a bound generic.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/member_lookup_crash/main.swift
@@ -10,7 +10,8 @@ extension Measurement where UnitType == UnitAngle {
   }
 
   func f() {
-    return //%self.expect('p self.radians', substrs=["property 'radians' requires the types 'UnitType' and 'UnitAngle' be equivalent"], error=True)
+    return //%self.expect('p self.radians', substrs=["(CGFloat) $R0 = 1.745"])
+           //%self.expect('p self', substrs=["Measurement<UnitAngle>"])
   }
 }
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -572,17 +572,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     imported_self_type = CompilerType(imported_self_type.GetTypeSystem(),
                                       object_type.getPointer());
 
-  // If the type of 'self' is a bound generic type, get the unbound version.
-  bool is_generic = imported_self_type_flags.AllSet(lldb::eTypeIsSwift |
-                                                    lldb::eTypeIsGeneric);
-  bool is_bound =
-      imported_self_type_flags.AllSet(lldb::eTypeIsSwift | lldb::eTypeIsBound);
-
-  if (is_generic) {
-    if (is_bound)
-      imported_self_type = imported_self_type.GetUnboundType();
-  }
-
   // If 'self' is a weak storage type, it must be an optional.  Look
   // through it and unpack the argument of "optional".
   if (swift::WeakStorageType *weak_storage_type =


### PR DESCRIPTION
There's no need, and it breaks type resolution for `self` in the
expression parser. Not only removing the hack fixes a crash but
now it also does the right thing WRT evaluating members, computed
properties et similia.

<rdar://problem/30933988>
<rdar://problem/51405362>