### PR TITLE
[Swift][test] Disable SwiftInterface REPL tests on Linux due to flakiness

### DIFF
--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -1,5 +1,8 @@
 // Test that .swiftinterface files can be loaded via the repl.
 
+// Disabled on linux due to flakiness in CI (rdar://problem/53181277)
+// REQUIRES: system-darwin
+
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cp %S/Inputs/A.swift %t/AA.swift

--- a/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -4,6 +4,9 @@
 // modes as this also causes the Swift stdlib to be loaded via its module
 // interface file, which slows down this test considerably.
 
+// Disabled on linux due to flakiness in CI (rdar://problem/53312825)
+// REQUIRES: system-darwin
+
 // RUN: rm -rf %t && mkdir %t
 
 // Setup generates a dylib and .swiftinterface for A.swift as is, but generates


### PR DESCRIPTION
One or the other is failing every so often in CI with `Exit Code: 74`

Tracking radars:
rdar://problem/53312825 for lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
rdar://problem/53181277 for lit/SwiftREPL/SwiftInterface.test