### PR TITLE
Update LLDB for the FileManager API change

### DIFF
--- a/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -954,7 +954,7 @@ ClangExpressionParser::ParseInternal(DiagnosticManager &diagnostic_manager,
       auto file = m_compiler->getFileManager().getFile(temp_source_path);
       if (file) {
         source_mgr.setMainFileID(
-            source_mgr.createFileID(file, SourceLocation(), SrcMgr::C_User));
+            source_mgr.createFileID(*file, SourceLocation(), SrcMgr::C_User));
         created_main_file = true;
       }
     }


### PR DESCRIPTION
Change LLDB's swift parts to work with the new FileManager API which now
returns and ErrorOr<FileEntry*> instead of just the pointer.