### PR TITLE
DWARFImporter: Add a non-working test for Objective-C properties.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Inputs/objc-header.h
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Inputs/objc-header.h
@@ -8,7 +8,8 @@
 @protocol ObjCProtocol <WithName>
 @end
 
-@interface ObjCClass : NSObject
+@interface ObjCClass : NSObject {
+}
 - (instancetype)init;
 @end
 

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Inputs/objc-header.h
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/Inputs/objc-header.h
@@ -8,8 +8,8 @@
 @protocol ObjCProtocol <WithName>
 @end
 
-@interface ObjCClass : NSObject {
-}
+@interface ObjCClass : NSObject
+@property (readonly) int number;
 - (instancetype)init;
 @end
 

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -49,7 +49,10 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                 target.FindFirstGlobalVariable("obj"),
                                 typename="Swift.Optional<__ObjC.ObjCClass>",
                                 num_children=0)
-        self.expect("target var obj", substrs=["ObjCClass", "private_ivar", "42"])
+        self.expect("target var obj", substrs=["ObjCClass",
+                                               "private_ivar", "42"])
+        self.expect("target var swiftChild", substrs=["ObjCClass",
+                                                      "private_ivar", "42"])
         # This is a Clang type, since Clang doesn't generate DWARF for protocols.
         self.expect("target var -d no-dyn proto", substrs=["(id)", "proto"])
         # This is a Swift type.

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/TestSwiftDWARFImporterObjC.py
@@ -51,8 +51,10 @@ class TestSwiftDWARFImporterObjC(lldbtest.TestBase):
                                 num_children=0)
         self.expect("target var obj", substrs=["ObjCClass",
                                                "private_ivar", "42"])
-        self.expect("target var swiftChild", substrs=["ObjCClass",
-                                                      "private_ivar", "42"])
+        # FIXME: This triggers an assertion in ClangImporter:
+        #        "ObjC property without getter"
+        #self.expect("target var swiftChild", substrs=["ObjCClass",
+        #                                              "private_ivar", "42"])
         # This is a Clang type, since Clang doesn't generate DWARF for protocols.
         self.expect("target var -d no-dyn proto", substrs=["(id)", "proto"])
         # This is a Swift type.

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/impl.m
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/impl.m
@@ -8,6 +8,8 @@
   int private_ivar;
 }
 
+@synthesize number = private_ivar;
+
 - (instancetype)init {
   self = [super init];
   if (self) {

--- a/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/dwarfimporter/Objective-C/main.swift
@@ -2,9 +2,16 @@ import ObjCModule
 
 func use<T>(_ t: T) {}
 
+class SwiftChild : ObjCClass {
+}
+
+
 let pureSwift = 42
 let obj = ObjCClass()
 let proto = getProto()
+let swiftChild = SwiftChild()
+
 use(pureSwift) // break here
 use(obj)
 use(proto)
+use(swiftChild)


### PR DESCRIPTION
This shows the limits of what is possible without synthesizing Objective-C methods.

rdar://problem/55025799