### PR TITLE
[Swift] Make SIMD formatter capable of looking through typealiases.

### DIFF
--- a/lit/SwiftREPL/SIMD.test
+++ b/lit/SwiftREPL/SIMD.test
@@ -179,3 +179,8 @@ let patatino = SIMD4<Double>(1.5, 2.5, 3.5, 4.5)
 // Make sure we don't print the padding for SIMD3
 let claude = SIMD3(1, 2, 3)
 // CHECK: {{claude}}: SIMD3<Int> = (1, 2, 3)
+
+// Make sure we handle typealiasing correctly.
+typealias Tinky = SIMD3<Int>
+let winky = Tinky()
+// CHECK: {{winky}}: Tinky = (0, 0, 0)

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1047,7 +1047,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   // positive integer, we can calculate the number of elements and the
   // dynamic archetype (and hence its size). Everything follows naturally
   // as the elements are laid out in a contigous buffer without padding.
-  CompilerType simd_type = valobj.GetCompilerType();
+  CompilerType simd_type = valobj.GetCompilerType().GetCanonicalType();
   void *type_buffer = reinterpret_cast<void *>(simd_type.GetOpaqueQualType());
   llvm::Optional<uint64_t> opt_type_size = simd_type.GetByteSize(nullptr);
   if (!opt_type_size)
@@ -1081,7 +1081,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   // laid out contiguosly in memory. SIMD3, though, has an element of
   // padding. Given this is the only type in the standard library with
   // padding, we special-case it.
-  ConstString full_type_name = valobj.GetTypeName();
+  ConstString full_type_name = simd_type.GetTypeName();
   llvm::StringRef type_name = full_type_name.GetStringRef();
   uint64_t num_elements = type_size / arg_size;
   if (type_name.startswith("Swift.SIMD3"))

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -524,7 +524,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       ConstString("Swift.StridedRangeGenerator<.+>$"), summary_flags, true);
 
   TypeSummaryImpl::Flags simd_summary_flags;
-  simd_summary_flags.SetCascades(false)
+  simd_summary_flags.SetCascades(true)
       .SetDontShowChildren(true)
       .SetHideItemNames(true)
       .SetShowMembersOneLiner(false);


### PR DESCRIPTION
There were two bugs here:
1) the formatter wasn't set up to look through typealiases (SetCascade)
2) When realizing the bound generic was looking at the type (and not
at its canonical version)

<rdar://problem/50619290>