### PR TITLE
[Dematerializer] Remove unneded DoArchetypeBinding().

### DIFF
--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -988,13 +988,6 @@ public:
     lldb::ProcessSP process_sp =
         map.GetBestExecutionContextScope()->CalculateProcess();
 
-    if (lang == lldb::eLanguageTypeSwift) {
-      SwiftLanguageRuntime *language_runtime =
-          SwiftLanguageRuntime::Get(*process_sp);
-      if (language_runtime && frame_sp)
-        m_type = language_runtime->DoArchetypeBindingForType(*frame_sp, m_type);
-    }
-
     lldb::ExpressionVariableSP ret = persistent_state->CreatePersistentVariable(
         exe_scope, name, m_type, map.GetByteOrder(), map.GetAddressByteSize());
 


### PR DESCRIPTION
The (de)materializer works on variables that have been already
materialized, and fully realized. We don't need to perform archetype
binding, because the materializer did it already.