### PR TITLE
[Target] Clean up ThreadPlanStepInRange::DefaultShouldStopHere{Callback,Impl}

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -202,6 +202,11 @@ public:
   virtual bool isA(const void *ClassID) const { return ClassID == &ID; }
   static char ID;
 
+  virtual void FindFunctionPointersInCall(StackFrame &frame,
+                                          std::vector<Address> &addresses,
+                                          bool debug_only = true,
+                                          bool resolve_thunks = true){};
+
 protected:
   //------------------------------------------------------------------
   // Classes that inherit from LanguageRuntime can see and modify these

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -273,7 +273,7 @@ public:
   void FindFunctionPointersInCall(StackFrame &frame,
                                   std::vector<Address> &addresses,
                                   bool debug_only = true,
-                                  bool resolve_thunks = true);
+                                  bool resolve_thunks = true) override;
 
   lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
                                                   bool stop_others) override;

--- a/source/Target/ThreadPlanStepInRange.cpp
+++ b/source/Target/ThreadPlanStepInRange.cpp
@@ -484,16 +484,6 @@ bool ThreadPlanStepInRange::DefaultShouldStopHereCallback(
         static_cast<ThreadPlanStepInRange *>(current_plan);
     should_stop_here =
         step_in_range_plan->DefaultShouldStopHereImpl(flags, should_stop_here);
-
-    //        if (should_stop_here)
-    //        {
-    //            ThreadPlanStepInRange *step_in_range_plan =
-    //            static_cast<ThreadPlanStepInRange *> (current_plan);
-    //            // Don't log the should_step_out here, it's easier to do it in
-    //            FrameMatchesAvoidCriteria.
-    //            should_stop_here =
-    //            !step_in_range_plan->FrameMatchesAvoidCriteria ();
-    //        }
   }
 
   return should_stop_here;


### PR DESCRIPTION
The following 3 commits do the following:

1) Clear up some confusing logic in DefaultShouldStopHereImpl
2) Remove commented out (dead) code.
3) Hoist a method from SwiftLanguageRuntime into LanguageRuntime to generalize some behavior in ThreadPlanStepInRange.

cc @JDevlieghere @dcci @compnerd @adrian-prantl 