### PR TITLE
[cmake] Only set LLVM_CODESIGN_IDENTITY for repl_swift on Darwin

### DIFF
--- a/tools/repl/swift/CMakeLists.txt
+++ b/tools/repl/swift/CMakeLists.txt
@@ -10,8 +10,12 @@ if( CMAKE_SYSTEM_NAME MATCHES "Linux" )
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib/swift/linux:${CMAKE_INSTALL_RPATH}")
 endif()
 
-# Override locally, so the repl is ad-hoc signed.
-set(LLVM_CODESIGNING_IDENTITY "-")
+# Only set LLVM_CODESIGNING_IDENTITY for building on Apple hosts for Apple
+# targets
+if (CMAKE_HOST_APPLE AND APPLE)
+  # Override locally, so the repl is ad-hoc signed.
+  set(LLVM_CODESIGNING_IDENTITY "-")
+endif()
 
 # Requires system-provided Swift libs.
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14.4)


### PR DESCRIPTION
This variable being set was causing cross compilations from X -> Darwin
to attempt to codesign using xcrun. Simply opt out unless we have a
usable xcrun.