### PR TITLE
[Swift] Test simple cases of @_implementationOnly import

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/ReadMe.md
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/ReadMe.md
@@ -1,0 +1,11 @@
+These tests concern the experimental Swift feature `@_implementationOnly import`.\* Unlike a normal import, an `@_implementationOnly` import is guaranteed not to be part of a library's API or ABI, which means that client apps don't have to know about the import at all to use the library. However, the import *can* be used in the *implementation* of the library, so it's important for LLDB to handle the cases where the `@_implementationOnly` import is and isn't available when debugging.
+
+In a scenario with a client app, a library, and an implementation-only import that the library uses, there are three situations we care about:
+
+1. The library has no debug info, or just line tables. In this case, the implementation-only import is irrelevant; someone debugging the app can only use the public parts of the library.
+
+2. The library has debug info and the implementation-only import is available. In this case, the debugger should make everything available like it would with a normal import.
+
+3. The library has debug info, but the implementation-only import is not available (for whatever reason). In this case LLDB may still have to deal with internal parts of the library even though some types will not be available. (This is the least important case, but it'd be good to not crash or lie to users.)
+
+\* Hopefully someone will remember to edit this ReadMe before the feature goes public!

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/dylib.mk
@@ -1,0 +1,12 @@
+# There's one extra level here because this is called from the tests in the subdirectories.
+LEVEL = ../../../../make
+DYLIB_ONLY := YES
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+# Disable debug info for the library.
+override MAKE_DSYM := NO
+EXCLUDE_WRAPPED_SWIFTMODULE := YES
+SWIFTFLAGS := -gnone -I. -module-link-name $(BASENAME)
+LD_EXTRAS := -L.
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/Makefile
@@ -1,0 +1,21 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES=main.swift
+SWIFTFLAGS_EXTRAS= -I.
+LD_EXTRAS=-L.
+
+all: SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
+
+include $(LEVEL)/Makefile.rules
+
+SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
+	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \
+		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
+
+SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
+	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \
+		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
+
+clean::
+	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/SomeLibrary.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/SomeLibrary.swift
@@ -1,0 +1,16 @@
+@_implementationOnly import SomeLibraryCore
+
+internal class BoxedTwoInts {
+  internal var value: TwoInts
+  init(_ value: TwoInts) { self.value = value }
+}
+
+public struct ContainsTwoInts {
+  internal var wrapped: BoxedTwoInts
+  public var other: Int
+
+  public init(_ value: Int) {
+    wrapped = BoxedTwoInts(.init(2, 3))
+    other = value
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/SomeLibraryCore.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/SomeLibraryCore.swift
@@ -1,0 +1,8 @@
+public struct TwoInts {
+  public var first: Int
+  public var second: Int
+  public init(_ first: Int, _ second: Int) {
+    self.first = first
+    self.second = second
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -1,0 +1,89 @@
+# TestLibraryIndirect.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test `@_implementationOnly import` behind some indirection in a library used by the main executable
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import time
+import unittest2
+
+class TestLibraryIndirect(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def launch_info(self):
+        info = lldb.SBLaunchInfo([])
+
+        if self.getPlatform() == "freebsd" or self.getPlatform() == "linux":
+            # LD_LIBRARY_PATH must be set so the shared libraries are found on
+            # startup
+            library_path = os.environ.get("LD_LIBRARY_PATH", "")
+            if library_path:
+                library_path += ":"
+            library_path += self.getBuildDir()
+
+            info.SetEnvironmentEntries(["LD_LIBRARY_PATH=" + library_path], True)
+
+        return info
+
+    @swiftTest
+    def test_implementation_only_import_library(self):
+        """Test `@_implementationOnly import` behind some indirection in a library used by the main executable
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+        self.build()
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.ContainsTwoInts) container = {\n  wrapped = 0x",
+            "\n    value = (first = 2, second = 3)\n  }\n  other = 10\n}",
+            "(Int) simple = 1"])
+        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
+        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "{}"])
+        self.expect("e container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])
+
+    @swiftTest
+    def test_implementation_only_import_library_no_library_module(self):
+        """Test `@_implementationOnly import` behind some indirection in a library used by the main executable, after removing the implementation-only library's swiftmodule
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build()
+        os.remove(self.getBuildArtifact("SomeLibraryCore.swiftmodule"))
+        os.remove(self.getBuildArtifact("SomeLibraryCore.swiftinterface"))
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.ContainsTwoInts) container = (wrapped = 0x",
+            ", other = 10)",
+            "(Int) simple = 1"])
+        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "(wrapped = 0x", ", other = 10"])
+        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "{}"])
+        self.expect("e container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/main.swift
@@ -1,0 +1,11 @@
+import SomeLibrary
+
+func stop() {}
+
+func test() {
+  let container = ContainsTwoInts(10)
+  let simple = 1
+  stop() // break here
+}
+
+test()

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/Makefile
@@ -1,0 +1,23 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES=main.swift
+SWIFTFLAGS_EXTRAS= -I.
+LD_EXTRAS=-L.
+
+all: SomeLibraryCore.swiftmodule SomeLibrary.swiftmodule a.out
+
+include $(LEVEL)/Makefile.rules
+
+SomeLibraryCore.swiftmodule: SomeLibraryCore.swift
+	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \
+		SWIFTFLAGS_EXTRAS=-enable-library-evolution \
+		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
+
+SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
+	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \
+		SWIFTFLAGS_EXTRAS=-enable-library-evolution \
+		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
+
+clean::
+	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/SomeLibrary.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/SomeLibrary.swift
@@ -1,0 +1,11 @@
+@_implementationOnly import SomeLibraryCore
+
+public struct ContainsTwoInts {
+  internal var wrapped: TwoInts
+  public var other: Int
+
+  public init(_ value: Int) {
+    wrapped = .init(2, 3)
+    other = value
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/SomeLibraryCore.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/SomeLibraryCore.swift
@@ -1,0 +1,8 @@
+public struct TwoInts {
+  public var first: Int
+  public var second: Int
+  public init(_ first: Int, _ second: Int) {
+    self.first = first
+    self.second = second
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -1,0 +1,88 @@
+# TestLibraryResilient.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test `@_implementationOnly import` in a resilient library used by the main executable
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import time
+import unittest2
+
+class TestLibraryResilient(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def launch_info(self):
+        info = lldb.SBLaunchInfo([])
+
+        if self.getPlatform() == "freebsd" or self.getPlatform() == "linux":
+            # LD_LIBRARY_PATH must be set so the shared libraries are found on
+            # startup
+            library_path = os.environ.get("LD_LIBRARY_PATH", "")
+            if library_path:
+                library_path += ":"
+            library_path += self.getBuildDir()
+
+            info.SetEnvironmentEntries(["LD_LIBRARY_PATH=" + library_path], True)
+
+        return info
+
+    @swiftTest
+    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    def test_implementation_only_import_library(self):
+        """Test `@_implementationOnly import` in a resilient library used by the main executable
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build()
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}",
+            "(Int) simple = 1"])
+        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
+        self.expect("e container.wrapped", error=True, substrs=["value of type 'ContainsTwoInts' has no member 'wrapped'"])
+
+    @swiftTest
+    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    def test_implementation_only_import_library_no_library_module(self):
+        """Test `@_implementationOnly import` in a resilient library used by the main executable, after removing the implementation-only library's swiftmodule
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build()
+        os.remove(self.getBuildArtifact("SomeLibraryCore.swiftmodule"))
+        os.remove(self.getBuildArtifact("SomeLibraryCore.swiftinterface"))
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.ContainsTwoInts) container = (other = 10)",
+            "(Int) simple = 1"])
+        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
+        self.expect("e container.wrapped", error=True, substrs=["value of type 'ContainsTwoInts' has no member 'wrapped'"])

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/main.swift
@@ -1,0 +1,11 @@
+import SomeLibrary
+
+func stop() {}
+
+func test() {
+  let container = ContainsTwoInts(10)
+  let simple = 1
+  stop() // break here
+}
+
+test()

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -1,0 +1,19 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES=main.swift
+SWIFTFLAGS_EXTRAS= -I$(shell pwd)
+MODULENAME=main
+LD_EXTRAS=-L$(shell pwd)
+
+all: SomeLibrary.swiftmodule a.out
+
+include $(LEVEL)/Makefile.rules
+
+SomeLibrary.swiftmodule: SomeLibrary.swift
+	$(MAKE) BASENAME=$(shell basename $@ .swiftmodule) \
+		SWIFTFLAGS_EXTRAS=$(LIBRARY_SWIFTFLAGS_EXTRAS) \
+		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
+
+clean::
+	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/SomeLibrary.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/SomeLibrary.swift
@@ -1,0 +1,8 @@
+public struct TwoInts {
+  public var first: Int
+  public var second: Int
+  public init(_ first: Int, _ second: Int) {
+    self.first = first
+    self.second = second
+  }
+}

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -1,0 +1,147 @@
+# TestMainExecutable.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+"""
+Test `@_implementationOnly import` in the main executable
+"""
+import commands
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import os.path
+import time
+import unittest2
+
+class TestMainExecutable(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    def launch_info(self):
+        info = lldb.SBLaunchInfo([])
+
+        if self.getPlatform() == "freebsd" or self.getPlatform() == "linux":
+            # LD_LIBRARY_PATH must be set so the shared libraries are found on
+            # startup
+            library_path = os.environ.get("LD_LIBRARY_PATH", "")
+            if library_path:
+                library_path += ":"
+            library_path += self.getBuildDir()
+
+            info.SetEnvironmentEntries(["LD_LIBRARY_PATH=" + library_path], True)
+
+        return info
+
+    @swiftTest
+    def test_implementation_only_import_main_executable(self):
+        """Test `@_implementationOnly import` in the main executable
+
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build()
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.TwoInts) value = (first = 2, second = 3)",
+            "(main.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}",
+            "(Int) simple = 1"])
+        self.expect("e value", substrs=["(SomeLibrary.TwoInts)", "= (first = 2, second = 3)"])
+        self.expect("e container", substrs=["(main.ContainsTwoInts)", "wrapped = (first = 2, second = 3)", "other = 10"])
+        self.expect("e TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
+    
+    @swiftTest
+    def test_implementation_only_import_main_executable_no_library_module(self):
+        """Test `@_implementationOnly import` in the main executable, after removing the library's swiftmodule
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build()
+        os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
+        os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # FIXME: This particular test config is producing different results on
+        # different machines, but it's also the least important configuration
+        # (trying to debug something built against a library without that
+        # library present, implementation-only or not, and that library doesn't
+        # even have library evolution support enabled. Just make sure we don't
+        # crash.
+        self.expect("fr var", substrs=[
+            "value = <could not resolve type>",
+#            "container = {}",
+            "simple = 1"])
+
+        self.expect("e value", error=True)
+        self.expect("e container", error=True)
+        self.expect("e TwoInts(4, 5)", error=True)
+
+    @swiftTest
+    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    def test_implementation_only_import_main_executable_resilient(self):
+        """Test `@_implementationOnly import` in the main executable with a resilient library
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build(dictionary={"LIBRARY_SWIFTFLAGS_EXTRAS": "-enable-library-evolution"})
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "(SomeLibrary.TwoInts) value = (first = 2, second = 3)",
+            "(main.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}",
+            "(Int) simple = 1"])
+        self.expect("e value", substrs=["(SomeLibrary.TwoInts)", "= (first = 2, second = 3)"])
+        self.expect("e container", substrs=["(main.ContainsTwoInts)", "wrapped = (first = 2, second = 3)", "other = 10"])
+        self.expect("e TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
+    
+    @swiftTest
+    @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
+    def test_implementation_only_import_main_executable_resilient_no_library_module(self):
+        """Test `@_implementationOnly import` in the main executable with a resilient library, after removing the library's swiftmodule
+        
+        See the ReadMe.md in the parent directory for more information.
+        """
+
+        self.build(dictionary={"LIBRARY_SWIFTFLAGS_EXTRAS": "-enable-library-evolution"})
+        os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
+        os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
+        def cleanup():
+            lldbutil.execute_command("make cleanup")
+        self.addTearDownHook(cleanup)
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+
+        # This test is deliberately checking what the user will see, rather than
+        # the structure provided by the Python API, in order to test the recovery.
+        self.expect("fr var", substrs=[
+            "value = <could not resolve type>",
+            "(main.ContainsTwoInts) container = (other = 10)",
+            "(Int) simple = 1"])
+        # FIXME: If we could figure out how to ignore this failure but still not
+        # crash if we touch something that can't be loaded, that would be nice.
+        self.expect("e value", error=True, substrs=["failed to get module \"SomeLibrary\" from AST context"])
+        self.expect("e container", error=True, substrs=["failed to get module \"SomeLibrary\" from AST context"])
+        self.expect("e TwoInts(4, 5)", error=True, substrs=["failed to get module \"SomeLibrary\" from AST context"])

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/main.swift
@@ -1,0 +1,16 @@
+@_implementationOnly import SomeLibrary
+
+func stop() {}
+
+struct ContainsTwoInts {
+  var wrapped: TwoInts
+  var other: Int
+}
+
+func test(_ value: TwoInts) {
+  let container = ContainsTwoInts(wrapped: value, other: 10)
+  let simple = 1
+  stop() // break here
+}
+
+test(TwoInts(2, 3))

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -651,10 +651,10 @@ endif
 ifeq "$(USESWIFTDRIVER)" "1"
 #----------------------------------------------------------------------
 ifeq "$(DYLIB_NAME)" ""
-MODULENAME=$(shell basename $(EXE) .out)
+MODULENAME?=$(shell basename $(EXE) .out)
 else
 EXE = $(DYLIB_FILENAME)
-MODULENAME=$(DYLIB_NAME)
+MODULENAME?=$(DYLIB_NAME)
 SWIFT_FEFLAGS += -parse-as-library
 endif
 


### PR DESCRIPTION
This feature deserves more tests, but this gets the "don't crash" part in place, and helped shake out early bugs on the compiler side. Continuing from #1414; I think it's ready to go now!