### PR TITLE
[SwiftASTContext] Fix printing for Obj-C enum.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/Makefile
@@ -1,0 +1,3 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/Makefile
@@ -1,3 +1,4 @@
 LEVEL = ../../../make
 SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) -Xfrontend -validate-tbd-against-ir=none
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/TestEnumObjC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/TestEnumObjC.py
@@ -1,4 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipUnlessDarwin])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/TestEnumObjC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/TestEnumObjC.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/enum.h
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/enum.h
@@ -1,0 +1,17 @@
+typedef enum __attribute__((enum_extensibility(closed))) ComparisonResult : long ComparisonResult; enum ComparisonResult : long {
+    OrderedAscending = -1L,
+    OrderedSame,
+    OrderedDescending
+};
+
+ComparisonResult getReturn(long x) {
+  switch (x) {
+    case 0:
+      return OrderedSame;
+    case -1:
+      return OrderedAscending;
+    case 1:
+    default:
+      return OrderedDescending;
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+func test()
+{
+    let a : NSNumber = 0.0
+    let b : NSNumber = 1.0
+    let ascending = a.compare(b)
+    let descending = b.compare(a)
+    let same = a.compare(a)
+    return //%self.expect('frame var -d run-target -- ascending', substrs=['orderedAscending'])
+           //%self.expect('frame var -d run-target -- descending', substrs=['orderedDescending'])
+           //%self.expect('frame var -d run-target -- same', substrs=['orderedSame'])
+           //%self.expect('expr -d run-target -- ascending', substrs=['orderedAscending'])
+           //%self.expect('expr -d run-target -- descending', substrs=['orderedDescending'])
+           //%self.expect('expr -d run-target -- same', substrs=['orderedSame'])
+}
+
+_ = test()

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/main.swift
@@ -1,18 +1,16 @@
-import Foundation
+import Enum 
 
 func test()
 {
-    let a : NSNumber = 0.0
-    let b : NSNumber = 1.0
-    let ascending = a.compare(b)
-    let descending = b.compare(a)
-    let same = a.compare(a)
-    return //%self.expect('frame var -d run-target -- ascending', substrs=['orderedAscending'])
-           //%self.expect('frame var -d run-target -- descending', substrs=['orderedDescending'])
-           //%self.expect('frame var -d run-target -- same', substrs=['orderedSame'])
-           //%self.expect('expr -d run-target -- ascending', substrs=['orderedAscending'])
-           //%self.expect('expr -d run-target -- descending', substrs=['orderedDescending'])
-           //%self.expect('expr -d run-target -- same', substrs=['orderedSame'])
+    let ascending = getReturn(-1)
+    let descending = getReturn(1)
+    let same = getReturn(0)
+    return //%self.expect('frame var -d run-target -- ascending', substrs=['OrderedAscending'])
+           //%self.expect('frame var -d run-target -- descending', substrs=['OrderedDescending'])
+           //%self.expect('frame var -d run-target -- same', substrs=['OrderedSame'])
+           //%self.expect('expr -d run-target -- ascending', substrs=['OrderedAscending'])
+           //%self.expect('expr -d run-target -- descending', substrs=['OrderedDescending'])
+           //%self.expect('expr -d run-target -- same', substrs=['OrderedSame'])
 }
 
 _ = test()

--- a/packages/Python/lldbsuite/test/lang/swift/enum_objc/module.modulemap
+++ b/packages/Python/lldbsuite/test/lang/swift/enum_objc/module.modulemap
@@ -1,0 +1,3 @@
+module Enum {
+  header "enum.h"
+}


### PR DESCRIPTION
The value is not an increasing number [starting from zero] as
it happens for the pure no-payload swift-enum, they can have
arbitrary values.

<rdar://problem/51678061>