### PR TITLE
[ReproducerInstrumentation] Remove stale Recorder::Log.

### DIFF
--- a/include/lldb/Utility/ReproducerInstrumentation.h
+++ b/include/lldb/Utility/ReproducerInstrumentation.h
@@ -685,7 +685,6 @@ private:
   }
 
   bool ShouldCapture() { return m_local_boundary; }
-  void Log(unsigned id);
 
 #ifdef LLDB_REPRO_INSTR_TRACE
   void Log(unsigned id) {

--- a/source/Utility/ReproducerInstrumentation.cpp
+++ b/source/Utility/ReproducerInstrumentation.cpp
@@ -119,13 +119,4 @@ Recorder::~Recorder() {
   UpdateBoundary();
 }
 
-void Recorder::Log(unsigned id) {
-#ifndef LLDB_REPRO_INSTR_TRACE
-  LLDB_LOG(GetLogIfAllCategoriesSet(LIBLLDB_LOG_API), "Recording {0}: {1}", id,
-           m_pretty_func);
-#else
-  llvm::errs() << "Recording " << id << ": " << m_pretty_func << "\n";
-#endif
-}
-
 bool lldb_private::repro::Recorder::g_global_boundary;


### PR DESCRIPTION
This function doesn't exist anymore on llvm.org. My understanding
is that https://reviews.llvm.org/D60984 removed it, but maybe
was mismerged to github.