### PR TITLE
[Target][NFC] Simplify ThreadPlanStepOut constructor

### DIFF
--- a/source/Target/ThreadPlanStepOut.cpp
+++ b/source/Target/ThreadPlanStepOut.cpp
@@ -164,27 +164,14 @@ ThreadPlanStepOut::ThreadPlanStepOut(
   // step out.  That's more than I have time to do right now.
 
   if (frame_idx == 0) {
-    bool stepping_from_swift = false;
     StackFrameSP frame_sp = m_thread.GetStackFrameAtIndex(0);
-    Symbol *symbol = frame_sp->GetSymbolContext(eSymbolContextSymbol).symbol;
-    if (symbol) {
-      Mangled symbol_mangled = symbol->GetMangled();
-      if (symbol_mangled.GuessLanguage() == eLanguageTypeSwift)
-        stepping_from_swift = true;
-    } else {
-      CompileUnit *comp_unit =
-          frame_sp->GetSymbolContext(eSymbolContextCompUnit).comp_unit;
-      if (comp_unit && comp_unit->GetLanguage() == eLanguageTypeSwift)
-        stepping_from_swift = true;
-    }
-
-    if (stepping_from_swift) {
+    if (frame_sp->GuessLanguage() == eLanguageTypeSwift) {
       SwiftLanguageRuntime *swift_runtime =
           SwiftLanguageRuntime::Get(*m_thread.GetProcess());
       if (swift_runtime) {
         m_swift_error_return =
-            swift_runtime->GetErrorReturnLocationBeforeReturn(frame_sp,
-                                                              m_swift_error_check_after_return);
+            swift_runtime->GetErrorReturnLocationBeforeReturn(
+                frame_sp, m_swift_error_check_after_return);
       }
     }
   }


### PR DESCRIPTION
The constructor tries to figure out if it's stepping out of a frame with swift
code because it wants to ensure any potential error is preserved. This commit
simplifies the process of determining the language of the frame by asking the
frame to try to determine it.

This should be equivalent, because StackFrame::GuessLanguage does what the
constructor was doing before and more.

cc @dcci @JDevlieghere 