### PR TITLE
[TestSwiftUninitializedVariable] Re-enable on Linux.

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/Makefile
@@ -1,7 +1,3 @@
 LEVEL = ../../../../make
 SWIFT_SOURCES := main.swift
 include $(LEVEL)/Makefile.rules
-
-cleanup:
-	rm -f Makefile *.d
-

--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -1,16 +1,4 @@
-# TestSwiftUninitializedVariable.py
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ------------------------------------------------------------------------------
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/uninitialized/main.swift
@@ -1,15 +1,3 @@
-// main.swift
-//
-// This source file is part of the Swift.org open source project
-//
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-//
-// -----------------------------------------------------------------------------
-
 struct A<T> {
     let d : Int
     var cs : [T]


### PR DESCRIPTION
There's nothing darwin specific here. Also, clean up unneeded
copyright and Makefile while I'm around.

<rdar://problem/55498143>