### PR TITLE
[ScriptInterpreter] Initialize globals when loading a scripting module.

### DIFF
--- a/lit/Commands/Inputs/frame.py
+++ b/lit/Commands/Inputs/frame.py
@@ -1,0 +1,2 @@
+import lldb
+print(lldb.frame)

--- a/lit/Commands/command-script-import.test
+++ b/lit/Commands/command-script-import.test
@@ -1,0 +1,8 @@
+# RUN: echo 'b main' > %t.in
+# RUN: echo 'run' >> %t.in
+# RUN: echo 'command script import %S/Inputs/frame.py' >> %t.in
+
+# RUN: %clang -g -O0 %S/../Settings/Inputs/main.c -o %t.out
+# RUN: %lldb -b -s %t.in %t.out | FileCheck %s
+
+# CHECK: frame #0

--- a/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2717,12 +2717,12 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
     StreamString command_stream;
 
     // Before executing Python code, lock the GIL.
-    Locker py_lock(this,
-                   Locker::AcquireLock |
-                       (init_session ? Locker::InitSession : 0) |
-                       Locker::NoSTDIN,
-                   Locker::FreeAcquiredLock |
-                       (init_session ? Locker::TearDownSession : 0));
+    Locker py_lock(
+        this,
+        Locker::AcquireLock | (init_session ? Locker::InitSession : 0) |
+            (init_session ? Locker::InitGlobals : 0) | Locker::NoSTDIN,
+        Locker::FreeAcquiredLock |
+            (init_session ? Locker::TearDownSession : 0));
     namespace fs = llvm::sys::fs;
     fs::file_status st;
     std::error_code ec = status(target_file.GetPath(), st);


### PR DESCRIPTION
The LoadScriptingModule used by command script import wasn't
initializing the LLDB global variables (things like `lldb.frame` and
`lldb.debugger`). They would get initialized however when running the
interactive script interpreter or running a single script line (e.g.
`script print(lldb.frame)`). This patch fixes that by properly
initializing the globals when loading a Python module.

Differential revision: https://reviews.llvm.org/D67644

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@372060 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit b918d182f9ca995929092f0131977abb761d86a4)