### PR TITLE
DWARFImporterDelegate: Adopt the new FindFiles API

### DIFF
--- a/include/lldb/Symbol/SymbolFile.h
+++ b/include/lldb/Symbol/SymbolFile.h
@@ -199,8 +199,8 @@ public:
             bool append, uint32_t max_matches,
             llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
             TypeMap &types);
-  virtual size_t FindTypes(const std::vector<CompilerContext> &context,
-                           bool append, TypeMap &types);
+  virtual size_t FindTypes(llvm::ArrayRef<CompilerContext> pattern, bool append,
+                           TypeMap &types);
 
   virtual void
   GetMangledNamesForFunction(const std::string &scope_qualified_name,

--- a/include/lldb/Symbol/SymbolVendor.h
+++ b/include/lldb/Symbol/SymbolVendor.h
@@ -105,7 +105,7 @@ public:
             llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
             TypeMap &types);
 
-  virtual size_t FindTypes(const std::vector<CompilerContext> &context,
+  virtual size_t FindTypes(llvm::ArrayRef<lldb_private::CompilerContext> context,
                            bool append, TypeMap &types);
 
   virtual CompilerDeclContext

--- a/include/lldb/Symbol/Type.h
+++ b/include/lldb/Symbol/Type.h
@@ -22,23 +22,27 @@
 #include <set>
 
 namespace lldb_private {
-//----------------------------------------------------------------------
-// CompilerContext allows an array of these items to be passed to perform
-// detailed lookups in SymbolVendor and SymbolFile functions.
-//----------------------------------------------------------------------
+
+/// CompilerContext allows an array of these items to be passed to perform
+/// detailed lookups in SymbolVendor and SymbolFile functions.
 struct CompilerContext {
-  CompilerContext(CompilerContextKind t, ConstString n)
-      : type(t), name(n) {}
+  CompilerContext(CompilerContextKind t, ConstString n) : kind(t), name(n) {}
 
   bool operator==(const CompilerContext &rhs) const {
-    return type == rhs.type && name == rhs.name;
+    return kind == rhs.kind && name == rhs.name;
   }
+  bool operator!=(const CompilerContext &rhs) const { return !(*this == rhs); }
 
   void Dump() const;
 
-  CompilerContextKind type;
+  CompilerContextKind kind;
   ConstString name;
 };
+
+/// Match \p context_chain against \p pattern, which may contain "Any"
+/// kinds. The \p context_chain should *not* contain any "Any" kinds.
+bool contextMatches(llvm::ArrayRef<CompilerContext> context_chain,
+                    llvm::ArrayRef<CompilerContext> pattern);
 
 class SymbolFileType : public std::enable_shared_from_this<SymbolFileType>,
                        public UserID {

--- a/include/lldb/lldb-private-enumerations.h
+++ b/include/lldb/lldb-private-enumerations.h
@@ -251,18 +251,24 @@ enum class TypeValidatorResult : bool { Success = true, Failure = false };
 //----------------------------------------------------------------------
 // Enumerations that can be used to specify scopes types when looking up types.
 //----------------------------------------------------------------------
-enum class CompilerContextKind {
+enum class CompilerContextKind : uint16_t {
   Invalid = 0,
-  TranslationUnit,
-  Module,
-  Namespace,
-  Class,
-  Structure,
-  Union,
-  Function,
-  Variable,
-  Enumeration,
-  Typedef
+  TranslationUnit = 1,
+  Module = 1 << 1,
+  Namespace = 1 << 2,
+  Class = 1 << 3,
+  Struct = 1 << 4,
+  Union = 1 << 5,
+  Function = 1 << 6,
+  Variable = 1 << 7,
+  Enum = 1 << 8,
+  Typedef = 1 << 9,
+
+  Any = 1 << 15,
+  /// Match 0..n nested modules.
+  AnyModule = Any | Module,
+  /// Match any type.
+  AnyType = Any | Class | Struct | Union | Enum | Typedef
 };
 
 //----------------------------------------------------------------------

--- a/lit/SymbolFile/DWARF/compilercontext.ll
+++ b/lit/SymbolFile/DWARF/compilercontext.ll
@@ -1,0 +1,49 @@
+; Test finding types by CompilerContext.
+; RUN: llc %s -filetype=obj -o %t.o
+; RUN: lldb-test symbols %t.o -find=type \
+; RUN:   -compiler-context="Module:CModule,Module:SubModule,Struct:FromSubmoduleX" \
+; RUN:   | FileCheck %s --check-prefix=NORESULTS
+; RUN: lldb-test symbols %t.o -find=type \
+; RUN:   -compiler-context="Module:CModule,Module:SubModule,Struct:FromSubmodule" \
+; RUN:   | FileCheck %s
+; RUN: lldb-test symbols %t.o -find=type \
+; RUN:   -compiler-context="Module:CModule,AnyModule:*,Struct:FromSubmodule" \
+; RUN:   | FileCheck %s
+; RUN: lldb-test symbols %t.o -find=type \
+; RUN:   -compiler-context="AnyModule:*,Struct:FromSubmodule" \
+; RUN:   | FileCheck %s
+; RUN: lldb-test symbols %t.o -find=type \
+; RUN:   -compiler-context="Module:CModule,Module:SubModule,AnyType:FromSubmodule" \
+; RUN:   | FileCheck %s
+;
+; NORESULTS: Found 0 types
+; CHECK: Found 1 types:
+; CHECK: struct FromSubmodule {
+; CHECK-NEXT:     unsigned int x;
+; CHECK-NEXT:     unsigned int y;
+; CHECK-NEXT:     unsigned int z;
+; CHECK-NEXT: }
+
+source_filename = "/t.c"
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.14.0"
+
+!llvm.dbg.cu = !{!2}
+!llvm.linker.options = !{}
+!llvm.module.flags = !{!18, !19}
+!llvm.ident = !{!22}
+
+; This simulates the debug info for a Clang module.
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, nameTableKind: GNU, retainedTypes: !{!11})
+!3 = !DIFile(filename: "t.c", directory: "/")
+!8 = !DIModule(scope: !9, name: "SubModule", includePath: "", isysroot: "/")
+!9 = !DIModule(scope: null, name: "CModule", includePath: "", isysroot: "/")
+!11 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "FromSubmodule", scope: !8, file: !3, line: 1, size: 96, elements: !13)
+!13 = !{!14, !16, !17}
+!14 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !11, file: !3, line: 2, baseType: !15, size: 32)
+!15 = !DIBasicType(name: "unsigned int", size: 32, encoding: DW_ATE_unsigned)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !11, file: !3, line: 2, baseType: !15, size: 32, offset: 32)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !11, file: !3, line: 2, baseType: !15, size: 32, offset: 64)
+!18 = !{i32 2, !"Dwarf Version", i32 4}
+!19 = !{i32 2, !"Debug Info Version", i32 3}
+!22 = !{!"clang version 10.0.0 (https://github.com/llvm/llvm-project 056f1b5cc7c2133f0cb3e30e7f24808d321096d7)"}

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -57,8 +57,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         self.expect("ta v pureSwiftStruct", substrs=["pure swift"])
         self.expect("ta v swiftStructCMember",
                     substrs=["point", "x = 3", "y = 4",
-                             # FIXME: <rdar://problem/54471165>
-                             # "sub", "x = 1", "y = 2", "z = 3",
+                             "sub", "x = 1", "y = 2", "z = 3",
                              "swift struct c member"])
         self.expect("ta v typedef", substrs=["x = 5", "y = 6"])
         self.expect("ta v union", substrs=["(DoubleLongUnion)", "long_val = 42"])

--- a/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
+++ b/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
@@ -162,9 +162,8 @@ uint32_t SymbolFileBreakpad::FindTypes(
   return types.GetSize();
 }
 
-size_t
-SymbolFileBreakpad::FindTypes(const std::vector<CompilerContext> &context,
-                              bool append, TypeMap &types) {
+size_t SymbolFileBreakpad::FindTypes(llvm::ArrayRef<CompilerContext> pattern,
+                                     bool append, TypeMap &types) {
   if (!append)
     types.Clear();
   return types.GetSize();

--- a/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.h
+++ b/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.h
@@ -118,7 +118,7 @@ public:
                      llvm::DenseSet<SymbolFile *> &searched_symbol_files,
                      TypeMap &types) override;
 
-  size_t FindTypes(const std::vector<CompilerContext> &context, bool append,
+  size_t FindTypes(llvm::ArrayRef<CompilerContext> pattern, bool append,
                    TypeMap &types) override;
 
   TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language) override {

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -145,7 +145,7 @@ TypeSP DWARFASTParserClang::ParseTypeFromDWO(const DWARFDIE &die, Log *log) {
   // If this type comes from a Clang module, look in the DWARF section
   // of the pcm file in the module cache. Clang generates DWO skeleton
   // units as breadcrumbs to find them.
-  std::vector<CompilerContext> decl_context;
+  llvm::SmallVector<CompilerContext, 4> decl_context;
   die.GetDeclContext(decl_context);
   TypeMap dwo_types;
 

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -228,7 +228,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
 void DWARFASTParserSwift::GetClangType(const DWARFDIE &die,
                                        llvm::StringRef mangled_name,
                                        TypeMap &clang_types) const {
-  std::vector<CompilerContext> decl_context;
+  llvm::SmallVector<CompilerContext, 4> decl_context;
   die.GetDeclContext(decl_context);
   if (!decl_context.size())
     return;
@@ -254,7 +254,7 @@ void DWARFASTParserSwift::GetClangType(const DWARFDIE &die,
       return;
     for (NodePointer child : *node)
       if (child->getKind() == Node::Kind::Identifier && child->hasText()) {
-        decl_context.back().type = CompilerContextKind::Typedef;
+        decl_context.back().kind = CompilerContextKind::Typedef;
         decl_context.back().name = ConstString(child->getText());
         return;
       }
@@ -264,13 +264,13 @@ void DWARFASTParserSwift::GetClangType(const DWARFDIE &die,
   auto *sym_file = die.GetCU()->GetSymbolFileDWARF();
   sym_file->UpdateExternalModuleListIfNeeded();
 
-  CompilerContextKind kinds[] = {decl_context.back().type,
+  CompilerContextKind kinds[] = {decl_context.back().kind,
                                  CompilerContextKind::Union,
-                                 CompilerContextKind::Enumeration};
+                                 CompilerContextKind::Enum};
 
   // The Swift projection of all Clang type is a struct; search every kind.
   for (CompilerContextKind kind : kinds) {
-    decl_context.back().type = kind;
+    decl_context.back().kind = kind;
     // Search any modules referenced by DWARF.
     for (const auto &name_module : sym_file->getExternalTypeModules()) {
       if (!name_module.second)

--- a/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -165,7 +165,8 @@ void DWARFDIE::GetDWARFDeclContext(DWARFDeclContext &dwarf_decl_ctx) const {
   }
 }
 
-void DWARFDIE::GetDeclContext(std::vector<CompilerContext> &context) const {
+void DWARFDIE::GetDeclContext(
+    llvm::SmallVectorImpl<lldb_private::CompilerContext> &context) const {
   const dw_tag_t tag = Tag();
   if (tag == DW_TAG_compile_unit || tag == DW_TAG_partial_unit)
     return;
@@ -174,40 +175,33 @@ void DWARFDIE::GetDeclContext(std::vector<CompilerContext> &context) const {
     parent.GetDeclContext(context);
   switch (tag) {
   case DW_TAG_module:
-    context.push_back(
-        CompilerContext(CompilerContextKind::Module, ConstString(GetName())));
+    context.push_back({CompilerContextKind::Module, ConstString(GetName())});
     break;
   case DW_TAG_namespace:
-    context.push_back(CompilerContext(CompilerContextKind::Namespace,
-                                      ConstString(GetName())));
+    context.push_back({CompilerContextKind::Namespace, ConstString(GetName())});
     break;
   case DW_TAG_structure_type:
-    context.push_back(CompilerContext(CompilerContextKind::Structure,
-                                      ConstString(GetName())));
+    context.push_back({CompilerContextKind::Struct, ConstString(GetName())});
     break;
   case DW_TAG_union_type:
-    context.push_back(
-        CompilerContext(CompilerContextKind::Union, ConstString(GetName())));
+    context.push_back({CompilerContextKind::Union, ConstString(GetName())});
     break;
   case DW_TAG_class_type:
-    context.push_back(
-        CompilerContext(CompilerContextKind::Class, ConstString(GetName())));
+    context.push_back({CompilerContextKind::Class, ConstString(GetName())});
     break;
   case DW_TAG_enumeration_type:
-    context.push_back(CompilerContext(CompilerContextKind::Enumeration,
-                                      ConstString(GetName())));
+    context.push_back({CompilerContextKind::Enum, ConstString(GetName())});
     break;
   case DW_TAG_subprogram:
-    context.push_back(CompilerContext(CompilerContextKind::Function,
-                                      ConstString(GetPubname())));
+    context.push_back(
+        {CompilerContextKind::Function, ConstString(GetPubname())});
     break;
   case DW_TAG_variable:
-    context.push_back(CompilerContext(CompilerContextKind::Variable,
-                                      ConstString(GetPubname())));
+    context.push_back(
+        {CompilerContextKind::Variable, ConstString(GetPubname())});
     break;
   case DW_TAG_typedef:
-    context.push_back(
-        CompilerContext(CompilerContextKind::Typedef, ConstString(GetName())));
+    context.push_back({CompilerContextKind::Typedef, ConstString(GetName())});
     break;
   default:
     break;

--- a/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
@@ -91,8 +91,8 @@ public:
 
   /// Return this DIE's decl context as it is needed to look up types
   /// in Clang's -gmodules debug info format.
-  void
-  GetDeclContext(std::vector<lldb_private::CompilerContext> &context) const;
+  void GetDeclContext(
+      llvm::SmallVectorImpl<lldb_private::CompilerContext> &context) const;
 
   //----------------------------------------------------------------------
   // Getting attribute values from the DIE.

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2558,7 +2558,7 @@ size_t SymbolFileDWARF::FindTypes(llvm::ArrayRef<CompilerContext> pattern,
     if (ModuleSP external_module_sp = pair.second) {
       SymbolVendor *sym_vendor = external_module_sp->GetSymbolVendor();
       if (sym_vendor)
-        num_matches += sym_vendor->FindTypes(context, true, types);
+        num_matches += sym_vendor->FindTypes(pattern, true, types);
     }
   return num_matches;
 }

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2505,15 +2505,15 @@ uint32_t SymbolFileDWARF::FindTypes(
   return num_die_matches;
 }
 
-size_t SymbolFileDWARF::FindTypes(const std::vector<CompilerContext> &context,
+size_t SymbolFileDWARF::FindTypes(llvm::ArrayRef<CompilerContext> pattern,
                                   bool append, TypeMap &types) {
   if (!append)
     types.Clear();
 
-  if (context.empty())
+  if (pattern.empty())
     return 0;
 
-  ConstString name = context.back().name;
+  ConstString name = pattern.back().name;
 
   if (!name)
     return 0;
@@ -2532,9 +2532,9 @@ size_t SymbolFileDWARF::FindTypes(const std::vector<CompilerContext> &context,
       if (die.GetCU()->GetLanguageType() == eLanguageTypeSwift)
         continue;
 
-      std::vector<CompilerContext> die_context;
+      llvm::SmallVector<CompilerContext, 4> die_context;
       die.GetDeclContext(die_context);
-      if (die_context != context)
+      if (!contextMatches(die_context, pattern))
         continue;
 
       Type *matching_type = ResolveType(die, true, true);

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -202,7 +202,7 @@ public:
             llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
             lldb_private::TypeMap &types) override;
 
-  size_t FindTypes(const std::vector<lldb_private::CompilerContext> &context,
+  size_t FindTypes(llvm::ArrayRef<lldb_private::CompilerContext> pattern,
                    bool append, lldb_private::TypeMap &types) override;
 
   lldb_private::TypeList *GetTypeList() override;

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1198,7 +1198,7 @@ uint32_t SymbolFileDWARFDebugMap::FindTypes(
 }
 
 size_t
-SymbolFileDWARFDebugMap::FindTypes(const std::vector<CompilerContext> &context,
+SymbolFileDWARFDebugMap::FindTypes(llvm::ArrayRef<CompilerContext> context,
                                    bool append, TypeMap &types) {
   if (!append)
     types.Clear();

--- a/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -121,7 +121,7 @@ public:
             bool append, uint32_t max_matches,
             llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
             lldb_private::TypeMap &types) override;
-  size_t FindTypes(const std::vector<lldb_private::CompilerContext> &context,
+  size_t FindTypes(llvm::ArrayRef<lldb_private::CompilerContext> context,
                    bool append, lldb_private::TypeMap &types) override;
   lldb_private::CompilerDeclContext FindNamespace(
       lldb_private::ConstString name,

--- a/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -1237,9 +1237,8 @@ uint32_t SymbolFileNativePDB::FindTypes(
   return match_count;
 }
 
-size_t
-SymbolFileNativePDB::FindTypes(const std::vector<CompilerContext> &context,
-                               bool append, TypeMap &types) {
+size_t SymbolFileNativePDB::FindTypes(llvm::ArrayRef<CompilerContext> pattern,
+                                      bool append, TypeMap &types) {
   return 0;
 }
 

--- a/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
+++ b/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h
@@ -144,7 +144,7 @@ public:
                      llvm::DenseSet<SymbolFile *> &searched_symbol_files,
                      TypeMap &types) override;
 
-  size_t FindTypes(const std::vector<CompilerContext> &context, bool append,
+  size_t FindTypes(llvm::ArrayRef<CompilerContext> pattern, bool append,
                    TypeMap &types) override;
 
   TypeSystem *GetTypeSystemForLanguage(lldb::LanguageType language) override;

--- a/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -1510,9 +1510,8 @@ void SymbolFilePDB::FindTypesByName(
   }
 }
 
-size_t SymbolFilePDB::FindTypes(
-    const std::vector<lldb_private::CompilerContext> &contexts, bool append,
-    lldb_private::TypeMap &types) {
+size_t SymbolFilePDB::FindTypes(llvm::ArrayRef<CompilerContext> pattern,
+                                bool append, lldb_private::TypeMap &types) {
   return 0;
 }
 

--- a/source/Plugins/SymbolFile/PDB/SymbolFilePDB.h
+++ b/source/Plugins/SymbolFile/PDB/SymbolFilePDB.h
@@ -142,7 +142,7 @@ public:
             llvm::DenseSet<lldb_private::SymbolFile *> &searched_symbol_files,
             lldb_private::TypeMap &types) override;
 
-  size_t FindTypes(const std::vector<lldb_private::CompilerContext> &context,
+  size_t FindTypes(llvm::ArrayRef<lldb_private::CompilerContext> pattern,
                    bool append, lldb_private::TypeMap &types) override;
 
   void FindTypesByRegex(const lldb_private::RegularExpression &regex,

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3198,7 +3198,7 @@ public:
                    llvm::SmallVectorImpl<clang::Decl *> &results) override {
     std::vector<CompilerContext> decl_context;
     ConstString name_cs(name);
-    decl_context.push_back({CompilerContextKind::Structure, name_cs});
+    decl_context.push_back({CompilerContextKind::Struct, name_cs});
     auto clang_importer = m_swift_ast_ctx.GetClangImporter();
     if (!clang_importer)
       return;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3188,6 +3188,32 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
     }
     return nullptr;
   }
+  
+  static CompilerContextKind
+  GetCompilerContextKind(llvm::Optional<swift::ClangTypeKind> kind) {
+    if (!kind)
+      return CompilerContextKind::AnyType;
+    switch (*kind) {
+    case swift::ClangTypeKind::Typedef:
+      /*=swift::ClangTypeKind::ObjCClass:*/
+      return (CompilerContextKind)((uint16_t)CompilerContextKind::Any |
+                                   (uint16_t)CompilerContextKind::Typedef |
+                                   (uint16_t)CompilerContextKind::Struct);
+      break;
+    case swift::ClangTypeKind::Tag:
+      return (CompilerContextKind)((uint16_t)CompilerContextKind::Any |
+                                   (uint16_t)CompilerContextKind::Class |
+                                   (uint16_t)CompilerContextKind::Struct |
+                                   (uint16_t)CompilerContextKind::Union |
+                                   (uint16_t)CompilerContextKind::Enum);
+      // case swift::ClangTypeKind::ObjCProtocol:
+      // Not implemented since Objective-C protocols aren't yet
+      // described in DWARF.
+    default:
+      return CompilerContextKind::Invalid;
+    }
+  }
+
 
 public:
   SwiftDWARFImporterDelegate(SwiftASTContext &swift_ast_ctx)
@@ -3196,9 +3222,6 @@ public:
   void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
                    StringRef inModule,
                    llvm::SmallVectorImpl<clang::Decl *> &results) override {
-    std::vector<CompilerContext> decl_context;
-    ConstString name_cs(name);
-    decl_context.push_back({CompilerContextKind::Struct, name_cs});
     auto clang_importer = m_swift_ast_ctx.GetClangImporter();
     if (!clang_importer)
       return;
@@ -3207,52 +3230,27 @@ public:
       return;
 
     // Find the type in the debug info.
-    TypeList clang_types;
+    TypeMap clang_types;
 
+    llvm::SmallVector<CompilerContext, 3> decl_context;
     // Perform a lookup in a specific module, if requested.
-    if (!inModule.empty()) {
-      TypeMap type_map;
-      std::vector<CompilerContext> decl_context;
-      ConstString mod_name(inModule);
-      ConstString type_name(name);
-      // There's a bit of an impedance mismatch between the
-      // interfaces, Swift passes in either inModule (when looking up
-      // an inner Clang type) or kind (when coming through
-      // ASTDemangler), but it would be much more efficient if we had
-      // both. Alternatively, adding a wildcard CompilerContextKind
-      // would also save us from doing reedundant lookups here.
-      CompilerContextKind cc_kinds[] = {
-          CompilerContextKind::Class, CompilerContextKind::Structure,
-          CompilerContextKind::Union, CompilerContextKind::Enumeration,
-          CompilerContextKind::Typedef};
-      for (auto cc_kind : cc_kinds)
-        if (module->GetSymbolVendor()->FindTypes(
-                {{CompilerContextKind::Module, mod_name}, {cc_kind, type_name}},
-                true, type_map))
-          break;
-      type_map.ForEach([&](lldb::TypeSP &type_sp) {
-        clang_types.Insert(type_sp);
-        return true;
-      });
-    } else {
-      // Search globally.
-      const bool exact_match = true;
-      const uint32_t max_matches = UINT32_MAX;
-      llvm::DenseSet<SymbolFile *> searched_symbol_files;
-      module->FindTypes(name_cs, exact_match, max_matches,
-                        searched_symbol_files, clang_types);
-    }
+    if (!inModule.empty())
+      decl_context.push_back(
+          {CompilerContextKind::Module, ConstString(inModule)});
+    // Swift doesn't keep track of submodules.
+    decl_context.push_back({CompilerContextKind::AnyModule, ConstString()});
+    decl_context.push_back({GetCompilerContextKind(kind), ConstString(name)});
+    module->GetSymbolVendor()->FindTypes(decl_context, true, clang_types);
 
     clang::FileSystemOptions file_system_options;
     clang::FileManager file_manager(file_system_options);
-    for (unsigned i = 0; i < clang_types.GetSize(); ++i) {
-      TypeSP clang_type_sp = clang_types.GetTypeAtIndex(i);
+    clang_types.ForEach([&](lldb::TypeSP &clang_type_sp) {
       if (!clang_type_sp)
-        continue;
+        return true;
 
       // Filter out types with a mismatching type kind.
       if (kind && HasTypeKind(clang_type_sp, *kind))
-        continue;
+        return true;
 
       // Realize the full type.
       CompilerType compiler_type = clang_type_sp->GetFullCompilerType();
@@ -3261,13 +3259,13 @@ public:
       auto *type_system = llvm::dyn_cast_or_null<ClangASTContext>(
           compiler_type.GetTypeSystem());
       if (!type_system)
-        continue;
+        return true;
 
       // Import the type into the DWARFImporter's context.
       clang::ASTContext &to_ctx = clang_importer->getClangASTContext();
       clang::ASTContext *from_ctx = type_system->getASTContext();
       if (!from_ctx)
-        continue;
+        return true;
       clang::ASTImporter importer(to_ctx, file_manager, *from_ctx, file_manager,
                                   false);
       clang::QualType clang_type(
@@ -3285,7 +3283,8 @@ public:
           if (clang::Decl *clang_decl = GetDeclForTypeAndKind(clang_type, kind))
             results.push_back(clang_decl);
       }
-    }
+      return true;
+    });
   }
 };
 } // namespace lldb_private

--- a/source/Symbol/SymbolFile.cpp
+++ b/source/Symbol/SymbolFile.cpp
@@ -197,7 +197,7 @@ uint32_t SymbolFile::FindTypes(
   return 0;
 }
 
-size_t SymbolFile::FindTypes(const std::vector<CompilerContext> &context,
+size_t SymbolFile::FindTypes(llvm::ArrayRef<CompilerContext> pattern,
                              bool append, TypeMap &types) {
   if (!append)
     types.Clear();

--- a/source/Symbol/SymbolVendor.cpp
+++ b/source/Symbol/SymbolVendor.cpp
@@ -335,7 +335,7 @@ size_t SymbolVendor::FindTypes(
   return 0;
 }
 
-size_t SymbolVendor::FindTypes(const std::vector<CompilerContext> &context,
+size_t SymbolVendor::FindTypes(llvm::ArrayRef<CompilerContext> context,
                                bool append, TypeMap &types) {
   ModuleSP module_sp(GetModule());
   if (module_sp) {

--- a/source/Symbol/Type.cpp
+++ b/source/Symbol/Type.cpp
@@ -35,9 +35,38 @@
 using namespace lldb;
 using namespace lldb_private;
 
+bool lldb_private::contextMatches(llvm::ArrayRef<CompilerContext> context_chain,
+                                  llvm::ArrayRef<CompilerContext> pattern) {
+  auto ctx = context_chain.begin();
+  auto ctx_end = context_chain.end();
+  for (const CompilerContext &pat : pattern) {
+    // Early exit if the pattern is too long.
+    if (ctx == ctx_end)
+      return false;
+    if (*ctx != pat) {
+      // Skip any number of module matches.
+      if (pat.kind == CompilerContextKind::AnyModule) {
+        // Greedily match 0..n modules.
+        ctx = std::find_if(ctx, ctx_end, [](const CompilerContext &ctx) {
+          return ctx.kind != CompilerContextKind::Module;
+        });
+        continue;
+      }
+      // See if there is a kind mismatch; they should have 1 bit in common.
+      if (((uint16_t)ctx->kind & (uint16_t)pat.kind) == 0)
+        return false;
+      // The name is ignored for AnyModule, but not for AnyType.
+      if (pat.kind != CompilerContextKind::AnyModule && ctx->name != pat.name)
+        return false;
+    }
+    ++ctx;
+  }
+  return true;
+}
+
 void CompilerContext::Dump() const {
-  switch (type) {
-  case CompilerContextKind::Invalid:
+  switch (kind) {
+  default:
     printf("Invalid");
     break;
   case CompilerContextKind::TranslationUnit:
@@ -52,7 +81,7 @@ void CompilerContext::Dump() const {
   case CompilerContextKind::Class:
     printf("Class");
     break;
-  case CompilerContextKind::Structure:
+  case CompilerContextKind::Struct:
     printf("Structure");
     break;
   case CompilerContextKind::Union:
@@ -64,11 +93,17 @@ void CompilerContext::Dump() const {
   case CompilerContextKind::Variable:
     printf("Variable");
     break;
-  case CompilerContextKind::Enumeration:
+  case CompilerContextKind::Enum:
     printf("Enumeration");
     break;
   case CompilerContextKind::Typedef:
     printf("Typedef");
+    break;
+  case CompilerContextKind::AnyModule:
+    printf("AnyModule");
+    break;
+  case CompilerContextKind::AnyType:
+    printf("AnyType");
     break;
   }
   printf("(\"%s\")\n", name.GetCString());

--- a/tools/lldb-test/lldb-test.cpp
+++ b/tools/lldb-test/lldb-test.cpp
@@ -138,6 +138,11 @@ static cl::opt<std::string>
             cl::desc("Restrict search to the context of the given variable."),
             cl::value_desc("variable"), cl::sub(SymbolsSubcommand));
 
+static cl::opt<std::string> CompilerContext(
+    "compiler-context",
+    cl::desc("Specify a compiler context as \"kind:name,...\"."),
+    cl::value_desc("context"), cl::sub(SymbolsSubcommand));
+ 
 static cl::list<FunctionNameType> FunctionNameFlags(
     "function-flags", cl::desc("Function search flags:"),
     cl::values(clEnumValN(eFunctionNameTypeAuto, "auto",
@@ -218,6 +223,46 @@ int evaluateMemoryMapCommands(Debugger &Dbg);
 } // namespace irmemorymap
 
 } // namespace opts
+
+std::vector<CompilerContext> parseCompilerContext() {
+  std::vector<CompilerContext> result;
+  if (opts::symbols::CompilerContext.empty())
+    return result;
+
+  StringRef str{opts::symbols::CompilerContext};
+  SmallVector<StringRef, 8> entries_str;
+  str.split(entries_str, ',', /*maxSplit*/-1, /*keepEmpty=*/false);
+  for (auto entry_str : entries_str) {
+    StringRef key, value;
+    std::tie(key, value) = entry_str.split(':');
+    auto kind =
+        StringSwitch<CompilerContextKind>(key)
+            .Case("TranslationUnit", CompilerContextKind::TranslationUnit)
+            .Case("Module", CompilerContextKind::Module)
+            .Case("Namespace", CompilerContextKind::Namespace)
+            .Case("Class", CompilerContextKind::Class)
+            .Case("Struct", CompilerContextKind::Struct)
+            .Case("Union", CompilerContextKind::Union)
+            .Case("Function", CompilerContextKind::Function)
+            .Case("Variable", CompilerContextKind::Variable)
+            .Case("Enum", CompilerContextKind::Enum)
+            .Case("Typedef", CompilerContextKind::Typedef)
+            .Case("AnyModule", CompilerContextKind::AnyModule)
+            .Case("AnyType", CompilerContextKind::AnyType)
+            .Default(CompilerContextKind::Invalid);
+    if (value.empty()) {
+      WithColor::error() << "compiler context entry has no \"name\"\n";
+      exit(1);
+    }
+    result.push_back({kind, ConstString{value}});
+  }
+  outs() << "Search context: {\n";
+  for (auto entry: result)
+    entry.Dump();
+  outs() << "}\n";
+
+  return result;
+}
 
 template <typename... Args>
 static Error make_string_error(const char *Format, Args &&... args) {
@@ -460,8 +505,11 @@ Error opts::symbols::findTypes(lldb_private::Module &Module) {
 
   DenseSet<SymbolFile *> SearchedFiles;
   TypeMap Map;
-  Vendor.FindTypes(ConstString(Name), ContextPtr, true, UINT32_MAX,
-                   SearchedFiles, Map);
+  if (!Name.empty())
+    Symfile.FindTypes(ConstString(Name), ContextPtr, true, UINT32_MAX,
+                      SearchedFiles, Map);
+  else
+    Symfile.FindTypes(parseCompilerContext(), true, Map);
 
   outs() << formatv("Found {0} types:\n", Map.GetSize());
   StreamString Stream;

--- a/tools/lldb-test/lldb-test.cpp
+++ b/tools/lldb-test/lldb-test.cpp
@@ -497,6 +497,7 @@ Error opts::symbols::findNamespaces(lldb_private::Module &Module) {
 
 Error opts::symbols::findTypes(lldb_private::Module &Module) {
   SymbolVendor &Vendor = *Module.GetSymbolVendor();
+  auto &Symfile = Vendor;
   Expected<CompilerDeclContext> ContextOr = getDeclContext(Vendor);
   if (!ContextOr)
     return ContextOr.takeError();

--- a/unittests/Symbol/TestType.cpp
+++ b/unittests/Symbol/TestType.cpp
@@ -48,3 +48,47 @@ TEST(Type, GetTypeScopeAndBasename) {
       "std::set<int, std::less<int>>::iterator<bool>", true,
       "std::set<int, std::less<int>>::", "iterator<bool>");
 }
+
+TEST(Type, CompilerContextPattern) {
+  std::vector<CompilerContext> mms = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Module, ConstString("B")},
+      {CompilerContextKind::Struct, ConstString("S")}};
+  EXPECT_TRUE(contextMatches(mms, mms));
+  std::vector<CompilerContext> mmc = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Module, ConstString("B")},
+      {CompilerContextKind::Class, ConstString("S")}};
+  EXPECT_FALSE(contextMatches(mms, mmc));
+  std::vector<CompilerContext> ms = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Struct, ConstString("S")}};
+  std::vector<CompilerContext> mas = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::AnyModule, ConstString("*")},
+      {CompilerContextKind::Struct, ConstString("S")}};
+  EXPECT_TRUE(contextMatches(mms, mas));
+  EXPECT_TRUE(contextMatches(ms, mas));
+  EXPECT_FALSE(contextMatches(mas, ms));
+  std::vector<CompilerContext> mmms = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Module, ConstString("B")},
+      {CompilerContextKind::Module, ConstString("C")},
+      {CompilerContextKind::Struct, ConstString("S")}};
+  EXPECT_TRUE(contextMatches(mmms, mas));
+  std::vector<CompilerContext> mme = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Module, ConstString("B")},
+      {CompilerContextKind::Enum, ConstString("S")}};
+  std::vector<CompilerContext> mma = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Module, ConstString("B")},
+      {CompilerContextKind::AnyType, ConstString("S")}};
+  EXPECT_TRUE(contextMatches(mme, mma));
+  EXPECT_TRUE(contextMatches(mms, mma));
+  std::vector<CompilerContext> mme2 = {
+      {CompilerContextKind::Module, ConstString("A")},
+      {CompilerContextKind::Module, ConstString("B")},
+      {CompilerContextKind::Enum, ConstString("S2")}};
+  EXPECT_FALSE(contextMatches(mme2, mma));
+}


### PR DESCRIPTION
By using the new LLDB FindFiles API that llows for fuzzy CompilerContext matching, we can unify the two lookup implementations, dramatically improve the performance by only looking types up once, and look for types inside of unknown submodules.
    
rdar://problem/49233932
rdar://problem/54471165