### PR TITLE
 Surface Swift deserialization problems to the user.

### DIFF
--- a/include/lldb/Core/Module.h
+++ b/include/lldb/Core/Module.h
@@ -1014,6 +1014,10 @@ public:
     m_type_system_map = type_system_map;
   }
 
+  /// Call \p callback for each \p TypeSystem in this \p Module.
+  /// Return true from callback to keep iterating, false to stop iterating.
+  void ForEachTypeSystem(std::function<bool(TypeSystem *)> const &callback);
+
   //----------------------------------------------------------------------
   /// @class LookupInfo Module.h "lldb/Core/Module.h"
   /// A class that encapsulates name lookup information.

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -376,6 +376,7 @@ public:
   }
 
   Status GetFatalErrors();
+  void DiagnoseWarnings(Process &process, Module &module) const override;
 
   const swift::irgen::TypeInfo *GetSwiftTypeInfo(void *type);
 
@@ -815,8 +816,9 @@ protected:
   llvm::once_flag m_ir_gen_module_once;
   std::unique_ptr<swift::DiagnosticConsumer> m_diagnostic_consumer_ap;
   std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_ap;
-  /// Any errors that were found while creating or using the AST context.
-  Status m_error;
+  /// A collection of (not necessarily fatal) error messages that
+  /// should be printed by Process::PrintWarningCantLoadSwift().
+  std::vector<std::string> m_module_import_warnings;
   swift::ModuleDecl *m_scratch_module = nullptr;
   std::unique_ptr<swift::SILModule> m_sil_module_ap;
   /// Owned by the AST.

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -533,6 +533,11 @@ public:
   // meaningless type itself, instead preferring to use the dynamic type
   virtual bool IsMeaninglessWithoutDynamicResolution(void *type);
 
+  /// A TypeSystem may belong to more than one debugger, so it doesn't
+  /// have a way to communicate errors. This method can be called by a
+  /// process to tell the TypeSystem to send any diagnostics to the
+  /// process so they can be surfaced to the user.
+  virtual void DiagnoseWarnings(Process &process, Module &module) const;
 protected:
   const LLVMCastKind m_kind; // Support for llvm casting
   SymbolFile *m_sym_file;

--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -536,7 +536,7 @@ public:
   //------------------------------------------------------------------
   /// Process warning types.
   //------------------------------------------------------------------
-  enum Warnings { eWarningsOptimization = 1, eWarningsCantLoadSwift };
+  enum Warnings { eWarningsOptimization = 1, eWarningsSwiftImport };
 
   typedef Range<lldb::addr_t, lldb::addr_t> LoadRange;
   // We use a read/write lock to allow on or more clients to access the process
@@ -1590,19 +1590,15 @@ public:
   void PrintWarningOptimization(const SymbolContext &sc);
 
   //------------------------------------------------------------------
-  /// Print a user-visible warning about a module having Swift settings
-  /// incompatible with the current system
-  ///
-  /// Prints a async warning message to the user one time per Process for a
-  /// Module
-  /// whose Swift AST sections couldn't be loaded because they aren't buildable
-  /// on
-  /// the current machine.
+  /// Prints a async warning message to the user one time per Process
+  /// for a Module whose Swift AST sections couldn't be loaded because
+  /// they aren't buildable on the current machine.
   ///
   /// @param [in] module
   ///     The affected Module.
   //------------------------------------------------------------------
-  void PrintWarningCantLoadSwift(const Module &module);
+  void PrintWarningCantLoadSwiftModule(const Module &module,
+                                       std::string details);
 
   virtual bool GetProcessInfo(ProcessInstanceInfo &info);
 

--- a/include/lldb/Target/Thread.h
+++ b/include/lldb/Target/Thread.h
@@ -1314,7 +1314,7 @@ protected:
     m_temporary_resume_state = new_state;
   }
 
-  void FunctionOptimizationWarning(lldb_private::StackFrame *frame);
+  void FrameSelectedCallback(lldb_private::StackFrame *frame);
 
   //------------------------------------------------------------------
   // Classes that inherit from Process can see and modify these

--- a/lit/Swift/DeserializationFailure.test
+++ b/lit/Swift/DeserializationFailure.test
@@ -1,0 +1,18 @@
+# REQUIRES: system-darwin
+# Tests that error messages from deserializing Swift modules are
+# printed to the error stream. Architecturally it is not possible to
+# write this as a dotest.py test.
+
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: cp %p/../../packages/Python/lldbsuite/test/lang/swift/deserialization_failure/Inputs/main.swift %t/main.swift
+# RUN: %target-swiftc -g -Onone -Xfrontend -serialize-debugging-options -c %t/main.swift -o %t/a.o
+# RUN: rm %t/main.swift
+# RUN: echo "I am damaged." >%t/a.swiftmodule
+# RUN: %target-swiftc %t/a.o -Xlinker -add_ast_path -Xlinker %t/a.swiftmodule -o %t/a.out
+# RUN: %lldb %t/a.out -s %s -o quit 2>&1 | FileCheck %s
+
+b main
+run
+
+# The {{ }} avoids accidentally matching the input script!
+# CHECK: a.out:{{ }}{{.*}}The serialized module is corrupted.

--- a/packages/Python/lldbsuite/test/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/packages/Python/lldbsuite/test/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -25,7 +25,8 @@ class TestSwiftDeserializationFailure(TestBase):
         dynamic_bkpt = target.BreakpointCreateByName('dynamicTypes')
         generic_bkpt = target.BreakpointCreateByName('genericTypes')
         lldbutil.continue_to_breakpoint(process, static_bkpt)
-        self.expect("fr var hello", substrs=["(String)", "world"])
+        self.expect("fr var i", substrs=["23"])
+        self.expect("fr var s", substrs=["(String)", "world"])
 
         # We should not be able to resolve the types defined in the module.
         lldbutil.continue_to_breakpoint(process, dynamic_bkpt)
@@ -50,5 +51,6 @@ class TestSwiftDeserializationFailure(TestBase):
         self.prepare()
         with open(self.getBuildArtifact("a.swiftmodule"), 'w') as mod:
             mod.write('I am damaged.\n')
+
         target, process, _, _ = lldbutil.run_to_name_breakpoint(self, 'main')
         self.run_tests(target, process)

--- a/source/Core/Module.cpp
+++ b/source/Core/Module.cpp
@@ -1697,3 +1697,8 @@ bool Module::GetIsDynamicLinkEditor() {
 
   return false;
 }
+
+void Module::ForEachTypeSystem(
+    std::function<bool(TypeSystem *)> const &callback) {
+  m_type_system_map.ForEach(callback);
+}

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1335,22 +1335,24 @@ static bool DeserializeCompilerFlags(swift::CompilerInvocation &invocation,
   return false;
 }
 
-static void printASTValidationInfo(
+static void printASTValidationError(
     llvm::raw_ostream &errs,
     const swift::serialization::ValidationInfo &ast_info,
     const swift::serialization::ExtendedValidationInfo &ext_ast_info,
-    const Module &module, StringRef module_buf, bool invalid_name,
+    Module &module, StringRef module_buf, bool invalid_name,
     bool invalid_size) {
   const char *error = getImportFailureString(ast_info.status);
-  errs << error;
-  if (invalid_name) {
-    error = "The module has an invalid name.";
-    errs << ' ' << error;
-  }
-  if (invalid_size) {
-    error = "The module has an invalid file size.";
-    errs << ' ' << error;
-  }
+  errs << "AST validation error";
+  if (!invalid_name)
+    errs << " in \"" << ast_info.name << '"';
+  errs << ": ";
+  // Instead of printing the generic Status::Malformed error, be specific.
+  if (invalid_size)
+    errs << "The serialized module is corrupted.";
+  else if (invalid_name)
+    errs << "The serialized module has an invalid name.";
+  else
+    errs << error;
 
   llvm::SmallString<1> m_description;
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
@@ -1369,6 +1371,11 @@ static void printASTValidationInfo(
     LLDB_LOG(log, "  -- {0}", ExtraOpt);
 }
 
+void SwiftASTContext::DiagnoseWarnings(Process &process, Module &module) const {
+  for (const std::string &message : m_module_import_warnings)
+    process.PrintWarningCantLoadSwiftModule(module, message);
+}
+
 /// Retrieve the serialized AST data blobs and initialize the compiler
 /// invocation with the concatenated search paths from the blobs.
 /// \returns true if an error was encountered.
@@ -1378,6 +1385,7 @@ static bool DeserializeAllCompilerFlags(SwiftASTContext &swift_ast,
                                         llvm::raw_ostream &error,
                                         bool &got_serialized_options) {
   Log *log(lldb_private::GetLogIfAllCategoriesSet(LIBLLDB_LOG_TYPES));
+  bool found_validation_errors = false;
   std::string last_sdk_path;
   got_serialized_options = false;
   auto &invocation = swift_ast.GetCompilerInvocation();
@@ -1408,8 +1416,9 @@ static bool DeserializeAllCompilerFlags(SwiftASTContext &swift_ast,
       bool invalid_name = info.name.empty();
       if (invalid_ast || invalid_size || invalid_name) {
         // Validation errors are diagnosed, but not fatal for the context.
-        printASTValidationInfo(error, info, extended_validation_info, module,
-                               buf, invalid_name, invalid_size);
+        found_validation_errors = true;
+        printASTValidationError(error, info, extended_validation_info, module,
+                                buf, invalid_name, invalid_size);
         // If there's a size error, quit the loop early, otherwise try the next.
         if (invalid_size)
           break;
@@ -1433,7 +1442,7 @@ static bool DeserializeAllCompilerFlags(SwiftASTContext &swift_ast,
   }
   LOG_PRINTF(LIBLLDB_LOG_TYPES, "Picking SDK path \"%s\".",
              invocation.getSDKPath().str().c_str());
-  return false;
+  return found_validation_errors;
 }
 
 /// Return whether this module contains any serialized Swift ASTs.
@@ -1705,12 +1714,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
     bool got_serialized_options;
     llvm::SmallString<0> error;
     llvm::raw_svector_ostream errs(error);
-
     if (DeserializeAllCompilerFlags(*swift_ast_sp, module, m_description, errs,
                                     got_serialized_options)) {
-      swift_ast_sp->m_fatal_errors.SetErrorString(error.str());
-      assert(swift_ast_sp->HasFatalErrors() && "error string was empty");
-      return swift_ast_sp;
+      // Validation errors are not fatal for the context.
+      swift_ast_sp->m_module_import_warnings.push_back(error.str());
     }
 
     // Some of the bits in the compiler options we keep separately, so
@@ -1888,6 +1895,11 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   auto logError = [&](const char *message) {
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "Failed to create scratch context - %s",
                message);
+    // Avoid spamming the user with errors.
+    if (!target.UseScratchTypesystemPerModule()) {
+      StreamSP errs_sp = target.GetDebugger().GetAsyncErrorStream();
+      errs_sp->Printf("Cannot create Swift scratch context (%s)", message);
+    }
   };
 
   ArchSpec arch = target.GetArchitecture();
@@ -1999,15 +2011,16 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   if (exe_module_sp) {
     llvm::SmallString<0> error;
     llvm::raw_svector_ostream errs(error);
-    bool failed = DeserializeAllCompilerFlags(*swift_ast_sp, *exe_module_sp,
-                                              m_description, errs,
-                                              got_serialized_options);
-
-    if (failed)
+    if (DeserializeAllCompilerFlags(*swift_ast_sp, *exe_module_sp,
+                                    m_description, errs,
+                                    got_serialized_options)) {
+      if (Process *process = target.GetProcessSP().get())
+        process->PrintWarningCantLoadSwiftModule(*exe_module_sp, error.c_str());
       LOG_PRINTF(
           LIBLLDB_LOG_TYPES,
           "Attempt to load compiler options from serialized AST failed: %s",
           error.c_str());
+    }
   }
 
   // Now if the user fully specified the triple, let that override the one
@@ -2195,17 +2208,14 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(lldb::LanguageType language,
   swift_ast_sp->LogConfiguration();
 
   if (swift_ast_sp->HasFatalErrors()) {
-    const char *errors = swift_ast_sp->GetFatalErrors().AsCString();
-    swift_ast_sp->m_error.SetErrorStringWithFormat(
-        "Error creating target Swift AST context: %s", errors);
-    logError(errors);
-    return lldb::TypeSystemSP();
+    logError(swift_ast_sp->GetFatalErrors().AsCString());
+    return {};
   }
 
   const bool can_create = true;
   if (!swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create)) {
     logError("couldn't load the Swift stdlib");
-    return lldb::TypeSystemSP();
+    return {};
   }
 
   return swift_ast_sp;
@@ -3392,9 +3402,6 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
                                    "context:\nAST context is in a fatal "
                                    "error state",
                                    module.path.front().GetCString());
-    printf("error in SwiftASTContext::GetModule(%s): AST context is in a "
-           "fatal error stat",
-           module.path.front().GetCString());
     return nullptr;
   }
 
@@ -3407,11 +3414,6 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
         "failed to get module \"%s\" from AST context:\n%s",
         module.path.front().GetCString(),
         diagnostic_manager.GetString().data());
-#ifdef LLDB_CONFIGURATION_DEBUG
-    printf("error in SwiftASTContext::GetModule(%s): \"%s\"",
-           module.path.front().GetCString(),
-           diagnostic_manager.GetString().data());
-#endif
 
     LOG_PRINTF(LIBLLDB_LOG_TYPES, "(\"%s\") -- error: %s",
                module.path.front().GetCString(),

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -144,6 +144,8 @@ bool TypeSystem::IsMeaninglessWithoutDynamicResolution(void *type) {
   return false;
 }
 
+void TypeSystem::DiagnoseWarnings(Process &process, Module &module) const {}
+
 Status TypeSystem::IsCompatible() {
   // Assume a language is compatible. Override this virtual function
   // in your TypeSystem plug-in if version checking is desired.
@@ -310,3 +312,4 @@ void TypeSystemMap::AddToMap(lldb::LanguageType language,
   if (!m_clear_in_progress)
     m_map[language] = type_system_sp;
 }
+

--- a/source/Target/Process.cpp
+++ b/source/Target/Process.cpp
@@ -6087,11 +6087,11 @@ void Process::PrintWarningOptimization(const SymbolContext &sc) {
   }
 }
 
-void Process::PrintWarningCantLoadSwift(const Module &module) {
-  PrintWarning(Process::Warnings::eWarningsCantLoadSwift, (void *)&module,
-               "%s had Swift information that isn't usable on the current "
-               "system; its internals will be unavailable.\n",
-               module.GetFileSpec().GetCString());
+void Process::PrintWarningCantLoadSwiftModule(const Module &module,
+                                              std::string details) {
+  PrintWarning(Process::Warnings::eWarningsSwiftImport, (void *)&module,
+               "%s: Cannot load Swift type information; %s\n",
+               module.GetFileSpec().GetCString(), details.c_str());
 }
 
 bool Process::GetProcessInfo(ProcessInstanceInfo &info) {


### PR DESCRIPTION
Error messages such as .swiftmodules being produced by an older
compiler are common, but were previously not visible to and LLDB user
unless they also turned on the types log. This patch changes that by
surfacing the errors on the LLDB error stream, but only once per
module.

<rdar://problem/51686950>