### PR TITLE
[SwiftASTContext] Fix GetTypeBitAlign to work in the general case

### DIFF
--- a/include/lldb/Expression/Materializer.h
+++ b/include/lldb/Expression/Materializer.h
@@ -120,8 +120,6 @@ public:
     void SetOffset(uint32_t offset) { m_offset = offset; }
 
   protected:
-    void SetSizeAndAlignmentFromType(CompilerType &type);
-
     uint32_t m_alignment;
     uint32_t m_size;
     uint32_t m_offset;

--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -769,7 +769,8 @@ public:
 
   lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
 
-  size_t GetTypeBitAlign(lldb::opaque_compiler_type_t type) override;
+  llvm::Optional<size_t>
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type) override;
 
   uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
                           bool omit_empty_base_classes,

--- a/include/lldb/Symbol/ClangASTContext.h
+++ b/include/lldb/Symbol/ClangASTContext.h
@@ -770,7 +770,8 @@ public:
   lldb::Format GetFormat(lldb::opaque_compiler_type_t type) override;
 
   llvm::Optional<size_t>
-  GetTypeBitAlign(lldb::opaque_compiler_type_t type) override;
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                  ExecutionContextScope *exe_scope) override;
 
   uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
                           bool omit_empty_base_classes,

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -309,7 +309,7 @@ public:
 
   lldb::Format GetFormat() const;
 
-  size_t GetTypeBitAlign() const;
+  llvm::Optional<size_t> GetTypeBitAlign() const;
 
   uint32_t GetNumChildren(bool omit_empty_base_classes,
                           const ExecutionContext *exe_ctx) const;

--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -309,7 +309,7 @@ public:
 
   lldb::Format GetFormat() const;
 
-  llvm::Optional<size_t> GetTypeBitAlign() const;
+  llvm::Optional<size_t> GetTypeBitAlign(ExecutionContextScope *exe_scope) const;
 
   uint32_t GetNumChildren(bool omit_empty_base_classes,
                           const ExecutionContext *exe_ctx) const;

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -673,7 +673,8 @@ public:
 
   bool IsCStringType(void *type, uint32_t &length) override;
 
-  size_t GetTypeBitAlign(void *type) override;
+  llvm::Optional<size_t> GetTypeBitAlign(void *type,
+                                         ExecutionContextScope *exe_scope) override;
 
   CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) override;
 

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -448,7 +448,8 @@ public:
   virtual bool IsCStringType(lldb::opaque_compiler_type_t type,
                              uint32_t &length) = 0;
 
-  virtual size_t GetTypeBitAlign(lldb::opaque_compiler_type_t type) = 0;
+  virtual llvm::Optional<size_t>
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type) = 0;
 
   virtual CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) = 0;
 

--- a/include/lldb/Symbol/TypeSystem.h
+++ b/include/lldb/Symbol/TypeSystem.h
@@ -449,7 +449,8 @@ public:
                              uint32_t &length) = 0;
 
   virtual llvm::Optional<size_t>
-  GetTypeBitAlign(lldb::opaque_compiler_type_t type) = 0;
+  GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                  ExecutionContextScope *exe_scope) = 0;
 
   virtual CompilerType GetBasicTypeFromAST(lldb::BasicType basic_type) = 0;
 

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -311,6 +311,9 @@ public:
   /// Ask Remote mirrors for the stride of a Swift type.
   llvm::Optional<uint64_t> GetByteStride(CompilerType type);
 
+  /// Ask Remote mirrors for the alignment of a Swift type.
+  llvm::Optional<size_t> GetBitAlignment(CompilerType type);
+
   bool IsWhitelistedRuntimeValue(ConstString name) override;
 
   virtual CompilerType DoArchetypeBindingForType(StackFrame &stack_frame,

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -46,20 +46,6 @@ uint32_t Materializer::AddStructMember(Entity &entity) {
   return ret;
 }
 
-void Materializer::Entity::SetSizeAndAlignmentFromType(CompilerType &type) {
-  if (llvm::Optional<uint64_t> size = type.GetByteSize(nullptr))
-    m_size = *size;
-
-  uint32_t bit_alignment = type.GetTypeBitAlign();
-
-  if (bit_alignment % 8) {
-    bit_alignment += 8;
-    bit_alignment &= ~((uint32_t)0x111u);
-  }
-
-  m_alignment = bit_alignment / 8;
-}
-
 class EntityPersistentVariable : public Materializer::Entity {
 public:
   EntityPersistentVariable(lldb::ExpressionVariableSP &persistent_variable_sp,

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -584,11 +584,15 @@ public:
                 *frame_sp, layout_type);
         }
 
-        size_t bit_align = layout_type.GetTypeBitAlign();
-        size_t byte_align = (bit_align + 7) / 8;
+        llvm::Optional<size_t> opt_bit_align =
+            m_variable_sp->GetType()->GetLayoutCompilerType().GetTypeBitAlign();
+        if (!opt_bit_align) {
+          err.SetErrorStringWithFormat("can't get the type alignment for %s",
+                                       m_variable_sp->GetName().AsCString());
+          return;
+        }
 
-        if (!byte_align)
-          byte_align = 1;
+        size_t byte_align = (*opt_bit_align + 7) / 8;
 
         Status alloc_error;
         const bool zero_memory = false;
@@ -859,11 +863,14 @@ public:
         err.SetErrorString("can't get size of type");
         return;
       }
-      size_t bit_align = m_type.GetTypeBitAlign();
-      size_t byte_align = (bit_align + 7) / 8;
 
-      if (!byte_align)
-        byte_align = 1;
+      llvm::Optional<size_t> opt_bit_align = m_type.GetTypeBitAlign();
+      if (!opt_bit_align) {
+        err.SetErrorStringWithFormat("can't get the type alignment");
+        return;
+      }
+
+      size_t byte_align = (*opt_bit_align + 7) / 8;
 
       Status alloc_error;
       const bool zero_memory = true;

--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -585,7 +585,7 @@ public:
         }
 
         llvm::Optional<size_t> opt_bit_align =
-            m_variable_sp->GetType()->GetLayoutCompilerType().GetTypeBitAlign();
+            m_variable_sp->GetType()->GetLayoutCompilerType().GetTypeBitAlign(scope);
         if (!opt_bit_align) {
           err.SetErrorStringWithFormat("can't get the type alignment for %s",
                                        m_variable_sp->GetName().AsCString());
@@ -864,7 +864,7 @@ public:
         return;
       }
 
-      llvm::Optional<size_t> opt_bit_align = m_type.GetTypeBitAlign();
+      llvm::Optional<size_t> opt_bit_align = m_type.GetTypeBitAlign(exe_scope);
       if (!opt_bit_align) {
         err.SetErrorStringWithFormat("can't get the type alignment");
         return;

--- a/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -1372,7 +1372,7 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
     llvm::Optional<uint64_t> value_size = compiler_type.GetByteSize(nullptr);
     if (!value_size)
       return false;
-    llvm::Optional<size_t> opt_alignment = compiler_type.GetTypeBitAlign();
+    llvm::Optional<size_t> opt_alignment = compiler_type.GetTypeBitAlign(nullptr);
     if (!opt_alignment)
       return false;
     lldb::offset_t value_alignment = (*opt_alignment + 7ull) / 8ull;

--- a/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -1372,8 +1372,10 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
     llvm::Optional<uint64_t> value_size = compiler_type.GetByteSize(nullptr);
     if (!value_size)
       return false;
-    lldb::offset_t value_alignment =
-        (compiler_type.GetTypeBitAlign() + 7ull) / 8ull;
+    llvm::Optional<size_t> opt_alignment = compiler_type.GetTypeBitAlign();
+    if (!opt_alignment)
+      return false;
+    lldb::offset_t value_alignment = (*opt_alignment + 7ull) / 8ull;
 
     if (log) {
       log->Printf("Type of \"%s\" is [clang \"%s\", llvm \"%s\"] [size %" PRIu64

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5162,7 +5162,8 @@ ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
 }
 
 llvm::Optional<size_t>
-ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type) {
+ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type,
+                                 ExecutionContextScope *exe_scope) {
   if (GetCompleteType(type))
     return getASTContext()->getTypeAlign(GetQualType(type));
   return {};

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -5161,10 +5161,11 @@ ClangASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
   return {};
 }
 
-size_t ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type) {
+llvm::Optional<size_t>
+ClangASTContext::GetTypeBitAlign(lldb::opaque_compiler_type_t type) {
   if (GetCompleteType(type))
     return getASTContext()->getTypeAlign(GetQualType(type));
-  return 0;
+  return {};
 }
 
 lldb::Encoding ClangASTContext::GetEncoding(lldb::opaque_compiler_type_t type,

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -560,10 +560,10 @@ CompilerType::GetByteStride(ExecutionContextScope *exe_scope) const {
 
 uint64_t CompilerType::GetAlignedBitSize() const { return 0; }
 
-size_t CompilerType::GetTypeBitAlign() const {
+llvm::Optional<size_t> CompilerType::GetTypeBitAlign() const {
   if (IsValid())
     return m_type_system->GetTypeBitAlign(m_type);
-  return 0;
+  return {};
 }
 
 lldb::Encoding CompilerType::GetEncoding(uint64_t &count) const {

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -560,9 +560,9 @@ CompilerType::GetByteStride(ExecutionContextScope *exe_scope) const {
 
 uint64_t CompilerType::GetAlignedBitSize() const { return 0; }
 
-llvm::Optional<size_t> CompilerType::GetTypeBitAlign() const {
+llvm::Optional<size_t> CompilerType::GetTypeBitAlign(ExecutionContextScope *exe_scope) const {
   if (IsValid())
-    return m_type_system->GetTypeBitAlign(m_type);
+    return m_type_system->GetTypeBitAlign(m_type, exe_scope);
   return {};
 }
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6164,6 +6164,12 @@ llvm::Optional<size_t> SwiftASTContext::GetTypeBitAlign(void *type,
       GetSwiftFixedTypeInfo(type);
   if (fixed_type_info)
     return fixed_type_info->getFixedAlignment().getValue();
+
+  // Ask the dynamic type system.
+  if (!exe_scope)
+    return {};
+  if (auto *runtime = SwiftLanguageRuntime::Get(*exe_scope->CalculateProcess()))
+    return runtime->GetBitAlignment({this, type});
   return {};
 }
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6142,14 +6142,14 @@ SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
   return {};
 }
 
-size_t SwiftASTContext::GetTypeBitAlign(void *type) {
+llvm::Optional<size_t> SwiftASTContext::GetTypeBitAlign(void *type) {
   if (type) {
     const swift::irgen::FixedTypeInfo *fixed_type_info =
         GetSwiftFixedTypeInfo(type);
     if (fixed_type_info)
       return fixed_type_info->getFixedAlignment().getValue();
   }
-  return 0;
+  return {};
 }
 
 lldb::Encoding SwiftASTContext::GetEncoding(void *type, uint64_t &count) {

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6142,7 +6142,8 @@ SwiftASTContext::GetByteStride(lldb::opaque_compiler_type_t type,
   return {};
 }
 
-llvm::Optional<size_t> SwiftASTContext::GetTypeBitAlign(void *type) {
+llvm::Optional<size_t> SwiftASTContext::GetTypeBitAlign(void *type,
+                                                        ExecutionContextScope *exe_scope) {
   if (type) {
     const swift::irgen::FixedTypeInfo *fixed_type_info =
         GetSwiftFixedTypeInfo(type);

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -2594,6 +2594,12 @@ llvm::Optional<uint64_t> SwiftLanguageRuntime::GetByteStride(CompilerType type) 
   return {};
 }
 
+llvm::Optional<size_t> SwiftLanguageRuntime::GetBitAlignment(CompilerType type) {
+  if (auto *type_info = GetTypeInfo(type))
+    return type_info->getAlignment();
+  return {};
+}
+
 bool SwiftLanguageRuntime::IsWhitelistedRuntimeValue(ConstString name) {
   return name == g_self;
 }


### PR DESCRIPTION
In particular:
1) Generic types [which aren't currently mapped]
2) non-fixed layout types.