### PR TITLE
Implement IsWhitelistedRuntimeValue for Swift

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -308,7 +308,7 @@ public:
   /// Ask Remote Mirrors for the size of a Swift type.
   llvm::Optional<uint64_t> GetBitSize(CompilerType type);
 
-  bool IsRuntimeSupportValue(ValueObject &valobj) override;
+  bool IsWhitelistedRuntimeValue(ConstString name) override;
 
   virtual CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,
                                                  CompilerType base_type);

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2586,19 +2586,8 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetBitSize(CompilerType type) {
   return type_info->getSize() * 8;
 }
 
-bool SwiftLanguageRuntime::IsRuntimeSupportValue(ValueObject &valobj) {
-  // All runtime support values have to be marked as artificial by the
-  // compiler. But not all artificial variables should be hidden from
-  // the user.
-  if (!valobj.GetVariable())
-    return false;
-  if (!valobj.GetVariable()->IsArtificial())
-    return false;
-
-  // Whitelist "self".
-  if (valobj.GetName() == g_self)
-     return false;
-  return true;
+bool SwiftLanguageRuntime::IsWhitelistedRuntimeValue(ConstString name) {
+  return name == g_self;
 }
 
 bool SwiftLanguageRuntime::CouldHaveDynamicValue(ValueObject &in_value) {


### PR DESCRIPTION
IsRuntimeSupportValue in value object was changed to
IsWhitelistedRuntimeValue in upstream lldb.

See also:
git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@364845
91177308-0d34-0410-b5e6-96231b3b80d8