### PR TITLE
[SwiftLanguageRuntime] Fix resilient types in hashed containers.

### DIFF
--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -308,6 +308,9 @@ public:
   /// Ask Remote Mirrors for the size of a Swift type.
   llvm::Optional<uint64_t> GetBitSize(CompilerType type);
 
+  /// Ask Remote mirrors for the stride of a Swift type.
+  llvm::Optional<uint64_t> GetByteStride(CompilerType type);
+
   bool IsWhitelistedRuntimeValue(ConstString name) override;
 
   virtual CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,

--- a/lit/SwiftREPL/ResilientArray.test
+++ b/lit/SwiftREPL/ResilientArray.test
@@ -1,0 +1,9 @@
+// RUN: %lldb --repl < %s | FileCheck %s
+
+import Foundation
+
+let x : [URL] = [URL(string: "https://github.com")!, URL(string: "https://apple.com")!]
+// CHECK: {{x}}: [URL] = 2 values {
+// CHECK-NEXT:  [0] = "https://github.com"
+// CHECK-NEXT:  [1] = "https://apple.com"
+// CHECK-NEXT: }

--- a/lit/SwiftREPL/ResilientArray.test
+++ b/lit/SwiftREPL/ResilientArray.test
@@ -1,3 +1,4 @@
+// REQUIRES: system-darwin
 // RUN: %lldb --repl < %s | FileCheck %s
 
 import Foundation

--- a/lit/SwiftREPL/ResilientDict.test
+++ b/lit/SwiftREPL/ResilientDict.test
@@ -1,3 +1,4 @@
+// REQUIRES: system-darwin
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 // The dictionary order isn't deterministic, so print the dictionary

--- a/lit/SwiftREPL/ResilientDict.test
+++ b/lit/SwiftREPL/ResilientDict.test
@@ -1,0 +1,20 @@
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
+
+// The dictionary order isn't deterministic, so print the dictionary
+// once per element.
+
+import Foundation
+
+let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23] 
+// DICT-LABEL: {{x}}: [URL : Int] = 2 key/value pairs {
+// DICT:      [{{[0-1]}}] = {
+// DICT:         key = "https://apple.com"
+// DICT-NEXT:    value = 23
+// DICT-NEXT:  }
+
+let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23] 
+// DICT-LABEL: {{y}}: [URL : Int] = 2 key/value pairs {
+// DICT:       [{{[0-1]}}] = {
+// DICT:          key = "https://github.com"
+// DICT-NEXT:     value = 4
+// DICT-NEXT:  }

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6144,11 +6144,28 @@ SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
                                ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
+  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
+  if (swift_can_type->hasTypeParameter()) {
+    if (!exe_scope)
+      return {};
+    ExecutionContext exe_ctx;
+    exe_scope->CalculateExecutionContext(exe_ctx);
+    auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
+    CompilerType bound_type = BindAllArchetypes({this, type}, exe_scope);
+    // Note thay the bound type may be in a different AST context.
+    return bound_type.GetByteStride(exe_scope);
+  }
+
   const swift::irgen::FixedTypeInfo *fixed_type_info =
       GetSwiftFixedTypeInfo(type);
-  if (!fixed_type_info)
+  if (fixed_type_info)
+    return fixed_type_info->getFixedStride().getValue();
+
+  if (!exe_scope)
     return {};
-  return fixed_type_info->getFixedStride().getValue();
+  if (auto *runtime = SwiftLanguageRuntime::Get(*exe_scope->CalculateProcess()))
+    return runtime->GetByteStride({this, type});
+  return {};
 }
 
 size_t SwiftASTContext::GetTypeBitAlign(void *type) {

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2578,24 +2578,21 @@ SwiftLanguageRuntime::GetTypeInfo(CompilerType type) {
 }
 
 bool SwiftLanguageRuntime::IsStoredInlineInBuffer(CompilerType type) {
-  auto *type_info = GetTypeInfo(type);
-  if (!type_info)
-    return true;
-  return type_info->isBitwiseTakable() && type_info->getSize() <= 24;
+  if (auto *type_info = GetTypeInfo(type))
+    return type_info->isBitwiseTakable() && type_info->getSize() <= 24;
+  return true;
 }
 
 llvm::Optional<uint64_t> SwiftLanguageRuntime::GetBitSize(CompilerType type) {
-  auto *type_info = GetTypeInfo(type);
-  if (!type_info)
-    return {};
-  return type_info->getSize() * 8;
+  if (auto *type_info = GetTypeInfo(type))
+    return type_info->getSize() * 8;
+  return {};
 }
 
 llvm::Optional<uint64_t> SwiftLanguageRuntime::GetByteStride(CompilerType type) {
-  auto *type_info = GetTypeInfo(type);
-  if (!type_info)
-    return {};
-  return type_info->getStride();
+  if (auto *type_info = GetTypeInfo(type))
+    return type_info->getStride();
+  return {};
 }
 
 bool SwiftLanguageRuntime::IsWhitelistedRuntimeValue(ConstString name) {

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2591,6 +2591,13 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetBitSize(CompilerType type) {
   return type_info->getSize() * 8;
 }
 
+llvm::Optional<uint64_t> SwiftLanguageRuntime::GetByteStride(CompilerType type) {
+  auto *type_info = GetTypeInfo(type);
+  if (!type_info)
+    return {};
+  return type_info->getStride();
+}
+
 bool SwiftLanguageRuntime::IsWhitelistedRuntimeValue(ConstString name) {
   return name == g_self;
 }


### PR DESCRIPTION
The formatters for arrays and hash table called GetByteStride(),
which was only looking at the type _statically_, asking IRGen
about the properties.

This doesn't work for non-fixed-size types, e.g. resilient ones.
This patch implements the support to ask to the Runtime (i.e.
Remote mirrors about the properties).