### PR TITLE
[5.1][SwiftLanguageRuntime] Fix resilient types in hashed containers. 

### DIFF
--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -760,7 +760,8 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
 
-  uint64_t GetByteStride(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type) override;
 
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                              uint64_t &count) override;

--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -761,7 +761,8 @@ public:
              ExecutionContextScope *exe_scope) override;
 
   llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type) override;
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) override;
 
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                              uint64_t &count) override;

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -302,7 +302,8 @@ public:
   /// Return the size of the type in bits.
   llvm::Optional<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
 
-  uint64_t GetByteStride() const;
+  /// Return the stride of the type in bits.
+  llvm::Optional<uint64_t> GetByteStride() const;
 
   uint64_t GetAlignedBitSize() const;
 

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -301,9 +301,9 @@ public:
   llvm::Optional<uint64_t> GetByteSize(ExecutionContextScope *exe_scope) const;
   /// Return the size of the type in bits.
   llvm::Optional<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
-
   /// Return the stride of the type in bits.
-  llvm::Optional<uint64_t> GetByteStride() const;
+  llvm::Optional<uint64_t>
+  GetByteStride(ExecutionContextScope *exe_scope) const;
 
   uint64_t GetAlignedBitSize() const;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -570,7 +570,8 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
 
-  uint64_t GetByteStride(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type) override;
 
   lldb::Encoding GetEncoding(void *type, uint64_t &count) override;
 

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -571,7 +571,8 @@ public:
              ExecutionContextScope *exe_scope) override;
 
   llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type) override;
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) override;
 
   lldb::Encoding GetEncoding(void *type, uint64_t &count) override;
 

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -307,7 +307,8 @@ public:
              ExecutionContextScope *exe_scope) = 0;
 
   virtual llvm::Optional<uint64_t>
-  GetByteStride(lldb::opaque_compiler_type_t type) = 0;
+  GetByteStride(lldb::opaque_compiler_type_t type,
+                ExecutionContextScope *exe_scope) = 0;
 
   virtual lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                                      uint64_t &count) = 0;

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -306,7 +306,8 @@ public:
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) = 0;
 
-  virtual uint64_t GetByteStride(lldb::opaque_compiler_type_t type) = 0;
+  virtual llvm::Optional<uint64_t>
+  GetByteStride(lldb::opaque_compiler_type_t type) = 0;
 
   virtual lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                                      uint64_t &count) = 0;

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -288,6 +288,9 @@ public:
   /// Ask Remote Mirrors for the size of a Swift type.
   llvm::Optional<uint64_t> GetBitSize(CompilerType type);
 
+  /// Ask Remote mirrors for the stride of a Swift type.
+  llvm::Optional<uint64_t> GetByteStride(CompilerType type);
+ 
   bool IsRuntimeSupportValue(ValueObject &valobj) override;
 
   virtual CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,

--- a/lit/SwiftREPL/ResilientArray.test
+++ b/lit/SwiftREPL/ResilientArray.test
@@ -1,0 +1,9 @@
+// RUN: %lldb --repl < %s | FileCheck %s
+
+import Foundation
+
+let x : [URL] = [URL(string: "https://github.com")!, URL(string: "https://apple.com")!]
+// CHECK: {{x}}: [URL] = 2 values {
+// CHECK-NEXT:  [0] = "https://github.com"
+// CHECK-NEXT:  [1] = "https://apple.com"
+// CHECK-NEXT: }

--- a/lit/SwiftREPL/ResilientArray.test
+++ b/lit/SwiftREPL/ResilientArray.test
@@ -1,3 +1,4 @@
+// REQUIRES: system-darwin
 // RUN: %lldb --repl < %s | FileCheck %s
 
 import Foundation

--- a/lit/SwiftREPL/ResilientDict.test
+++ b/lit/SwiftREPL/ResilientDict.test
@@ -1,3 +1,4 @@
+// REQUIRES: system-darwin
 // RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
 
 // The dictionary order isn't deterministic, so print the dictionary

--- a/lit/SwiftREPL/ResilientDict.test
+++ b/lit/SwiftREPL/ResilientDict.test
@@ -1,0 +1,20 @@
+// RUN: %lldb --repl < %s | FileCheck %s --check-prefix=DICT
+
+// The dictionary order isn't deterministic, so print the dictionary
+// once per element.
+
+import Foundation
+
+let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23] 
+// DICT-LABEL: {{x}}: [URL : Int] = 2 key/value pairs {
+// DICT:      [{{[0-1]}}] = {
+// DICT:         key = "https://apple.com"
+// DICT-NEXT:    value = 23
+// DICT-NEXT:  }
+
+let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23] 
+// DICT-LABEL: {{y}}: [URL : Int] = 2 key/value pairs {
+// DICT:       [{{[0-1]}}] = {
+// DICT:          key = "https://github.com"
+// DICT-NEXT:     value = 4
+// DICT-NEXT:  }

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -84,11 +84,10 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
   ProcessSP process_sp(m_exe_ctx_ref.GetProcessSP());
   if (!process_sp)
     return;
-  auto element_stride = m_elem_type.GetByteStride();
   auto opt_size = elem_type.GetByteSize(process_sp.get());
   if (opt_size)
     m_element_size = *opt_size;
-  auto opt_stride = elem_type.GetByteStride();
+  auto opt_stride = elem_type.GetByteStride(process_sp.get());
   if (opt_stride)
     m_element_stride = *opt_stride;
   size_t ptr_size = process_sp->GetAddressByteSize();
@@ -215,7 +214,7 @@ SwiftArraySliceBufferHandler::SwiftArraySliceBufferHandler(
   if (opt_size)
     m_element_size = *opt_size;
 
-  auto opt_stride = elem_type.GetByteStride();
+  auto opt_stride = elem_type.GetByteStride(process_sp.get());
   if (opt_stride)
     m_element_stride = *opt_stride;
 

--- a/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -432,14 +432,14 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
   if (!m_process)
     return;
 
-  auto key_stride = key_type.GetByteStride();
+  auto key_stride = key_type.GetByteStride(m_process);
   if (key_stride) {
     m_key_stride = *key_stride;
     m_key_stride_padded = *key_stride;
   }
 
   if (value_type) {
-    auto value_type_stride = value_type.GetByteStride();
+    auto value_type_stride = value_type.GetByteStride(m_process);
     m_value_stride = value_type_stride ? *value_type_stride : 0;
     if (SwiftASTContext *swift_ast =
             llvm::dyn_cast_or_null<SwiftASTContext>(key_type.GetTypeSystem())) {
@@ -455,7 +455,7 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
       m_element_type = swift_ast->CreateTupleType(tuple_elements);
       auto *swift_type = reinterpret_cast<::swift::TypeBase *>(
           m_element_type.GetCanonicalType().GetOpaqueQualType());
-      auto element_stride = m_element_type.GetByteStride();
+      auto element_stride = m_element_type.GetByteStride(m_process);
       if (element_stride) {
         m_key_stride_padded = *element_stride - m_value_stride;
       }

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5155,8 +5155,9 @@ ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
   return None;
 }
 
-uint64_t ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
-  return GetByteSize(type, nullptr).getValueOr(0);
+Optional<uint64_t>
+ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+  return {};
 }
 
 size_t ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type) {

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5156,7 +5156,8 @@ ClangASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 }
 
 Optional<uint64_t>
-ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) {
   return {};
 }
 

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -566,9 +566,10 @@ CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
   return {};
 }
 
-llvm::Optional<uint64_t> CompilerType::GetByteStride() const {
+llvm::Optional<uint64_t>
+CompilerType::GetByteStride(ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    return m_type_system->GetByteStride(m_type);
+    return m_type_system->GetByteStride(m_type, exe_scope);
   return {};
 }
 

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -566,10 +566,10 @@ CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
   return {};
 }
 
-uint64_t CompilerType::GetByteStride() const {
+llvm::Optional<uint64_t> CompilerType::GetByteStride() const {
   if (IsValid())
     return m_type_system->GetByteStride(m_type);
-  return 0;
+  return {};
 }
 
 uint64_t CompilerType::GetAlignedBitSize() const { return 0; }

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6044,14 +6044,15 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
   return 0;
 }
 
-uint64_t SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
-  if (type) {
-    const swift::irgen::FixedTypeInfo *fixed_type_info =
-        GetSwiftFixedTypeInfo(type);
-    if (fixed_type_info)
-      return fixed_type_info->getFixedStride().getValue();
-  }
-  return 0;
+llvm::Optional<uint64_t>
+SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+  if (!type)
+    return {};
+  const swift::irgen::FixedTypeInfo *fixed_type_info =
+      GetSwiftFixedTypeInfo(type);
+  if (!fixed_type_info)
+    return {};
+  return fixed_type_info->getFixedStride().getValue();
 }
 
 size_t SwiftASTContext::GetTypeBitAlign(void *type) {

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6049,11 +6049,28 @@ SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
                                ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
+  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
+  if (swift_can_type->hasTypeParameter()) {
+    if (!exe_scope)
+      return {};
+    ExecutionContext exe_ctx;
+    exe_scope->CalculateExecutionContext(exe_ctx);
+    auto swift_scratch_ctx_lock = SwiftASTContextLock(&exe_ctx);
+    CompilerType bound_type = BindAllArchetypes({this, type}, exe_scope);
+    // Note thay the bound type may be in a different AST context.
+    return bound_type.GetByteStride(exe_scope);
+  }
+
   const swift::irgen::FixedTypeInfo *fixed_type_info =
       GetSwiftFixedTypeInfo(type);
-  if (!fixed_type_info)
+  if (fixed_type_info)
+    return fixed_type_info->getFixedStride().getValue();
+
+  if (!exe_scope)
     return {};
-  return fixed_type_info->getFixedStride().getValue();
+  if (auto *runtime = SwiftLanguageRuntime::Get(*exe_scope->CalculateProcess()))
+    return runtime->GetByteStride({this, type});
+  return {};
 }
 
 size_t SwiftASTContext::GetTypeBitAlign(void *type) {

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6068,7 +6068,7 @@ SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
 
   if (!exe_scope)
     return {};
-  if (auto *runtime = SwiftLanguageRuntime::Get(*exe_scope->CalculateProcess()))
+  if (auto *runtime = exe_scope->CalculateProcess()->GetSwiftLanguageRuntime())
     return runtime->GetByteStride({this, type});
   return {};
 }

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6045,7 +6045,8 @@ SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
 }
 
 llvm::Optional<uint64_t>
-SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type) {
+SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) {
   if (!type)
     return {};
   const swift::irgen::FixedTypeInfo *fixed_type_info =

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -513,7 +513,7 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntime *runtime,
   }
 
   auto stride = 0;
-  auto opt_stride = static_type.GetByteStride();
+  auto opt_stride = static_type.GetByteStride(frame_sp.get());
   if (opt_stride)
     stride = *opt_stride;
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2588,6 +2588,13 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetBitSize(CompilerType type) {
   return type_info->getSize() * 8;
 }
 
+llvm::Optional<uint64_t> SwiftLanguageRuntime::GetByteStride(CompilerType type) {
+  auto *type_info = GetTypeInfo(type);
+  if (!type_info)
+    return {};
+  return type_info->getStride();
+}
+
 bool SwiftLanguageRuntime::IsRuntimeSupportValue(ValueObject &valobj) {
   // All runtime support values have to be marked as artificial by the
   // compiler. But not all artificial variables should be hidden from

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -512,9 +512,13 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntime *runtime,
     static_type = runtime->DoArchetypeBindingForType(*frame_sp, static_type);
   }
 
+  auto stride = 0;
+  auto opt_stride = static_type.GetByteStride();
+  if (opt_stride)
+    stride = *opt_stride;
+
   lldb::addr_t copy_location = process->AllocateMemory(
-      static_type.GetByteStride(), ePermissionsReadable | ePermissionsWritable,
-      error);
+      stride, ePermissionsReadable | ePermissionsWritable, error);
   if (copy_location == LLDB_INVALID_ADDRESS) {
     if (log)
       log->Printf("[GetObjectDescription_ObjectCopy] copy_location invalid");


### PR DESCRIPTION
The formatters for arrays and hash table called GetByteStride(),
which was only looking at the type _statically_, asking IRGen
about the properties.

This doesn't work for non-fixed-size types, e.g. resilient ones.
This patch implements the support to ask to the Runtime (i.e.
Remote mirrors about the properties).