### PR TITLE
TF-743: Fix completions in jupyter, attempt 2

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -547,8 +547,9 @@ int SwiftREPL::CompleteCode(const std::string &current_code,
         m_target.GetScratchTypeSystemForLanguage(&error, eLanguageTypeSwift));
     if (target_swift_ast)
       m_swift_ast_sp.reset(new SwiftASTContext(*target_swift_ast));
-    swift::registerIDERequestFunctions(
-        m_swift_ast_sp.get()->GetASTContext()->evaluator);
+    // SWIFT_ENABLE_TENSORFLOW
+    // We have deleted the call to swift::registerIDERequestFunctions because
+    // we're doing it in SwiftASTContext::GetASTContext() instead.
   }
   SwiftASTContext *swift_ast = m_swift_ast_sp.get();
 

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -240,13 +240,12 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
   // == Prepare a module and source files ==
 
   // Get or create the module that we do completions in.
-  const char *CompletionsModuleName = "completions";
+  static ConstString CompletionsModuleName("completions");
+  SourceModule CompletionsModuleInfo;
+  CompletionsModuleInfo.path.push_back(CompletionsModuleName);
   ModuleDecl *CompletionsModule =
-      Ctx.getLoadedModule(Ctx.getIdentifier(CompletionsModuleName));
+      SwiftCtx.GetModule(CompletionsModuleInfo, Error);
   if (!CompletionsModule) {
-    static ConstString CompletionsModuleConstString(CompletionsModuleName);
-    SourceModule CompletionsModuleInfo;
-    CompletionsModuleInfo.path.push_back(CompletionsModuleConstString);
     CompletionsModule = SwiftCtx.CreateModule(CompletionsModuleInfo, Error);
     if (!CompletionsModule)
       return CompletionResponse::error("could not make completions module");

--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -240,12 +240,16 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
   // == Prepare a module and source files ==
 
   // Get or create the module that we do completions in.
-  static ConstString CompletionsModuleName("completions");
-  SourceModule CompletionsModuleInfo;
-  CompletionsModuleInfo.path.push_back(CompletionsModuleName);
-  ModuleDecl *CompletionsModule =
-      SwiftCtx.GetModule(CompletionsModuleInfo, Error);
+  const char *CompletionsModuleName = "completions";
+  ModuleDecl *CompletionsModule = nullptr;
+  auto CompletionsModuleIt =
+      SwiftCtx.GetModuleCache().find(CompletionsModuleName);
+  if (CompletionsModuleIt != SwiftCtx.GetModuleCache().end())
+    CompletionsModule = CompletionsModuleIt->second;
   if (!CompletionsModule) {
+    static ConstString CompletionsModuleConstString(CompletionsModuleName);
+    SourceModule CompletionsModuleInfo;
+    CompletionsModuleInfo.path.push_back(CompletionsModuleConstString);
     CompletionsModule = SwiftCtx.CreateModule(CompletionsModuleInfo, Error);
     if (!CompletionsModule)
       return CompletionResponse::error("could not make completions module");

--- a/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -98,13 +98,6 @@ public:
   virtual ConstString GetPluginName() override;
 
   virtual uint32_t GetPluginVersion() override;
-
-// SWIFT_ENABLE_TENSORFLOW
-private:
-  // An ASTContext used for completion requests. We use a different ASTContext
-  // from the one used for expression evaluation so that we can
-  // `registerIDERequestFunctions` on it when we create it.
-  lldb::SwiftASTContextSP completion_ast_context;
 };
 
 } // namespace lldb_private

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -3290,6 +3290,9 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   // Set up the required state for the evaluator in the TypeChecker.
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  registerIDERequestFunctions(m_ast_context_ap->evaluator);
+
   GetASTMap().Insert(m_ast_context_ap.get(), this);
 
   VALID_OR_RETURN(nullptr);


### PR DESCRIPTION
This reverts my previous attempt (#1958), and adds 2 fixes:

* Call `registerIDERequestFunctions` when Swift's ASTContext is constructed. (#1958 tried to construct a special ASTContext just for completions and call `registerIDERequestFunctions` on that. This was wrong because the completion request looks at Decls from the evaluator's ASTContext, and mixing ASTContexts causes problems.) (I needed to disable the REPL's call to `registerIDERequestFunctions`. I'll try to upstream this change.)
* Look up the `CompletionsModule` in `SwiftCtx.GetModuleCache()` instead of with `Ctx.getLoadedModule`, because the modules that we create using `SwiftCtx.CreateModule()` show up in the `SwiftCtx.GetModuleCache()` but not in the `Ctx.getLoadedModule`.