### PR TITLE
Backport fix for detecting illegal command options

### DIFF
--- a/packages/Python/lldbsuite/test/help/TestHelp.py
+++ b/packages/Python/lldbsuite/test/help/TestHelp.py
@@ -243,6 +243,11 @@ class HelpCommandTestCase(TestBase):
                     substrs=["'alongaliasna' is an abbreviation for 'help'"])
 
     @no_debug_info_test
+    def test_help_unknown_flag(self):
+        self.expect("help -z", error=True,
+                    substrs=["unknown or ambiguous option"])
+
+    @no_debug_info_test
     def test_help_format_output(self):
         """Test that help output reaches TerminalWidth."""
         self.runCmd(

--- a/source/Interpreter/Options.cpp
+++ b/source/Interpreter/Options.cpp
@@ -1448,9 +1448,10 @@ llvm::Expected<Args> Options::Parse(const Args &args,
     } else {
       error.SetErrorStringWithFormat("invalid option with value '%i'", val);
     }
-    if (error.Fail())
-      return error.ToError();
   }
+
+  if (error.Fail())
+    return error.ToError();
 
   argv.pop_back();
   argv.erase(argv.begin(), argv.begin() + OptionParser::GetOptionIndex());


### PR DESCRIPTION
Fixes rdar://53280240 (swift-5.1 branch lldb doesn't filter out illegal command options)

Original test didn't have a test, so I back ported part of the test that is upstream.