### PR TITLE
[CommandObjectExpression] Remove swift-only option.

### DIFF
--- a/source/Commands/CommandObjectExpression.cpp
+++ b/source/Commands/CommandObjectExpression.cpp
@@ -203,9 +203,6 @@ void CommandObjectExpression::CommandOptions::OptionParsingStarting(
   try_all_threads = true;
   timeout = 0;
   debug = false;
-#ifdef LLDB_CONFIGURATION_DEBUG
-  playground = false;
-#endif
   language = eLanguageTypeUnknown;
   m_verbosity = eLanguageRuntimeDescriptionDisplayVerbosityCompact;
   auto_apply_fixits = eLazyBoolCalculate;
@@ -229,11 +226,6 @@ CommandObjectExpression::CommandObjectExpression(
       m_option_group(), m_format_options(eFormatDefault),
       m_repl_option(LLDB_OPT_SET_1, false, "repl", 'r', "Drop into Swift REPL",
                     false, true),
-#ifdef LLDB_CONFIGURATION_DEBUG
-      m_playground_option(LLDB_OPT_SET_1, false, "playground", 'z',
-                          "Execute the expresssion as a playground expression",
-                          false, true),
-#endif
       m_command_options(), m_expr_line_count(0), m_expr_lines() {
   SetHelpLong(
       R"(
@@ -308,9 +300,6 @@ Examples:
   m_option_group.Append(&m_varobj_options, LLDB_OPT_SET_ALL,
                         LLDB_OPT_SET_1 | LLDB_OPT_SET_2);
   m_option_group.Append(&m_repl_option, LLDB_OPT_SET_ALL, LLDB_OPT_SET_3);
-#ifdef LLDB_CONFIGURATION_DEBUG
-  m_option_group.Append(&m_playground_option, LLDB_OPT_SET_ALL, LLDB_OPT_SET_1);
-#endif
   m_option_group.Finalize();
 }
 
@@ -422,9 +411,6 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
     options.SetUseDynamic(m_varobj_options.use_dynamic);
     options.SetTryAllThreads(m_command_options.try_all_threads);
     options.SetDebug(m_command_options.debug);
-#ifdef LLDB_CONFIGURATION_DEBUG
-    options.SetPlaygroundTransformEnabled(m_command_options.playground);
-#endif
 
     // If the language was not specified in the expression command,
     // set it to the language in the target's properties if
@@ -655,11 +641,6 @@ bool CommandObjectExpression::DoExecute(llvm::StringRef command,
   if (args.HasArgs()) {
     if (!ParseOptionsAndNotify(args.GetArgs(), result, m_option_group, exe_ctx))
       return false;
-
-#ifdef LLDB_CONFIGURATION_DEBUG
-    m_command_options.playground =
-        m_playground_option.GetOptionValue().GetCurrentValue();
-#endif
 
     if (m_repl_option.GetOptionValue().GetCurrentValue()) {
       Target *target = m_interpreter.GetExecutionContext().GetTargetPtr();

--- a/source/Commands/CommandObjectExpression.h
+++ b/source/Commands/CommandObjectExpression.h
@@ -41,9 +41,6 @@ public:
     bool show_types;
     bool show_summary;
     bool debug;
-#ifdef LLDB_CONFIGURATION_DEBUG
-    bool playground;
-#endif
     uint32_t timeout;
     bool try_all_threads;
     lldb::LanguageType language;
@@ -81,9 +78,6 @@ protected:
   OptionGroupFormat m_format_options;
   OptionGroupValueObjectDisplay m_varobj_options;
   OptionGroupBoolean m_repl_option;
-#ifdef LLDB_CONFIGURATION_DEBUG
-  OptionGroupBoolean m_playground_option;
-#endif
   CommandOptions m_command_options;
   uint32_t m_expr_line_count;
   std::string m_expr_lines;       // Multi-line expression support


### PR DESCRIPTION
This is probably unused, only enabled under DEBUG, and in
a central place [so it causes merge conflicts]. Another difference
between llvm.org and github gone.