### PR TITLE
DWARFImporterDelegate: Support dynamic type resolution for ObjC proto…

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -287,6 +287,10 @@ public:
   // Get a function type that returns nothing and take no parameters
   CompilerType GetVoidFunctionType();
 
+  /// Import and Swiftify a Clang type.
+  /// \return Returns an invalid type if unsuccessful.
+  CompilerType ImportClangType(CompilerType clang_type);
+
   static SwiftASTContext *GetSwiftASTContext(swift::ASTContext *ast);
 
   swift::irgen::IRGenerator &GetIRGenerator(swift::IRGenOptions &opts,
@@ -294,6 +298,8 @@ public:
 
   swift::irgen::IRGenModule &GetIRGenModule();
 
+  lldb::TargetWP GetTarget() const { return m_target_wp; }
+  
   llvm::Triple GetTriple() const;
 
   bool SetTriple(const llvm::Triple triple,

--- a/include/lldb/Target/SwiftLanguageRuntime.h
+++ b/include/lldb/Target/SwiftLanguageRuntime.h
@@ -418,6 +418,12 @@ protected:
       ValueObject &in_value, lldb::DynamicValueType use_dynamic,
       TypeAndOrName &class_type_or_name, Address &address);
 
+  bool GetDynamicTypeAndAddress_ClangType(ValueObject &in_value,
+                                          lldb::DynamicValueType use_dynamic,
+                                          TypeAndOrName &class_type_or_name,
+                                          Address &address,
+                                          Value::ValueType &value_type);
+
   MetadataPromiseSP GetPromiseForTypeNameAndFrame(const char *type_name,
                                                   StackFrame *frame);
 

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -34,26 +34,13 @@ class TestSwiftMacroConflict(TestBase):
         if os.path.isdir(mod_cache):
           shutil.rmtree(mod_cache)
 
+        self.runCmd('settings set symbols.use-swift-dwarfimporter false')
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.build()
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        bar_breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', lldb.SBFileSpec('Bar.swift'))
-
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        threads = lldbutil.get_threads_stopped_at_breakpoint(
-            process, bar_breakpoint)
-        frame = threads[0].GetFrameAtIndex(0)
-        bar_value = frame.EvaluateExpression("bar")
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('Bar.swift'))
+        bar_value = self.frame().EvaluateExpression("bar")
         self.expect("fr var bar", "correct bar", substrs=["23"])
 
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
@@ -69,7 +56,34 @@ class TestSwiftMacroConflict(TestBase):
                         bar_value.GetError().Success())
 
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+        lldb.SBDebugger.MemoryPressureDetected()
 
+    @skipUnlessDarwin
+    @swiftTest
+    @add_test_categories(["swiftpr"])
+    def test_with_dwarfimporter(self):
+        """
+        With DWARFImporter installed, both variables should be visible.
+        """
+        # To ensure we hit the rebuild problem remove the cache to avoid caching.
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.use-swift-dwarfimporter true')
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+        self.build()
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('Bar.swift'))
+        self.expect("v bar", substrs=["23"])
+        foo_breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Foo.swift'))
+        process.Continue()
+        self.expect("v foo", substrs=["42"])
+        self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
+        lldb.SBDebugger.MemoryPressureDetected()
+        
 if __name__ == '__main__':
     import atexit
     lldb.SBDebugger.Initialize()

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -49,7 +49,9 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                 target.FindFirstGlobalVariable("obj"),
                                 typename="Swift.Optional<__ObjC.ObjCClass>",
                                 num_children=0)
-        self.expect("fr v obj", substrs=["ObjCClass", "private_ivar", "42"])
+        self.expect("target var obj", substrs=["ObjCClass", "private_ivar", "42"])
         # This is a Clang type, since Clang doesn't generate DWARF for protocols.
-        self.expect("fr v proto", substrs=["(id)", "proto"])
-        self.expect("fr v -O proto", substrs=["<ProtoImpl"])
+        self.expect("target var -d no-dyn proto", substrs=["(id)", "proto"])
+        # This is a Swift type.
+        self.expect("target var -d run proto", substrs=["(ProtoImpl?)", "proto"])
+        self.expect("target var -O proto", substrs=["<ProtoImpl"])

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -73,6 +73,7 @@ class TestMainExecutable(TestBase):
         """
 
         self.build()
+        self.runCmd("settings set symbols.use-swift-dwarfimporter false")
         os.remove(self.getBuildArtifact("SomeLibrary.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibrary.swiftinterface"))
         def cleanup():
@@ -94,6 +95,8 @@ class TestMainExecutable(TestBase):
         self.expect("e value", error=True)
         self.expect("e container", error=True)
         self.expect("e TwoInts(4, 5)", error=True)
+        lldb.SBDebugger.MemoryPressureDetected()
+        self.runCmd("settings set symbols.use-swift-dwarfimporter true")
 
     @swiftTest
     @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -135,6 +135,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
     compiler_type = m_ast.GetTypeFromMangledTypename(mangled_name, error);
   }
 
+  ConstString preferred_name;
   if (!compiler_type &&
       swift::Demangle::isObjCSymbol(mangled_name.GetStringRef())) {
     // When we failed to look up the type because no .swiftmodule is
@@ -168,11 +169,13 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
       if (!compiler_type) {
         is_clang_type = true;
         compiler_type = clang_ctx->GetBasicType(eBasicTypeObjCID);
+        // Stash away the mangled name for resolving it through
+        // the Objective-C runtime later.
+        preferred_name = mangled_name;
       }
     }
   }
 
-  ConstString preferred_name;
   if (!compiler_type && name) {
     // Handle Archetypes, which are typedefs to RawPointerType.
     if (GetTypedefName(die).startswith("$sBp")) {


### PR DESCRIPTION
…cols.

Protocols are not represented in DWARF and LLDB's ObjC runtime
implementation doesn't know how to deal with them either.  Use the
Objective-C runtime to perform dynamic type resolution first, and then
map the dynamic Objective-C type back into Swift.

rdar://problem/49233932