### PR TITLE
[LanguageRuntime] Hoist SwiftLanguageRuntime::IsSymbolARuntimeThunk

### DIFF
--- a/include/lldb/Target/LanguageRuntime.h
+++ b/include/lldb/Target/LanguageRuntime.h
@@ -189,7 +189,10 @@ public:
     return false;
   }
 
-  static bool IsSymbolAnyRuntimeThunk(Symbol &symbol);
+  // FIXME: This should be upstreamed into llvm.org, but only
+  // SwiftLanguageRuntime overrides this. That means that upstreaming in its
+  // current form would be introducing dead code into llvm.org
+  virtual bool IsSymbolARuntimeThunk(const Symbol &symbol) { return false; }
 
   // Given the name of a runtime symbol (e.g. in Objective-C, an ivar offset
   // symbol), try to determine from the runtime what the value of that symbol

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -236,7 +236,7 @@ public:
   
   static bool IsSwiftClassName(const char *name);
 
-  static bool IsSymbolARuntimeThunk(const Symbol &symbol);
+  bool IsSymbolARuntimeThunk(const Symbol &symbol) override;
 
   static const std::string GetCurrentMangledName(const char *mangled_name);
 

--- a/source/API/SBFrame.cpp
+++ b/source/API/SBFrame.cpp
@@ -1226,7 +1226,10 @@ bool SBFrame::IsSwiftThunk() const {
   sc = frame->GetSymbolContext(eSymbolContextSymbol);
   if (!sc.symbol)
     return false;
-  return SwiftLanguageRuntime::IsSymbolARuntimeThunk(*sc.symbol);
+  auto *runtime = process->GetLanguageRuntime(eLanguageTypeSwift);
+  if (!runtime)
+    return false;
+  return runtime->IsSymbolARuntimeThunk(*sc.symbol);
 }
 
 const char *SBFrame::GetFunctionName() const {

--- a/source/Target/LanguageRuntime.cpp
+++ b/source/Target/LanguageRuntime.cpp
@@ -296,7 +296,3 @@ void LanguageRuntime::InitializeCommands(CommandObject *parent) {
   }
 }
 
-bool LanguageRuntime::IsSymbolAnyRuntimeThunk(Symbol &symbol) {
-  return SwiftLanguageRuntime::IsSymbolARuntimeThunk(symbol);
-}
-

--- a/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/source/Target/ThreadPlanShouldStopHere.cpp
@@ -86,8 +86,9 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
     Symbol *symbol = frame->GetSymbolContext(eSymbolContextSymbol).symbol;
     if (symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
-      if (LanguageRuntime::IsSymbolAnyRuntimeThunk(*symbol)) {
-        should_stop_here = false;
+      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+        if (runtime->IsSymbolARuntimeThunk(*symbol))
+          should_stop_here = false;
       }
     }
   }
@@ -132,12 +133,13 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
     bool just_step_out = false;
     if (sc.symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
-
-      if (LanguageRuntime::IsSymbolAnyRuntimeThunk(*sc.symbol)) {
-        if (log)
-          log->Printf("In runtime thunk %s - stepping out.",
-                      sc.symbol->GetName().GetCString());
-        just_step_out = true;
+      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+        if (runtime->IsSymbolARuntimeThunk(*sc.symbol)) {
+          if (log)
+            log->Printf("In runtime thunk %s - stepping out.",
+                        sc.symbol->GetName().GetCString());
+          just_step_out = true;
+        }
       }
       // If the whole function is marked line 0 just step out, that's easier &
       // faster than continuing to step through it.


### PR DESCRIPTION
There's nothing swift-specific about thunks. There was a static function
in LanguageRuntime to determine if a symbol is a runtime thunk, but this just
creates a circular dependency between LanguageRuntime and SwiftLanguageRuntime.
I think if we hoist the one in SwiftLanguageRuntime into LanguageRuntime and
make it a virtual method, we should have a better, more general implementation.

cc @dcci @JDevlieghere @compnerd @adrian-prantl 