### PR TITLE
Make test pass on swift-5.1-branch.

### DIFF
--- a/lit/Driver/TestProcessAttach.test
+++ b/lit/Driver/TestProcessAttach.test
@@ -1,2 +1,2 @@
 # RUN: %lldb -x -b -S %S/Inputs/process_attach_pid.in 2>&1 | FileCheck %s
-# CHECK: last option requires an argument
+# CHECK: no process specified


### PR DESCRIPTION
The underlying patch is to avoid a crash, so the exact error message
is not substantial.