### PR TITLE
[Symbol] Remove swift from CompilerType

### DIFF
--- a/include/lldb/Symbol/CompilerType.h
+++ b/include/lldb/Symbol/CompilerType.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "lldb/Core/SwiftForward.h"
 #include "lldb/lldb-private.h"
 #include "llvm/ADT/APSInt.h"
 
@@ -32,7 +31,6 @@ class CompilerType {
 public:
   // Constructors and Destructors
   CompilerType(TypeSystem *type_system, lldb::opaque_compiler_type_t type);
-  CompilerType(swift::Type qual_type);
 
   CompilerType(const CompilerType &rhs)
       : m_type(rhs.m_type), m_type_system(rhs.m_type_system) {}

--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -739,6 +739,8 @@ public:
                                 lldb::StackFrameWP &stack_frame_wp,
                                 swift::SourceFile *source_file, Status &error);
 
+  static CompilerType GetCompilerType(swift::Type swift_type);
+
 protected:
   /// This map uses the string value of ConstStrings as the key, and the TypeBase
   /// * as the value. Since the ConstString strings are uniqued, we can use

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -749,7 +749,7 @@ void SwiftASTManipulator::FindVariableDeclarations(
     auto type = var_decl->getDeclContext()->mapTypeIntoContext(
         var_decl->getInterfaceType());
     persistent_info.m_name = name;
-    persistent_info.m_type = {type.getPointer()};
+    persistent_info.m_type = SwiftASTContext::GetCompilerType(type);
     persistent_info.m_decl = var_decl;
 
     m_variables.push_back(persistent_info);
@@ -815,7 +815,7 @@ void SwiftASTManipulator::InsertResult(
     SwiftASTManipulator::ResultLocationInfo &result_info) {
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType return_ast_type(result_type.getPointer());
+  CompilerType return_ast_type = SwiftASTContext::GetCompilerType(result_type);
 
   result_var->overwriteAccess(swift::AccessLevel::Public);
   result_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -856,7 +856,8 @@ void SwiftASTManipulator::InsertError(swift::VarDecl *error_var,
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType error_ast_type(error_type.getPointer());
+  CompilerType error_ast_type =
+      SwiftASTContext::GetCompilerType(error_type);
 
   error_var->overwriteAccess(swift::AccessLevel::Public);
   error_var->overwriteSetterAccess(swift::AccessLevel::Public);
@@ -956,7 +957,8 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
 
   swift::ASTContext &ast_context = m_source_file.getASTContext();
 
-  CompilerType return_ast_type(result_type.getPointer());
+  CompilerType return_ast_type =
+      SwiftASTContext::GetCompilerType(result_type);
   swift::Identifier result_var_name =
       ast_context.getIdentifier(GetResultName());
   SwiftASTManipulatorBase::VariableMetadataSP metadata_sp(
@@ -1000,7 +1002,7 @@ bool SwiftASTManipulator::FixupResultAfterTypeChecking(Status &error) {
               continue;
 
             swift::Type error_type = var_decl->getInterfaceType();
-            CompilerType error_ast_type(error_type.getPointer());
+            CompilerType error_ast_type = SwiftASTContext::GetCompilerType(error_type);
             SwiftASTManipulatorBase::VariableMetadataSP error_metadata_sp(
                 new VariableMetadataError());
 

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionVariable.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionVariable.h
@@ -28,6 +28,7 @@
 
 // Project includes
 #include "lldb/Core/ClangForward.h"
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Symbol/TaggedASTType.h"

--- a/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.h
@@ -13,6 +13,7 @@
 #ifndef liblldb_SwiftREPLMaterializer_h
 #define liblldb_SwiftREPLMaterializer_h
 
+#include "lldb/Core/SwiftForward.h"
 #include "lldb/Expression/Materializer.h"
 
 namespace lldb_private {

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1044,7 +1044,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   if (generic_args.size() != 1)
     return false;
   auto swift_arg_type = generic_args[0];
-  CompilerType arg_type(swift_arg_type);
+  CompilerType arg_type = SwiftASTContext::GetCompilerType(swift_arg_type);
 
   llvm::Optional<uint64_t> opt_arg_size = arg_type.GetByteSize(nullptr);
   if (!opt_arg_size)

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1315,8 +1315,8 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                   } else if (local_results.empty() && module &&
                              name_parts.size() == 1 &&
                              name_parts.front() == module->getName().str())
-                    results.insert(
-                        CompilerType(swift::ModuleType::get(module)));
+                    results.insert(SwiftASTContext::GetCompilerType(
+                        swift::ModuleType::get(module)));
                 }
               };
 

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -192,7 +192,8 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         return {};
       }
       preferred_name = name;
-      compiler_type = {swift_ast_ctx->TheRawPointerType};
+      compiler_type =
+          SwiftASTContext::GetCompilerType(swift_ast_ctx->TheRawPointerType);
     }
   }
 

--- a/source/Symbol/CompilerType.cpp
+++ b/source/Symbol/CompilerType.cpp
@@ -10,7 +10,6 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/StreamFile.h"
-#include "lldb/Symbol/SwiftASTContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/Process.h"
@@ -24,20 +23,12 @@
 #include <iterator>
 #include <mutex>
 
-#include "swift/AST/Type.h"
-#include "swift/AST/Types.h"
-
 using namespace lldb;
 using namespace lldb_private;
 
 CompilerType::CompilerType(TypeSystem *type_system,
                            lldb::opaque_compiler_type_t type)
     : m_type(type), m_type_system(type_system) {}
-
-CompilerType::CompilerType(swift::Type qual_type)
-    : m_type(qual_type.getPointer()),
-      m_type_system(
-          SwiftASTContext::GetSwiftASTContext(&qual_type->getASTContext())) {}
 
 CompilerType::~CompilerType() {}
 

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -1642,7 +1642,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Protocol(
   }
 
   auto type_and_address = result.getValue();
-  class_type_or_name.SetCompilerType(type_and_address.InstanceType);
+  class_type_or_name.SetCompilerType(
+      SwiftASTContext::GetCompilerType(type_and_address.InstanceType));
   address.SetRawAddress(type_and_address.PayloadAddress.getAddressData());
   return true;
 }
@@ -1801,7 +1802,7 @@ SwiftLanguageRuntime::DoArchetypeBindingForType(StackFrame &stack_frame,
         swift::SubstFlags::DesugarMemberTypes);
     assert(target_swift_type);
 
-    return {target_swift_type.getPointer()};
+    return SwiftASTContext::GetCompilerType(target_swift_type);
   }
   return base_type;
 }
@@ -2319,7 +2320,7 @@ lldb::addr_t SwiftLanguageRuntime::FixupAddress(lldb::addr_t addr,
 const swift::reflection::TypeInfo *
 SwiftLanguageRuntime::GetTypeInfo(CompilerType type) {
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  CompilerType can_type(swift_can_type);
+  CompilerType can_type = SwiftASTContext::GetCompilerType(swift_can_type);
   ConstString mangled_name(can_type.GetMangledTypeName());
   StringRef mangled_no_prefix =
       swift::Demangle::dropSwiftManglingPrefix(mangled_name.GetStringRef());


### PR DESCRIPTION
I removed clang from CompilerType, so removing swift seems like the natural
progression.