### PR TITLE
[5.1][test][Swift] Test the expected default prebuilt module cache path exists in the host default toolchain

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/Makefile
@@ -6,6 +6,8 @@ LD_EXTRAS = -L$(BUILDDIR) -lAA -lBB -lCC -Xlinker -rpath -Xlinker $(BUILDDIR)
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 SWIFT_MODULE_CACHE_FLAGS = -module-cache-path MCP
 
+.PHONY: setup sharedA sharedB sharedC clear_modules
+
 # setup `all` to run each of the below before building the main executable
 all: setup sharedA sharedB sharedC clear_modules
 
@@ -18,6 +20,9 @@ setup:
 	cp $(SRCDIR)/libs/A.swift libs/AA.swift
 	cp $(SRCDIR)/libs/B.swift libs/BB.swift
 	cp $(SRCDIR)/libs/C.swift libs/CC.swift
+
+	# record the used SDKROOT, to use from the python test file
+	echo $(SWIFTSDKROOT) > $(BUILDDIR)/sdk-root.txt
 
 sharedA:
 	$(MAKE) MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
@@ -50,3 +55,4 @@ clean::
 	$(MAKE) VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
 	rm -rf libs
 	rm -rf MCP
+	rm -f sdk-root.txt

--- a/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -63,15 +63,39 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
            exe_name=self.getBuildArtifact("main"))
 
         # Check the prebuilt cache path in the log output
-        found = False
         prefix = 'Using prebuilt module cache path: '
-        logfile = open(log, "r")
-        for line in logfile:
-            if prefix in line:
-                self.assertTrue(line.endswith('/macosx/prebuilt-modules\n'), 'unexpected prebuilt cache path: ' + line)
-                found = True
+        expected_suffix = os.path.join('macosx', 'prebuilt-modules')
+        found = False
+        with open(log, "r") as logfile:
+            for line in logfile:
+                if prefix in line:
+                    self.assertTrue(line.rstrip().endswith(os.path.sep + expected_suffix), 'unexpected prebuilt cache path: ' + line)
+                    found = True
+                    break
         self.assertTrue(found, 'prebuilt cache path log entry not found')
 
+        # Check the host toolchain has a prebuilt cache in the same subdirectory of its swift resource directory
+        prebuilt_path = os.path.join(self.get_toolchain(), 'usr', 'lib', 'swift', expected_suffix)
+        self.assertTrue(len(os.listdir(prebuilt_path)) > 0)
+
+    def get_toolchain(self):
+        sdkroot = self.get_sdkroot()
+        # The SDK root is expected to be wihin the Xcode.app/Contents
+        # directory. Drop the last path component from the sdkroot until we get
+        # up to that level.
+        self.assertTrue('{0}Contents{0}'.format(os.path.sep) in sdkroot)
+        contents = os.path.abspath(sdkroot)
+        while os.path.split(contents)[1] != 'Contents':
+            (contents, _) =  os.path.split(contents)
+        # Construct the expected path to the default toolchain from there and
+        # check it exists.
+        toolchain = os.path.join(contents, 'Developer', 'Toolchains', 'XcodeDefault.xctoolchain')
+        self.assertTrue(os.path.exists(toolchain), 'no default toolchain?')
+        return toolchain
+
+    def get_sdkroot(self):
+        with open(self.getBuildArtifact("sdk-root.txt"), "r") as sdkroot:
+            return sdkroot.read().rstrip()
 
     def setUp(self):
         TestBase.setUp(self)


### PR DESCRIPTION
Extend the test that lldb is using the correct default prebuilt module cache path to also check that that path exists in the host toolchain's Swift resource directory.

Resolves rdar://problem/50501694