### PR TITLE
Prevent assignment to "let"-bound values in Swift expressions.

### DIFF
--- a/include/lldb/Symbol/Variable.h
+++ b/include/lldb/Symbol/Variable.h
@@ -30,11 +30,10 @@ public:
   Variable(lldb::user_id_t uid, const char *name,
            const char
                *mangled, // The mangled or fully qualified name of the variable.
-           const lldb::SymbolFileTypeSP &symfile_type_sp,
-           lldb::ValueType scope, SymbolContextScope *owner_scope,
-           const RangeList &scope_range, Declaration *decl,
-           const DWARFExpression &location, bool external, bool artificial,
-           bool static_member = false);
+           const lldb::SymbolFileTypeSP &symfile_type_sp, lldb::ValueType scope,
+           SymbolContextScope *owner_scope, const RangeList &scope_range,
+           Declaration *decl, const DWARFExpression &location, bool external,
+           bool artificial, bool static_member, bool constant);
 
   virtual ~Variable();
 
@@ -70,6 +69,8 @@ public:
   bool IsArtificial() const { return m_artificial; }
 
   bool IsStaticMember() const { return m_static_member; }
+
+  bool IsConstant() const { return m_constant; }
 
   DWARFExpression &LocationExpression() { return m_location; }
 
@@ -127,6 +128,10 @@ protected:
                                // location
       m_static_member : 1; // Non-zero if variable is static member of a class
                            // or struct.
+  /// Indicates whether the variable is a constant, for example, Swift \c let
+  /// binding.
+  uint8_t m_constant : 1;
+
 private:
   Variable(const Variable &rhs) = delete;
   Variable &operator=(const Variable &rhs) = delete;

--- a/packages/Python/lldbsuite/test/lang/swift/variables/let/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/let/Makefile
@@ -1,0 +1,5 @@
+LEVEL = ../../../../make
+
+SWIFT_SOURCES := main.swift
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/variables/let/TestSwiftLetConstants.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/let/TestSwiftLetConstants.py
@@ -1,0 +1,34 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftLetConstants(TestBase):
+    mydir = TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_let_constants(self):
+        """Test that let constants aren't writeable"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        # Test globals.
+        self.expect("expression  -- global_constant = 3333", error=True)
+        self.expect("frame variable global_constant", substrs=['1111'])
+        self.expect("expression  -- global_variable = 4444") # FIXME:, substrs=['4444'])
+        self.expect("frame variable global_variable", substrs=['4444'])
+
+        # Test function parameters.
+        self.expect("expression  -- parameter_constant = 3333", error=True)
+        self.expect("frame variable parameter_constant", substrs=['1111'])
+        self.expect("expression  -- parameter_variable = 4444") # FIXME:, substrs=['4444'])
+        self.expect("frame variable parameter_variable", substrs=['4444'])
+
+        # Test local variables.
+        self.expect("expression  -- local_constant = 3333", error=True)
+        self.expect("frame variable local_constant", substrs=['1111'])
+        self.expect("expression  -- local_variable = 4444") # FIXME:, substrs=['4444'])
+        self.expect("frame variable local_variable", substrs=['4444'])

--- a/packages/Python/lldbsuite/test/lang/swift/variables/let/main.swift
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/let/main.swift
@@ -1,0 +1,12 @@
+func use<T>(_ t : T) {}
+
+let global_constant = 1111
+var global_variable = 2222
+
+func f(_ parameter_constant : Int, _ parameter_variable : inout Int) {
+  let local_constant = parameter_constant
+  var local_variable = parameter_variable
+  use((local_constant, local_variable)) // break here
+}
+
+f(global_constant, &global_variable)

--- a/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1156,6 +1156,8 @@ bool SwiftASTManipulator::AddExternalVariables(
         if (!m_wrapper_decl)
           continue;
 
+        // We need to mutate the $__lldb_wrapped_expr_%d member of self later.
+        introducer = swift::VarDecl::Introducer::Var;
         loc = m_wrapper_decl->getBody()->getLBraceLoc();
         containing_function = m_wrapper_decl;
       }

--- a/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -708,7 +708,9 @@ static void AddVariableInfo(
       new VariableMetadataVariable(variable_sp));
   SwiftASTManipulator::VariableInfo variable_info(
       target_type, ast_context.GetASTContext()->getIdentifier(overridden_name),
-      metadata_sp, swift::VarDecl::Introducer::Var);
+      metadata_sp,
+      variable_sp->IsConstant() ? swift::VarDecl::Introducer::Let
+                                : swift::VarDecl::Introducer::Var);
 
   local_variables.push_back(variable_info);
   processed_variables.insert(overridden_name);

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -99,6 +99,13 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         case DW_AT_byte_size:
           dwarf_byte_size = form_value.Unsigned();
           break;
+        case DW_AT_type:
+          if (die.Tag() == DW_TAG_const_type)
+            // This is how let bindings are represented. This doesn't
+            // change the underlying Swift type.
+            return ParseTypeFromDWARF(sc, die.GetReferencedDIE(attr),
+                                      log, type_is_new_ptr);
+          break;
         default:
           break;
         }

--- a/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -811,7 +811,7 @@ VariableSP SymbolFileNativePDB::CreateGlobalVariable(PdbGlobalSymId var_id) {
   VariableSP var_sp = std::make_shared<Variable>(
       toOpaqueUid(var_id), name.str().c_str(), global_name.c_str(), type_sp,
       scope, comp_unit.get(), ranges, &decl, location, is_external, false,
-      false);
+      false, false);
   var_sp->SetLocationIsConstantValueData(false);
 
   return var_sp;
@@ -839,7 +839,7 @@ SymbolFileNativePDB::CreateConstantSymbol(PdbGlobalSymId var_id,
   VariableSP var_sp = std::make_shared<Variable>(
       toOpaqueUid(var_id), constant.Name.str().c_str(), global_name.c_str(),
       type_sp, eValueTypeVariableGlobal, module.get(), ranges, &decl, location,
-      false, false, false);
+      false, false, false, true);
   var_sp->SetLocationIsConstantValueData(true);
   return var_sp;
 }
@@ -1371,7 +1371,7 @@ VariableSP SymbolFileNativePDB::CreateLocalVariable(PdbCompilandSymId scope_id,
   VariableSP var_sp = std::make_shared<Variable>(
       toOpaqueUid(var_id), name.c_str(), name.c_str(), sftype, var_scope,
       comp_unit_sp.get(), *var_info.ranges, &decl, *var_info.location, false,
-      false, false);
+      false, false, false);
 
   if (!is_param)
     m_ast->GetOrCreateVariableDecl(scope_id, var_id);

--- a/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -1020,7 +1020,8 @@ VariableSP SymbolFilePDB::ParseVariableForPDBData(
 
   var_sp = std::make_shared<Variable>(
       var_uid, var_name.c_str(), mangled_cstr, type_sp, scope, context_scope,
-      ranges, &decl, location, is_external, is_artificial, is_static_member);
+      ranges, &decl, location, is_external, is_artificial, is_static_member,
+      is_constant);
   var_sp->SetLocationIsConstantValueData(is_constant);
 
   m_variables.insert(std::make_pair(var_uid, var_sp));

--- a/source/Symbol/Variable.cpp
+++ b/source/Symbol/Variable.cpp
@@ -42,13 +42,13 @@ Variable::Variable(
     const lldb::SymbolFileTypeSP &symfile_type_sp, ValueType scope,
     SymbolContextScope *context, const RangeList &scope_range,
     Declaration *decl_ptr, const DWARFExpression &location, bool external,
-    bool artificial, bool static_member)
+    bool artificial, bool static_member, bool constant)
     : UserID(uid), m_name(name), m_mangled(ConstString(mangled)),
       m_symfile_type_sp(symfile_type_sp), m_scope(scope),
       m_owner_scope(context), m_scope_range(scope_range),
       m_declaration(decl_ptr), m_location(location), m_external(external),
       m_artificial(artificial), m_loc_is_const_data(false),
-      m_static_member(static_member) {}
+      m_static_member(static_member), m_constant(constant) {}
 
 // Destructor
 Variable::~Variable() {}


### PR DESCRIPTION
Due to the way that SIL and IR is generated in the Swift compiler
assigning a new value to a let-binding often does not have the desired
effect since there may be many copies of the value in flight and LLDB
only knows about one of them per PC. Worse, sometimes the value known
to LLDB is only a shadow copy that is only used in the debugger.

rdar://problem/16042273