### PR TITLE
Options: Correctly check for missing arguments

### DIFF
--- a/source/Interpreter/Options.cpp
+++ b/source/Interpreter/Options.cpp
@@ -1338,6 +1338,9 @@ llvm::Expected<Args> Options::Parse(const Args &args,
                                                llvm::inconvertibleErrorCode());
   }
 
+  // Leading : tells getopt to return a : for a missing option argument AND to
+  // suppress error messages.
+  sstr << ":";
   for (int i = 0; long_options[i].definition != nullptr; ++i) {
     if (long_options[i].flag == nullptr) {
       if (isprint8(long_options[i].val)) {
@@ -1359,8 +1362,7 @@ llvm::Expected<Args> Options::Parse(const Args &args,
   std::vector<char *> argv = GetArgvForParsing(args);
   // If the last option requires an argument but doesn't have one,
   // some implementations of getopt_long will still try to read it.
-  char overflow = 0;
-  argv.push_back(&overflow);
+  argv.push_back(nullptr);
   std::unique_lock<std::mutex> lock;
   OptionParser::Prepare(lock);
   int val;
@@ -1369,7 +1371,7 @@ llvm::Expected<Args> Options::Parse(const Args &args,
     val = OptionParser::Parse(argv.size() - 1, &*argv.begin(), sstr.GetString(),
                               long_options, &long_options_index);
 
-    if ((size_t)OptionParser::GetOptionIndex() > argv.size() - 1) {
+    if (val == ':') {
       error.SetErrorStringWithFormat("last option requires an argument");
       break;
     }


### PR DESCRIPTION
Relying on the value of optind for detecting missing arguments is
unreliable because its value after a failed parse is an implementation
detail. A more correct way to achieve this is to pass ':' at the
beginning of option string, which tells getopt to return ':' for missing
arguments.

For this to work, I also had to add a nullptr at the end of the argv
vector, as some getopt implementations did not work without that. This
is also an implementation detail, as getopt should normally be called
with argc+argc "as to main function" (i.e. null-terminated).

Thanks to Michał Górny for testing this patch out on NetBSD.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@364317 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 0ac377d30b749d3c59b747fd9826bb165b0e14e1)