### PR TITLE
Process: generalise Windows thread setup

### DIFF
--- a/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
+++ b/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
@@ -20,9 +20,10 @@
 #include "ProcessWindowsLog.h"
 #include "TargetThreadWindows.h"
 
-#if defined(_WIN64)
+// TODO support _M_ARM and _M_ARM64
+#if defined(_M_AMD64)
 #include "x64/RegisterContextWindows_x64.h"
-#else
+#elif defined(_M_IX86)
 #include "x86/RegisterContextWindows_x86.h"
 #endif
 
@@ -66,23 +67,33 @@ TargetThreadWindows::CreateRegisterContextForFrame(StackFrame *frame) {
     if (!m_thread_reg_ctx_sp) {
       ArchSpec arch = HostInfo::GetArchitecture();
       switch (arch.GetMachine()) {
+      case llvm::Triple::arm:
+      case llvm::Triple::thumb:
+        LLDB_LOG(log, "debugging ARM (NT) targets is currently unsupported");
+        break;
+
+      case llvm::Triple::aarch64:
+        LLDB_LOG(log, "debugging ARM64 targets is currently unsupported");
+        break;
+
       case llvm::Triple::x86:
-#if defined(_WIN64)
-        // FIXME: This is a Wow64 process, create a RegisterContextWindows_Wow64
-        LLDB_LOG(log, "This is a Wow64 process, we should create a "
-                      "RegisterContextWindows_Wow64, but we don't.");
-#else
+#if defined(_M_IX86)
         m_thread_reg_ctx_sp.reset(
             new RegisterContextWindows_x86(*this, concrete_frame_idx));
+#else
+        LLDB_LOG(log, "debugging foreign targets is currently unsupported");
 #endif
         break;
+
       case llvm::Triple::x86_64:
-#if defined(_WIN64)
+#if defined(_M_AMD64)
         m_thread_reg_ctx_sp.reset(
             new RegisterContextWindows_x64(*this, concrete_frame_idx));
 #else
-        LLDB_LOG(log, "LLDB is 32-bit, but the target process is 64-bit.");
+        LLDB_LOG(log, "debugging foreign targets is currently unsupported");
 #endif
+        break;
+
       default:
         break;
       }


### PR DESCRIPTION
The Windows build currently cannot support debugging foreign targets or
debugging Windows ARM NT and Windows ARM64 targets.  Do not assume a
x64/x86 host.  This enables building lldb for Windows ARM64.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@365282 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit aae5c084b04052d26e0273ec8e63c0c602d21f21)