### PR TITLE
Future-proofing: Added check for Python 3.8 and higher

### DIFF
--- a/scripts/Python/finishSwigPythonLLDB.py
+++ b/scripts/Python/finishSwigPythonLLDB.py
@@ -673,7 +673,15 @@ def get_pylib_for_platform(vstrPythonInstallDir):
 
     from distutils.sysconfig import get_python_lib
     if platform.system() == 'Linux':
-        if platform.linux_distribution()[0] == 'Fedora':
+        linux_distro = ''
+        # platform.linux_distribution() is not available in
+        # Python >= 3.8
+        if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+            from distro import linux_distribution
+            linux_distro = linux_distribution()[0]
+        else:
+            linux_distro = platform.linux_distribution()[0]
+        if linux_distro == 'Fedora':
             dbg.dump_text("Platform is Fedora Linux")
             # On Fedora the installation gets split into lib and lib64,
             # which prevents building lldb from completing successfully.


### PR DESCRIPTION
where platform.linux_distribution() is no longer available and causes the build to fail. Python 3.8 is scheduled to be released this year per https://www.python.org/dev/peps/pep-0569/. 