### PR TITLE
Cherrypick PR-1882

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -547,12 +547,13 @@ int SwiftREPL::CompleteCode(const std::string &current_code,
         m_target.GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift));
     if (target_swift_ast)
       m_swift_ast_sp.reset(new SwiftASTContext(*target_swift_ast));
+    swift::registerIDERequestFunctions(
+        m_swift_ast_sp.get()->GetASTContext()->evaluator);
   }
   SwiftASTContext *swift_ast = m_swift_ast_sp.get();
 
   if (swift_ast) {
     swift::ASTContext *ast = swift_ast->GetASTContext();
-    swift::registerIDERequestFunctions(ast->evaluator);
     swift::REPLCompletions completions;
     SourceModule completion_module_info;
     completion_module_info.path.push_back(ConstString("repl"));


### PR DESCRIPTION
This PR cherry-picks https://github.com/apple/swift-lldb/pull/1882, which fixes the crash in the completer.

