### PR TITLE
 [SwiftASTContext] Change GetByteStride() to return an Optional.

### DIFF
--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -760,7 +760,8 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
 
-  uint64_t GetByteStride(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type) override;
 
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                              uint64_t &count) override;

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -300,7 +300,8 @@ public:
   /// Return the size of the type in bits.
   llvm::Optional<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
 
-  uint64_t GetByteStride() const;
+  /// Return the stride of the type in bits.
+  llvm::Optional<uint64_t> GetByteStride() const;
 
   uint64_t GetAlignedBitSize() const;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -568,7 +568,8 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
 
-  uint64_t GetByteStride(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type) override;
 
   lldb::Encoding GetEncoding(void *type, uint64_t &count) override;
 

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -302,7 +302,8 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) = 0;
 
-  virtual uint64_t GetByteStride(lldb::opaque_compiler_type_t type) = 0;
+  virtual llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type) = 0;
 
   virtual lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                                      uint64_t &count) = 0;

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5155,8 +5155,9 @@ ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
   return None;
 }
 
-uint64_t ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
-  return GetByteSize(type, nullptr).getValueOr(0);
+Optional<uint64_t>
+ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+  return {};
 }
 
 size_t ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type) {

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -551,10 +551,10 @@ CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
   return {};
 }
 
-uint64_t CompilerType::GetByteStride() const {
+llvm::Optional<uint64_t> CompilerType::GetByteStride() const {
   if (IsValid())
     return m_type_system->GetByteStride(m_type);
-  return 0;
+  return {};
 }
 
 uint64_t CompilerType::GetAlignedBitSize() const { return 0; }

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -523,14 +523,6 @@ CompilerType CompilerType::GetUnboundType() const {
   return CompilerType();
 }
 
-// CompilerType
-// CompilerType::RemoveFastQualifiers () const
-//{
-//    if (IsValid())
-//        return m_type_system->RemoveFastQualifiers(m_type);
-//    return CompilerType();
-//}
-
 //----------------------------------------------------------------------
 // Create related types using the current type's AST
 //----------------------------------------------------------------------

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6038,14 +6038,15 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
   return {};
 }
 
-uint64_t SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
-  if (type) {
-    const swift::irgen::FixedTypeInfo *fixed_type_info =
-        GetSwiftFixedTypeInfo(type);
-    if (fixed_type_info)
-      return fixed_type_info->getFixedStride().getValue();
-  }
-  return 0;
+llvm::Optional<uint64_t>
+SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+  if (!type)
+    return {};
+  const swift::irgen::FixedTypeInfo *fixed_type_info =
+      GetSwiftFixedTypeInfo(type);
+  if (!fixed_type_info)
+    return {};
+  return fixed_type_info->getFixedStride().getValue();
 }
 
 size_t SwiftASTContext::GetTypeBitAlign(void *type) {

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -514,9 +514,13 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntime *runtime,
     static_type = runtime->DoArchetypeBindingForType(*frame_sp, static_type);
   }
 
+  auto stride = 0;
+  auto opt_stride = static_type.GetByteStride();
+  if (opt_stride)
+    stride = *opt_stride;
+
   lldb::addr_t copy_location = process->AllocateMemory(
-      static_type.GetByteStride(), ePermissionsReadable | ePermissionsWritable,
-      error);
+      stride, ePermissionsReadable | ePermissionsWritable, error);
   if (copy_location == LLDB_INVALID_ADDRESS) {
     if (log)
       log->Printf("[GetObjectDescription_ObjectCopy] copy_location invalid");


### PR DESCRIPTION
Before, we didn't have a way to notify whether the function
errored out or not. NFCI, for now.

<rdar://problem/54004017>
