### PR TITLE
Fixing build break with upstream lldb (SwiftASTContext::GetFloatTypeSemantics)

### DIFF
--- a/include/lldb/Symbol/SwiftASTContext.h
+++ b/include/lldb/Symbol/SwiftASTContext.h
@@ -547,6 +547,8 @@ public:
 
   // Exploring the type
 
+  const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) override;
+
   llvm::Optional<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -6151,6 +6151,11 @@ bool SwiftASTContext::IsFixedSize(CompilerType compiler_type) {
   return false;
 }
 
+const llvm::fltSemantics &
+SwiftASTContext::GetFloatTypeSemantics(size_t byte_size) {
+  llvm_unreachable("SwiftASTContext::GetFloatTypeSemantics not implemented.");
+}
+
 llvm::Optional<uint64_t>
 SwiftASTContext::GetBitSize(lldb::opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {


### PR DESCRIPTION


SwiftASTContext::GetFloatTypeSemantics not implemented was causing build break.