### PR TITLE
Plugins: permit building on Windows ARM64

### DIFF
--- a/source/Plugins/Process/Windows/Common/CMakeLists.txt
+++ b/source/Plugins/Process/Windows/Common/CMakeLists.txt
@@ -1,24 +1,11 @@
-set(PROC_WINDOWS_COMMON_SOURCES
+
+add_lldb_library(lldbPluginProcessWindowsCommon PLUGIN
   DebuggerThread.cpp
   LocalDebugDelegate.cpp
   ProcessWindows.cpp
   ProcessWindowsLog.cpp
   RegisterContextWindows.cpp
   TargetThreadWindows.cpp
-  )
-
-if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-  set(PROC_WINDOWS_COMMON_SOURCES ${PROC_WINDOWS_COMMON_SOURCES}
-    x86/RegisterContextWindows_x86.cpp
-    )
-elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(PROC_WINDOWS_COMMON_SOURCES ${PROC_WINDOWS_COMMON_SOURCES}
-    x64/RegisterContextWindows_x64.cpp
-    )
-endif()
-
-add_lldb_library(lldbPluginProcessWindowsCommon PLUGIN
-  ${PROC_WINDOWS_COMMON_SOURCES}
 
   LINK_LIBS
     lldbCore
@@ -31,3 +18,13 @@ add_lldb_library(lldbPluginProcessWindowsCommon PLUGIN
   LINK_COMPONENTS
     Support
   )
+
+# TODO add support for ARM (NT) and ARM64
+# TODO build these unconditionally as we cannot do cross-debugging or WoW
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+  target_sources(lldbPluginProcessWindowsCommon PRIVATE
+    x64/RegisterContextWindows_x64.cpp)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i?86|X86")
+  target_sources(lldbPluginProcessWindowsCommon PRIVATE
+    x86/RegisterContextWindows_x86.cpp)
+endif()


### PR DESCRIPTION
Rather than relying on `sizeof(void *)` to determine the architecture,
use the `CMAKE_SYSTEM_PROCESSOR` variable.  This should allow us to
build for Windows and cross-compile.  Without this, we would attempt to
build the x64 plugin on ARM64 which would fail due to the `CONTEXT` type
being defined for ARM64 rather than `x64`.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@365155 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 74acd9b072c2c454690af165fbe2038348e94083)