### PR TITLE
Document DWARFImporter's inability to import Objective-C Protocol types.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Inputs/objc-header.h
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Inputs/objc-header.h
@@ -1,5 +1,17 @@
+/* -*- ObjC -*- */
 @import Foundation;
+
+@protocol WithName
+- (NSString *)name;
+@end
+
+@protocol ObjCProtocol <WithName>
+@end
 
 @interface ObjCClass : NSObject
 - (instancetype)init;
 @end
+
+// FIXME: id<ObjCProtocol> doesn't anchor the type since Clang doesn't
+// yet describe protocol conformances in DWARF.
+id<ObjCProtocol> getProto();

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -50,3 +50,5 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                 typename="Swift.Optional<__ObjC.ObjCClass>",
                                 num_children=0)
         self.expect("fr v obj", substrs=["ObjCClass", "private_ivar", "42"])
+        # This is a Clang type, since Clang doesn't generate DWARF for protocols.
+        self.expect("fr v -O proto", substrs=["ProtoImpl"])

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/impl.m
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/impl.m
@@ -1,5 +1,9 @@
 @import ObjCModule;
 
+@interface ProtoImpl : NSObject <ObjCProtocol>
+- (NSString *)name;
+@end
+
 @implementation ObjCClass {
   int private_ivar;
 }
@@ -12,3 +16,14 @@
   return self;
 }
 @end
+
+id<ObjCProtocol> getProto() {
+  return [ProtoImpl new];
+}
+
+@implementation ProtoImpl
+- (NSString *)name {
+  return @"I am implementing an Objective-C protocol.";
+}
+@end
+

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/main.swift
@@ -4,5 +4,7 @@ func use<T>(_ t: T) {}
 
 let pureSwift = 42
 let obj = ObjCClass()
+let proto = getProto()
 use(pureSwift) // break here
 use(obj)
+use(proto)

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3155,7 +3155,8 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
     clang::QualType qual_type = ClangUtil::GetQualType(fwd_type);
     switch (kind) {
     case swift::Demangle::Node::Kind::Protocol:
-      // Not implemented.
+      // Not implemented since Objective-C protocols aren't yet
+      // described in DWARF.
       return true;
     case swift::Demangle::Node::Kind::Class:
       return !qual_type->isObjCObjectOrInterfaceType();


### PR DESCRIPTION
Protocols are not emitted into DWARF by Clang. We may be able to
salvage them as dynamic types using the AppleObjectiveCDeclVendor.

rdar://problem/49233932