### PR TITLE
[Host/macox] Remove an unneeded #ifdef static_analyzer.

### DIFF
--- a/source/Host/macosx/objcxx/Host.mm
+++ b/source/Host/macosx/objcxx/Host.mm
@@ -1440,13 +1440,9 @@ HostThread Host::StartMonitoringChildProcess(
 
   if (source) {
     Host::MonitorChildProcessCallback callback_copy = callback;
-#ifndef __clang_analyzer__
-    // This works around a bug in the static analyzer where it claims
-    // "dispatch_release" isn't a valid identifier.
     ::dispatch_source_set_cancel_handler(source, ^{
       dispatch_release(source);
     });
-#endif
     ::dispatch_source_set_event_handler(source, ^{
 
       int status = 0;


### PR DESCRIPTION
Reduces the difference with llvm.org/lldb.