### PR TITLE
 Avoid a crash when the ClangImporter couldn't be initialized.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/packages/Python/lldbsuite/test/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -64,7 +64,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
 
         # Check the prebuilt cache path in the log output
         found = False
-        prefix = 'Using prebuilt module cache path: '
+        prefix = 'Using prebuilt Swift module cache path: '
         logfile = open(log, "r")
         for line in logfile:
             if prefix in line:


### PR DESCRIPTION
This needs more cleanup and a better architecture, most notably
the property getter should never return an empty string, but that
needs to happen upstream and not on swift-5.1-branch.

<rdar://problem/52222566>