### PR TITLE
[x86-64] Use `//` for integer division in the target definition.

### DIFF
--- a/examples/python/x86_64_target_definition.py
+++ b/examples/python/x86_64_target_definition.py
@@ -744,7 +744,7 @@ def get_target_definition():
             # info
             if 'slice' not in reg_info and 'composite' not in reg_info:
                 reg_info['offset'] = offset
-                offset += reg_info['bitsize'] / 8
+                offset += reg_info['bitsize'] // 8
 
             # Set the GCC/DWARF register number for this register if it has one
             reg_num = get_reg_num(name_to_gcc_dwarf_regnum, reg_name)


### PR DESCRIPTION
This forces integer division and works with python 2 and python 3.

<rdar://problem/52073911>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@364465 91177308-0d34-0410-b5e6-96231b3b80d8