### PR TITLE
Porting 'Replace `lldb_private::CleanUp` by `llvm::scope_exit`' to swift-lldb.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -111,7 +111,7 @@
 #include "lldb/Target/SwiftLanguageRuntime.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ArchSpec.h"
-#include "lldb/Utility/CleanUp.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Log.h"

--- a/source/Target/SwiftLanguageRuntime.cpp
+++ b/source/Target/SwiftLanguageRuntime.cpp
@@ -74,7 +74,7 @@
 #include "lldb/Target/ThreadPlanStepOverRange.h"
 #include "lldb/Utility/Status.h"
 
-#include "lldb/Utility/CleanUp.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "lldb/Utility/DataBuffer.h"
 #include "lldb/Utility/LLDBAssert.h"
 #include "lldb/Utility/Log.h"
@@ -318,8 +318,9 @@ static bool GetObjectDescription_ObjectCopy(SwiftLanguageRuntime *runtime,
       log->Printf("[GetObjectDescription_ObjectCopy] copy_location invalid");
     return false;
   }
-  CleanUp cleanup(
-      [process, copy_location] { process->DeallocateMemory(copy_location); });
+
+  auto cleanup = llvm::make_scope_exit(
+      [&]() { process->DeallocateMemory(copy_location); });
 
   DataExtractor data_extractor;
   if (0 == static_sp->GetData(data_extractor, error)) {


### PR DESCRIPTION

llvm svn version r371474 changed CleanUp to scope_exit. This makes it so
the swift specific bits here build.

(cherry picked from commit 9c20e413a40c36033f096de94933ebdc2c042220)