### PR TITLE
[swift] Adopt new ModuleInterfaceLoader APIs

### DIFF
--- a/include/lldb/lldb-private-enumerations.h
+++ b/include/lldb/lldb-private-enumerations.h
@@ -215,11 +215,11 @@ typedef enum LanguageRuntimeDescriptionDisplayVerbosity {
 typedef enum SwiftModuleLoadingMode {
   eSwiftModuleLoadingModePreferSerialized, // Prefer loading via .swiftmodule,
                                            // falling back to .swiftinterface
-  eSwiftModuleLoadingModePreferParseable,  // Prefer Loading via
+  eSwiftModuleLoadingModePreferInterface,  // Prefer Loading via
                                            // .swiftinterface, falling back to
                                            // .swiftmodule
   eSwiftModuleLoadingModeOnlySerialized,   // Load via .swiftmodule only
-  eSwiftModuleLoadingModeOnlyParseable,    // Load via .swiftinterface only
+  eSwiftModuleLoadingModeOnlyInterface,    // Load via .swiftinterface only
 } SwiftModuleLoadingMode;
 
 //----------------------------------------------------------------------

--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -6,7 +6,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cp %S/Inputs/A.swift %t/AA.swift
-// RUN: %target-swiftc -module-name AA -emit-parseable-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: %target-swiftc -module-name AA -emit-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
 // RUN: rm %t/AA.swift
 // RUN: %lldb --repl="-I%t -L%t -lAA" < %s | FileCheck %s
 

--- a/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -1,6 +1,6 @@
 // This test checks that the value of the symbols.swift-module-loading-mode
 // setting is respected when loading Swift modules.
-// Note: It intentionally does not check the only-parseable or prefer-parseable
+// Note: It intentionally does not check the only-interface or prefer-interface
 // modes as this also causes the Swift stdlib to be loaded via its module
 // interface file, which slows down this test considerably.
 
@@ -18,7 +18,7 @@
 // RUN: mkdir %t/mcp
 // RUN: mkdir %t/lib
 // RUN: cp %S/Inputs/A.swift %t/AA.swift
-// RUN: %target-swiftc -module-name AA -emit-parseable-module-interface-path %t/lib/AA.swiftinterface -emit-library -o %t/lib/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: %target-swiftc -module-name AA -emit-module-interface-path %t/lib/AA.swiftinterface -emit-library -o %t/lib/libAA%target-shared-library-suffix %t/AA.swift
 // RUN: sed -e 's/FromInterface/FromSerialized/g' %t/AA.swift | %target-swiftc -module-name AA -emit-module -o %t/lib/AA.swiftmodule -
 // RUN: rm %t/AA.swift
 

--- a/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -694,7 +694,7 @@ $(MODULENAME).swiftmodule: $(OBJECTS) $(DYLIB_OBJECTS)
 	@echo "### Merging swift modules for $(MODULENAME)"
 	$(SWIFT_FE) $(SWIFT_FEFLAGS) -merge-modules \
 	  -emit-module $(patsubst %.swift,%.partial.swiftmodule,$(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)) \
-	  -emit-parseable-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface \
+	  -emit-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface \
 	  -sil-merge-partial-modules \
 	  -disable-diagnostic-passes -disable-sil-perf-optzns \
 	  -module-name $(MODULENAME) \

--- a/source/Core/ModuleList.cpp
+++ b/source/Core/ModuleList.cpp
@@ -69,13 +69,13 @@ static bool KeepLookingInDylinker(SymbolContextList &sc_list, size_t start_idx);
 namespace {
 
 static constexpr OptionEnumValueElement g_swift_module_loading_mode_enums[] = {
-  {eSwiftModuleLoadingModePreferParseable, "prefer-parseable",
+  {eSwiftModuleLoadingModePreferInterface, "prefer-interface",
     "Prefer loading Swift modules via their .swiftinterface file, but fall back "
     " to the .swiftmodule if it is missing."},
   {eSwiftModuleLoadingModePreferSerialized, "prefer-serialized",
     "Prefer loading Swift module via their .swiftmodule file if present, but "
     "fall back to the .swiftinterface if it is missing or invalid (default)."},
-  {eSwiftModuleLoadingModeOnlyParseable, "only-parseable",
+  {eSwiftModuleLoadingModeOnlyInterface, "only-interface",
     "Only load Swift modules via their .swiftinterface file - ignore "
     ".swiftmodule files."},
   {eSwiftModuleLoadingModeOnlySerialized, "only-serialized",

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -45,7 +45,7 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Frontend/Frontend.h"
-#include "swift/Frontend/ParseableInterfaceModuleLoader.h"
+#include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILModule.h"
@@ -3442,14 +3442,14 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   case eSwiftModuleLoadingModePreferSerialized:
     loading_mode = swift::ModuleLoadingMode::PreferSerialized;
     break;
-  case eSwiftModuleLoadingModePreferParseable:
-    loading_mode = swift::ModuleLoadingMode::PreferParseable;
+  case eSwiftModuleLoadingModePreferInterface:
+    loading_mode = swift::ModuleLoadingMode::PreferInterface;
     break;
   case eSwiftModuleLoadingModeOnlySerialized:
     loading_mode = swift::ModuleLoadingMode::OnlySerialized;
     break;
-  case eSwiftModuleLoadingModeOnlyParseable:
-    loading_mode = swift::ModuleLoadingMode::OnlyParseable;
+  case eSwiftModuleLoadingModeOnlyInterface:
+    loading_mode = swift::ModuleLoadingMode::OnlyInterface;
     break;
   }
 
@@ -3465,21 +3465,21 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
     m_ast_context_ap->addModuleLoader(std::move(memory_buffer_loader_ap));
   }
 
-  // 2. Create and install the parseable interface module loader.
+  // 2. Create and install the module interface loader.
   //
-  // TODO: It may be nice to reverse the order between PIML and SML in
+  // TODO: It may be nice to reverse the order between MIL and SML in
   //       LLDB, since binary swift modules likely contain private
-  //       types that the parseable interfaces are missing. On the
+  //       types that the module interfaces are missing. On the
   //       other hand if we need to go looking for a module on disk,
   //       something is already screwed up in the debug info.
-  std::unique_ptr<swift::ModuleLoader> parseable_module_loader_ap;
+  std::unique_ptr<swift::ModuleLoader> module_interface_loader_ap;
   if (loading_mode != swift::ModuleLoadingMode::OnlySerialized) {
-    std::unique_ptr<swift::ModuleLoader> parseable_module_loader_ap(
-        swift::ParseableInterfaceModuleLoader::create(
+    std::unique_ptr<swift::ModuleLoader> module_interface_loader_ap(
+        swift::ModuleInterfaceLoader::create(
             *m_ast_context_ap, moduleCachePath, prebuiltModuleCachePath,
             tracker, loading_mode));
-    if (parseable_module_loader_ap)
-      m_ast_context_ap->addModuleLoader(std::move(parseable_module_loader_ap));
+    if (module_interface_loader_ap)
+      m_ast_context_ap->addModuleLoader(std::move(module_interface_loader_ap));
   }
 
   // 3. Create and install the serialized module loader.


### PR DESCRIPTION
This patch adopts the new APIs in https://github.com/apple/swift/pull/27175
and removes the usage of `-emit-parseable-module-interface[-path]` in
favor of the final flags, `-emit-module-interface[-path]`.