### PR TITLE
[SBThread] lldb_private functions are not instrumented.

### DIFF
--- a/source/API/SBThread.cpp
+++ b/source/API/SBThread.cpp
@@ -1418,21 +1418,11 @@ bool SBThread::SafeToCallFunctions() {
 }
 
 lldb_private::Thread *SBThread::operator->() {
-  LLDB_RECORD_METHOD_NO_ARGS(lldb_private::Thread *, SBThread, operator->);
-
-  ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
-  if (thread_sp)
-    return LLDB_RECORD_RESULT(thread_sp.get());
-  return nullptr;
+  return get();
 }
 
 lldb_private::Thread *SBThread::get() {
-  LLDB_RECORD_METHOD_NO_ARGS(lldb_private::Thread *, SBThread, get);
-
-  ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
-  if (thread_sp)
-    return LLDB_RECORD_RESULT(thread_sp.get());
-  return nullptr;
+  return m_opaque_sp->GetThreadSP().get();
 }
 
 namespace lldb_private {


### PR DESCRIPTION
This was a mismerge from llvm.org. This commit gets rid of
an unneeded difference between github and llvm.org