### PR TITLE
[SwiftASTManipulator] Stop overriding access control.

### DIFF
--- a/lit/SwiftREPL/OpenClass.test
+++ b/lit/SwiftREPL/OpenClass.test
@@ -25,4 +25,4 @@ class Baz: Foo {
   override func foo() -> Int { return 4 }
 }
 
-// CHECK: error: overriding non-open instance method outside of its defining module
+// CHECK: error: instance method overrides a 'final' instance method

--- a/lit/SwiftREPL/ProtocolExtended.test
+++ b/lit/SwiftREPL/ProtocolExtended.test
@@ -1,0 +1,11 @@
+// RUN: %lldb --repl < %s 2>&1 | FileCheck %s
+
+struct Foo {}
+
+extension Foo: CustomStringConvertible {
+  var description: String {
+    return "foo"
+  }
+}
+
+// CHECK-NOT: error:

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -155,8 +155,6 @@ public:
 
   bool RewriteResult();
 
-  void MakeDeclarationsPublic();
-
   void
   FindVariableDeclarations(llvm::SmallVectorImpl<size_t> &found_declarations,
                            bool repl);

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -921,8 +921,7 @@ static swift::ASTContext *SetupASTContext(
   swift_ast_context->GetLanguageOptions().DebuggerSupport = true;
   // No longer part of debugger support, set it separately.
   swift_ast_context->GetLanguageOptions().EnableDollarIdentifiers = true;
-  swift_ast_context->GetLanguageOptions().EnableAccessControl =
-      (repl || playground);
+  swift_ast_context->GetLanguageOptions().EnableAccessControl = false;
   swift_ast_context->GetLanguageOptions().EnableTargetOSChecking = false;
 
   if (disable_objc_runtime())
@@ -1507,10 +1506,6 @@ unsigned SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
     log->Printf("Source file after type checking:");
     log->PutCString(s.c_str());
-  }
-
-  if (repl) {
-    parsed_expr->code_manipulator->MakeDeclarationsPublic();
   }
 
   Status error;


### PR DESCRIPTION
Defer this work to the compiler.

Also fixes <rdar://problem/40955478>