### PR TITLE
[CMake] Pass the correct CMake directory for Swift

### DIFF
--- a/cmake/modules/LLDBStandalone.cmake
+++ b/cmake/modules/LLDBStandalone.cmake
@@ -73,7 +73,7 @@ endif()
 # We append the directory in which LLVMConfig.cmake lives. We expect LLVM's
 # CMake modules to be in that directory as well.
 list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${Swift_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${SWIFT_CMAKE_DIR}")
 include(AddLLVM)
 include(TableGen)
 include(HandleLLVMOptions)


### PR DESCRIPTION
Swift sets its module directory through `SWIFT_CMAKE_DIR`. We are
currently incorrectly using `Swift_DIR` instead. This is different than
LLVM, which is special because its modules live in the `LLVM_DIR`.