### PR TITLE
[NameLookup:ASTScope] Disable ASTScopeLookup

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -837,6 +837,9 @@ SwiftASTContext::SwiftASTContext(std::string description, llvm::Triple triple,
     : TypeSystem(TypeSystem::eKindSwift),
       m_compiler_invocation_ap(new swift::CompilerInvocation()),
       m_description(description) {
+  // rdar://53971116
+  m_compiler_invocation_ap->disableASTScopeLookup();
+
   // Set the clang modules cache path.
   m_compiler_invocation_ap->setClangModuleCachePath(GetClangModulesCacheProperty());
 
@@ -855,6 +858,9 @@ SwiftASTContext::SwiftASTContext(const SwiftASTContext &rhs)
     : TypeSystem(rhs.getKind()),
       m_compiler_invocation_ap(new swift::CompilerInvocation()),
       m_description(rhs.m_description) {
+  // rdar://53971116
+  m_compiler_invocation_ap->disableASTScopeLookup();
+
   if (rhs.m_compiler_invocation_ap) {
     SetTriple(rhs.GetTriple());
     llvm::StringRef module_cache_path =


### PR DESCRIPTION
ASTScope lookup does not work let with lldb, so fall back to context-based lookup.
rdar://53971116
Requires https://github.com/apple/swift/pull/26511