### PR TITLE
[Reproducers] Add support for Swift modules

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -34,6 +34,7 @@
 namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
 class CanType;
+class DependencyTracker;
 class DWARFImporter;
 class IRGenOptions;
 class NominalTypeDecl;
@@ -822,6 +823,7 @@ protected:
   std::unique_ptr<swift::irgen::IRGenModule> m_ir_gen_module_ap;
   llvm::once_flag m_ir_gen_module_once;
   std::unique_ptr<swift::DiagnosticConsumer> m_diagnostic_consumer_ap;
+  std::unique_ptr<swift::DependencyTracker> m_dependency_tracker;
   std::unique_ptr<DWARFASTParser> m_dwarf_ast_parser_ap;
   /// A collection of (not necessarily fatal) error messages that
   /// should be printed by Process::PrintWarningCantLoadSwift().

--- a/lit/Reproducer/Swift/Inputs/Module.in
+++ b/lit/Reproducer/Swift/Inputs/Module.in
@@ -1,0 +1,8 @@
+breakpoint set -f Module.swift -l 4
+run
+bt
+p let $bar = Foo(i: 95126)
+p $bar.i
+cont
+reproducer status
+reproducer generate

--- a/lit/Reproducer/Swift/Inputs/Module.swift
+++ b/lit/Reproducer/Swift/Inputs/Module.swift
@@ -1,0 +1,7 @@
+import Bar
+
+func main() {
+  let foo = Foo(i: 42)
+}
+
+main()

--- a/lit/Reproducer/Swift/Inputs/module.modulemap
+++ b/lit/Reproducer/Swift/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module Bar {
+    header "Foo.h"
+    export *
+}

--- a/lit/Reproducer/Swift/TestModule.test
+++ b/lit/Reproducer/Swift/TestModule.test
@@ -1,0 +1,37 @@
+# UNSUPPORTED: system-windows, system-freebsd
+
+# This tests replaying a Swift reproducer with bridging.
+
+# Start clean.
+# RUN: rm -rf %t.build && mkdir %t.build && cd %t.build
+# RUN: cp %S/Inputs/Module.swift %t.build/Module.swift
+# RUN: cp %S/Inputs/module.modulemap %t.build/module.modulemap
+# RUN: cp %S/Inputs/Foo.h %t.build/Foo.h
+
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t.build/cache %t.build/Module.swift \
+# RUN:          -I. \
+# RUN:          -module-name main -o %t.out
+
+# Change to run directory.
+# RUN: rm -rf %t.repro
+# RUN: rm -rf %t.run && mkdir %t.run && cd %t.run
+
+# Capture the reproducer.
+# RUN: %lldb -x -b -s %S/Inputs/Module.in \
+# RUN:          --capture \
+# RUN:          --capture-path %t.repro \
+# RUN:          %t.out | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+
+# Cleanup build directory.
+# RUN: rm -rf %t.build
+
+# Replay the reproducer in place.
+# RUN: %lldb --replay %t.repro | FileCheck %s --check-prefix CHECK
+
+# CHECK: Breakpoint 1
+# CHECK: Process {{.*}} stopped
+# CHECK: thread {{.*}} stop reason = breakpoint
+# CHECK: frame {{.*}} Module.swift
+# CHECK: $R0 = 95126
+


### PR DESCRIPTION
This add support for Swift modules and a corresponding test case. For
this to work we need to add a callback in Swift's dependency collector,
to notify LLDB's FileCollector. This will ensure the modulemap and
header end up in the reproducer.