### PR TITLE
[5.1][Swift] Infer the canonical type of the condition in breakpoints.

### DIFF
--- a/lit/Swift/Inputs/main.swift
+++ b/lit/Swift/Inputs/main.swift
@@ -1,0 +1,3 @@
+func main() { return }
+
+_ = main()

--- a/lit/Swift/cond-breakpoint.test
+++ b/lit/Swift/cond-breakpoint.test
@@ -1,0 +1,10 @@
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: %target-swiftc -g %S/Inputs/main.swift -o a.out
+# RUN: %lldb a.out -b -s %s 2>&1 | FileCheck %s
+
+# CHECK-NOT: Stopped due to an error evaluating condition of breakpoint
+
+# The parentheses surrounding the expression matter.
+br s -n main -c '((nil == nil))'
+r
+c

--- a/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1453,7 +1453,8 @@ LazyBool SwiftLanguage::IsLogicalTrue(ValueObject &valobj, Status &error) {
 
   Scalar scalar_value;
 
-  CompilerType valobj_type(valobj.GetCompilerType());
+  auto swift_ty = GetCanonicalSwiftType(valobj.GetCompilerType());
+  CompilerType valobj_type(swift_ty);
   Flags type_flags(valobj_type.GetTypeInfo());
   if (llvm::isa<SwiftASTContext>(valobj_type.GetTypeSystem())) {
     if (type_flags.AllSet(eTypeIsStructUnion) &&


### PR DESCRIPTION
lldb checks that the type of the condition is `Swift.Bool`.
Parentheses in the condition are carried in the type, e.g.
((cond)) will have type ((Swift.Bool)). Always desugar the
type as sugar doesn't matter for this check.

Fixes <rdar://problem/55372511>