### PR TITLE
[SwiftLanguageRuntime] TypeDecoder wants a canonical name.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/optional_url/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/optional_url/Makefile
@@ -1,0 +1,4 @@
+LEVEL = ../../../make
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/optional_url/TestOptionalURL.py
+++ b/packages/Python/lldbsuite/test/lang/swift/optional_url/TestOptionalURL.py
@@ -1,0 +1,4 @@
+import lldbsuite.test.lldbinline as lldbinline
+from lldbsuite.test.decorators import *
+
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessDarwin])

--- a/packages/Python/lldbsuite/test/lang/swift/optional_url/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/optional_url/main.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+let u : URL? = URL(string: "https://github.com")
+print(u) //%self.expect('po u', substrs=['https://github.com'])

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2560,7 +2560,8 @@ lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
 const swift::reflection::TypeInfo *
 SwiftLanguageRuntime::GetTypeInfo(CompilerType type) {
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  ConstString mangled_name(type.GetMangledTypeName());
+  CompilerType can_type(swift_can_type);
+  ConstString mangled_name(can_type.GetMangledTypeName());
   StringRef mangled_no_prefix =
       swift::Demangle::dropSwiftManglingPrefix(mangled_name.GetStringRef());
   swift::Demangle::Demangler Dem;


### PR DESCRIPTION
Otherwise mangledName -> typeRef conversion fails, we can't retrieve
the type, and we can't print it.

SR-11226.