### PR TITLE
Change debugserver to use the brk #0 for breakpoints.

### DIFF
--- a/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
+++ b/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
@@ -49,8 +49,6 @@
 
 static const uint8_t g_arm64_breakpoint_opcode[] = {
     0x00, 0x00, 0x20, 0xD4}; // "brk #0", 0xd4200000 in BE byte order
-static const uint8_t g_arm_breakpoint_opcode[] = {
-    0xFE, 0xDE, 0xFF, 0xE7}; // this armv7 insn also works in arm64
 
 // If we need to set one logical watchpoint by using
 // two hardware watchpoint registers, the watchpoint
@@ -79,7 +77,7 @@ DNBArchProtocol *DNBArchMachARM64::Create(MachThread *thread) {
 
 const uint8_t *
 DNBArchMachARM64::SoftwareBreakpointOpcode(nub_size_t byte_size) {
-  return g_arm_breakpoint_opcode;
+  return g_arm64_breakpoint_opcode;
 }
 
 uint32_t DNBArchMachARM64::GetCPUType() { return CPU_TYPE_ARM64; }


### PR DESCRIPTION
Change debugserver to use the brk #0 for breakpoints.
debugserver had been using an instruction that would work
for armv7 or aarch64 processes, but we don't have armv7 code
running on arm64 devices any more so this is unnecessary.

<rdar://problem/56133118>



git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@374264 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit fdebaf769010c566ad3050b20894e9a3b0d4510d)