### PR TITLE
[CMake] Always copy clang and swift resource directories when rebuilding

### DIFF
--- a/source/API/CMakeLists.txt
+++ b/source/API/CMakeLists.txt
@@ -194,7 +194,7 @@ endif()
 
 # Copy the clang resource directory.
 add_custom_command_target(
-    unused_var
+    copy-clang-resource-dir
     COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CLANG_RESOURCE_PATH}" "${lib_dir}/lldb/clang/"
     OUTPUT "${lib_dir}/lldb/clang/"
     VERBATIM
@@ -202,12 +202,14 @@ add_custom_command_target(
     DEPENDS ${clang_headers_target})
 
 add_custom_command_target(
-    unused_var
+    copy-swift-resource-dir
     COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${SWIFT_RESOURCE_PATH}" "${lib_dir}/lldb/swift/"
     OUTPUT "${lib_dir}/lldb/swift/"
     VERBATIM
     ALL
     DEPENDS ${SWIFT_RESOURCE_PATH})
+
+add_dependencies(liblldb ${copy-clang-resource-dir} ${copy-swift-resource-dir})
 
 install(
   CODE "file(MAKE_DIRECTORY ${lib_dir}/lldb)")


### PR DESCRIPTION
Currently the clang and swift resource dirs are only copied during configure
time. This could be a problem for iterative builds of lldb, where the clang and/or swift
resource dir being built against could have changed. In order to make sure that
we have the most up-to-date clang and swift resource directories, we copy them
whenever we rebuild liblldb.