### PR TITLE
[Symbol] Add DeclVendor::FindTypes

### DIFF
--- a/include/lldb/Symbol/DeclVendor.h
+++ b/include/lldb/Symbol/DeclVendor.h
@@ -53,6 +53,19 @@ public:
                              uint32_t max_matches,
                              std::vector<clang::NamedDecl *> &decls) = 0;
 
+  /// Look up the types that the DeclVendor currently knows about matching a
+  /// given name.
+  ///
+  /// \param[in] name
+  ///     The name to look for.
+  ///
+  /// \param[in] max_matches
+  //      The maximum number of matches. UINT32_MAX means "as many as possible".
+  ///
+  /// \return
+  ///     The vector of CompilerTypes that was found.
+  std::vector<CompilerType> FindTypes(ConstString name, uint32_t max_matches);
+
   //------------------------------------------------------------------
   /// Interface for ExternalASTMerger.  Returns an ImporterSource 
   /// allowing type completion.

--- a/source/API/SBTarget.cpp
+++ b/source/API/SBTarget.cpp
@@ -1881,18 +1881,12 @@ lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {
     }
 
     // Didn't find the type in the symbols; Try the loaded language runtimes
-    // FIXME: This depends on clang, but should be able to support any
-    // TypeSystem/compiler.
     if (auto process_sp = target_sp->GetProcessSP()) {
       for (auto *runtime : process_sp->GetLanguageRuntimes()) {
         if (auto vendor = runtime->GetDeclVendor()) {
-          std::vector<clang::NamedDecl *> decls;
-          if (vendor->FindDecls(const_typename, /*append*/ true,
-                                /*max_matches*/ 1, decls) > 0) {
-            if (CompilerType type =
-                    ClangASTContext::GetTypeForDecl(decls.front()))
-              return LLDB_RECORD_RESULT(SBType(type));
-          }
+          auto types = vendor->FindTypes(const_typename, /*max_matches*/ 1);
+          if (!types.empty())
+            return LLDB_RECORD_RESULT(SBType(types.front()));
         }
       }
     }
@@ -1945,19 +1939,13 @@ lldb::SBTypeList SBTarget::FindTypes(const char *typename_cstr) {
     }
 
     // Try the loaded language runtimes
-    // FIXME: This depends on clang, but should be able to support any
-    // TypeSystem/compiler.
     if (auto process_sp = target_sp->GetProcessSP()) {
       for (auto *runtime : process_sp->GetLanguageRuntimes()) {
         if (auto *vendor = runtime->GetDeclVendor()) {
-          std::vector<clang::NamedDecl *> decls;
-          if (vendor->FindDecls(const_typename, /*append*/ true,
-                                /*max_matches*/ 1, decls) > 0) {
-            for (auto *decl : decls) {
-              if (CompilerType type = ClangASTContext::GetTypeForDecl(decl))
-                sb_type_list.Append(SBType(type));
-            }
-          }
+          auto types =
+              vendor->FindTypes(const_typename, /*max_matches*/ UINT32_MAX);
+          for (auto type : types)
+            sb_type_list.Append(SBType(type));
         }
       }
     }

--- a/source/Core/ValueObject.cpp
+++ b/source/Core/ValueObject.cpp
@@ -365,16 +365,15 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
           std::vector<clang::NamedDecl *> decls;
 
           // try the modules
-          if (TargetSP target_sp = GetTargetSP()) {
+          if (auto target_sp = GetTargetSP()) {
             if (auto clang_modules_decl_vendor =
                     target_sp->GetClangModulesDeclVendor()) {
-              if (clang_modules_decl_vendor->FindDecls(class_name, false,
-                                                       UINT32_MAX, decls) > 0 &&
-                  decls.size() > 0) {
-                CompilerType module_type =
-                    ClangASTContext::GetTypeForDecl(decls.front());
+              std::vector<CompilerType> types =
+                  clang_modules_decl_vendor->FindTypes(
+                      class_name, /*max_matches*/ UINT32_MAX);
+              if (!types.empty()) {
                 m_override_type =
-                    make_pointer_if_needed(module_type, is_pointer_type);
+                    make_pointer_if_needed(types.front(), is_pointer_type);
               }
 
               if (m_override_type.IsValid())
@@ -384,13 +383,11 @@ CompilerType ValueObject::MaybeCalculateCompleteType() {
 
           // then try the runtime
           if (auto runtime_vendor = objc_language_runtime->GetDeclVendor()) {
-            if (runtime_vendor->FindDecls(class_name, false, UINT32_MAX,
-                                          decls) > 0 &&
-                decls.size() > 0) {
-              CompilerType runtime_type =
-                  ClangASTContext::GetTypeForDecl(decls.front());
+            std::vector<CompilerType> types = runtime_vendor->FindTypes(
+                class_name, /*max_matches*/ UINT32_MAX);
+            if (!types.empty()) {
               m_override_type =
-                  make_pointer_if_needed(runtime_type, is_pointer_type);
+                  make_pointer_if_needed(types.front(), is_pointer_type);
             }
 
             if (m_override_type.IsValid())

--- a/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -942,25 +942,16 @@ std::unique_ptr<Language::TypeScavenger> ObjCLanguage::GetTypeScavenger() {
                    ResultSet &results) override {
       bool result = false;
 
-      Process *process = exe_scope->CalculateProcess().get();
-      if (process) {
-        auto objc_runtime = ObjCLanguageRuntime::Get(*process);
-        if (objc_runtime) {
-          auto decl_vendor = objc_runtime->GetDeclVendor();
-          if (decl_vendor) {
-            std::vector<clang::NamedDecl *> decls;
+      if (auto *process = exe_scope->CalculateProcess().get()) {
+        if (auto *objc_runtime = ObjCLanguageRuntime::Get(*process)) {
+          if (auto *decl_vendor = objc_runtime->GetDeclVendor()) {
             ConstString name(key);
-            decl_vendor->FindDecls(name, true, UINT32_MAX, decls);
-            for (auto decl : decls) {
-              if (decl) {
-                if (CompilerType candidate =
-                        ClangASTContext::GetTypeForDecl(decl)) {
-                  result = true;
-                  std::unique_ptr<Language::TypeScavenger::Result> result(
-                      new ObjCScavengerResult(candidate));
-                  results.insert(std::move(result));
-                }
-              }
+            for (const CompilerType &type :
+                 decl_vendor->FindTypes(name, /*max_matches*/ UINT32_MAX)) {
+              result = true;
+              std::unique_ptr<Language::TypeScavenger::Result> result(
+                  new ObjCScavengerResult(type));
+              results.insert(std::move(result));
             }
           }
         }
@@ -978,21 +969,16 @@ std::unique_ptr<Language::TypeScavenger> ObjCLanguage::GetTypeScavenger() {
                    ResultSet &results) override {
       bool result = false;
 
-      Target *target = exe_scope->CalculateTarget().get();
-      if (target) {
-        if (auto clang_modules_decl_vendor =
+      if (auto *target = exe_scope->CalculateTarget().get()) {
+        if (auto *clang_modules_decl_vendor =
                 target->GetClangModulesDeclVendor()) {
-          std::vector<clang::NamedDecl *> decls;
           ConstString key_cs(key);
-
-          if (clang_modules_decl_vendor->FindDecls(key_cs, false, UINT32_MAX,
-                                                   decls) > 0 &&
-              !decls.empty()) {
-            CompilerType module_type =
-                ClangASTContext::GetTypeForDecl(decls.front());
+          auto types = clang_modules_decl_vendor->FindTypes(
+              key_cs, /*max_matches*/ UINT32_MAX);
+          if (!types.empty()) {
             result = true;
             std::unique_ptr<Language::TypeScavenger::Result> result(
-                new ObjCScavengerResult(module_type));
+                new ObjCScavengerResult(types.front()));
             results.insert(std::move(result));
           }
         }

--- a/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
+++ b/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
@@ -74,27 +74,20 @@ ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(size_t idx) {
           DeclVendor *vendor = runtime->GetDeclVendor();
           if (!vendor)
             break;
-          std::vector<clang::NamedDecl *> decls;
           auto descriptor_sp(m_provider->m_descriptor_sp);
           if (!descriptor_sp)
             break;
           descriptor_sp = descriptor_sp->GetSuperclass();
           if (!descriptor_sp)
             break;
-          const bool append = false;
-          const uint32_t max = 1;
-          if (0 ==
-              vendor->FindDecls(descriptor_sp->GetClassName(), append, max,
-                                decls))
+          std::vector<CompilerType> types = vendor->FindTypes(
+              descriptor_sp->GetClassName(), /*max_matches*/ 1);
+          if (types.empty())
             break;
           const uint32_t offset = 0;
           const bool can_create = true;
-          if (decls.empty())
-            break;
-          CompilerType type = ClangASTContext::GetTypeForDecl(decls[0]);
-          if (!type.IsValid())
-            break;
-          child_sp = m_backend.GetSyntheticBase(offset, type, can_create);
+          child_sp =
+              m_backend.GetSyntheticBase(offset, types.front(), can_create);
         } while (false);
         return child_sp;
       } else

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -442,12 +442,10 @@ bool AppleObjCRuntimeV2::GetDynamicTypeAndAddress(
           class_type_or_name.SetTypeSP(type_sp);
         } else {
           // try to go for a CompilerType at least
-          DeclVendor *vendor = GetDeclVendor();
-          if (vendor) {
-            std::vector<clang::NamedDecl *> decls;
-            if (vendor->FindDecls(class_name, false, 1, decls) && decls.size())
-              class_type_or_name.SetCompilerType(
-                  ClangASTContext::GetTypeForDecl(decls[0]));
+          if (auto *vendor = GetDeclVendor()) {
+            auto types = vendor->FindTypes(class_name, /*max_matches*/ 1);
+            if (!types.empty())
+              class_type_or_name.SetCompilerType(types.front());
           }
         }
       }

--- a/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
+++ b/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTypeEncodingParser.cpp
@@ -245,25 +245,19 @@ clang::QualType AppleObjCTypeEncodingParser::BuildObjCObjectPointerType(
     if (!decl_vendor)
       return clang::QualType();
 
-    const bool append = false;
-    const uint32_t max_matches = 1;
-    std::vector<clang::NamedDecl *> decls;
-
-    uint32_t num_types =
-        decl_vendor->FindDecls(ConstString(name), append, max_matches, decls);
+    auto types = decl_vendor->FindTypes(ConstString(name), /*max_matches*/ 1);
 
 // The user can forward-declare something that has no definition.  The runtime
 // doesn't prohibit this at all. This is a rare and very weird case.  We keep
 // this assert in debug builds so we catch other weird cases.
 #ifdef LLDB_CONFIGURATION_DEBUG
-    assert(num_types);
+    assert(!types.empty());
 #else
-    if (!num_types)
+    if (types.empty())
       return ast_ctx.getObjCIdType();
 #endif
 
-    return ClangUtil::GetQualType(
-        ClangASTContext::GetTypeForDecl(decls[0]).GetPointerType());
+    return ClangUtil::GetQualType(types.front().GetPointerType());
   } else {
     // We're going to resolve this dynamically anyway, so just smile and wave.
     return ast_ctx.getObjCIdType();

--- a/source/Symbol/CMakeLists.txt
+++ b/source/Symbol/CMakeLists.txt
@@ -13,7 +13,9 @@ add_lldb_library(lldbSymbol
   CompactUnwindInfo.cpp
   DebugMacros.cpp
   Declaration.cpp
+  DeclVendor.cpp
   DWARFCallFrameInfo.cpp
+  FuncUnwinders.cpp
   Function.cpp
   FuncUnwinders.cpp
   LineEntry.cpp

--- a/source/Symbol/DeclVendor.cpp
+++ b/source/Symbol/DeclVendor.cpp
@@ -1,0 +1,29 @@
+//===-- DeclVendor.cpp ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Symbol/DeclVendor.h"
+
+#include "lldb/Symbol/ClangASTContext.h"
+
+#include <vector>
+
+using namespace lldb;
+using namespace lldb_private;
+
+std::vector<CompilerType> DeclVendor::FindTypes(ConstString name,
+                                                uint32_t max_matches) {
+  // FIXME: This depends on clang, but should be able to support any
+  // TypeSystem.
+  std::vector<CompilerType> ret;
+  std::vector<clang::NamedDecl *> decls;
+  if (FindDecls(name, /*append*/ true, max_matches, decls))
+    for (auto *decl : decls)
+      if (auto type = ClangASTContext::GetTypeForDecl(decl))
+        ret.push_back(type);
+  return ret;
+}


### PR DESCRIPTION
[Symbol] Add DeclVendor::FindTypes

Summary:
Following up on the plan I outlined in D63622, we can remove the
dependence on clang in all the places where we only want to find the
types from the DeclVendor. This means that currently DeclVendor depends
on clang, but centralizing the dependency makes it easier to refactor
cleanly.

Differential Revision: https://reviews.llvm.org/D63853

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@364962 91177308-0d34-0410-b5e6-96231b3b80d8

This also contains a patch on top to account for swift changes.