### PR TITLE
[SwiftASTContext] Trim down the interface quite a bit.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -305,8 +305,6 @@ public:
   bool SetTriple(const llvm::Triple triple,
                  lldb_private::Module *module = nullptr);
 
-  uint32_t GetPointerBitAlignment();
-
   // Imports the type from the passed in type into this SwiftASTContext. The
   // type must be a Swift type. If the type can be imported, returns the
   // CompilerType for the imported type.
@@ -332,10 +330,6 @@ public:
   CompilerType CreateTupleType(const std::vector<TupleElement> &elements);
 
   CompilerType GetErrorType();
-
-  CompilerType GetNSErrorType(Status &error);
-
-  CompilerType CreateMetatypeType(CompilerType instance_type);
 
   bool HasErrors();
 
@@ -503,9 +497,6 @@ public:
   static bool IsNonTriviallyManagedReferenceType(
       const CompilerType &type, NonTriviallyManagedReferenceStrategy &strategy,
       CompilerType *underlying_type = nullptr);
-
-  bool IsObjCObjectPointerType(const CompilerType &type,
-                               CompilerType *class_type_ptr);
 
   //----------------------------------------------------------------------
   // Type Completion

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4812,23 +4812,6 @@ CompilerType SwiftASTContext::GetErrorType() {
   return {};
 }
 
-CompilerType SwiftASTContext::GetNSErrorType(Status &error) {
-  VALID_OR_RETURN(CompilerType());
-
-  std::string mangled =
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtC10Foundation7NSError");
-  return GetTypeFromMangledTypename(ConstString(StringRef(mangled)), error);
-}
-
-CompilerType SwiftASTContext::CreateMetatypeType(CompilerType instance_type) {
-  VALID_OR_RETURN(CompilerType());
-
-  if (llvm::dyn_cast_or_null<SwiftASTContext>(instance_type.GetTypeSystem()))
-    return {swift::MetatypeType::get(GetSwiftType(instance_type),
-                                     *GetASTContext())};
-  return {};
-}
-
 SwiftASTContext *SwiftASTContext::GetSwiftASTContext(swift::ASTContext *ast) {
   SwiftASTContext *swift_ast = GetASTMap().Lookup(ast);
   return swift_ast;
@@ -4843,17 +4826,6 @@ uint32_t SwiftASTContext::GetPointerByteSize() {
             .GetByteSize(nullptr)
             .getValueOr(0);
   return m_pointer_byte_size;
-}
-
-uint32_t SwiftASTContext::GetPointerBitAlignment() {
-  VALID_OR_RETURN(0);
-
-  if (m_pointer_bit_align == 0) {
-    swift::ASTContext *ast = GetASTContext();
-    m_pointer_bit_align =
-        CompilerType(ast->TheRawPointerType.getPointer()).GetAlignedBitSize();
-  }
-  return m_pointer_bit_align;
 }
 
 bool SwiftASTContext::HasErrors() {
@@ -5454,22 +5426,6 @@ SwiftASTContext::GetAllocationStrategy(const CompilerType &type) {
 }
 
 bool SwiftASTContext::IsBeingDefined(void *type) { return false; }
-
-bool SwiftASTContext::IsObjCObjectPointerType(const CompilerType &type,
-                                              CompilerType *class_type_ptr) {
-  if (!type)
-    return false;
-
-  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  const swift::TypeKind type_kind = swift_can_type->getKind();
-  if (type_kind == swift::TypeKind::BuiltinNativeObject ||
-      type_kind == swift::TypeKind::BuiltinUnknownObject)
-    return true;
-
-  if (class_type_ptr)
-    class_type_ptr->Clear();
-  return false;
-}
 
 //----------------------------------------------------------------------
 // Type Completion


### PR DESCRIPTION
All these functions are not used. No need to carry them around.