### PR TITLE
[Python] Flush prompt before reading input

### DIFF
--- a/source/Interpreter/embedded_interpreter.py
+++ b/source/Interpreter/embedded_interpreter.py
@@ -72,6 +72,7 @@ def get_terminal_size(fd):
 
 def readfunc_stdio(prompt):
     sys.stdout.write(prompt)
+    sys.stdout.flush()
     return sys.stdin.readline().rstrip()
 
 


### PR DESCRIPTION
Make sure the prompt has been flushed before reading commands. Buffering
is different in Python 3, which led to the prompt not being displayed in
the Xcode console.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@364335 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 1ef7d01da26909e017be2a6250aca6d26ef7b82d)