### PR TITLE
Update for upstream changes in r373927

### DIFF
--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -26,7 +26,7 @@ public:
   virtual ~DWARFASTParserSwift();
 
   lldb::TypeSP ParseTypeFromDWARF(const lldb_private::SymbolContext &sc,
-                                  const DWARFDIE &die, lldb_private::Log *log,
+                                  const DWARFDIE &die,
                                   bool *type_is_new_ptr) override;
 
   lldb_private::Function *


### PR DESCRIPTION
The log parameter was removed from `ParseTypeFromDWARF` this updates
Swift-lldb to match