### PR TITLE
[Python] Implement __next__ for value_iter

### DIFF
--- a/packages/Python/lldbsuite/test/python_api/value/TestValueAPI.py
+++ b/packages/Python/lldbsuite/test/python_api/value/TestValueAPI.py
@@ -168,6 +168,13 @@ class ValueAPITestCase(TestBase):
         self.assertTrue(int(lldb.value(frame0.FindVariable('sinthex')))
                         == -526164208, 'sinthex == -526164208')
 
+        # Check value_iter works correctly.
+        for v in [
+                lldb.value(frame0.FindVariable('uinthex')),
+                lldb.value(frame0.FindVariable('sinthex'))
+        ]:
+            self.assertTrue(v)
+
         self.assertTrue(
             frame0.FindVariable('uinthex').GetValueAsUnsigned() == 3768803088,
             'unsigned uinthex == 3768803088')

--- a/scripts/Python/python-extensions.swig
+++ b/scripts/Python/python-extensions.swig
@@ -46,18 +46,18 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
-    %pythoncode %{ 
+
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 
@@ -97,17 +97,17 @@
 }
 
 %extend lldb::SBBroadcaster {
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -127,7 +127,7 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
+
         /* the write() and flush() calls are not part of the SB API proper, and are solely for Python usage
         they are meant to make an SBCommandReturnObject into a file-like object so that instructions of the sort
         print >>sb_command_return_object, "something"
@@ -156,17 +156,17 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -217,18 +217,18 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
-    %pythoncode %{ 
+
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 
@@ -296,18 +296,18 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
-    %pythoncode %{ 
+
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 
@@ -359,18 +359,18 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
-    %pythoncode %{ 
+
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -407,18 +407,18 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
-    %pythoncode %{ 
+
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -488,18 +488,18 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-        
-    %pythoncode %{ 
+
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -534,15 +534,15 @@
         %clearnothreadallow;
     %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -595,17 +595,17 @@
         }
         %clearnothreadallow;
 
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -657,17 +657,17 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -750,17 +750,17 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -779,17 +779,17 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -808,17 +808,17 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -837,17 +837,17 @@
                     return lldb_private::PythonString("").release();
         }
         %clearnothreadallow;
-    %pythoncode %{ 
+    %pythoncode %{
         def __eq__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return False 
-            
+            if not isinstance(rhs, type(self)):
+                return False
+
             return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-            
+
         def __ne__(self, rhs):
-            if not isinstance(rhs, type(self)): 
-                return True 
-            
+            if not isinstance(rhs, type(self)):
+                return True
+
             return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
     %}
 }
@@ -945,14 +945,17 @@ class declaration(object):
 class value_iter(object):
     def __iter__(self):
         return self
-    
-    def next(self):
+
+    def __next__(self):
         if self.index >= self.length:
             raise StopIteration()
         child_sbvalue = self.sbvalue.GetChildAtIndex(self.index)
         self.index += 1
         return value(child_sbvalue)
-        
+
+    def next(self):
+        return self.__next__()
+
     def __init__(self,value):
         self.index = 0
         self.sbvalue = value
@@ -965,7 +968,7 @@ class value(object):
     can be used as a variable would be in code. So if you have a Point structure
     variable in your code in the current frame named "pt", you can initialize an instance
     of this class with it:
-    
+
     pt = lldb.value(lldb.frame.FindVariable("pt"))
     print pt
     print pt.x
@@ -979,6 +982,9 @@ class value(object):
 
     def __nonzero__(self):
         return self.sbvalue.__nonzero__()
+
+    def __bool__(self):
+        return self.sbvalue.__bool__()
 
     def __str__(self):
         return self.sbvalue.__str__()
@@ -1005,131 +1011,131 @@ class value(object):
 
     def __add__(self, other):
         return int(self) + int(other)
-        
+
     def __sub__(self, other):
         return int(self) - int(other)
-        
+
     def __mul__(self, other):
         return int(self) * int(other)
-        
+
     def __floordiv__(self, other):
         return int(self) // int(other)
-        
+
     def __mod__(self, other):
         return int(self) % int(other)
-        
+
     def __divmod__(self, other):
         return int(self) % int(other)
-        
+
     def __pow__(self, other):
         return int(self) ** int(other)
-        
+
     def __lshift__(self, other):
         return int(self) << int(other)
-        
+
     def __rshift__(self, other):
         return int(self) >> int(other)
-        
+
     def __and__(self, other):
         return int(self) & int(other)
-        
+
     def __xor__(self, other):
         return int(self) ^ int(other)
-        
+
     def __or__(self, other):
         return int(self) | int(other)
-        
+
     def __div__(self, other):
         return int(self) / int(other)
-        
+
     def __truediv__(self, other):
         return int(self) / int(other)
-        
+
     def __iadd__(self, other):
         result = self.__add__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __isub__(self, other):
         result = self.__sub__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __imul__(self, other):
         result = self.__mul__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __idiv__(self, other):
         result = self.__div__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __itruediv__(self, other):
         result = self.__truediv__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __ifloordiv__(self, other):
         result =  self.__floordiv__(self, other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __imod__(self, other):
         result =  self.__and__(self, other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __ipow__(self, other):
         result = self.__pow__(self, other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __ipow__(self, other, modulo):
         result = self.__pow__(self, other, modulo)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __ilshift__(self, other):
         result = self.__lshift__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __irshift__(self, other):
         result =  self.__rshift__(other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __iand__(self, other):
         result =  self.__and__(self, other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __ixor__(self, other):
         result =  self.__xor__(self, other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __ior__(self, other):
         result =  self.__ior__(self, other)
         self.sbvalue.SetValueFromCString (str(result))
         return result
-        
+
     def __neg__(self):
         return -int(self)
-        
+
     def __pos__(self):
         return +int(self)
-        
+
     def __abs__(self):
         return abs(int(self))
-        
+
     def __invert__(self):
         return ~int(self)
-        
+
     def __complex__(self):
         return complex (int(self))
-        
+
     def __int__(self):
         is_num,is_sign = is_numeric_type(self.sbvalue.GetType().GetCanonicalType().GetBasicType())
         if is_num and not is_sign: return self.sbvalue.GetValueAsUnsigned()
@@ -1140,10 +1146,10 @@ class value(object):
 
     def __float__(self):
         return float (self.sbvalue.GetValueAsSigned())
-        
+
     def __oct__(self):
         return '0%o' % self.sbvalue.GetValueAsUnsigned()
-        
+
     def __hex__(self):
         return '0x%x' % self.sbvalue.GetValueAsUnsigned()
 


### PR DESCRIPTION
Python 3 iteration calls the next() method instead of next() and
value_iter only implemented the Python 2 version.

Differential revision: https://reviews.llvm.org/D67184

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@370954 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 03d3365e571ea10fd130a0f019fcdbb8bd22903e)