### PR TITLE
test: only pass `-sdk` on Darwin targets

### DIFF
--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -538,7 +538,9 @@ ifeq "$(USESWIFTDRIVER)" "1"
 	ifneq "$(TRIPLE)" ""
 		SWIFTFLAGS += -target $(TRIPLE)
 	endif
-	SWIFTFLAGS += -sdk "$(SWIFTSDKROOT)"
+	ifeq "$(OS)" "Darwin"
+		SWIFTFLAGS += -sdk "$(SWIFTSDKROOT)"
+	endif
 endif
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
On non-Darwin targets, the `-sdk` parameter may or may not contain the
sysroot which is needed to enable the use of `-sdk` to allow
cross-compilation.  This SDK contains the swift modules and the swift
runtime registrar.  Setting the SDKROOT to `/` on Linux requires that
the Swift SDK contents are installed to `/`.