### PR TITLE
[Swift] Pass an execution context scope to GetByteStride().

### DIFF
--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -761,7 +761,8 @@ public:
              ExecutionContextScope *exe_scope) override;
 
   llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type) override;
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) override;
 
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                              uint64_t &count) override;

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -299,9 +299,9 @@ public:
   llvm::Optional<uint64_t> GetByteSize(ExecutionContextScope *exe_scope) const;
   /// Return the size of the type in bits.
   llvm::Optional<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
-
   /// Return the stride of the type in bits.
-  llvm::Optional<uint64_t> GetByteStride() const;
+  llvm::Optional<uint64_t>
+  GetByteStride(ExecutionContextScope *exe_scope) const;
 
   uint64_t GetAlignedBitSize() const;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -569,7 +569,8 @@ public:
              ExecutionContextScope *exe_scope) override;
 
   llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type) override;
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) override;
 
   lldb::Encoding GetEncoding(void *type, uint64_t &count) override;
 

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -303,7 +303,8 @@ public:
              ExecutionContextScope *exe_scope) = 0;
 
   virtual llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type) = 0;
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) = 0;
 
   virtual lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                                      uint64_t &count) = 0;

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -84,11 +84,10 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
   ProcessSP process_sp(m_exe_ctx_ref.GetProcessSP());
   if (!process_sp)
     return;
-  auto element_stride = m_elem_type.GetByteStride();
   auto opt_size = elem_type.GetByteSize(process_sp.get());
   if (opt_size)
     m_element_size = *opt_size;
-  auto opt_stride = elem_type.GetByteStride();
+  auto opt_stride = elem_type.GetByteStride(process_sp.get());
   if (opt_stride)
     m_element_stride = *opt_stride;
   size_t ptr_size = process_sp->GetAddressByteSize();
@@ -215,7 +214,7 @@ SwiftArraySliceBufferHandler::SwiftArraySliceBufferHandler(
   if (opt_size)
     m_element_size = *opt_size;
 
-  auto opt_stride = elem_type.GetByteStride();
+  auto opt_stride = elem_type.GetByteStride(process_sp.get());
   if (opt_stride)
     m_element_stride = *opt_stride;
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -432,14 +432,14 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
   if (!m_process)
     return;
 
-  auto key_stride = key_type.GetByteStride();
+  auto key_stride = key_type.GetByteStride(m_process);
   if (key_stride) {
     m_key_stride = *key_stride;
     m_key_stride_padded = *key_stride;
   }
 
   if (value_type) {
-    auto value_type_stride = value_type.GetByteStride();
+    auto value_type_stride = value_type.GetByteStride(m_process);
     m_value_stride = value_type_stride ? *value_type_stride : 0;
     if (SwiftASTContext *swift_ast =
             llvm::dyn_cast_or_null<SwiftASTContext>(key_type.GetTypeSystem())) {
@@ -455,7 +455,7 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
       m_element_type = swift_ast->CreateTupleType(tuple_elements);
       auto *swift_type = reinterpret_cast<::swift::TypeBase *>(
           m_element_type.GetCanonicalType().GetOpaqueQualType());
-      auto element_stride = m_element_type.GetByteStride();
+      auto element_stride = m_element_type.GetByteStride(m_process);
       if (element_stride) {
         m_key_stride_padded = *element_stride - m_value_stride;
       }

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5156,7 +5156,8 @@ ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 }
 
 Optional<uint64_t>
-ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) {
   return {};
 }
 

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -551,9 +551,10 @@ CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
   return {};
 }
 
-llvm::Optional<uint64_t> CompilerType::GetByteStride() const {
+llvm::Optional<uint64_t>
+CompilerType::GetByteStride(ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    return m_type_system->GetByteStride(m_type);
+    return m_type_system->GetByteStride(m_type, exe_scope);
   return {};
 }
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6045,7 +6045,8 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 }
 
 llvm::Optional<uint64_t>
-SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
   const swift::irgen::FixedTypeInfo *fixed_type_info =

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -515,7 +515,7 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntime *runtime,
   }
 
   auto stride = 0;
-  auto opt_stride = static_type.GetByteStride();
+  auto opt_stride = static_type.GetByteStride(frame_sp.get());
   if (opt_stride)
     stride = *opt_stride;
 


### PR DESCRIPTION
This time we can ask the runtime to resolve the type.