### PR TITLE
[Reproducers] Add a bridging header test

### DIFF
--- a/lit/Reproducer/Swift/Inputs/Bridging.in
+++ b/lit/Reproducer/Swift/Inputs/Bridging.in
@@ -1,0 +1,8 @@
+breakpoint set -f Bridging.swift -l 2
+run
+bt
+p let $bar = Foo(i: 95126)
+p $bar.i
+cont
+reproducer status
+reproducer generate

--- a/lit/Reproducer/Swift/Inputs/Bridging.swift
+++ b/lit/Reproducer/Swift/Inputs/Bridging.swift
@@ -1,0 +1,5 @@
+func main() {
+  let foo = Foo(i: 42)
+}
+
+main()

--- a/lit/Reproducer/Swift/Inputs/Foo.h
+++ b/lit/Reproducer/Swift/Inputs/Foo.h
@@ -1,0 +1,1 @@
+struct Foo { int i; };

--- a/lit/Reproducer/Swift/TestBridging.test
+++ b/lit/Reproducer/Swift/TestBridging.test
@@ -1,0 +1,32 @@
+# UNSUPPORTED: system-windows, system-freebsd
+
+# This tests replaying a Swift reproducer with bridging.
+
+# Start clean.
+# RUN: rm -rf %t.build && mkdir %t.build && cd %t.build
+# RUN: cp %S/Inputs/Bridging.swift %t.build/Bridging.swift
+# RUN: cp %S/Inputs/Foo.h %t.build/Foo.h
+
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t.build/cache %t.build/Bridging.swift \
+# RUN:          -import-objc-header %t.build/Foo.h \
+# RUN:          -module-name main -o %t.out
+
+# Cleanup build directory.
+# RUN: rm -rf %t.build
+# RUN: rm -rf %t.run && mkdir %t.run && cd %t.run
+
+# Capture the reproducer.
+# RUN: %lldb -x -b -s %S/Inputs/Bridging.in \
+# RUN:          --capture \
+# RUN:          --capture-path %t.repro \
+# RUN:          %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+
+# Replay the reproducer in place.
+# RUN: %lldb --replay %t.repro | FileCheck %s --check-prefix CHECK
+
+# CHECK: Breakpoint 1
+# CHECK: Process {{.*}} stopped
+# CHECK: thread {{.*}} stop reason = breakpoint
+# CHECK: frame {{.*}} Bridging.swift
+# CHECK: $R0 = 95126


### PR DESCRIPTION
Add a test that ensures we can reproduce Swift programs that use a
bridging header.