### PR TITLE
[Formatters] Temporarily disable libc++ std::function formatter due to performance issue

### DIFF
--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/function/TestLibCxxFunction.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/function/TestLibCxxFunction.py
@@ -23,6 +23,9 @@ class LibCxxFunctionTestCase(TestBase):
         var.SetPreferSyntheticValue(True)
         return var
 
+    # Temporarily skipping for everywhere b/c we are disabling the std::function formatter
+    # due to performance issues but plan on turning it back on once they are addressed.
+    @skipIf
     @add_test_categories(["libc++"])
     def test(self):
         """Test that std::function as defined by libc++ is correctly printed by LLDB"""

--- a/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -581,11 +581,6 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       ConstString("^(std::__(ndk)?1::)weak_ptr<.+>(( )?&)?$"), stl_synth_flags,
       true);
 
-  AddCXXSummary(
-      cpp_category_sp, lldb_private::formatters::LibcxxFunctionSummaryProvider,
-      "libc++ std::function summary provider",
-      ConstString("^std::__(ndk)?1::function<.+>$"), stl_summary_flags, true);
-
   stl_summary_flags.SetDontShowChildren(false);
   stl_summary_flags.SetSkipPointers(false);
   AddCXXSummary(cpp_category_sp,


### PR DESCRIPTION
Summary: We have been seeing increased reports of performance issue around large project and formatting std::function variables especially in functions signatures in back traces. There are some possible fixes but exploring those fixes may take time and it is better to temporarily disable the formatter due to its impact and re-enable it once we have a fix.

Differential Revision: https://reviews.llvm.org/D65666

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@367701 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit dd13fa23ee620c1d3b197389d902f0494a278889)