### PR TITLE
fix jupyter code completion for tensorflow merge

### DIFF
--- a/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
+++ b/source/Plugins/Language/Swift/SwiftCodeCompletion.cpp
@@ -176,7 +176,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode,
 
   const unsigned OriginalDeclCount = SF.Decls.size();
 
-  PersistentParserState PersistentState(Ctx);
+  PersistentParserState PersistentState;
   bool Done;
   do {
     parseIntoSourceFile(SF, BufferID, &Done, nullptr, &PersistentState);
@@ -187,6 +187,8 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode,
   performDelayedParsing(&SF, PersistentState, CompletionCallbacksFactory);
 
   SF.Decls.resize(OriginalDeclCount);
+
+  Ctx.SourceMgr.clearCodeCompletionPoint();
 
   // Reset the error state because it's only relevant to the code that we just
   // processed, which now gets thrown away.
@@ -326,11 +328,11 @@ SwiftCompleteCode(SwiftASTContext &SwiftCtx,
     const unsigned BufferID =
         Ctx.SourceMgr.addMemBufferCopy(AugmentedCode, "<REPL Input>");
     const unsigned OriginalDeclCount = EnteredCodeFile->Decls.size();
-    PersistentParserState PersistentState(Ctx);
+    PersistentParserState PersistentState;
     bool Done;
     do {
       parseIntoSourceFile(*EnteredCodeFile, BufferID, &Done, nullptr,
-                          &PersistentState, nullptr);
+                          &PersistentState);
     } while (!Done);
     for (auto it = EnteredCodeFile->Decls.begin() + OriginalDeclCount;
          it != EnteredCodeFile->Decls.end(); it++)


### PR DESCRIPTION
When the SourceMgr has a code completion point, the compiler can't do normal compilation. (It delays parsing of important things, thinking that they're not important because it thinks that it's serving a code completion request.)

The symptom is that you can't execute anything in jupyter after doing a code completion request through this code path. (Also the completion tests that I added [here](https://github.com/apple/swift-lldb/blob/c945e8c58309ff65e9cc2c1d4e48efc1b20b9009/packages/Python/lldbsuite/test/lang/swift/completions/TestSwiftCompletions.py) fail.)

So I fix it by clearing the code completion point after doing a completion.

Also I noticed a few arguments that became unnecessary because of recent changes in the swift compiler. So I remove those. Those changes don't affect the functionality though.

Corresponding swift compiler PR: https://github.com/apple/swift/pull/27273