### PR TITLE
[Reproducers] Extend reproducer support to Swift

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -803,7 +803,7 @@ protected:
   /// Data members.
   /// @{
   std::unique_ptr<swift::CompilerInvocation> m_compiler_invocation_ap;
-  std::unique_ptr<swift::SourceManager> m_source_manager_ap;
+  std::unique_ptr<swift::SourceManager> m_source_manager_up;
   std::unique_ptr<swift::DiagnosticEngine> m_diagnostic_engine_ap;
   // CompilerInvocation, SourceMgr, and DiagEngine must come
   // before the ASTContext, so they get deallocated *after* the

--- a/lit/Reproducer/Swift/Inputs/Simple.in
+++ b/lit/Reproducer/Swift/Inputs/Simple.in
@@ -1,0 +1,6 @@
+breakpoint set -f Simple.swift -l 2
+run
+bt
+cont
+reproducer status
+reproducer generate

--- a/lit/Reproducer/Swift/Inputs/Simple.swift
+++ b/lit/Reproducer/Swift/Inputs/Simple.swift
@@ -1,0 +1,11 @@
+func foo() -> String {
+    return "Foo"
+}
+
+
+func bar() -> String {
+    return foo() + "bar"
+}
+
+let b = bar()
+print("testing")

--- a/lit/Reproducer/Swift/TestSimple.test
+++ b/lit/Reproducer/Swift/TestSimple.test
@@ -1,0 +1,27 @@
+# UNSUPPORTED: system-windows, system-freebsd
+
+# This tests replaying a simple reproducer.
+
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t/cache %S/Inputs/Simple.swift \
+# RUN:          -module-name main -o %t.out
+# RUN: %lldb -x -b -s %S/Inputs/Simple.in \
+# RUN:          --capture \
+# RUN:          --capture-path %t.repro \
+# RUN:          %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+
+# CHECK: Breakpoint 1
+# CHECK: Process {{.*}} stopped
+# CHECK: Process {{.*}} launched
+# CHECK: thread {{.*}} stop reason = breakpoint
+# CHECK: frame {{.*}} Simple.swift
+
+# CAPTURE: testing
+# REPLAY-NOT: testing
+
+# CHECK: Process {{.*}} resuming
+# CHECK: Process {{.*}} exited
+
+# CAPTURE: Reproducer is in capture mode.
+# CAPTURE: Reproducer written

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -2630,9 +2630,10 @@ swift::CompilerInvocation &SwiftASTContext::GetCompilerInvocation() {
 }
 
 swift::SourceManager &SwiftASTContext::GetSourceManager() {
-  if (m_source_manager_ap.get() == NULL)
-    m_source_manager_ap.reset(new swift::SourceManager());
-  return *m_source_manager_ap;
+  if (!m_source_manager_up)
+    m_source_manager_up = llvm::make_unique<swift::SourceManager>(
+        FileSystem::Instance().GetVirtualFileSystem());
+  return *m_source_manager_up;
 }
 
 swift::LangOptions &SwiftASTContext::GetLanguageOptions() {

--- a/source/Utility/FileCollector.cpp
+++ b/source/Utility/FileCollector.cpp
@@ -134,7 +134,7 @@ std::error_code FileCollector::CopyFiles(bool stop_on_error) {
 std::error_code FileCollector::WriteMapping(const FileSpec &mapping_file) {
   std::lock_guard<std::mutex> lock(m_mutex);
 
-  llvm::StringRef root = m_overlay_root.GetPath();
+  std::string root = m_overlay_root.GetPath();
 
   m_vfs_writer.setOverlayDir(root);
   m_vfs_writer.setCaseSensitivity(IsCaseSensitivePath(root));


### PR DESCRIPTION
This extends reproducer support to Swift and adds a test case, similar
to the one we have for C.