### PR TITLE
Dont install swift headers

### DIFF
--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -74,6 +74,7 @@ if(LLDB_BUILD_FRAMEWORK)
   set(LLDB_FRAMEWORK_VERSION A CACHE STRING "LLDB.framework version (default is A)")
   set(LLDB_FRAMEWORK_BUILD_DIR bin CACHE STRING "Output directory for LLDB.framework")
   set(LLDB_FRAMEWORK_INSTALL_DIR Library/Frameworks CACHE STRING "Install directory for LLDB.framework")
+  set(LLDB_FRAMEWORK_COPY_SWIFT_RESOURCES 1 CACHE BOOL "Copy the Swift headers into the resource directory of the LLDB.framework")
 
   # Essentially, emit the framework's dSYM outside of the framework directory.
   set(LLDB_DEBUGINFO_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin CACHE STRING

--- a/cmake/modules/LLDBFramework.cmake
+++ b/cmake/modules/LLDBFramework.cmake
@@ -121,10 +121,12 @@ if(NOT IOS)
     COMMENT "LLDB.framework: copy clang vendor-specific headers"
   )
 
-  add_custom_command(TARGET liblldb POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${SWIFT_BINARY_DIR}/lib/swift
-            $<TARGET_FILE_DIR:liblldb>/Resources/Swift
-    COMMENT "LLDB.framework: copy Swift vendor-specific headers"
-  )
+  if(LLDB_FRAMEWORK_COPY_SWIFT_RESOURCES)
+    add_custom_command(TARGET liblldb POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_directory
+              ${SWIFT_BINARY_DIR}/lib/swift
+              $<TARGET_FILE_DIR:liblldb>/Resources/Swift
+      COMMENT "LLDB.framework: copy Swift vendor-specific headers"
+    )
+  endif()
 endif()

--- a/cmake/modules/LLDBFramework.cmake
+++ b/cmake/modules/LLDBFramework.cmake
@@ -118,9 +118,13 @@ if(NOT IOS)
     COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${clang_resource_headers_dir}
             $<TARGET_FILE_DIR:liblldb>/Resources/Clang/include
+    COMMENT "LLDB.framework: copy clang vendor-specific headers"
+  )
+
+  add_custom_command(TARGET liblldb POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${SWIFT_BINARY_DIR}/lib/swift
             $<TARGET_FILE_DIR:liblldb>/Resources/Swift
-    COMMENT "LLDB.framework: copy clang vendor-specific headers"
+    COMMENT "LLDB.framework: copy Swift vendor-specific headers"
   )
 endif()


### PR DESCRIPTION
The Swift headers are needed for development and testing, but should not
be present in the LLDB.framework when it's installed. I couldn't figure
out a good way to prevent just these files from getting installed, so
instead this adds a configuration option to prevent the headers from
getting copied in the first place.