### PR TITLE
If commands modules fails to load, use subprocess module

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -12,7 +12,7 @@
 """
 Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 """
-try
+try:
     import commands
 except ImportError:    
     import subprocess

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -12,14 +12,10 @@
 """
 Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 """
-
-#SWIFT_TENSORFLOW: Since tensorflow uses Python 3 and commands is deprected
-# there, import subprocess instead.
 try
     import commands
 except ImportError:    
     import subprocess
-    
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -12,7 +12,14 @@
 """
 Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 """
-import commands
+
+#SWIFT_TENSORFLOW: Since tensorflow uses Python 3 and commands is deprected
+# there, import subprocess instead.
+try
+    import commands
+except ImportError:    
+    import subprocess
+    
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -12,13 +12,10 @@
 """
 Test `@_implementationOnly import` in a resilient library used by the main executable
 """
-#SWIFT_TENSORFLOW: Since tensorflow uses Python 3 and commands is deprected
-# there, import subprocess instead.
 try
     import commands
 except ImportError:    
     import subprocess
-
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -12,7 +12,13 @@
 """
 Test `@_implementationOnly import` in a resilient library used by the main executable
 """
-import commands
+#SWIFT_TENSORFLOW: Since tensorflow uses Python 3 and commands is deprected
+# there, import subprocess instead.
+try
+    import commands
+except ImportError:    
+    import subprocess
+
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -12,7 +12,7 @@
 """
 Test `@_implementationOnly import` in a resilient library used by the main executable
 """
-try
+try:
     import commands
 except ImportError:    
     import subprocess

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -12,7 +12,7 @@
 """
 Test `@_implementationOnly import` in the main executable
 """
-try
+try:
     import commands
 except ImportError:    
     import subprocess

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -12,7 +12,14 @@
 """
 Test `@_implementationOnly import` in the main executable
 """
-import commands
+
+#SWIFT_TENSORFLOW: Since tensorflow uses Python 3 and commands is deprected
+# there, import subprocess instead.
+try
+    import commands
+except ImportError:    
+    import subprocess
+    
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -12,14 +12,10 @@
 """
 Test `@_implementationOnly import` in the main executable
 """
-
-#SWIFT_TENSORFLOW: Since tensorflow uses Python 3 and commands is deprected
-# there, import subprocess instead.
 try
     import commands
 except ImportError:    
     import subprocess
-    
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *


### PR DESCRIPTION
The commands module has been removed in Python3. Use subprocess instead if it fails to load as recommended by https://docs.python.org/2/library/commands.html.