### PR TITLE
Remove LanguageRuntime::IsSymbolAnyRuntimeThunk from botched rebase

### DIFF
--- a/source/Target/LanguageRuntime.cpp
+++ b/source/Target/LanguageRuntime.cpp
@@ -295,7 +295,3 @@ void LanguageRuntime::InitializeCommands(CommandObject *parent) {
     }
   }
 }
-
-bool LanguageRuntime::IsSymbolAnyRuntimeThunk(Symbol &symbol) {
-  return SwiftLanguageRuntime::IsSymbolARuntimeThunk(symbol);
-}


### PR DESCRIPTION
apl@fb.com removed this in 72f7ee901a8a0a52a7ecf and the rebase
brought it back. Remove it so that builds continue.