### PR TITLE
Remove importing commands module since it's not used

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -12,7 +12,10 @@
 """
 Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 """
-import commands
+try:
+    import commands
+except ImportError:    
+    import subprocess
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -12,10 +12,6 @@
 """
 Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 """
-try:
-    import commands
-except ImportError:    
-    import subprocess
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -12,7 +12,10 @@
 """
 Test `@_implementationOnly import` in a resilient library used by the main executable
 """
-import commands
+try:
+    import commands
+except ImportError:    
+    import subprocess
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -12,10 +12,6 @@
 """
 Test `@_implementationOnly import` in a resilient library used by the main executable
 """
-try:
-    import commands
-except ImportError:    
-    import subprocess
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -12,7 +12,10 @@
 """
 Test `@_implementationOnly import` in the main executable
 """
-import commands
+try:
+    import commands
+except ImportError:    
+    import subprocess
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/packages/Python/lldbsuite/test/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -12,10 +12,6 @@
 """
 Test `@_implementationOnly import` in the main executable
 """
-try:
-    import commands
-except ImportError:    
-    import subprocess
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *


### PR DESCRIPTION
The commands module has been removed in Python3. Use subprocess instead if it fails to load as recommended by https://docs.python.org/2/library/commands.html.  Future proofing fixes for Python3.

Augmented this pull request to just remove importing the commands module since it's not used.