### PR TITLE
[Swift/Optional] Fix the formatter to print the right value.

### DIFF
--- a/lit/SwiftREPL/Optional.test
+++ b/lit/SwiftREPL/Optional.test
@@ -21,5 +21,18 @@ let y : Optional<Test> = Test(a: 1, b: Patatino.first)
 // CHECK-NEXT: b = first
 // CHECK-NEXT: }
 
+class A {
+  var x : Int
+  init(_ x : Int) {
+    self.x = x
+  }
+}
+
+var q : A? = A(23)
+
+// CHECK-NEXT: {{q}}: A? = 0x{{.*}} {
+// CHECK-NEXT:   x = 23
+// CHECK-NEXT: }
+
 let tinky : UInt8? = 250
 // CHECK-NEXT: {{tinky}}: UInt8? = 250

--- a/lit/SwiftREPL/Optional.test
+++ b/lit/SwiftREPL/Optional.test
@@ -20,3 +20,6 @@ let y : Optional<Test> = Test(a: 1, b: Patatino.first)
 // CHECK-NEXT: a = 1
 // CHECK-NEXT: b = first
 // CHECK-NEXT: }
+
+let tinky : UInt8? = 250
+// CHECK-NEXT: {{tinky}}: UInt8? = 250

--- a/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -126,10 +126,13 @@ SwiftOptional_SummaryProvider_Impl(ValueObject &valobj, Stream &stream,
     return true;
   }
 
-  const char *value_summary = some->GetSummaryAsCString();
+  const char *summary = some->GetSummaryAsCString();
+  const char *value = some->GetValueAsCString();
 
-  if (value_summary)
-    stream.Printf("%s", value_summary);
+  if (summary)
+    stream.Printf("%s", summary);
+  else if (value)
+    stream.Printf("%s", value);
   else if (lldb_private::DataVisualization::ShouldPrintAsOneLiner(*some)) {
     TypeSummaryImpl::Flags oneliner_flags;
     oneliner_flags.SetHideItemNames(false)


### PR DESCRIPTION
There's a peculiarity in the way lldb represents `Int/UInt` types
in Swift. They don't have summaries, but values. This historical
choice forces us to switch between GetSummary() and GetValue()
in the formatters. Maybe we should revisit this choice because it
caused several issues over the last couple of years.

<rdar://problem/37835998>