### PR TITLE
[Misc] Replace std::once_flag with llvm::once_flag.

### DIFF
--- a/include/lldb/Core/Debugger.h
+++ b/include/lldb/Core/Debugger.h
@@ -427,7 +427,7 @@ protected:
   HostThread m_io_handler_thread;
   Broadcaster m_sync_broadcaster;
   lldb::ListenerSP m_forward_listener_sp;
-  std::once_flag m_clear_once;
+  llvm::once_flag m_clear_once;
 
   //----------------------------------------------------------------------
   // Events for m_sync_broadcaster

--- a/include/lldb/Target/Process.h
+++ b/include/lldb/Target/Process.h
@@ -3135,7 +3135,7 @@ protected:
   enum { eCanJITDontKnow = 0, eCanJITYes, eCanJITNo } m_can_jit;
   
   std::unique_ptr<UtilityFunction> m_dlopen_utility_func_up;
-  std::once_flag m_dlopen_utility_func_flag_once;
+  llvm::once_flag m_dlopen_utility_func_flag_once;
 
   size_t RemoveBreakpointOpcodesFromBuffer(lldb::addr_t addr, size_t size,
                                            uint8_t *buf) const;

--- a/source/Commands/CommandObjectPlatform.cpp
+++ b/source/Commands/CommandObjectPlatform.cpp
@@ -1238,7 +1238,7 @@ protected:
   public:
     CommandOptions()
         : Options(), match_info(), show_args(false), verbose(false) {
-      static std::once_flag g_once_flag;
+      static llvm::once_flag g_once_flag;
       llvm::call_once(g_once_flag, []() {
         PosixPlatformCommandOptionValidator *posix_validator =
             new PosixPlatformCommandOptionValidator();

--- a/source/Core/Mangled.cpp
+++ b/source/Core/Mangled.cpp
@@ -154,7 +154,7 @@ get_demangled_name_without_arguments(ConstString mangled,
 static ThreadSafeDenseMap<const char *, ConstString> *
 GetDisplayDemangledNamesCache() {
   ThreadSafeDenseMap<const char *, ConstString> *g_cache;
-  std::once_flag g_flag;
+  llvm::once_flag g_flag;
   std::call_once(g_flag, [&g_cache]() -> void {
     g_cache = new ThreadSafeDenseMap<const char *, ConstString>();
   });

--- a/source/Host/common/Editline.cpp
+++ b/source/Host/common/Editline.cpp
@@ -1170,7 +1170,7 @@ Editline::Editline(const char *editline_name, FILE *input_file,
     if (term_fd != -1) {
       static std::mutex *g_init_terminal_fds_mutex_ptr = nullptr;
       static std::set<int> *g_init_terminal_fds_ptr = nullptr;
-      static std::once_flag g_once_flag;
+      static llvm::once_flag g_once_flag;
       llvm::call_once(g_once_flag, [&]() {
         g_init_terminal_fds_mutex_ptr =
             new std::mutex(); // NOTE: Leak to avoid C++ destructor chain issues

--- a/source/Host/windows/HostInfoWindows.cpp
+++ b/source/Host/windows/HostInfoWindows.cpp
@@ -85,7 +85,7 @@ bool HostInfoWindows::GetHostname(std::string &s) {
 }
 
 FileSpec HostInfoWindows::GetProgramFileSpec() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
   llvm::call_once(g_once_flag, []() {
     std::vector<wchar_t> buffer(PATH_MAX);
     ::GetModuleFileNameW(NULL, buffer.data(), buffer.size());

--- a/source/Plugins/ExpressionParser/Swift/SwiftHost.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftHost.cpp
@@ -90,7 +90,7 @@ bool lldb_private::ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
 }
 
 FileSpec lldb_private::GetSwiftResourceDir() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
   static FileSpec g_swift_resource_dir;
   std::call_once(g_once_flag, []() {
     FileSpec lldb_file_spec = HostInfo::GetShlibDir();

--- a/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -941,7 +941,7 @@ std::unique_ptr<Language::TypeScavenger> CPlusPlusLanguage::GetTypeScavenger() {
 }
 
 lldb::TypeCategoryImplSP CPlusPlusLanguage::GetFormatters() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static TypeCategoryImplSP g_category;
 
   llvm::call_once(g_initialize, [this]() -> void {
@@ -957,7 +957,7 @@ lldb::TypeCategoryImplSP CPlusPlusLanguage::GetFormatters() {
 
 HardcodedFormatters::HardcodedSummaryFinder
 CPlusPlusLanguage::GetHardcodedSummaries() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static ConstString g_vectortypes("VectorTypes");
   static HardcodedFormatters::HardcodedSummaryFinder g_formatters;
 
@@ -1021,7 +1021,7 @@ CPlusPlusLanguage::GetHardcodedSummaries() {
 
 HardcodedFormatters::HardcodedSyntheticFinder
 CPlusPlusLanguage::GetHardcodedSynthetics() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static ConstString g_vectortypes("VectorTypes");
   static HardcodedFormatters::HardcodedSyntheticFinder g_formatters;
 

--- a/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -866,7 +866,7 @@ static void LoadCoreMediaFormatters(TypeCategoryImplSP objc_category_sp) {
 }
 
 lldb::TypeCategoryImplSP ObjCLanguage::GetFormatters() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static TypeCategoryImplSP g_category;
 
   llvm::call_once(g_initialize, [this]() -> void {

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -659,7 +659,7 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 }
 
 lldb::TypeCategoryImplSP SwiftLanguage::GetFormatters() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static TypeCategoryImplSP g_category;
 
   std::call_once(g_initialize, [this]() -> void {
@@ -674,7 +674,7 @@ lldb::TypeCategoryImplSP SwiftLanguage::GetFormatters() {
 
 HardcodedFormatters::HardcodedSummaryFinder
 SwiftLanguage::GetHardcodedSummaries() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static HardcodedFormatters::HardcodedSummaryFinder g_formatters;
 
   std::call_once(g_initialize, []() -> void {
@@ -744,7 +744,7 @@ SwiftLanguage::GetHardcodedSummaries() {
 
 HardcodedFormatters::HardcodedSyntheticFinder
 SwiftLanguage::GetHardcodedSynthetics() {
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
   static ConstString g_runtime_synths_category_name("runtime-synthetics");
   static HardcodedFormatters::HardcodedSyntheticFinder g_formatters;
 
@@ -1183,7 +1183,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
 
     static Hoarders &GetHoarders() {
       static Hoarders g_hoarders;
-      static std::once_flag g_init;
+      static llvm::once_flag g_init;
       std::call_once(g_init, []() -> void {
         g_hoarders.push_back([](const char *input,
                                 ExecutionContextScope *exe_scope,

--- a/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -237,7 +237,7 @@ FileSpec PlatformAppleSimulator::GetCoreSimulatorPath() {
 
 void PlatformAppleSimulator::LoadCoreSimulator() {
 #if defined(__APPLE__)
-  static std::once_flag g_load_core_sim_flag;
+  static llvm::once_flag g_load_core_sim_flag;
   llvm::call_once(g_load_core_sim_flag, [this] {
     const std::string core_sim_path(GetCoreSimulatorPath().GetPath());
     if (core_sim_path.size())

--- a/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1306,7 +1306,7 @@ static FileSpec CheckPathForXcode(const FileSpec &fspec) {
 
 static FileSpec GetXcodeContentsPath() {
   static FileSpec g_xcode_filespec;
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
   llvm::call_once(g_once_flag, []() {
 
     FileSpec fspec;

--- a/source/Plugins/Process/FreeBSD/ProcessFreeBSD.cpp
+++ b/source/Plugins/Process/FreeBSD/ProcessFreeBSD.cpp
@@ -79,7 +79,7 @@ ProcessFreeBSD::CreateInstance(lldb::TargetSP target_sp,
 }
 
 void ProcessFreeBSD::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -68,7 +68,7 @@ using namespace llvm;
 
 static bool ProcessVmReadvSupported() {
   static bool is_supported;
-  static std::once_flag flag;
+  static llvm::once_flag flag;
 
   llvm::call_once(flag, [] {
     Log *log(ProcessPOSIXLog::GetLogIfAllCategoriesSet(POSIX_LOG_PROCESS));

--- a/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
+++ b/source/Plugins/Process/MacOSX-Kernel/ProcessKDP.cpp
@@ -717,7 +717,7 @@ Status ProcessKDP::DoSignal(int signo) {
 }
 
 void ProcessKDP::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -117,7 +117,7 @@ ProcessSP ProcessWindows::CreateInstance(lldb::TargetSP target_sp,
 }
 
 void ProcessWindows::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -398,7 +398,7 @@ void ProcessElfCore::Clear() {
 }
 
 void ProcessElfCore::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -517,7 +517,7 @@ bool GDBRemoteCommunicationServerPlatform::FreePortForProcess(lldb::pid_t pid) {
 
 const FileSpec &GDBRemoteCommunicationServerPlatform::GetDomainSocketDir() {
   static FileSpec g_domainsocket_dir;
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     const char *domainsocket_dir_env =

--- a/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3652,7 +3652,7 @@ void ProcessGDBRemote::KillDebugserverProcess() {
 }
 
 void ProcessGDBRemote::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -661,7 +661,7 @@ Status ProcessMachCore::GetMemoryRegionInfo(addr_t load_addr,
 void ProcessMachCore::Clear() { m_thread_list.Clear(); }
 
 void ProcessMachCore::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -154,7 +154,7 @@ ProcessMinidump::~ProcessMinidump() {
 }
 
 void ProcessMinidump::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
+++ b/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
@@ -39,7 +39,7 @@ void ScriptInterpreterNone::ExecuteInterpreterLoop() {
 }
 
 void ScriptInterpreterNone::Initialize() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
 
   llvm::call_once(g_once_flag, []() {
     PluginManager::RegisterPlugin(GetPluginNameStatic(),

--- a/source/Symbol/ClangASTContext.cpp
+++ b/source/Symbol/ClangASTContext.cpp
@@ -324,7 +324,7 @@ typedef lldb_private::ThreadSafeDenseMap<clang::ASTContext *, ClangASTContext *>
 
 static ClangASTMap &GetASTMap() {
   static ClangASTMap *g_map_ptr = nullptr;
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
   llvm::call_once(g_once_flag, []() {
     g_map_ptr = new ClangASTMap(); // leaked on purpose to avoid spins
   });
@@ -1081,7 +1081,7 @@ ClangASTContext::GetBasicTypeEnumeration(ConstString name) {
   if (name) {
     typedef UniqueCStringMap<lldb::BasicType> TypeNameToBasicTypeMap;
     static TypeNameToBasicTypeMap g_type_map;
-    static std::once_flag g_once_flag;
+    static llvm::once_flag g_once_flag;
     llvm::call_once(g_once_flag, []() {
       // "void"
       g_type_map.Append(ConstString("void"), eBasicTypeVoid);

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -174,7 +174,7 @@ static ThreadSafeSwiftASTMap &GetASTMap() {
   // gone away. So we will leak this list intentionally so we can
   // avoid global destructor problems.
   static ThreadSafeSwiftASTMap *g_map_ptr = NULL;
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
   std::call_once(g_once_flag, []() {
     // Intentional leak.
     g_map_ptr = new ThreadSafeSwiftASTMap();
@@ -984,7 +984,7 @@ static SDKTypeMinVersion GetSDKType(const llvm::Triple &target,
 }
 
 static StringRef GetXcodeContentsPath() {
-  static std::once_flag g_once_flag;
+  static llvm::once_flag g_once_flag;
   static std::string g_xcode_contents_path;
   std::call_once(g_once_flag, [&]() {
     const char substr[] = ".app/Contents/";

--- a/source/Target/Language.cpp
+++ b/source/Target/Language.cpp
@@ -30,7 +30,7 @@ typedef std::map<lldb::LanguageType, LanguageUP> LanguagesMap;
 
 static LanguagesMap &GetLanguagesMap() {
   static LanguagesMap *g_map = nullptr;
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
 
   llvm::call_once(g_initialize, [] {
     g_map = new LanguagesMap(); // NOTE: INTENTIONAL LEAK due to global
@@ -41,7 +41,7 @@ static LanguagesMap &GetLanguagesMap() {
 }
 static std::mutex &GetLanguagesMutex() {
   static std::mutex *g_mutex = nullptr;
-  static std::once_flag g_initialize;
+  static llvm::once_flag g_initialize;
 
   llvm::call_once(g_initialize, [] {
     g_mutex = new std::mutex(); // NOTE: INTENTIONAL LEAK due to global

--- a/source/Utility/ConstString.cpp
+++ b/source/Utility/ConstString.cpp
@@ -188,7 +188,7 @@ protected:
 // ConstStrings is difficult.  So we leak the pool instead.
 //----------------------------------------------------------------------
 static Pool &StringPool() {
-  static std::once_flag g_pool_initialization_flag;
+  static llvm::once_flag g_pool_initialization_flag;
   static Pool *g_string_pool = nullptr;
 
   llvm::call_once(g_pool_initialization_flag,

--- a/tools/debugserver/source/MacOSX/DarwinLog/DarwinLogCollector.cpp
+++ b/tools/debugserver/source/MacOSX/DarwinLog/DarwinLogCollector.cpp
@@ -46,7 +46,7 @@ static os_activity_stream_set_event_handler_t
     s_os_activity_stream_set_event_handler;
 
 bool LookupSPICalls() {
-  static std::once_flag s_once_flag;
+  static llvm::once_flag s_once_flag;
   static bool s_has_spi;
 
   std::call_once(s_once_flag, [] {


### PR DESCRIPTION
The latter is what's used upstream and apparently some platforms
have bugs in the std implementation.
This reduces the diff with llvm.org