### PR TITLE
[SwiftASTContext] Only a variant of CreateTupleType is used.

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -315,13 +315,6 @@ public:
   swift::ClangImporter *GetClangImporter();
   swift::DWARFImporter *GetDWARFImporter();
 
-  // ***********************************************************
-  //  these calls create non-nominal types which are given in
-  //  metadata just in terms of their building blocks and for
-  //  which there is no one basic type to compose from
-  // ***********************************************************
-  CompilerType CreateTupleType(const std::vector<CompilerType> &elements);
-
   struct TupleElement {
     ConstString element_name;
     CompilerType element_type;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4751,26 +4751,6 @@ swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
 }
 
 CompilerType
-SwiftASTContext::CreateTupleType(const std::vector<CompilerType> &elements) {
-  VALID_OR_RETURN(CompilerType());
-
-  Status error;
-  if (elements.size() == 0)
-    return {GetASTContext()->TheEmptyTupleType};
-  else {
-    std::vector<swift::TupleTypeElt> tuple_elems;
-    for (const CompilerType &type : elements) {
-      if (auto swift_type = GetSwiftType(type))
-        tuple_elems.push_back(swift::TupleTypeElt(swift_type));
-      else
-        return CompilerType();
-    }
-    llvm::ArrayRef<swift::TupleTypeElt> fields(tuple_elems);
-    return {swift::TupleType::get(fields, *GetASTContext()).getPointer()};
-  }
-}
-
-CompilerType
 SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
   VALID_OR_RETURN(CompilerType());
 


### PR DESCRIPTION
Remove the other.