### PR TITLE
[SwiftInterface] Reenable these two tests on linux.

### DIFF
--- a/lit/SwiftREPL/SwiftInterface.test
+++ b/lit/SwiftREPL/SwiftInterface.test
@@ -1,8 +1,5 @@
 // Test that .swiftinterface files can be loaded via the repl.
 
-// Disabled on linux due to flakiness in CI (rdar://problem/53181277)
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cp %S/Inputs/A.swift %t/AA.swift

--- a/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lit/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -4,9 +4,6 @@
 // modes as this also causes the Swift stdlib to be loaded via its module
 // interface file, which slows down this test considerably.
 
-// Disabled on linux due to flakiness in CI (rdar://problem/53312825)
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir %t
 
 // Setup generates a dylib and .swiftinterface for A.swift as is, but generates


### PR DESCRIPTION
Turns out the reason why they're failing was unrelated to
the nature of the tests themselves.

<rdar://problem/53312825>