### PR TITLE
Set DYLD_LIBRARY_PATH to test with the just-built stdlib

### DIFF
--- a/lit/lit-lldb-init.in
+++ b/lit/lit-lldb-init.in
@@ -1,3 +1,4 @@
 # LLDB init file for the LIT tests.
+env DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@' LD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@' SIMCTL_CHILD_DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@'
 settings set symbols.enable-external-lookup false
 settings set interpreter.echo-comment-commands false

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,8 @@ option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 if(LLDB_TEST_SWIFT)
   set(SWIFT_TEST_ARGS
     --swift-compiler ${LLDB_SWIFTC}
-    --swift-library ${LLDB_SWIFT_LIBS})
+    --swift-library ${LLDB_SWIFT_LIBS}
+    --env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}\\\" LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}\\\" SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}\\\"")
 endif()
 # END - Swift Mods
 


### PR DESCRIPTION
With Swift in the OS, we need to ensure that the test suite runs with
the standard library we just built, instead of the one form the
operating system. We do this by telling dyld to pick the one from our
build directory by setting the `DYLD_LIBRARY_PATH`. Swift takes the same
approach in their test suite.