### PR TITLE
Update for upstream rL369555

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3208,7 +3208,7 @@ public:
                    llvm::SmallVectorImpl<clang::Decl *> &results) override {
     std::vector<CompilerContext> decl_context;
     ConstString name_cs(name);
-    decl_context.push_back({CompilerContextKind::Structure, name_cs});
+    decl_context.push_back({CompilerContextKind::Struct, name_cs});
     auto clang_importer = m_swift_ast_ctx.GetClangImporter();
     if (!clang_importer)
       return;


### PR DESCRIPTION
- CompilerContextKind::Enumeration -> CompilerContextKind::Enum
- CompilerContextKind::Structure -> CompilerContextKind::Struct
- CompilerContext::type -> CompilerContext::kind
- GetDeclContext now takes a llvm::SmallVectorImpl