### PR TITLE
Use llvm::Expected when getting TypeSystems

### DIFF
--- a/include/lldb/Core/Module.h
+++ b/include/lldb/Core/Module.h
@@ -812,24 +812,8 @@ public:
 
   bool GetIsDynamicLinkEditor();
 
-  // This function must be called immediately after construction of the Module
-  // in the cases where the AST is to be shared.
-  void SetTypeSystemForLanguage(lldb::LanguageType language,
-                                const lldb::TypeSystemSP &type_system_sp);
-
-#ifdef __clang_analyzer__
-  // See GetScratchTypeSystemForLanguage() in Target.h for what this block does
-  TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language)
-      __attribute__((always_inline)) {
-    TypeSystem *ret = GetTypeSystemForLanguageImpl(language);
-    return ret ? ret : nullptr;
-  }
-
-  TypeSystem *GetTypeSystemForLanguageImpl(lldb::LanguageType language);
-#else
-  TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language);
-  TypeSystem *GetTypeSystemForLanguageNoCreate(lldb::LanguageType language);
-#endif
+  llvm::Expected<TypeSystem &>
+  GetTypeSystemForLanguage(lldb::LanguageType language);
 
   // Special error functions that can do printf style formatting that will
   // prepend the message with something appropriate for this module (like the

--- a/include/lldb/Symbol/SymbolFile.h
+++ b/include/lldb/Symbol/SymbolFile.h
@@ -203,7 +203,7 @@ public:
 
   virtual void PreloadSymbols();
 
-  virtual lldb_private::TypeSystem *
+  virtual llvm::Expected<lldb_private::TypeSystem &>
   GetTypeSystemForLanguage(lldb::LanguageType language);
 
   virtual CompilerDeclContext

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/APSInt.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Error.h"
 
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Expression/Expression.h"
@@ -539,21 +540,17 @@ public:
   // callback to keep iterating, false to stop iterating.
   void ForEach(std::function<bool(TypeSystem *)> const &callback);
 
-  TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language,
-                                       Module *module, bool can_create);
-
-  TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language,
-                                       Target *target, bool can_create,
-                                       const char *compiler_options);
-
   void RemoveTypeSystemsForLanguage(lldb::LanguageType language);
 
-protected:
-  // This function does not take the map mutex, and should only be called from
-  // functions that do take the mutex.
-  void AddToMap(lldb::LanguageType language,
-                lldb::TypeSystemSP const &type_system_sp);
+  llvm::Expected<TypeSystem &>
+  GetTypeSystemForLanguage(lldb::LanguageType language, Module *module,
+                           bool can_create);
 
+  llvm::Expected<TypeSystem &>
+  GetTypeSystemForLanguage(lldb::LanguageType language, Target *target,
+                           bool can_create, const char *compiler_options);
+
+protected:
   typedef std::map<lldb::LanguageType, lldb::TypeSystemSP> collection;
   mutable std::mutex m_mutex; ///< A mutex to keep this object happy in
                               ///multi-threaded environments.

--- a/include/lldb/Target/Target.h
+++ b/include/lldb/Target/Target.h
@@ -1063,8 +1063,8 @@ public:
 
   PathMappingList &GetImageSearchPathList();
 
-  TypeSystem *
-  GetScratchTypeSystemForLanguage(Status *error, lldb::LanguageType language,
+  llvm::Expected<TypeSystem &>
+  GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                                   bool create_on_demand = true,
                                   const char *compiler_options = nullptr);
 

--- a/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
+++ b/source/Plugins/InstrumentationRuntime/MainThreadChecker/MainThreadCheckerRuntime.cpp
@@ -81,8 +81,14 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
   ModuleSP swiftModule = swiftFrame->GetFrameCodeAddress().GetModule();
   if (!swiftModule)
     return "";
-  SwiftASTContext *ctx = llvm::dyn_cast_or_null<SwiftASTContext>(
-      swiftModule->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift));
+
+  auto type_system_or_err = swiftModule->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+  if (!type_system_or_err) {
+    llvm::consumeError(type_system_or_err.takeError());
+    return "";
+  }
+
+  auto *ctx = llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/source/Plugins/Language/ObjC/CoreMedia.cpp
+++ b/source/Plugins/Language/ObjC/CoreMedia.cpp
@@ -10,6 +10,7 @@
 #include "CoreMedia.h"
 
 #include "lldb/Utility/Flags.h"
+#include "lldb/Utility/Log.h"
 
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Target/Target.h"
@@ -25,18 +26,21 @@ bool lldb_private::formatters::CMTimeSummaryProvider(
   if (!type.IsValid())
     return false;
 
-  TypeSystem *type_system =
+  auto type_system_or_err =
       valobj.GetExecutionContextRef()
           .GetTargetSP()
-          ->GetScratchTypeSystemForLanguage(nullptr, lldb::eLanguageTypeC);
-  if (!type_system)
+          ->GetScratchTypeSystemForLanguage(lldb::eLanguageTypeC);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(
+        lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_DATAFORMATTERS),
+        std::move(err), "Failed to get scratch type system");
     return false;
-
+  }
   // fetch children by offset to compensate for potential lack of debug info
-  auto int64_ty =
-      type_system->GetBuiltinTypeForEncodingAndBitSize(eEncodingSint, 64);
-  auto int32_ty =
-      type_system->GetBuiltinTypeForEncodingAndBitSize(eEncodingSint, 32);
+  auto int64_ty = type_system_or_err->GetBuiltinTypeForEncodingAndBitSize(
+      eEncodingSint, 64);
+  auto int32_ty = type_system_or_err->GetBuiltinTypeForEncodingAndBitSize(
+      eEncodingSint, 32);
 
   auto value_sp(valobj.GetSyntheticChildAtOffset(0, int64_ty, true));
   auto timescale_sp(valobj.GetSyntheticChildAtOffset(8, int32_ty, true));

--- a/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.h
+++ b/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.h
@@ -118,8 +118,11 @@ public:
   size_t FindTypes(const std::vector<CompilerContext> &context, bool append,
                    TypeMap &types) override;
 
-  TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language) override {
-    return nullptr;
+  llvm::Expected<TypeSystem &>
+  GetTypeSystemForLanguage(lldb::LanguageType language) override {
+    return llvm::make_error<llvm::StringError>(
+        "SymbolFileBreakpad does not support GetTypeSystemForLanguage",
+        llvm::inconvertibleErrorCode());
   }
 
   CompilerDeclContext

--- a/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFBaseDIE.h
@@ -12,6 +12,8 @@
 #include "lldb/Core/dwarf.h"
 #include "lldb/lldb-types.h"
 
+#include "llvm/Support/Error.h"
+
 class DIERef;
 class DWARFASTParser;
 class DWARFAttributes;
@@ -55,7 +57,7 @@ public:
 
   llvm::Optional<DIERef> GetDIERef() const;
 
-  lldb_private::TypeSystem *GetTypeSystem() const;
+  llvm::Expected<lldb_private::TypeSystem &> GetTypeSystem() const;
 
   DWARFASTParser *GetDWARFParser() const;
 

--- a/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -438,7 +438,7 @@ lldb::ByteOrder DWARFUnit::GetByteOrder() const {
   return m_dwarf.GetObjectFile()->GetByteOrder();
 }
 
-TypeSystem *DWARFUnit::GetTypeSystem() {
+llvm::Expected<TypeSystem &> DWARFUnit::GetTypeSystem() {
   return m_dwarf.GetTypeSystemForLanguage(GetLanguageType());
 }
 

--- a/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -153,7 +153,7 @@ public:
 
   lldb::ByteOrder GetByteOrder() const;
 
-  lldb_private::TypeSystem *GetTypeSystem();
+  llvm::Expected<lldb_private::TypeSystem &> GetTypeSystem();
 
   const DWARFDebugAranges &GetFunctionAranges();
 

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -369,17 +369,17 @@ UniqueDWARFASTTypeMap &SymbolFileDWARF::GetUniqueDWARFASTTypeMap() {
     return m_unique_ast_type_map;
 }
 
-TypeSystem *SymbolFileDWARF::GetTypeSystemForLanguage(LanguageType language) {
-  SymbolFileDWARFDebugMap *debug_map_symfile = GetDebugMapSymfile();
-  TypeSystem *type_system;
-  if (debug_map_symfile) {
-    type_system = debug_map_symfile->GetTypeSystemForLanguage(language);
-  } else {
-    type_system = m_obj_file->GetModule()->GetTypeSystemForLanguage(language);
-    if (type_system)
-      type_system->SetSymbolFile(this);
+llvm::Expected<TypeSystem &>
+SymbolFileDWARF::GetTypeSystemForLanguage(LanguageType language) {
+  if (SymbolFileDWARFDebugMap *debug_map_symfile = GetDebugMapSymfile())
+    return debug_map_symfile->GetTypeSystemForLanguage(language);
+
+  auto type_system_or_err =
+      m_obj_file->GetModule()->GetTypeSystemForLanguage(language);
+  if (type_system_or_err) {
+    type_system_or_err->SetSymbolFile(this);
   }
-  return type_system;
+  return type_system_or_err;
 }
 
 void SymbolFileDWARF::InitializeObject() {
@@ -735,17 +735,21 @@ CompUnitSP SymbolFileDWARF::ParseCompileUnitAtIndex(uint32_t cu_idx) {
 Function *SymbolFileDWARF::ParseFunction(CompileUnit &comp_unit,
                                          const DWARFDIE &die) {
   ASSERT_MODULE_LOCK(this);
-  if (die.IsValid()) {
-    TypeSystem *type_system =
-        GetTypeSystemForLanguage(die.GetCU()->GetLanguageType());
+  if (!die.IsValid())
+    return nullptr;
 
-    if (type_system) {
-      DWARFASTParser *dwarf_ast = type_system->GetDWARFParser();
-      if (dwarf_ast)
-        return dwarf_ast->ParseFunctionFromDWARF(comp_unit, die);
-    }
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(die.GetCU()->GetLanguageType());
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to parse function");
+    return nullptr;
   }
-  return nullptr;
+  DWARFASTParser *dwarf_ast = type_system_or_err->GetDWARFParser();
+  if (!dwarf_ast)
+    return nullptr;
+
+  return dwarf_ast->ParseFunctionFromDWARF(comp_unit, die);
 }
 
 bool SymbolFileDWARF::FixupAddress(Address &addr) {
@@ -1184,7 +1188,9 @@ bool SymbolFileDWARF::ClassOrStructIsVirtual(const DWARFDIE &parent_die) {
 }
 
 void SymbolFileDWARF::ParseDeclsForContext(CompilerDeclContext decl_ctx) {
-  TypeSystem *type_system = decl_ctx.GetTypeSystem();
+  auto *type_system = decl_ctx.GetTypeSystem();
+  if (!type_system)
+    return;
   DWARFASTParser *ast_parser = type_system->GetDWARFParser();
   std::vector<DWARFDIE> decl_ctx_die_list =
       ast_parser->GetDIEForDeclContext(decl_ctx);
@@ -1955,9 +1961,16 @@ bool SymbolFileDWARF::DeclContextMatchesThisSymbolFile(
   }
 
   TypeSystem *decl_ctx_type_system = decl_ctx->GetTypeSystem();
-  TypeSystem *type_system = GetTypeSystemForLanguage(
+  auto type_system_or_err = GetTypeSystemForLanguage(
       decl_ctx_type_system->GetMinimumLanguage(nullptr));
-  if (decl_ctx_type_system == type_system)
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err),
+                   "Unable to match namespace decl using TypeSystem");
+    return false;
+  }
+
+  if (decl_ctx_type_system == &type_system_or_err.get())
     return true; // The type systems match, return true
 
   // The namespace AST was valid, and it does not match...
@@ -2868,10 +2881,18 @@ TypeSP SymbolFileDWARF::FindDefinitionTypeForDWARFDeclContext(
       // use this to ensure any matches we find are in a language that this
       // type system supports
       const LanguageType language = dwarf_decl_ctx.GetLanguage();
-      TypeSystem *type_system = (language == eLanguageTypeUnknown)
-                                    ? nullptr
-                                    : GetTypeSystemForLanguage(language);
-
+      TypeSystem *type_system = nullptr;
+      if (language != eLanguageTypeUnknown) {
+        auto type_system_or_err = GetTypeSystemForLanguage(language);
+        if (auto err = type_system_or_err.takeError()) {
+          LLDB_LOG_ERROR(
+              lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+              std::move(err), "Cannot get TypeSystem for language {}",
+              Language::GetNameForLanguageType(language));
+        } else {
+          type_system = &type_system_or_err.get();
+        }
+      }
       if (num_matches) {
         for (size_t i = 0; i < num_matches; ++i) {
           const DIERef &die_ref = die_offsets[i];
@@ -3094,12 +3115,15 @@ TypeSP SymbolFileDWARF::ParseType(const SymbolContext &sc, const DWARFDIE &die,
   if (!die)
     return {};
 
-  TypeSystem *type_system =
+  auto type_system_or_err =
       GetTypeSystemForLanguage(die.GetCU()->GetLanguageType());
-  if (!type_system)
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to parse type");
     return {};
+  }
 
-  DWARFASTParser *dwarf_ast = type_system->GetDWARFParser();
+  DWARFASTParser *dwarf_ast = type_system_or_err->GetDWARFParser();
   if (!dwarf_ast)
     return {};
 
@@ -3856,8 +3880,10 @@ void SymbolFileDWARF::Dump(lldb_private::Stream &s) {
 }
 
 void SymbolFileDWARF::DumpClangAST(Stream &s) {
-  TypeSystem *ts = GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
-  ClangASTContext *clang = llvm::dyn_cast_or_null<ClangASTContext>(ts);
+  auto ts_or_err = GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
+  if (!ts_or_err)
+    return;
+  ClangASTContext *clang = llvm::dyn_cast_or_null<ClangASTContext>(&ts_or_err.get());
   if (!clang)
     return;
   clang->Dump(s);

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -192,7 +192,7 @@ public:
                   lldb::TypeClass type_mask,
                   lldb_private::TypeList &type_list) override;
 
-  lldb_private::TypeSystem *
+  llvm::Expected<lldb_private::TypeSystem &>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   lldb_private::CompilerDeclContext FindNamespace(

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
@@ -140,7 +140,7 @@ SymbolFileDWARFDwo::GetLocationListFormat() const {
   return DWARFExpression::SplitDwarfLocationList;
 }
 
-TypeSystem *
+llvm::Expected<TypeSystem &>
 SymbolFileDWARFDwo::GetTypeSystemForLanguage(LanguageType language) {
   return GetBaseSymbolFile().GetTypeSystemForLanguage(language);
 }

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
@@ -30,7 +30,7 @@ public:
   size_t GetObjCMethodDIEOffsets(lldb_private::ConstString class_name,
                                  DIEArray &method_die_offsets) override;
 
-  lldb_private::TypeSystem *
+  llvm::Expected<lldb_private::TypeSystem &>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   DWARFDIE

--- a/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -121,13 +121,6 @@ AnyScopesHaveTemplateParams(llvm::ArrayRef<llvm::ms_demangle::Node *> scopes) {
   return false;
 }
 
-static ClangASTContext &GetClangASTContext(ObjectFile &obj) {
-  TypeSystem *ts =
-      obj.GetModule()->GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
-  lldbassert(ts);
-  return static_cast<ClangASTContext &>(*ts);
-}
-
 static llvm::Optional<clang::CallingConv>
 TranslateCallingConvention(llvm::codeview::CallingConvention conv) {
   using CC = llvm::codeview::CallingConvention;
@@ -209,8 +202,8 @@ static bool IsAnonymousNamespaceName(llvm::StringRef name) {
   return name == "`anonymous namespace'" || name == "`anonymous-namespace'";
 }
 
-PdbAstBuilder::PdbAstBuilder(ObjectFile &obj, PdbIndex &index)
-    : m_index(index), m_clang(GetClangASTContext(obj)) {
+PdbAstBuilder::PdbAstBuilder(ObjectFile &obj, PdbIndex &index, ClangASTContext &clang)
+    : m_index(index), m_clang(clang) {
   BuildParentMap();
 }
 

--- a/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -51,7 +51,7 @@ struct DeclStatus {
 class PdbAstBuilder {
 public:
   // Constructors and Destructors
-  PdbAstBuilder(ObjectFile &obj, PdbIndex &index);
+  PdbAstBuilder(ObjectFile &obj, PdbIndex &index, ClangASTContext &clang);
 
   lldb_private::CompilerDeclContext GetTranslationUnitDecl();
 

--- a/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
+++ b/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
@@ -137,7 +137,8 @@ public:
   size_t FindTypes(const std::vector<CompilerContext> &context, bool append,
                    TypeMap &types) override;
 
-  TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language) override;
+  llvm::Expected<TypeSystem &>
+  GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   CompilerDeclContext
   FindNamespace(ConstString name,

--- a/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -24,6 +24,7 @@
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/TypeMap.h"
 #include "lldb/Symbol/Variable.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegularExpression.h"
 
 #include "llvm/DebugInfo/PDB/GenericError.h"
@@ -299,11 +300,15 @@ SymbolFilePDB::ParseCompileUnitFunctionForPDBFunc(const PDBSymbolFunc &pdb_func,
   comp_unit.AddFunction(func_sp);
 
   LanguageType lang = ParseLanguage(comp_unit);
-  TypeSystem *type_system = GetTypeSystemForLanguage(lang);
-  if (!type_system)
+  auto type_system_or_err = GetTypeSystemForLanguage(lang);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to parse PDBFunc");
     return nullptr;
+  }
+
   ClangASTContext *clang_type_system =
-    llvm::dyn_cast_or_null<ClangASTContext>(type_system);
+    llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_type_system)
     return nullptr;
   clang_type_system->GetPDBParser()->GetDeclForSymbol(pdb_func);
@@ -548,10 +553,16 @@ lldb_private::Type *SymbolFilePDB::ResolveTypeUID(lldb::user_id_t type_uid) {
   if (find_result != m_types.end())
     return find_result->second.get();
 
-  TypeSystem *type_system =
+  auto type_system_or_err =
       GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to ResolveTypeUID");
+    return nullptr;
+  }
+
   ClangASTContext *clang_type_system =
-      llvm::dyn_cast_or_null<ClangASTContext>(type_system);
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_type_system)
     return nullptr;
   PDBASTParser *pdb = clang_type_system->GetPDBParser();
@@ -579,8 +590,17 @@ bool SymbolFilePDB::CompleteType(lldb_private::CompilerType &compiler_type) {
   std::lock_guard<std::recursive_mutex> guard(
       GetObjectFile()->GetModule()->GetMutex());
 
-  ClangASTContext *clang_ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
-      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus));
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to get dynamic array info for UID");
+    return false;
+  }
+
+  ClangASTContext *clang_ast_ctx =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+
   if (!clang_ast_ctx)
     return false;
 
@@ -592,8 +612,16 @@ bool SymbolFilePDB::CompleteType(lldb_private::CompilerType &compiler_type) {
 }
 
 lldb_private::CompilerDecl SymbolFilePDB::GetDeclForUID(lldb::user_id_t uid) {
-  ClangASTContext *clang_ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
-      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus));
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to get decl for UID");
+    return CompilerDecl();
+  }
+
+  ClangASTContext *clang_ast_ctx =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return CompilerDecl();
 
@@ -614,8 +642,16 @@ lldb_private::CompilerDecl SymbolFilePDB::GetDeclForUID(lldb::user_id_t uid) {
 
 lldb_private::CompilerDeclContext
 SymbolFilePDB::GetDeclContextForUID(lldb::user_id_t uid) {
-  ClangASTContext *clang_ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
-      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus));
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to get DeclContext for UID");
+    return CompilerDeclContext();
+  }
+
+  ClangASTContext *clang_ast_ctx =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return CompilerDeclContext();
 
@@ -636,8 +672,16 @@ SymbolFilePDB::GetDeclContextForUID(lldb::user_id_t uid) {
 
 lldb_private::CompilerDeclContext
 SymbolFilePDB::GetDeclContextContainingUID(lldb::user_id_t uid) {
-  ClangASTContext *clang_ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
-      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus));
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to get DeclContext containing UID");
+    return CompilerDeclContext();
+  }
+
+  ClangASTContext *clang_ast_ctx =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return CompilerDeclContext();
 
@@ -657,8 +701,16 @@ SymbolFilePDB::GetDeclContextContainingUID(lldb::user_id_t uid) {
 
 void SymbolFilePDB::ParseDeclsForContext(
     lldb_private::CompilerDeclContext decl_ctx) {
-  ClangASTContext *clang_ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
-      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus));
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to parse decls for context");
+    return;
+  }
+
+  ClangASTContext *clang_ast_ctx =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_ast_ctx)
     return;
 
@@ -1412,11 +1464,19 @@ uint32_t SymbolFilePDB::FindTypes(
 }
 
 void SymbolFilePDB::DumpClangAST(Stream &s) {
-  auto type_system = GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
-  auto clang = llvm::dyn_cast_or_null<ClangASTContext>(type_system);
-  if (!clang)
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to dump ClangAST");
     return;
-  clang->Dump(s);
+  }
+
+  auto *clang_type_system =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
+  if (!clang_type_system)
+    return;
+  clang_type_system->Dump(s);
 }
 
 void SymbolFilePDB::FindTypesByRegex(
@@ -1609,18 +1669,27 @@ size_t SymbolFilePDB::GetTypes(lldb_private::SymbolContextScope *sc_scope,
   return type_list.GetSize() - old_size;
 }
 
-lldb_private::TypeSystem *
+llvm::Expected<lldb_private::TypeSystem &>
 SymbolFilePDB::GetTypeSystemForLanguage(lldb::LanguageType language) {
-  auto type_system =
+  auto type_system_or_err =
       m_obj_file->GetModule()->GetTypeSystemForLanguage(language);
-  if (type_system)
-    type_system->SetSymbolFile(this);
-  return type_system;
+  if (type_system_or_err) {
+    type_system_or_err->SetSymbolFile(this);
+  }
+  return type_system_or_err;
 }
 
 PDBASTParser *SymbolFilePDB::GetPDBAstParser() {
-  auto type_system = GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
-  auto clang_type_system = llvm::dyn_cast_or_null<ClangASTContext>(type_system);
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to get PDB AST parser");
+    return nullptr;
+  }
+
+  auto *clang_type_system =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_type_system)
     return nullptr;
 
@@ -1632,8 +1701,17 @@ lldb_private::CompilerDeclContext SymbolFilePDB::FindNamespace(
     lldb_private::ConstString name,
     const lldb_private::CompilerDeclContext *parent_decl_ctx) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
-  auto type_system = GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
-  auto clang_type_system = llvm::dyn_cast_or_null<ClangASTContext>(type_system);
+  auto type_system_or_err =
+      GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+                   std::move(err), "Unable to find namespace {}",
+                   name.AsCString());
+    return CompilerDeclContext();
+  }
+
+  auto *clang_type_system =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_type_system)
     return CompilerDeclContext();
 
@@ -1651,7 +1729,7 @@ lldb_private::CompilerDeclContext SymbolFilePDB::FindNamespace(
   if (!namespace_decl)
     return CompilerDeclContext();
 
-  return CompilerDeclContext(type_system,
+  return CompilerDeclContext(clang_type_system,
                              static_cast<clang::DeclContext *>(namespace_decl));
 }
 
@@ -1931,9 +2009,17 @@ bool SymbolFilePDB::DeclContextMatchesThisSymbolFile(
   TypeSystem *decl_ctx_type_system = decl_ctx->GetTypeSystem();
   if (!decl_ctx_type_system)
     return false;
-  TypeSystem *type_system = GetTypeSystemForLanguage(
+  auto type_system_or_err = GetTypeSystemForLanguage(
       decl_ctx_type_system->GetMinimumLanguage(nullptr));
-  if (decl_ctx_type_system == type_system)
+  if (auto err = type_system_or_err.takeError()) {
+    LLDB_LOG_ERROR(
+        lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+        std::move(err),
+        "Unable to determine if DeclContext matches this symbol file");
+    return false;
+  }
+
+  if (decl_ctx_type_system == &type_system_or_err.get())
     return true; // The type systems match, return true
 
   return false;

--- a/source/Plugins/SymbolFile/PDB/SymbolFilePDB.h
+++ b/source/Plugins/SymbolFile/PDB/SymbolFilePDB.h
@@ -142,7 +142,7 @@ public:
                   lldb::TypeClass type_mask,
                   lldb_private::TypeList &type_list) override;
 
-  lldb_private::TypeSystem *
+  llvm::Expected<lldb_private::TypeSystem &>
   GetTypeSystemForLanguage(lldb::LanguageType language) override;
 
   lldb_private::CompilerDeclContext FindNamespace(

--- a/source/Symbol/SymbolFile.cpp
+++ b/source/Symbol/SymbolFile.cpp
@@ -87,12 +87,14 @@ SymbolFile *SymbolFile::FindPlugin(ObjectFile *obj_file) {
   return best_symfile_up.release();
 }
 
-TypeSystem *SymbolFile::GetTypeSystemForLanguage(lldb::LanguageType language) {
-  TypeSystem *type_system =
+llvm::Expected<TypeSystem &>
+SymbolFile::GetTypeSystemForLanguage(lldb::LanguageType language) {
+  auto type_system_or_err =
       m_obj_file->GetModule()->GetTypeSystemForLanguage(language);
-  if (type_system)
-    type_system->SetSymbolFile(this);
-  return type_system;
+  if (type_system_or_err) {
+    type_system_or_err->SetSymbolFile(this);
+  }
+  return type_system_or_err;
 }
 
 bool SymbolFile::ForceInlineSourceFileCheck() {

--- a/source/Symbol/Type.cpp
+++ b/source/Symbol/Type.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/StreamString.h"
 
@@ -490,47 +491,54 @@ bool Type::ResolveClangType(ResolveState compiler_type_resolve_state) {
       }
     } else {
       // We have no encoding type, return void?
-      TypeSystem *type_system =
+      auto type_system_or_err =
           m_symbol_file->GetTypeSystemForLanguage(eLanguageTypeC);
-      CompilerType void_compiler_type =
-          type_system->GetBasicTypeFromAST(eBasicTypeVoid);
-      switch (m_encoding_uid_type) {
-      case eEncodingIsUID:
-        m_compiler_type = void_compiler_type;
-        break;
+      if (auto err = type_system_or_err.takeError()) {
+        LLDB_LOG_ERROR(
+            lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_SYMBOLS),
+            std::move(err),
+            "Unable to construct void type from ClangASTContext");
+      } else {
+        CompilerType void_compiler_type =
+            type_system_or_err->GetBasicTypeFromAST(eBasicTypeVoid);
+        switch (m_encoding_uid_type) {
+        case eEncodingIsUID:
+          m_compiler_type = void_compiler_type;
+          break;
 
-      case eEncodingIsConstUID:
-        m_compiler_type = void_compiler_type.AddConstModifier();
-        break;
+        case eEncodingIsConstUID:
+          m_compiler_type = void_compiler_type.AddConstModifier();
+          break;
 
-      case eEncodingIsRestrictUID:
-        m_compiler_type = void_compiler_type.AddRestrictModifier();
-        break;
+        case eEncodingIsRestrictUID:
+          m_compiler_type = void_compiler_type.AddRestrictModifier();
+          break;
 
-      case eEncodingIsVolatileUID:
-        m_compiler_type = void_compiler_type.AddVolatileModifier();
-        break;
+        case eEncodingIsVolatileUID:
+          m_compiler_type = void_compiler_type.AddVolatileModifier();
+          break;
 
-      case eEncodingIsTypedefUID:
-        m_compiler_type = void_compiler_type.CreateTypedef(
-            m_name.AsCString("__lldb_invalid_typedef_name"),
-            GetSymbolFile()->GetDeclContextContainingUID(GetID()));
-        break;
+        case eEncodingIsTypedefUID:
+          m_compiler_type = void_compiler_type.CreateTypedef(
+              m_name.AsCString("__lldb_invalid_typedef_name"),
+              GetSymbolFile()->GetDeclContextContainingUID(GetID()));
+          break;
 
-      case eEncodingIsPointerUID:
-        m_compiler_type = void_compiler_type.GetPointerType();
-        break;
+        case eEncodingIsPointerUID:
+          m_compiler_type = void_compiler_type.GetPointerType();
+          break;
 
-      case eEncodingIsLValueReferenceUID:
-        m_compiler_type = void_compiler_type.GetLValueReferenceType();
-        break;
+        case eEncodingIsLValueReferenceUID:
+          m_compiler_type = void_compiler_type.GetLValueReferenceType();
+          break;
 
-      case eEncodingIsRValueReferenceUID:
-        m_compiler_type = void_compiler_type.GetRValueReferenceType();
-        break;
+        case eEncodingIsRValueReferenceUID:
+          m_compiler_type = void_compiler_type.GetRValueReferenceType();
+          break;
 
-      default:
-        llvm_unreachable("Unhandled encoding_data_type.");
+        default:
+          llvm_unreachable("Unhandled encoding_data_type.");
+        }
       }
     }
 

--- a/source/Symbol/TypeSystem.cpp
+++ b/source/Symbol/TypeSystem.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Symbol/CompilerType.h"
+#include "lldb/Target/Language.h"
 
 using namespace lldb_private;
 using namespace lldb;
@@ -233,79 +234,154 @@ void TypeSystemMap::ForEach(std::function<bool(TypeSystem *)> const &callback) {
   }
 }
 
-TypeSystem *TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
-                                                    Module *module,
-                                                    bool can_create) {
+llvm::Expected<TypeSystem &>
+TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
+                                        Module *module, bool can_create) {
+  llvm::Error error = llvm::Error::success();
+  assert(!error); // Check the success value when assertions are enabled
   std::lock_guard<std::mutex> guard(m_mutex);
-  collection::iterator pos = m_map.find(language);
-  if (pos != m_map.end())
-    return pos->second.get();
+  if (m_clear_in_progress) {
+    error = llvm::make_error<llvm::StringError>(
+        "Unable to get TypeSystem because TypeSystemMap is being cleared",
+        llvm::inconvertibleErrorCode());
+  } else {
+    collection::iterator pos = m_map.find(language);
+    if (pos != m_map.end()) {
+      auto *type_system = pos->second.get();
+      if (type_system) {
+        llvm::consumeError(std::move(error));
+        return *type_system;
+      }
+      error = llvm::make_error<llvm::StringError>(
+          "TypeSystem for language " +
+              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              " doesn't exist",
+          llvm::inconvertibleErrorCode());
+      return std::move(error);
+    }
 
-  for (const auto &pair : m_map) {
-    if (pair.second && pair.second->SupportsLanguage(language)) {
-      // Add a new mapping for "language" to point to an already existing
-      // TypeSystem that supports this language
-      AddToMap(language, pair.second);
-      return pair.second.get();
+    for (const auto &pair : m_map) {
+      if (pair.second && pair.second->SupportsLanguage(language)) {
+        // Add a new mapping for "language" to point to an already existing
+        // TypeSystem that supports this language
+        m_map[language] = pair.second;
+        if (pair.second.get()) {
+          llvm::consumeError(std::move(error));
+          return *pair.second.get();
+        }
+        error = llvm::make_error<llvm::StringError>(
+            "TypeSystem for language " +
+                llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+                " doesn't exist",
+            llvm::inconvertibleErrorCode());
+        return std::move(error);
+      }
+    }
+
+    if (!can_create) {
+      error = llvm::make_error<llvm::StringError>(
+          "Unable to find type system for language " +
+              llvm::toStringRef(Language::GetNameForLanguageType(language)),
+          llvm::inconvertibleErrorCode());
+    } else {
+      // Cache even if we get a shared pointer that contains a null type system
+      // back
+      auto type_system_sp = TypeSystem::CreateInstance(language, module);
+      m_map[language] = type_system_sp;
+      if (type_system_sp.get()) {
+        llvm::consumeError(std::move(error));
+        return *type_system_sp.get();
+      }
+      error = llvm::make_error<llvm::StringError>(
+          "TypeSystem for language " +
+              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              " doesn't exist",
+          llvm::inconvertibleErrorCode());
     }
   }
 
-  if (!can_create)
-    return nullptr;
-
-  // Cache even if we get a shared pointer that contains null type system back
-  lldb::TypeSystemSP type_system_sp =
-      TypeSystem::CreateInstance(language, module);
-  AddToMap(language, type_system_sp);
-  return type_system_sp.get();
+  return std::move(error);
 }
 
-TypeSystem *
+llvm::Expected<TypeSystem &>
 TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
                                         Target *target, bool can_create,
                                         const char *compiler_options) {
+  llvm::Error error = llvm::Error::success();
+  assert(!error); // Check the success value when assertions are enabled
   std::lock_guard<std::mutex> guard(m_mutex);
-  collection::iterator pos = m_map.find(language);
-  if (pos != m_map.end())
-    return pos->second.get();
+  if (m_clear_in_progress) {
+    error = llvm::make_error<llvm::StringError>(
+        "Unable to get TypeSystem because TypeSystemMap is being cleared",
+        llvm::inconvertibleErrorCode());
+  } else {
+    collection::iterator pos = m_map.find(language);
+    if (pos != m_map.end()) {
+      auto *type_system = pos->second.get();
+      if (type_system) {
+        llvm::consumeError(std::move(error));
+        return *type_system;
+      }
+      error = llvm::make_error<llvm::StringError>(
+          "TypeSystem for language " +
+              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              " doesn't exist",
+          llvm::inconvertibleErrorCode());
+      return std::move(error);
+    }
 
-  for (const auto &pair : m_map) {
-    if (pair.second && pair.second->SupportsLanguage(language)) {
-      // Add a new mapping for "language" to point to an already existing
-      // TypeSystem that supports this language
+    for (const auto &pair : m_map) {
+      if (pair.second && pair.second->SupportsLanguage(language)) {
+        // Add a new mapping for "language" to point to an already existing
+        // TypeSystem that supports this language
+        m_map[language] = pair.second;
+        if (pair.second.get()) {
+          llvm::consumeError(std::move(error));
+          return *pair.second.get();
+        }
+        error = llvm::make_error<llvm::StringError>(
+            "TypeSystem for language " +
+                llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+                " doesn't exist",
+            llvm::inconvertibleErrorCode());
+        return std::move(error);
+      }
+    }
 
-      AddToMap(language, pair.second);
-      return pair.second.get();
+    if (!can_create) {
+      error = llvm::make_error<llvm::StringError>(
+          "Unable to find type system for language " +
+              llvm::toStringRef(Language::GetNameForLanguageType(language)),
+          llvm::inconvertibleErrorCode());
+    } else {
+      // Cache even if we get a shared pointer that contains a null type system
+      // back
+      auto type_system_sp = TypeSystem::CreateInstance(language, target,
+                                                       compiler_options);
+      m_map[language] = type_system_sp;
+      if (type_system_sp.get()) {
+        llvm::consumeError(std::move(error));
+        return *type_system_sp.get();
+      }
+      error = llvm::make_error<llvm::StringError>(
+          "TypeSystem for language " +
+              llvm::toStringRef(Language::GetNameForLanguageType(language)) +
+              " doesn't exist",
+          llvm::inconvertibleErrorCode());
     }
   }
 
-  if (!can_create)
-    return nullptr;
-
-  // Cache even if we get a shared pointer that contains null type system back
-  lldb::TypeSystemSP type_system_sp;
-  if (!m_clear_in_progress)
-    type_system_sp =
-        TypeSystem::CreateInstance(language, target, compiler_options);
-
-  AddToMap(language, type_system_sp);
-  return type_system_sp.get();
+  return std::move(error);
 }
 
 void TypeSystemMap::RemoveTypeSystemsForLanguage(lldb::LanguageType language) {
   std::lock_guard<std::mutex> guard(m_mutex);
   collection::iterator pos = m_map.find(language);
-  // If we are clearing the map, we don't need to remove this individual
-  // item.  It will go away soon enough.
+  // If we are clearning the map, we don't need to remove this individual item.
+  // It will go away soon enough.
   if (!m_clear_in_progress) {
     if (pos != m_map.end())
       m_map.erase(pos);
   }
-}
-
-void TypeSystemMap::AddToMap(lldb::LanguageType language,
-                             lldb::TypeSystemSP const &type_system_sp) {
-  if (!m_clear_in_progress)
-    m_map[language] = type_system_sp;
 }
 

--- a/source/Target/StackFrame.cpp
+++ b/source/Target/StackFrame.cpp
@@ -29,6 +29,7 @@
 #include "lldb/Target/StackFrameRecognizer.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 
 #include "lldb/lldb-enumerations.h"
@@ -1366,13 +1367,16 @@ lldb::ValueObjectSP StackFrame::GuessValueForAddress(lldb::addr_t addr) {
       if (target_sp->ResolveLoadAddress(base_and_offset.first->m_immediate +
                                             base_and_offset.second,
                                         addr)) {
-        TypeSystem *c_type_system =
-            target_sp->GetScratchTypeSystemForLanguage(nullptr, eLanguageTypeC);
-        if (!c_type_system) {
+        auto c_type_system_or_err =
+            target_sp->GetScratchTypeSystemForLanguage(eLanguageTypeC);
+        if (auto err = c_type_system_or_err.takeError()) {
+          LLDB_LOG_ERROR(
+              lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_THREAD),
+              std::move(err), "Unable to guess value for given address");
           return ValueObjectSP();
         } else {
           CompilerType void_ptr_type =
-              c_type_system
+              c_type_system_or_err
                   ->GetBasicTypeFromAST(lldb::BasicType::eBasicTypeChar)
                   .GetPointerType();
           return ValueObjectMemory::Create(this, "", addr, void_ptr_type);

--- a/source/Target/ThreadPlanTracer.cpp
+++ b/source/Target/ThreadPlanTracer.cpp
@@ -93,15 +93,20 @@ Disassembler *ThreadPlanAssemblyTracer::GetDisassembler() {
 
 TypeFromUser ThreadPlanAssemblyTracer::GetIntPointerType() {
   if (!m_intptr_type.IsValid()) {
-    TargetSP target_sp(m_thread.CalculateTarget());
-    if (target_sp) {
-      TypeSystem *type_system =
-          target_sp->GetScratchTypeSystemForLanguage(nullptr, eLanguageTypeC);
-      if (type_system)
-        m_intptr_type =
-            TypeFromUser(type_system->GetBuiltinTypeForEncodingAndBitSize(
+    if (auto target_sp = m_thread.CalculateTarget()) {
+      auto type_system_or_err =
+          target_sp->GetScratchTypeSystemForLanguage(eLanguageTypeC);
+      if (auto err = type_system_or_err.takeError()) {
+        LLDB_LOG_ERROR(
+            lldb_private::GetLogIfAnyCategoriesSet(LIBLLDB_LOG_TYPES),
+            std::move(err),
+            "Unable to get integer pointer type from TypeSystem");
+      } else {
+        m_intptr_type = TypeFromUser(
+            type_system_or_err->GetBuiltinTypeForEncodingAndBitSize(
                 eEncodingUint,
                 target_sp->GetArchitecture().GetAddressByteSize() * 8));
+      }
     }
   }
   return m_intptr_type;

--- a/tools/lldb-test/lldb-test.cpp
+++ b/tools/lldb-test/lldb-test.cpp
@@ -528,10 +528,15 @@ Error opts::symbols::dumpAST(lldb_private::Module &Module) {
   if (!symfile)
     return make_string_error("Module has no symbol file.");
 
-  auto clang_ast_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
-      symfile->GetTypeSystemForLanguage(eLanguageTypeC_plus_plus));
+  auto type_system_or_err =
+      symfile->GetTypeSystemForLanguage(eLanguageTypeC_plus_plus);
+  if (!type_system_or_err)
+    return make_string_error("Can't retrieve ClangASTContext");
+
+  auto *clang_ast_ctx =
+      llvm::dyn_cast_or_null<ClangASTContext>(&type_system_or_err.get());
   if (!clang_ast_ctx)
-    return make_string_error("Can't retrieve Clang AST context.");
+    return make_string_error("Retrieved TypeSystem was not a ClangASTContext");
 
   auto ast_ctx = clang_ast_ctx->getASTContext();
   if (!ast_ctx)


### PR DESCRIPTION
Summary:
This commit achieves the following:
- Functions used to return a `TypeSystem *` return an
  `llvm::Expected<TypeSystem *>` now. This means that the result of a call
  is always checked, forcing clients to move more carefully.
- `TypeSystemMap::GetTypeSystemForLanguage` will either return an Error or a
  non-null pointer to a TypeSystem.

Reviewers: JDevlieghere, davide, compnerd

Subscribers: jdoerfert, lldb-commits

Differential Revision: https://reviews.llvm.org/D65122

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@367360 91177308-0d34-0410-b5e6-96231b3b80d8