### PR TITLE
[lldb] Get the TargetAPI lock in SBProcess::IsInstrumentationRuntimePresent (backport of D67831)

### DIFF
--- a/source/API/SBProcess.cpp
+++ b/source/API/SBProcess.cpp
@@ -1180,6 +1180,9 @@ bool SBProcess::IsInstrumentationRuntimePresent(
   if (!process_sp)
     return false;
 
+  std::lock_guard<std::recursive_mutex> guard(
+      process_sp->GetTarget().GetAPIMutex());
+
   InstrumentationRuntimeSP runtime_sp =
       process_sp->GetInstrumentationRuntime(type);
 


### PR DESCRIPTION
We should get the TargetAPI lock here to prevent the process of being destroyed while we are in the function. Thanks Jim for explaining what's going on.

Fixes rdar://54424754