### PR TITLE
[Reproducer] Support Swift textual interfaces

### DIFF
--- a/lit/Reproducer/Swift/Inputs/A.swift
+++ b/lit/Reproducer/Swift/Inputs/A.swift
@@ -1,0 +1,19 @@
+public struct MyPoint {
+  let x: Int
+  let y: Int
+
+
+  public init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+
+  public var magnitudeSquared: Int {
+    return x*x + y*y
+  }
+}
+
+public struct FromInterface {}
+public struct OtherType {}
+
+public let testValue = FromInterface()

--- a/lit/Reproducer/Swift/Inputs/Main.swift
+++ b/lit/Reproducer/Swift/Inputs/Main.swift
@@ -1,0 +1,11 @@
+import AA
+
+func foo() {
+  let x = MyPoint(x: 10, y: 0)
+  let y = MyPoint(x: -2, y: 20)
+
+  print("x=\(x.magnitudeSquared)")
+  print("y=\(y.magnitudeSquared)")
+}
+
+foo()

--- a/lit/Reproducer/Swift/Inputs/SwiftInterface.in
+++ b/lit/Reproducer/Swift/Inputs/SwiftInterface.in
@@ -1,0 +1,10 @@
+settings set symbols.swift-module-loading-mode prefer-parseable
+b Main.swift:8
+run
+expr let x: OtherType = testValue
+expr y.magnitudeSquared
+expr MyPoint(x: 1, y: 2).magnitudeSquared
+expr import AA
+cont
+reproducer status
+reproducer generate

--- a/lit/Reproducer/Swift/TestSwiftInterface.test
+++ b/lit/Reproducer/Swift/TestSwiftInterface.test
@@ -1,0 +1,59 @@
+# Test that reproducers can deal with .swiftinterface files.
+
+# REQUIRES: system-darwin
+
+# Start clean.
+# RUN: rm -rf %t.build && mkdir %t.build && cd %t.build
+# RUN: rm -rf %t.lib && mkdir %t.lib
+# RUN: cp %S/Inputs/A.swift %t.build/AA.swift
+# RUN: cp %S/Inputs/Main.swift %t.build/Main.swift
+
+# RUN: %target-swiftc -module-name AA \
+# RUN:          -module-cache-path %t.build/cache \
+# RUN:          -enable-library-evolution \
+# RUN:          -emit-module-interface-path %t.lib/AA.swiftinterface \
+# RUN:          -emit-library \
+# RUN:          -o %t.lib/libAA%target-shared-library-suffix \
+# RUN:          %t.build/AA.swift
+
+# Regenerate the Swift module but with a different type.
+# RUN: sed -e 's/FromInterface/FromSerialized/g' %t.build/AA.swift | %target-swiftc -module-name AA -enable-library-evolution -emit-module -o %t.lib/AA.swiftmodule -
+
+# Remove the swift source file.
+# RUN: rm %t.build/AA.swift
+
+# RUN: %target-swiftc -g \
+# RUN:          -module-cache-path %t.build/cache \
+# RUN:          -I%t.lib -L%t.lib -lAA \
+# RUN:          -module-name main \
+# RUN:          -o %t.out \
+# RUN:          %t.build/Main.swift
+
+# Cleanup build directory.
+# RUN: rm -rf %t.build
+
+# Change to run directory.
+# RUN: rm -rf %t.repro
+# RUN: rm -rf %t.run && mkdir %t.run && cd %t.run
+
+# Capture the reproducer.
+# RUN: %lldb -x -b \
+# RUN:          -o 'settings set interpreter.stop-command-source-on-error false' \
+# RUN:          -s %S/Inputs/SwiftInterface.in \
+# RUN:          --capture \
+# RUN:          --capture-path %t.repro \
+# RUN:          %t.out 2>&1 | FileCheck %s --check-prefix CHECK --check-prefix CAPTURE
+
+# Cleanup lib directory and binary.
+# RUN: rm -rf %t.lib
+# RUN: rm -rf %t.out
+
+# Replay the reproducer in place.
+# RUN: %lldb --replay %t.repro 2>&1 | FileCheck %s --check-prefix CHECK --check-prefix REPLAY
+
+# CHECK: Breakpoint 1:{{.*}} Main.swift:8
+# CAPTURE: x=100
+# REPLAY-NOT: x=100
+# CHECK: cannot convert value of type 'FromInterface' to specified type 'OtherType'
+# CHECK: (Int) $R{{[0-9]+}} = 404
+# CHECK: (Int) $R{{[0-9]+}} = 5


### PR DESCRIPTION
Support was already there for capturing Swift's textual interfaces. This
adds a test to make sure that they're used by the reproducer.