### PR TITLE
[Swift] Remove hacks, workarounds et similia

### DIFF
--- a/source/Expression/Materializer.cpp
+++ b/source/Expression/Materializer.cpp
@@ -568,22 +568,6 @@ public:
           return;
         }
 
-        // FIXME: It would be better to map the type into the context when the
-        //        variable is created. 
-        auto layout_type = m_variable_sp->GetType()->GetLayoutCompilerType();
-
-        // IRGen wants a fully realized type so we do archetype binding
-        // before asking informations about this type (e.g. its size).
-        if (layout_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
-          lldb::ProcessSP process_sp =
-              map.GetBestExecutionContextScope()->CalculateProcess();
-          SwiftLanguageRuntime *language_runtime =
-              SwiftLanguageRuntime::Get(*process_sp);
-          if (language_runtime && frame_sp)
-            layout_type = language_runtime->DoArchetypeBindingForType(
-                *frame_sp, layout_type);
-        }
-
         llvm::Optional<size_t> opt_bit_align =
             m_variable_sp->GetType()->GetLayoutCompilerType().GetTypeBitAlign(scope);
         if (!opt_bit_align) {

--- a/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -299,9 +299,9 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
 
   // For now we have to keep the old mangled name since the Objc->Swift bindings
   // that are in Foundation don't get the new mangling.
-  if (valobj_typename.startswith(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs23_ContiguousArrayStorage"))
-      || valobj_typename.startswith("_TtCs23_ContiguousArrayStorage")
-      || valobj_typename.startswith("Swift._ContiguousArrayStorage")) {
+  if (valobj_typename.startswith("_TtCs23_ContiguousArrayStorage") ||
+      valobj_typename.startswith("_TtCs23_ContiguousArrayStorage") ||
+      valobj_typename.startswith("Swift._ContiguousArrayStorage")) {
     CompilerType anyobject_type =
         valobj.GetTargetSP()->GetScratchClangASTContext()->GetBasicType(
             lldb::eBasicTypeObjCID);
@@ -314,9 +314,9 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &valobj) {
     return nullptr;
   }
 
-  if (valobj_typename.startswith(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray"))
-      || valobj_typename.startswith("_TtCs22__SwiftDeferredNSArray")
-      || valobj_typename.startswith("Swift.__SwiftDeferredNSArray") ) {
+  if (valobj_typename.startswith("_TtCs22__SwiftDeferredNSArray") ||
+      valobj_typename.startswith("_TtCs22__SwiftDeferredNSArray") ||
+      valobj_typename.startswith("Swift.__SwiftDeferredNSArray")) {
     ProcessSP process_sp(valobj.GetProcessSP());
     if (!process_sp)
       return nullptr;

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -56,10 +56,9 @@ using lldb_private::formatters::swift::DictionaryConfig;
 using lldb_private::formatters::swift::SetConfig;
 
 void SwiftLanguage::Initialize() {
-  static ConstString g_SwiftSharedStringClass(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21__SharedStringStorage"));
-  static ConstString g_SwiftStringStorageClass(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs15__StringStorage"));
-  static ConstString g_NSArrayClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray"));
+  static ConstString g_SwiftSharedStringClass("_TtCs21__SharedStringStorage");
+  static ConstString g_SwiftStringStorageClass("_TtCs15__StringStorage");
+  static ConstString g_NSArrayClass1("_TtCs22__SwiftDeferredNSArray");
   PluginManager::RegisterPlugin(GetPluginNameStatic(), "Swift Language",
                                 CreateInstance);
 
@@ -81,10 +80,9 @@ void SwiftLanguage::Initialize() {
 
 void SwiftLanguage::Terminate() {
   // FIXME: Duplicating this list from Initialize seems error-prone.
-  static ConstString g_SwiftSharedStringClass(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21__SharedStringStorage"));
-  static ConstString g_SwiftStringStorageClass(
-      SwiftLanguageRuntime::GetCurrentMangledName("_TtCs15__StringStorage"));
-  static ConstString g_NSArrayClass1(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray"));
+  static ConstString g_SwiftSharedStringClass("_TtCs21__SharedStringStorage");
+  static ConstString g_SwiftStringStorageClass("_TtCs15__StringStorage");
+  static ConstString g_NSArrayClass1("_TtCs22__SwiftDeferredNSArray");
 
   lldb_private::formatters::NSString_Additionals::GetAdditionalSummaries()
       .erase(g_SwiftSharedStringClass);
@@ -317,7 +315,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::NSArraySummaryProvider,
       "Swift.Array summary provider",
-      ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray")), summary_flags, false);
+      ConstString("_TtCs22__SwiftDeferredNSArray"), summary_flags, false);
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Array_SummaryProvider,
       "Swift.Array summary provider",
@@ -369,8 +367,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSynthetic(swift_category_sp,
                   lldb_private::formatters::NSArraySyntheticFrontEndCreator,
                   "Swift.Array synthetic children",
-                  ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs22__SwiftDeferredNSArray")),
-                  synth_flags,
+                  ConstString("_TtCs22__SwiftDeferredNSArray"), synth_flags,
                   false);
   AddCXXSynthetic(swift_category_sp,
                   lldb_private::formatters::NSArraySyntheticFrontEndCreator,
@@ -435,7 +432,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::SwiftSharedString_SummaryProvider,
       "SharedStringStorage summary provider",
-      ConstString(SwiftLanguageRuntime::GetCurrentMangledName("_TtCs21__SharedStringStorage")), summary_flags);
+      ConstString("_TtCs21__SharedStringStorage"), summary_flags);
   summary_flags.SetSkipPointers(true);
   AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::BuiltinObjC_SummaryProvider,

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -794,26 +794,6 @@ bool SwiftLanguageRuntime::IsSwiftClassName(const char *name)
   return swift::Demangle::isClass(name);
 }
 
-const std::string SwiftLanguageRuntime::GetCurrentMangledName(const char *mangled_name)
-{
-#ifndef USE_NEW_MANGLING
-  return std::string(mangled_name);
-#else
-  //FIXME: Check if we need to cache these lookups...
-  swift::Demangle::Context demangle_ctx;
-  swift::Demangle::NodePointer node_ptr = demangle_ctx.demangleSymbolAsNode(mangled_name);
-  if (!node_ptr)
-  {
-    // Sometimes this gets passed the prefix of a name, in which case we
-    // won't be able to demangle it.  In that case return what was passed in.
-    printf ("Couldn't get mangled name for %s.\n", mangled_name);
-    return mangled_name;
-  }
-  else
-    return swift::Demangle::mangleNode(node_ptr);
-#endif
-}
-
 void SwiftLanguageRuntime::MethodName::Clear() {
   m_full.Clear();
   m_basename = llvm::StringRef();


### PR DESCRIPTION
[Materializer] Remove the last call to archetype binding in generic code.

Now all the magic happens in the swift specific code. This removes
a longstanding hack and brings us a step closer to separate core
and language support. Straightforward after the yak was shaved.


[Swift] Get rid of GetCurrentMangledName(). 
This was needed when the mangling name was changing pre-ABI
stability, but it's not anymore.