### PR TITLE
[cmake] Add LLVMDistributionSupport to LLDBStandalone

### DIFF
--- a/cmake/modules/LLDBStandalone.cmake
+++ b/cmake/modules/LLDBStandalone.cmake
@@ -89,6 +89,7 @@ include(AddLLVM)
 include(TableGen)
 include(HandleLLVMOptions)
 include(CheckAtomic)
+include(LLVMDistributionSupport)
 
 if (PYTHON_EXECUTABLE STREQUAL "")
   set(Python_ADDITIONAL_VERSIONS 3.7. 3.6 3.4 2.7)


### PR DESCRIPTION
This file was created a few months ago and brought in lldb recently.
stable does not yet have it while upstream does. Thus the merge needs
to include it.