### PR TITLE
[Python] Implement truth testing for lldb.value

### DIFF
--- a/packages/Python/lldbsuite/test/python_api/value/TestValueAPI.py
+++ b/packages/Python/lldbsuite/test/python_api/value/TestValueAPI.py
@@ -163,6 +163,10 @@ class ValueAPITestCase(TestBase):
                 val_i.GetType()).AddressOf(),
             VALID_VARIABLE)
 
+        # Check that lldb.value implements truth testing.
+        self.assertFalse(lldb.value(frame0.FindVariable('bogus')))
+        self.assertTrue(lldb.value(frame0.FindVariable('uinthex')))
+
         self.assertTrue(int(lldb.value(frame0.FindVariable('uinthex')))
                         == 3768803088, 'uinthex == 3768803088')
         self.assertTrue(int(lldb.value(frame0.FindVariable('sinthex')))

--- a/scripts/Python/python-extensions.swig
+++ b/scripts/Python/python-extensions.swig
@@ -980,6 +980,9 @@ class value(object):
     def __nonzero__(self):
         return self.sbvalue.__nonzero__()
 
+    def __bool__(self):
+        return self.sbvalue.__bool__()
+
     def __str__(self):
         return self.sbvalue.__str__()
 


### PR DESCRIPTION
Python 3 calls __bool__() instead of __len__() and lldb.value only
implemented the __len__ method. This adds the __bool__() implementation.

Differential revision: https://reviews.llvm.org/D67183

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@370953 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit d106062af0389b76c6ad4cdf1ce8e9c007ecd652)