### PR TITLE
remove delayed callbacks in lldb codecompletion

### DIFF
--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -16,7 +16,6 @@
 #include "swift/IDE/CodeCompletion.h"
 #include "swift/IDE/CodeCompletionCache.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
-#include "swift/Parse/DelayedParsingCallbacks.h"
 #include "swift/Subsystems.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -178,12 +177,9 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode,
   const unsigned OriginalDeclCount = SF.Decls.size();
 
   PersistentParserState PersistentState(Ctx);
-  std::unique_ptr<DelayedParsingCallbacks> DelayedCB(
-      new CodeCompleteDelayedCallbacks(Ctx.SourceMgr.getCodeCompletionLoc()));
   bool Done;
   do {
-    parseIntoSourceFile(SF, BufferID, &Done, nullptr, &PersistentState,
-                        DelayedCB.get());
+    parseIntoSourceFile(SF, BufferID, &Done, nullptr, &PersistentState);
   } while (!Done);
   performTypeChecking(SF, PersistentState.getTopLevelContext(), None,
                       OriginalDeclCount);


### PR DESCRIPTION
These have been removed upstream.

I simply imitated the changes to REPLCodeCompletion.cpp in the upstream commit https://github.com/apple/swift/commit/d7f6768a9dee046207cb0a4dee3c9fa597acf24d.

The completion tests are failing now, but I suspect for unrelated reasons. I'll investigate that separately.