### PR TITLE
Implement a swift::DWARFImporterDelegate.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -228,6 +228,8 @@ public:
 
   void CacheModule(swift::ModuleDecl *module);
 
+  Module *GetModule() const { return m_module; }
+
   // Call this after the search paths are set up, it will find the module given
   // by module, load the module into the AST context, and also load any
   // "LinkLibraries" that the module requires.
@@ -313,6 +315,7 @@ public:
   CompilerType ImportType(CompilerType &type, Status &error);
 
   swift::ClangImporter *GetClangImporter();
+  swift::DWARFImporter *GetDWARFImporter();
 
   // ***********************************************************
   //  these calls create non-nominal types which are given in
@@ -765,6 +768,9 @@ public:
                                 lldb::StackFrameWP &stack_frame_wp,
                                 swift::SourceFile *source_file, Status &error);
 
+  /// Import a Clang declaration into Swift.
+  swift::ValueDecl *importDecl(clang::Decl *clangDecl);
+  
 protected:
   /// This map uses the string value of ConstStrings as the key, and the TypeBase
   /// * as the value. Since the ConstString strings are uniqued, we can use
@@ -836,6 +842,7 @@ protected:
   /// Only if this AST belongs to a target, and an expression has been
   /// evaluated will the target's process pointer be filled in
   lldb_private::Process *m_process = nullptr;
+  Module *m_module = nullptr;
   std::string m_platform_sdk_path;
 
   typedef std::map<Module *, std::vector<lldb::DataBufferSP>> ASTFileDataMap;

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -20,7 +20,10 @@
 #include "SymbolFileDWARF.h"
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
 #include "swift/Demangling/Demangle.h"
+
+#include "clang/AST/DeclObjC.h"
 
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/ClangASTContext.h"
@@ -132,6 +135,10 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
     if (type_sp)
       return type_sp;
 
+    // Because of DWARFImporter, we may search for this type again while
+    // resolving the mangled name.
+    die.GetDWARF()->GetDIEToType()[die.GetDIE()] = DIE_IS_BEING_PARSED;
+
     // Try to import the type from one of the loaded Swift modules.
     compiler_type = m_ast.GetTypeFromMangledTypename(mangled_name, error);
   }
@@ -151,7 +158,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
       GetClangType(die, mangled_name.GetStringRef(), clang_types);
 
       // Import the Clang type into the Clang context.
-      if (clang_types.GetSize())
+      if (!compiler_type && clang_types.GetSize())
         if (TypeSP clang_type_sp = clang_types.GetTypeAtIndex(0))
           if (clang_type_sp) {
             is_clang_type = true;
@@ -221,6 +228,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   if (type_sp && mangled_name &&
       SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetCString()))
     m_ast.SetCachedType(mangled_name, type_sp);
+  die.GetDWARF()->GetDIEToType()[die.GetDIE()] = type_sp.get();
 
   return type_sp;
 }


### PR DESCRIPTION
During compile time, ClangImporter-imported Clang modules are compiled
with -gmodules, which emits a DWARF rendition of all types defined in
the module into the .pcm file. On Darwin, these types can be collected
by dsymutil. This delegate allows DWARFImporter to ask LLDB to look up
a Clang type by name, synthesize a Clang AST from it. DWARFImporter
then hands this Clang AST to ClangImporter to import the type into
Swift.

rdar://problem/49233932