### PR TITLE
[Core] Remove unused SwiftASTContextLock

### DIFF
--- a/source/Core/ValueObjectDynamicValue.cpp
+++ b/source/Core/ValueObjectDynamicValue.cpp
@@ -147,8 +147,6 @@ bool ValueObjectDynamicValue::UpdateValue() {
     m_data.SetAddressByteSize(target->GetArchitecture().GetAddressByteSize());
   }
  
-  auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
-
   // First make sure our Type and/or Address haven't changed:
   Process *process = exe_ctx.GetProcessPtr();
   if (!process)


### PR DESCRIPTION
If I understand how SwiftASTContextLock is used, I think that this instance is unused. I could be wrong as I'm not entirely confident in my understanding.

cc @dcci @JDevlieghere @adrian-prantl