### PR TITLE
build: allow the user to specify `llvm-tblgen`

### DIFF
--- a/cmake/modules/LLDBStandalone.cmake
+++ b/cmake/modules/LLDBStandalone.cmake
@@ -44,31 +44,35 @@ append_configuration_directories(${LLVM_TOOLS_BINARY_DIR} config_dirs)
 find_program(lit_full_path ${lit_file_name} ${config_dirs} NO_DEFAULT_PATH)
 set(LLVM_DEFAULT_EXTERNAL_LIT ${lit_full_path} CACHE PATH "Path to llvm-lit")
 
-if(CMAKE_CROSSCOMPILING)
-  set(LLVM_NATIVE_BUILD "${LLDB_PATH_TO_LLVM_BUILD}/NATIVE")
-  if (NOT EXISTS "${LLVM_NATIVE_BUILD}")
-    message(FATAL_ERROR
-      "Attempting to cross-compile LLDB standalone but no native LLVM build
-      found. Please cross-compile LLVM as well.")
-  endif()
-
-  if (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
-    set(HOST_EXECUTABLE_SUFFIX ".exe")
-  endif()
-
-  if (NOT CMAKE_CONFIGURATION_TYPES)
-    set(LLVM_TABLEGEN_EXE
-      "${LLVM_NATIVE_BUILD}/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
-  else()
-    # NOTE: LLVM NATIVE build is always built Release, as is specified in
-    # CrossCompile.cmake
-    set(LLVM_TABLEGEN_EXE
-      "${LLVM_NATIVE_BUILD}/Release/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
-  endif()
+if(LLVM_TABLEGEN)
+  set(LLVM_TABLEGEN_EXE ${LLVM_TABLEGEN})
 else()
-  set(tblgen_file_name "llvm-tblgen${CMAKE_EXECUTABLE_SUFFIX}")
-  append_configuration_directories(${LLVM_TOOLS_BINARY_DIR} config_dirs)
-  find_program(LLVM_TABLEGEN_EXE ${tblgen_file_name} ${config_dirs} NO_DEFAULT_PATH)
+  if(CMAKE_CROSSCOMPILING)
+    set(LLVM_NATIVE_BUILD "${LLDB_PATH_TO_LLVM_BUILD}/NATIVE")
+    if (NOT EXISTS "${LLVM_NATIVE_BUILD}")
+      message(FATAL_ERROR
+        "Attempting to cross-compile LLDB standalone but no native LLVM build
+        found. Please cross-compile LLVM as well.")
+    endif()
+
+    if (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+      set(HOST_EXECUTABLE_SUFFIX ".exe")
+    endif()
+
+    if (NOT CMAKE_CONFIGURATION_TYPES)
+      set(LLVM_TABLEGEN_EXE
+        "${LLVM_NATIVE_BUILD}/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
+    else()
+      # NOTE: LLVM NATIVE build is always built Release, as is specified in
+      # CrossCompile.cmake
+      set(LLVM_TABLEGEN_EXE
+        "${LLVM_NATIVE_BUILD}/Release/bin/llvm-tblgen${HOST_EXECUTABLE_SUFFIX}")
+    endif()
+  else()
+    set(tblgen_file_name "llvm-tblgen${CMAKE_EXECUTABLE_SUFFIX}")
+    append_configuration_directories(${LLVM_TOOLS_BINARY_DIR} config_dirs)
+    find_program(LLVM_TABLEGEN_EXE ${tblgen_file_name} ${config_dirs} NO_DEFAULT_PATH)
+  endif()
 endif()
 
 # They are used as destination of target generators.


### PR DESCRIPTION
This follows the same pattern as Clang and permits the user to specify
the tablegen to use via `-DLLVM_TABLEGEN=`.  This allows for
cross-compiling LLDB for a foreign target (e.g. Windows ARM64 on Windows
X64).  The LLVM dependency for LLDB in that case must be a Windows ARM64
build which cannot cross-compile llvm-tblgen due to the way that Visual
Studio works.  Instead, permit the user to have a separate tablegen
build which can be used during the build.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@366639 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit e69fd7651e7a5c51c7ea64246dc31fcac1dc0b94)