### PR TITLE
[WIP] Fix merge

### DIFF
--- a/include/lldb/Symbol/SymbolVendor.h
+++ b/include/lldb/Symbol/SymbolVendor.h
@@ -41,12 +41,6 @@ public:
 
   SymbolFile *GetSymbolFile() { return m_sym_file_up.get(); }
 
-  bool GetCompileOption(const char *option, std::string &value,
-                        CompileUnit *cu = nullptr);
-
-  int GetCompileOptions(const char *option, std::vector<std::string> &values,
-                        CompileUnit *cu = nullptr);
-
   void GetLoadedModules(lldb::LanguageType language, FileSpecList &modules);
 
   /// Notify the SymbolVendor that the file addresses in the Sections
@@ -58,16 +52,11 @@ public:
 
   uint32_t GetPluginVersion() override;
 
-  virtual bool SetLimitSourceFileRange(const FileSpec &file,
-                                       uint32_t first_line, uint32_t last_line);
-
   virtual bool SymbolContextShouldBeExcluded(const SymbolContext &sc,
                                              uint32_t actual_line);
 
   virtual std::vector<lldb::DataBufferSP>
   GetASTData(lldb::LanguageType language);
-
-  virtual bool ForceInlineSourceFileCheck();
 
 protected:
   std::unique_ptr<SymbolFile> m_sym_file_up; // A single symbol file. Subclasses

--- a/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -12,7 +12,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
-#include "lldb/Symbol/SymbolVendor.h"
+#include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 
@@ -230,7 +230,7 @@ BreakpointResolverFileLine::SearchCallback(SearchFilter &filter,
 
   const size_t num_comp_units = context.module_sp->GetNumCompileUnits();
   const bool force_check_inlines =
-      context.module_sp->GetSymbolVendor()->ForceInlineSourceFileCheck();
+      context.module_sp->GetSymbolFile()->ForceInlineSourceFileCheck();
   for (size_t i = 0; i < num_comp_units; i++) {
     CompUnitSP cu_sp(context.module_sp->GetCompileUnitAtIndex(i));
     if (cu_sp) {

--- a/source/Expression/IRExecutionUnit.cpp
+++ b/source/Expression/IRExecutionUnit.cpp
@@ -1383,12 +1383,10 @@ lldb::ModuleSP IRExecutionUnit::CreateJITModule(const char *name,
       jit_file.GetFilename() = const_name;
       jit_module_sp->SetFileSpecAndObjectName(jit_file, ConstString());
 
-      if (limit_file_ptr) {
-        SymbolVendor *symbol_vendor = jit_module_sp->GetSymbolVendor();
-        if (symbol_vendor)
-          symbol_vendor->SetLimitSourceFileRange(
+      if (limit_file_ptr)
+        if (SymbolFile *symbol_file = jit_module_sp->GetSymbolFile())
+          symbol_file->SetLimitSourceFileRange(
               *limit_file_ptr, limit_start_line, limit_end_line);
-      }
 
       target->GetImages().Append(jit_module_sp);
       return jit_module_sp;

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -400,10 +400,10 @@ public:
   virtual swift::Identifier getPreferredPrivateDiscriminator() {
     if (m_sc.comp_unit) {
       if (lldb_private::Module *module = m_sc.module_sp.get()) {
-        if (lldb_private::SymbolVendor *symbol_vendor =
-                module->GetSymbolVendor()) {
+        if (lldb_private::SymbolFile *symbol_file =
+                module->GetSymbolFile()) {
           std::string private_discriminator_string;
-          if (symbol_vendor->GetCompileOption("-private-discriminator",
+          if (symbol_file->GetCompileOption("-private-discriminator",
                                               private_discriminator_string,
                                               m_sc.comp_unit)) {
             return m_source_file.getASTContext().getIdentifier(

--- a/source/Symbol/SymbolVendor.cpp
+++ b/source/Symbol/SymbolVendor.cpp
@@ -75,29 +75,6 @@ void SymbolVendor::AddSymbolFileRepresentation(const ObjectFileSP &objfile_sp) {
   }
 }
 
-bool SymbolVendor::GetCompileOption(const char *option, std::string &value,
-                                    lldb_private::CompileUnit *cu) {
-  SymbolFile *sym_file = GetSymbolFile();
-
-  if (sym_file)
-    return sym_file->GetCompileOption(option, value, cu);
-
-  value.clear();
-  return false;
-}
-
-int SymbolVendor::GetCompileOptions(const char *option,
-                                    std::vector<std::string> &values,
-                                    lldb_private::CompileUnit *cu) {
-  SymbolFile *sym_file = GetSymbolFile();
-
-  if (sym_file)
-    return sym_file->GetCompileOptions(option, values, cu);
-
-  values.clear();
-  return false;
-}
-
 void SymbolVendor::GetLoadedModules(lldb::LanguageType language,
                                     FileSpecList &modules) {
   SymbolFile *sym_file = GetSymbolFile();
@@ -118,17 +95,6 @@ lldb_private::ConstString SymbolVendor::GetPluginName() {
 }
 
 uint32_t SymbolVendor::GetPluginVersion() { return 1; }
-
-bool SymbolVendor::SetLimitSourceFileRange(const FileSpec &file,
-                                           uint32_t first_line,
-                                           uint32_t last_line) {
-  SymbolFile *sym_file = GetSymbolFile();
-
-  if (sym_file)
-    return sym_file->SetLimitSourceFileRange(file, first_line, last_line);
-
-  return false;
-}
 
 bool SymbolVendor::SymbolContextShouldBeExcluded(const SymbolContext &sc,
                                                  uint32_t actual_line) {
@@ -172,12 +138,4 @@ SymbolVendor::GetASTData(lldb::LanguageType language) {
     ast_datas = sym_file->GetASTData(language);
 
   return ast_datas;
-}
-
-bool SymbolVendor::ForceInlineSourceFileCheck() {
-  SymbolFile *sym_file = GetSymbolFile();
-  if (sym_file)
-    return sym_file->ForceInlineSourceFileCheck();
-
-  return false;
 }

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -3068,7 +3068,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
                   ExecutionContext exe_ctx;
                   frame.CalculateExecutionContext(exe_ctx);
                   error = argument_values.GetValueAtIndex(0)->GetValueAsData(
-                      &exe_ctx, data, 0, NULL);
+                      &exe_ctx, data, NULL);
                   lldb::offset_t offset = 0;
                   lldb::addr_t fn_ptr_addr = data.GetPointer(&offset);
                   Address fn_ptr_address;


### PR DESCRIPTION
Deal with the GetSymbolVendor removal.

The GetASTData changes are incorrect, since SymbolVendor::GetASTData has
some extra logic that's not in SymbolFile. This gets things to build,
but GetASTData needs to be properly addressed.