### PR TITLE
DWARFImporterDelegate: Support enums.

### DIFF
--- a/lit/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lit/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -13,7 +13,7 @@ func f() {
   // The Objective-C runtime recognizes this as a tagged pointer.
   // CHECK-DAG: (NSNumber) inlined = {{.*}}42
   let inlined = NSNumber(value: 42)
-  // CHECK-DAG: (CMYK) enumerator = yellow
+  // CHECK-DAG: (CMYK) enumerator = [.yellow]
   let enumerator = yellow
   // CHECK-DAG: (FourColors) typedef = cyan
   let typedef = FourColors(0)

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -54,6 +54,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
                                 typename='__ObjC.Point', num_children=2)
         self.expect("fr v point", substrs=["x = 1", "y = 2"])
         self.expect("fr v point", substrs=["x = 1", "y = 2"])
+        self.expect("fr v enumerator", substrs=[".yellow"])
         self.expect("fr v pureSwiftStruct", substrs=["pure swift"])
         self.expect("fr v swiftStructCMember",
                     substrs=["x = 3", "y = 4", "swift struct c member"])

--- a/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -165,17 +165,20 @@ bool lldb_private::formatters::swift::SwiftOptionSetSummaryProvider::
 
     llvm::APInt matched_value(llvm::APInt::getNullValue(64));
 
-    auto iter = m_cases->begin(), end = m_cases->end();
-    for (; iter != end; ++iter) {
-      llvm::APInt case_value = iter->first;
+    for (auto val_name : *m_cases) {
+      llvm::APInt case_value = val_name.first;
+      // Don't display the zero case in an option set unless it's the
+      // only value.
+      if (case_value == 0 && value != 0)
+        continue;
       if ((case_value & value) == case_value) {
         // hey a case matched!!
         any_match = true;
         if (first_match) {
-          ss.Printf("[.%s", iter->second.AsCString());
+          ss.Printf("[.%s", val_name.second.AsCString());
           first_match = false;
         } else {
-          ss.Printf(", .%s", iter->second.AsCString());
+          ss.Printf(", .%s", val_name.second.AsCString());
         }
 
         matched_value |= case_value;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3163,11 +3163,11 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
     case swift::Demangle::Node::Kind::TypeAlias:
       // Not Implemented.
       return true;
+      // Oddly, the swiftified mangled name of a C enum can have kind=Structure.
     case swift::Demangle::Node::Kind::Structure:
-      return !qual_type->isStructureOrClassType();
     case swift::Demangle::Node::Kind::Enum:
-      // Not Implemented.
-      return true;
+      return !qual_type->isStructureOrClassType() &&
+             !qual_type->isEnumeralType();
     default:
       return true;
     }
@@ -3234,12 +3234,10 @@ public:
       clang::QualType clang_type(
           importer.Import(ClangUtil::GetQualType(compiler_type)));
 
-      auto *clang_record_type = clang_type->getAsStructureType();
-      if (!clang_record_type)
-        continue;
-      clang::Decl *clang_decl = clang_record_type->getDecl();
+      clang::Decl *clang_decl = clang_type->getAsTagDecl();
       if (!clang_decl)
         continue;
+
       results.push_back(clang_decl);
     }
   }


### PR DESCRIPTION
Also includes a tiny improvement to SwiftOptionSetSummaryProvider to
avoid printing the zero-case of an option set.