### PR TITLE
Cherry pick Fix CreateFunctionTemplateSpecialization to prevent dangling poiner to stack memory

### DIFF
--- a/packages/Python/lldbsuite/test/expression_command/function_template_specialization_temp_args/Makefile
+++ b/packages/Python/lldbsuite/test/expression_command/function_template_specialization_temp_args/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../make
+
+CXX_SOURCES := main.cpp
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/expression_command/function_template_specialization_temp_args/TestFunctionTemplateSpecializationTempArgs.py
+++ b/packages/Python/lldbsuite/test/expression_command/function_template_specialization_temp_args/TestFunctionTemplateSpecializationTempArgs.py
@@ -1,0 +1,17 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class TestFunctionTemplateSpecializationTempArgs(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def test_function_template_specialization_temp_args(self):
+        self.build()
+
+        (self.target, self.process, _, bkpt) = lldbutil.run_to_source_breakpoint(self, '// break here',
+                lldb.SBFileSpec("main.cpp", False))
+
+        self.expect("expr p0",
+                substrs=['(VType) $0 = {}'])

--- a/packages/Python/lldbsuite/test/expression_command/function_template_specialization_temp_args/main.cpp
+++ b/packages/Python/lldbsuite/test/expression_command/function_template_specialization_temp_args/main.cpp
@@ -1,0 +1,17 @@
+template <typename T> struct M {};
+
+template <typename T> void f(T &t);
+
+template <> void f<int>(int &t) {
+  typedef M<int> VType;
+
+  VType p0; // break here
+}
+
+int main() {
+  int x;
+
+  f(x);
+
+  return 0;
+}

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -1639,10 +1639,11 @@ clang::FunctionTemplateDecl *ClangASTContext::CreateFunctionTemplateDecl(
 void ClangASTContext::CreateFunctionTemplateSpecializationInfo(
     FunctionDecl *func_decl, clang::FunctionTemplateDecl *func_tmpl_decl,
     const TemplateParameterInfos &infos) {
-  TemplateArgumentList template_args(TemplateArgumentList::OnStack, infos.args);
+  TemplateArgumentList *template_args_ptr =
+      TemplateArgumentList::CreateCopy(func_decl->getASTContext(), infos.args);
 
-  func_decl->setFunctionTemplateSpecialization(func_tmpl_decl, &template_args,
-                                               nullptr);
+  func_decl->setFunctionTemplateSpecialization(func_tmpl_decl,
+                                               template_args_ptr, nullptr);
 }
 
 ClassTemplateDecl *ClangASTContext::CreateClassTemplateDecl(


### PR DESCRIPTION
In ClangASTContext::CreateFunctionTemplateSpecializationInfo a TemplateArgumentList is allocated on the stack but is treated as if it is persistent in subsequent calls. When we exit the function func_decl will still point to the stack allocated memory. We will use TemplateArgumentList::CreateCopy instead which will allocate memory out of the DeclContext.

Differential Revision: https://reviews.llvm.org/D64777

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@366365 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit ce6bbd355f9b9e999b8e2681a55b1f758d28de56)