### PR TITLE
[SwiftArray] Pass an execution scope when getting the size of the array.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/TestSwiftArrayTupleResilient.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/array_tuple_resilient/main.swift
@@ -1,0 +1,17 @@
+// Make sure we print array of tuples containing elements with
+// resilient types print correctly.
+
+import Foundation
+
+var patatino : [(URL, Int64)] = [(URL(string: "https://github.com")!, 1001)]
+var tinky : [(URL, URL)] = [(URL(string: "https://github.com")!,
+                            URL(string: "https://github.com")!)]
+print(patatino) //%self.expect('frame variable -d run -- patatino',
+                //%             substrs=['[0] = (0 = "https://github.com", 1 = 1001)'])
+                //%self.expect('expr -d run -- patatino',
+                //%             substrs=['[0] = (0 = "https://github.com", 1 = 1001)'])
+
+print(tinky)    //%self.expect('frame variable -d run -- tinky',
+                //%             substrs=['[0] = (0 = "https://github.com", 1 = "https://github.com")'])
+                //%self.expect('expr -d run -- tinky',
+                //%             substrs=['[0] = (0 = "https://github.com", 1 = "https://github.com")'])

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -68,8 +68,7 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
     : m_metadata_ptr(LLDB_INVALID_ADDRESS),
       m_reserved_word(LLDB_INVALID_ADDRESS), m_size(0), m_capacity(0),
       m_first_elem_ptr(LLDB_INVALID_ADDRESS), m_elem_type(elem_type),
-      m_element_size(elem_type.GetByteSize(nullptr).getValueOr(0)),
-      m_element_stride(elem_type.GetByteStride()),
+      m_element_size(0), m_element_stride(elem_type.GetByteStride()),
       m_exe_ctx_ref(valobj.GetExecutionContextRef()) {
   if (native_ptr == LLDB_INVALID_ADDRESS)
     return;
@@ -85,6 +84,9 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
   ProcessSP process_sp(m_exe_ctx_ref.GetProcessSP());
   if (!process_sp)
     return;
+  auto opt_size = elem_type.GetByteSize(process_sp.get());
+  if (opt_size)
+    m_element_size = *opt_size;
   size_t ptr_size = process_sp->GetAddressByteSize();
   Status error;
   lldb::addr_t next_read = native_ptr;
@@ -192,8 +194,7 @@ SwiftArraySliceBufferHandler::GetElementAtIndex(size_t idx) {
 SwiftArraySliceBufferHandler::SwiftArraySliceBufferHandler(
     ValueObject &valobj, CompilerType elem_type)
     : m_size(0), m_first_elem_ptr(LLDB_INVALID_ADDRESS), m_elem_type(elem_type),
-      m_element_size(elem_type.GetByteSize(nullptr).getValueOr(0)),
-      m_element_stride(elem_type.GetByteStride()),
+      m_element_size(0), m_element_stride(elem_type.GetByteStride()),
       m_exe_ctx_ref(valobj.GetExecutionContextRef()), m_native_buffer(false),
       m_start_index(0) {
   static ConstString g_start("subscriptBaseAddress");
@@ -205,6 +206,10 @@ SwiftArraySliceBufferHandler::SwiftArraySliceBufferHandler(
   ProcessSP process_sp(m_exe_ctx_ref.GetProcessSP());
   if (!process_sp)
     return;
+
+  auto opt_size = elem_type.GetByteSize(process_sp.get());
+  if (opt_size)
+    m_element_size = *opt_size;
 
   ValueObjectSP value_sp(valobj.GetChildAtNamePath({g_start, g__rawValue}));
   if (!value_sp)


### PR DESCRIPTION
For non-fixed layout types, we have to ask the runtime what's the
size of the type (and go through mirrors). This shows up with resilient
types, but probably it was a more general problem.
Thanks to Adrian for help to initially diagnose this!

<rdar://problem/51146107>