### PR TITLE
TF-743: Fix completions in jupyter

### DIFF
--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -240,12 +240,13 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
   // == Prepare a module and source files ==
 
   // Get or create the module that we do completions in.
-  static ConstString CompletionsModuleName("completions");
-  SourceModule CompletionsModuleInfo;
-  CompletionsModuleInfo.path.push_back(CompletionsModuleName);
+  const char *CompletionsModuleName = "completions";
   ModuleDecl *CompletionsModule =
-      SwiftCtx.GetModule(CompletionsModuleInfo, Error);
+      Ctx.getLoadedModule(Ctx.getIdentifier(CompletionsModuleName));
   if (!CompletionsModule) {
+    static ConstString CompletionsModuleConstString(CompletionsModuleName);
+    SourceModule CompletionsModuleInfo;
+    CompletionsModuleInfo.path.push_back(CompletionsModuleConstString);
     CompletionsModule = SwiftCtx.CreateModule(CompletionsModuleInfo, Error);
     if (!CompletionsModule)
       return CompletionResponse::error("could not make completions module");

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -45,6 +45,9 @@
 #include "Plugins/Language/ObjC/Cocoa.h"
 #include "Plugins/Language/ObjC/NSString.h"
 
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/Subsystems.h"
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -1703,15 +1706,20 @@ SwiftLanguage::CompleteCode(ExecutionContextScope &exe_scope,
                             const std::string &entered_code) {
   Target &target = *exe_scope.CalculateTarget();
   Status error;
-  SwiftASTContext *swift_ast =
-      target.GetScratchSwiftASTContext(error, exe_scope).get();
-  if (!swift_ast)
-    return CompletionResponse::error("could not get Swift ASTContext");
+  if (!completion_ast_context) {
+    SwiftASTContext *context = llvm::dyn_cast_or_null<SwiftASTContext>(
+        target.GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift));
+    if (!context)
+      return CompletionResponse::error("could not get Swift ASTContext");
+    completion_ast_context.reset(new SwiftASTContext(*context));
+    swift::registerIDERequestFunctions(
+        completion_ast_context.get()->GetASTContext()->evaluator);
+  }
   auto persistent_expression_state =
       target.GetSwiftPersistentExpressionState(exe_scope);
 
-  return SwiftCompleteCode(*swift_ast, *persistent_expression_state,
-                           entered_code);
+  return SwiftCompleteCode(*completion_ast_context.get(),
+                           *persistent_expression_state, entered_code);
 }
 
 //------------------------------------------------------------------

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -98,6 +98,13 @@ public:
   virtual ConstString GetPluginName() override;
 
   virtual uint32_t GetPluginVersion() override;
+
+// SWIFT_ENABLE_TENSORFLOW
+private:
+  // An ASTContext used for completion requests. We use a different ASTContext
+  // from the one used for expression evaluation so that we can
+  // `registerIDERequestFunctions` on it when we create it.
+  lldb::SwiftASTContextSP completion_ast_context;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
The upstream code completion fixes (#1830 #1882) work by calling `registerIDERequestFunctions` on the ASTContext used for completions. The jupyter code completions use a different ASTContext, so those upstream fixes did not fix jupyter code completions. This PR fixes completions by adding `registerIDERequestFunctions` to the ASTContext used by jupyter code completions.

Two additional changes were necessary:
* Previously, jupyter was using the expression evaluator's ASTContext for completions. I considered calling `registerIDERequestFunctions` on that ASTContext, but there was a problem with that approach: 
 `registerIDERequestFunctions` must be called exactly once per ASTContext. The code constructing the expression evaluator's ASTContext is complicated enough that I couldn't see a robust way to call `registerIDERequestFunctions` exactly once per time it gets constructed.
* Previously, `SwiftCtx.GetModule(CompletionsModuleInfo, Error)` was returning `nullptr` on the first call, giving us an opportunity to construct the `CompletionsModule`. Now the `DWARFImporter` is constructing a module when we ask for one. So I changed `SwiftCtx.GetModule(CompletionsModuleInfo, Error)` to `Ctx.getLoadedModule(Ctx.getIdentifier(CompletionsModuleName))`, which doesn't query any importers for modules.