### PR TITLE
DWARFmporterDelegate: Fix type lookup in DWARF (= no .dSYM) projects.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -49,16 +49,9 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("pureSwift"),
                                 value="42")
-        if self.getDebugInfo() == 'dsym':
-            # Swiftified type.
-            type_name = '__ObjC.Point'
-        else:
-            # Clang type, because -gmodules breadcrumb following isn't implented yet.
-            type_name = 'Point'
-
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("point"),
-                                typename=type_name, num_children=2)
+                                typename='__ObjC.Point', num_children=2)
         self.expect("fr v point", substrs=["x = 1", "y = 2"])
         self.expect("fr v point", substrs=["x = 1", "y = 2"])
         self.expect("fr v pureSwiftStruct", substrs=["pure swift"])

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2479,8 +2479,12 @@ uint32_t SymbolFileDWARF::FindTypes(
             name.GetCString(), append, max_matches, num_matches);
       }
     }
-    return num_matches;
-  } else {
+  }
+
+  // Next search through the reachable Clang modules. This only applies for
+  // DWARF objects compiled with -gmodules that haven't been processed by
+  // dsymutil.
+  if (num_die_matches < max_matches) {
     UpdateExternalModuleListIfNeeded();
 
     for (const auto &pair : m_external_type_modules) {
@@ -2498,7 +2502,7 @@ uint32_t SymbolFileDWARF::FindTypes(
     }
   }
 
-  return 0;
+  return num_die_matches;
 }
 
 size_t SymbolFileDWARF::FindTypes(const std::vector<CompilerContext> &context,

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3190,6 +3190,7 @@ public:
     if (!module)
       return;
 
+    // Find the type in the debug info.
     TypeList clang_types;
     const bool exact_match = true;
     const uint32_t max_matches = UINT32_MAX;
@@ -3201,6 +3202,7 @@ public:
     SymbolFile *sym_file = m_swift_ast_ctx.GetSymbolFile();
     if (!sym_file)
       return;
+    // Filter out non-Clang types.
     auto *clang_ctx = llvm::dyn_cast_or_null<ClangASTContext>(
         sym_file->GetTypeSystemForLanguage(eLanguageTypeObjC));
     if (!clang_ctx)


### PR DESCRIPTION
The SymbolFileDWARF change has also been made on llvm.org as r368345.