### PR TITLE
Install a TypeChecker in the ASTContext

### DIFF
--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -48,6 +48,7 @@
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IRGen/Linking.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/Serialization/Validation.h"
 #include "clang/AST/ASTContext.h"
@@ -3497,6 +3498,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   }
 
   // Set up the required state for the evaluator in the TypeChecker.
+  (void)swift::createTypeChecker(*m_ast_context_ap);
   registerParseRequestFunctions(m_ast_context_ap->evaluator);
   registerTypeCheckerRequestFunctions(m_ast_context_ap->evaluator);
 


### PR DESCRIPTION
Having the type checker requests available means that we actually do need a type checker to be installed here (for now).  Once the lazy resolver disappears, this should be re-evaluated.