### PR TITLE
[test] Disable implementation_only_imports/main_executable

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -22,6 +22,7 @@ import os.path
 import time
 import unittest2
 
+@skipIfDarwin # rdar://problem/54322424 Sometimes failing, sometimes truncated output.
 class TestMainExecutable(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)


### PR DESCRIPTION
Some test runs are passing.

Some test runs are failing:

    FAIL: test_implementation_only_import_main_executable_resilient_dwarf
    AssertionError: [...] 'fr var' returns expected result, got [...]
    (at TestMainExecutable.py:116)

(https://ci.swift.org/job/oss-swift-package-osx/3599/)

Some test runs don't even seem to complete:

    Unresolved Tests (1):
        lldb-Suite :: lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py

(https://ci.swift.org/job/swift-lldb-PR-osx/2211/)

Unfortunately I don't have time to look into this. The other two tests in the implementation_only_imports directory are more important/realistic anyway.

rdar://problem/54322424