### PR TITLE
[swift-lldb] Fixing build break in usws caused by llvm.org r371842.

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -1555,7 +1555,7 @@ void SwiftASTContext::AddUserClangArgs(TargetProperties &props) {
   Args args(props.GetSwiftExtraClangFlags());
   std::vector<std::string> user_clang_flags;
   for (const auto &arg : args.entries())
-    user_clang_flags.push_back(arg.ref);
+    user_clang_flags.push_back(arg.ref());
   AddExtraClangArgs(user_clang_flags);
 }
 


### PR DESCRIPTION
r371842 drops the public ref and replaces it with ref().