### PR TITLE
[Swift] Update for ASTWalker change with accessors

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -713,10 +713,7 @@ void SwiftASTManipulator::MakeDeclarationsPublic() {
   };
 
   Publicist p;
-
-  for (swift::Decl *decl : m_source_file.Decls) {
-    decl->walk(p);
-  }
+  m_source_file.walk(p);
 }
 
 static bool hasInit(swift::PatternBindingDecl *pattern_binding) {

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -494,6 +494,7 @@ bool SwiftASTManipulator::RewriteResult() {
 
       // Don't step into function declarations, they may have returns, but we
       // don't want to instrument them.
+      case swift::DeclKind::Accessor:
       case swift::DeclKind::Func:
       case swift::DeclKind::Class:
       case swift::DeclKind::Struct:


### PR DESCRIPTION
Accessors are now visited in between the pre- and post-visits of an
AbstractStorageDecl.