### PR TITLE
[Make] Remove spurious line break

### DIFF
--- a/packages/Python/lldbsuite/test/macosx/macabi/Makefile
+++ b/packages/Python/lldbsuite/test/macosx/macabi/Makefile
@@ -8,7 +8,7 @@ CFLAGS_EXTRAS := -target $(TRIPLE)
 
 all: libfoo.dylib a.out
 
-libfoo.dylib: foo.c \
+libfoo.dylib: foo.c
 	$(MAKE) -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES DYLIB_NAME=foo DYLIB_C_SOURCES=foo.c
 


### PR DESCRIPTION
This test is disabled upstream and therefore this went unnoticed.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@374462 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit c693f4dcaf98f26bd74bd9d60312ea1f4f50d514)