### PR TITLE
Tests: make ClangImporter tests compatible with cross-compilation and remote testing

### DIFF
--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -45,6 +45,8 @@ class TestSwiftBridgingHeaderHeadermap(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        self.registerSharedLibrariesWithTarget(target, ['dylib'])
+
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('dylib.swift'))
         self.expect("fr v -d run-target -- a",

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/Makefile
@@ -1,26 +1,17 @@
 LEVEL = ../../../../make
 SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -Xcc -DDEBUG=1 -Xcc -DSPACE -Xcc -UNDEBUG -I. -L. -lDylib
 
-all: a.out
+all: libDylib.dylib a.out
 
 include $(LEVEL)/Makefile.rules
 
-a.out: main.swift libDylib.dylib
-	$(SWIFTC) -g -Onone $^ -lDylib -L$(shell pwd) -o $@ $(SWIFTFLAGS) -I. \
-	  -Xcc -DDEBUG=1 -Xcc -DSPACE -Xcc -UNDEBUG \
-	  -toolchain-stdlib-rpath
-ifneq "$(CODESIGN)" ""
-	$(CODESIGN) -s - "$@"
-endif
-
 libDylib.dylib: dylib.swift
-	$(SWIFTC) -g -Onone $^ -emit-library -module-name Dylib -emit-module \
-	  -Xlinker -install_name -Xlinker @executable_path/$@ \
-	  -Xcc -DDEBUG=1 -Xcc -D -Xcc SPACE -Xcc -U -Xcc NDEBUG \
-          -toolchain-stdlib-rpath
-ifneq "$(CODESIGN)" ""
-	$(CODESIGN) -s - "$@"
-endif
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=$(shell basename $< .swift) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
 	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -46,6 +46,8 @@ class TestSwiftDedupMacros(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        self.registerSharedLibrariesWithTarget(target, ['Dylib'])
+
         # Set the breakpoints.
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('dylib.swift'))

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/config_macros/dylib.mk
@@ -1,0 +1,8 @@
+LEVEL = ../../../../make
+SWIFT_OBJC_INTEROP := 1
+DYLIB_SWIFT_SOURCES := dylib.swift
+DYLIB_NAME := Dylib
+
+SWIFTFLAGS_EXTRAS = -Xcc -DDEBUG=1 -Xcc -D -Xcc SPACE -Xcc -U -Xcc NDEBUG
+
+include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -44,6 +44,10 @@ class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.registerSharedLibrariesWithTarget(target, ['Dylib', 'Conflict'])
+
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'))
         # Destroy the scratch context with a dynamic type lookup.

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -37,6 +37,11 @@ class TestSwiftHeadermapConflict(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        self.registerSharedLibrariesWithTarget(target, ['dylib'])
+
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
         b_breakpoint = target.BreakpointCreateBySourceRegex(

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -37,6 +37,11 @@ class TestSwiftIncludeConflict(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        self.registerSharedLibrariesWithTarget(target, ['dylib'])
+
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
         b_breakpoint = target.BreakpointCreateBySourceRegex(

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -37,6 +37,10 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.registerSharedLibrariesWithTarget(target, ['Foo', 'Bar'])
+
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('Bar.swift'))
         bar_value = self.frame().EvaluateExpression("bar")
@@ -72,6 +76,10 @@ class TestSwiftMacroConflict(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % mod_cache)
         self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.registerSharedLibrariesWithTarget(target, ['Foo', 'Bar'])
+
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('Bar.swift'))
         self.expect("v bar", substrs=["23"])

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -43,6 +43,8 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        self.registerSharedLibrariesWithTarget(target, ['Foo', 'Bar'])
+
         # Set the breakpoints
         bar_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('Bar.swift'))

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -36,6 +36,8 @@ class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        self.registerSharedLibrariesWithTarget(target, ['Foo', 'Bar'])
+
         # Set the breakpoints
         bar_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('Bar.swift'))

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
@@ -1,13 +1,15 @@
 LEVEL = ../../../../make
-SWIFT_OBJC_INTEROP := 1
+
+OBJC_SOURCES := main.m
+LD_EXTRAS = -lFoo -lBar -L$(BUILDDIR)
+CFLAGS_EXTRAS = -I$(BUILDDIR) -fmodules
 
 # This test builds an Objective-C main program that imports two Swift
 # .dylibs with conflicting ClangImporter search paths.
 
-include $(LEVEL)/Makefile.rules
+all: libFoo.dylib libBar.dylib a.out
 
-a.out: main.m libFoo.dylib libBar.dylib
-	$(CC) $(CFLAGS) $(MANDATORY_MODULE_BUILD_CFLAGS) -I$(shell pwd) -lFoo -lBar -L$(shell pwd) -o $@ $<
+include $(LEVEL)/Makefile.rules
 
 lib%.dylib: %.swift
 	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -43,6 +43,8 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         target = self.dbg.CreateTarget(exe)
         self.assertTrue(target, VALID_TARGET)
 
+        self.registerSharedLibrariesWithTarget(target, ['Foo', 'Bar'])
+
         # Set the breakpoints
         bar_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('Bar.swift'))

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/dylib.mk
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/dylib.mk
@@ -6,4 +6,6 @@ SWIFTFLAGS_EXTRAS = \
   -Xcc -I$(SRCDIR) -Xcc -I$(SRCDIR)/$(BASENAME) \
   -emit-objc-header-path $(BASENAME).h
 
+SWIFT_OBJC_INTEROP := 1
+
 include $(LEVEL)/Makefile.rules

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -33,6 +33,11 @@ class TestSwiftRemoteASTImport(TestBase):
 
         """
         self.build()
+
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+        self.registerSharedLibrariesWithTarget(target, ['Library'])
+
         # The Makefile doesn't build a .dSYM, so we need to help with
         # finding the .swiftmodules.
         os.chdir(self.getBuildDir())

--- a/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/packages/Python/lldbsuite/test/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -71,6 +71,12 @@ class TestSwiftRewriteClangPaths(TestBase):
             # that this doesn't work by happy accident without it.
             os.remove(plist)
 
+        # Create the target
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+
+        self.registerSharedLibrariesWithTarget(target, ['Foo'])
+
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('Foo.swift'))
 


### PR DESCRIPTION
Those tests have 2 kinds of issues:
 - Some Makefiles were too adhoc. Modernize them to use the Makefile.rules support.
 - Shared libraries need to be registered to be transfered to the remote platform during testing.