### PR TITLE
[Target] Centralize creation of scratch SwiftASTContexts

### DIFF
--- a/include/lldb/Core/ValueObject.h
+++ b/include/lldb/Core/ValueObject.h
@@ -9,7 +9,6 @@
 #ifndef liblldb_ValueObject_h_
 #define liblldb_ValueObject_h_
 
-#include "lldb/Core/SwiftASTContextReader.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/Type.h"
@@ -613,8 +612,6 @@ public:
   lldb::ValueObjectSP GetSyntheticValue(bool use_synthetic = true);
 
   virtual bool HasSyntheticValue();
-
-  SwiftASTContextReader GetScratchSwiftASTContext();
 
   virtual bool IsSynthetic() { return false; }
 

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -24,6 +24,7 @@
 #include "lldb/Core/Architecture.h"
 #include "lldb/Core/Disassembler.h"
 #include "lldb/Core/ModuleList.h"
+#include "lldb/Core/SwiftASTContextReader.h"
 #include "lldb/Core/UserSettingsController.h"
 #include "lldb/Expression/Expression.h"
 #include "lldb/Interpreter/OptionValueBoolean.h"
@@ -1210,6 +1211,10 @@ public:
   SwiftASTContextReader
   GetScratchSwiftASTContext(Status &error, ExecutionContextScope &exe_scope,
                             bool create_on_demand = true);
+
+  SwiftASTContextReader GetScratchSwiftASTContext(Status &error,
+                                                  ValueObject &valobj,
+                                                  bool create_on_demand = true);
 
 private:
   void DisplayFallbackSwiftContextErrors(SwiftASTContext *swift_ast_ctx);

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/Core/Address.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/SwiftASTContextReader.h"
 #include "lldb/Core/ValueObjectCast.h"
 #include "lldb/Core/ValueObjectChild.h"
 #include "lldb/Core/ValueObjectConstResult.h"
@@ -28,7 +29,6 @@
 #include "lldb/Symbol/ClangASTContext.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/CompilerType.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Declaration.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/Type.h"
@@ -1706,16 +1706,6 @@ LanguageType ValueObject::GetObjectRuntimeLanguage() {
   if (GetCompilerType().IsValid())
     return GetCompilerType().GetMinimumLanguage();
   return lldb::eLanguageTypeUnknown;
-}
-
-SwiftASTContextReader ValueObject::GetScratchSwiftASTContext() {
-  lldb::TargetSP target_sp(GetTargetSP());
-  if (!target_sp)
-    return {};
-  Status error;
-  ExecutionContext ctx = GetExecutionContextRef().Lock(false);
-  auto *exe_scope = ctx.GetBestExecutionContextScope();
-  return target_sp->GetScratchSwiftASTContext(error, *exe_scope);
 }
 
 void ValueObject::AddSyntheticChild(ConstString key,

--- a/source/Core/ValueObjectDynamicValue.cpp
+++ b/source/Core/ValueObjectDynamicValue.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "lldb/Core/SwiftASTContextReader.h"
 #include "lldb/Core/ValueObjectDynamicValue.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Core/ValueObject.h"
@@ -420,7 +421,11 @@ bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
   if (!m_dynamic_type_info.HasType())
     return false;
 
-  auto *cached_ctx =
-      static_cast<SwiftASTContext *>(m_value.GetCompilerType().GetTypeSystem());
-  return cached_ctx == GetScratchSwiftASTContext().get();
+  Status error;
+  auto *scratch_ctx = GetTargetSP()->GetScratchSwiftASTContext(error, *this).get();
+  if (!error.Success())
+    return false;
+
+  auto *cached_ctx = m_value.GetCompilerType().GetTypeSystem();
+  return cached_ctx == scratch_ctx;
 }

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -446,7 +446,11 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
     m_value_stride = value_type.GetByteStride();
     if (SwiftASTContext *swift_ast =
             llvm::dyn_cast_or_null<SwiftASTContext>(key_type.GetTypeSystem())) {
-      auto scratch_ctx_reader = nativeStorage_sp->GetScratchSwiftASTContext();
+      Status error;
+      auto scratch_ctx_reader =
+          m_process->GetTarget().GetScratchSwiftASTContext(error, *nativeStorage_sp.get());
+      if (!error.Success())
+        return;
       auto scratch_ctx = scratch_ctx_reader.get();
       if (!scratch_ctx)
         return;

--- a/source/Target/Target.cpp
+++ b/source/Target/Target.cpp
@@ -2534,6 +2534,14 @@ SwiftASTContextReader Target::GetScratchSwiftASTContext(
   return SwiftASTContextReader(GetSwiftScratchContextLock(), swift_ast_ctx);
 }
 
+SwiftASTContextReader Target::GetScratchSwiftASTContext(Status &error,
+                                                        ValueObject &valobj,
+                                                        bool create_on_demand) {
+  ExecutionContext ctx = valobj.GetExecutionContextRef().Lock(false);
+  auto *exe_scope = ctx.GetBestExecutionContextScope();
+  return GetScratchSwiftASTContext(error, *exe_scope);
+}
+
 static SharedMutex *
 GetSwiftScratchContextMutex(const ExecutionContext *exe_ctx) {
   if (!exe_ctx)


### PR DESCRIPTION
I don't think it makes sense for ValueObject to know about SwiftASTContexts, so
we should centralize the creation logic into Target.

I know there are still references to SwiftASTContext in parts of ValueObject and its subclasses. I plan to try to factor those out  sometime later.