### PR TITLE
Add support for deterministically linked binaries on macOS to lldb. 

### DIFF
--- a/lit/SymbolFile/DWARF/deterministic-build.cpp
+++ b/lit/SymbolFile/DWARF/deterministic-build.cpp
@@ -1,0 +1,11 @@
+// Test that binaries linked deterministically (N_OSO has timestamp 0) can still
+// have their object files loaded by lldb. Note that the env var ZERO_AR_DATE
+// requires the ld64 linker, which clang invokes by default.
+// REQUIRES: system-darwin
+// RUN: %clang %s -g -c -o %t.o
+// RUN: ZERO_AR_DATE=1 %clang %t.o -g -o %t
+// RUN: %lldb %t -o "breakpoint set -f %s -l 11" -o run -o exit | FileCheck %s
+// CHECK: stop reason = breakpoint
+
+
+int main() { return 0; }

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -422,7 +422,11 @@ Module *SymbolFileDWARFDebugMap::GetModuleByCompUnitInfo(
         // than the one from the CU.
         auto oso_mod_time = std::chrono::time_point_cast<std::chrono::seconds>(
             FileSystem::Instance().GetModificationTime(oso_file));
-        if (oso_mod_time != comp_unit_info->oso_mod_time) {
+        // A timestamp of 0 means that the linker was in deterministic mode. In
+        // that case, we should skip the check against the filesystem last
+        // modification timestamp, since it will never match.
+        if (comp_unit_info->oso_mod_time != llvm::sys::TimePoint<>() &&
+            oso_mod_time != comp_unit_info->oso_mod_time) {
           obj_file->GetModule()->ReportError(
               "debug map object file '%s' has changed (actual time is "
               "%s, debug map time is %s"


### PR DESCRIPTION
When ld64 links a binary deterministically using the flag ZERO_AR_DATE,
it sets a timestamp of 0 for N_OSO members in the symtab section, rather
than the usual last modified date of the object file. Prior to this
patch, lldb would compare the timestamp from the N_OSO member against
the last modified date of the object file, and skip loading the object
file if there was a mismatch. This patch updates the logic to ignore the
timestamp check if the N_OSO member has timestamp 0.

The original logic was added in https://reviews.llvm.org/rL181631 as a
safety check to avoid problems when debugging if the object file was out
of date. This was prior to the introduction of deterministic build in
ld64. lld still doesn't support deterministic build.

Other code in llvm already relies on and uses the assumption that a
timestamp of 0 means deterministic build. For example, commit
9ccfddc39d4d27f9b16fcc72ab30d483151d6d08 adds similar timestamp checking
logic to dsymutil, but special cases timestamp 0. Likewise, commit
0d1bb79a0413f221432a7b1d0d2d10c84c4bbb99 adds a long comment describing
deterministic archive, which mostly uses timestamp 0 for determinism.

Patch from Erik Chen <erikchen@chromium.org>!

Differential Revision: https://reviews.llvm.org/D65826

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@368199 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit f6ba8da08fdfbdb2ec190a5725729493a7ce5e51)

rdar://problem/54046060