### PR TITLE
[Target] Remove unused link against swiftFrontend

### DIFF
--- a/source/Target/CMakeLists.txt
+++ b/source/Target/CMakeLists.txt
@@ -64,7 +64,6 @@ add_lldb_library(lldbTarget
   LINK_LIBS
     swiftAST
     swiftBasic
-    swiftFrontend
     swiftReflection
     swiftRemoteAST
     lldbBreakpoint


### PR DESCRIPTION
lldbTarget doesn't use swiftFrontend.