### PR TITLE
[crashlog] Fix a mismatch between bytes and strings.

### DIFF
--- a/examples/python/crashlog.py
+++ b/examples/python/crashlog.py
@@ -300,7 +300,7 @@ class CrashLog(symbolication.Symbolicator):
             if os.path.exists(self.dsymForUUIDBinary):
                 dsym_for_uuid_command = '%s %s' % (
                     self.dsymForUUIDBinary, uuid_str)
-                s = subprocess.check_output(dsym_for_uuid_command, shell=True).decode("utf-8")
+                s = subprocess.check_output(dsym_for_uuid_command, shell=True)
                 if s:
                     try:
                         plist_root = read_plist(s)


### PR DESCRIPTION
The functions in read_plist() want bytes as input, not
strings.

<rdar://problem/52600712>

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@365416 91177308-0d34-0410-b5e6-96231b3b80d8