### PR TITLE
Target: attempt to repair the VS2017 build

### DIFF
--- a/source/Target/CMakeLists.txt
+++ b/source/Target/CMakeLists.txt
@@ -85,9 +85,10 @@ add_lldb_library(lldbTarget
   LINK_COMPONENTS
     Support
   )
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   target_compile_options(lldbTarget PRIVATE -Wno-dollar-in-identifier-extension)
+elseif(MSVC)
+  target_compile_options(lldbTarget PRIVATE /permissive-)
 endif()
 
 add_dependencies(lldbTarget


### PR DESCRIPTION
The use of the Swift metadata.h which uses variadic templates causes a
failure in permissive mode.  Disable the permissive mode to try to get
this to build again.