### PR TITLE
[Swift] Update for validateDecl() (almost) removal

### DIFF
--- a/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -553,10 +553,10 @@ int SwiftREPL::CompleteCode(const std::string &current_code,
         llvm::dyn_cast_or_null<SwiftASTContext>(&*type_system_or_err);
     if (target_swift_ast)
       m_swift_ast_sp.reset(new SwiftASTContext(*target_swift_ast));
-    swift::registerIDERequestFunctions(
-        m_swift_ast_sp.get()->GetASTContext()->evaluator);
-    swift::registerTypeCheckerRequestFunctions(
-        m_swift_ast_sp.get()->GetASTContext()->evaluator);
+    auto &ctx = *m_swift_ast_sp.get()->GetASTContext();
+    swift::registerIDERequestFunctions(ctx.evaluator);
+    swift::registerTypeCheckerRequestFunctions(ctx.evaluator);
+    swift::createTypeChecker(ctx);
   }
   SwiftASTContext *swift_ast = m_swift_ast_sp.get();
 

--- a/source/Symbol/SwiftASTContext.cpp
+++ b/source/Symbol/SwiftASTContext.cpp
@@ -4370,13 +4370,10 @@ static CompilerType ValueDeclToType(swift::ValueDecl *decl,
     case swift::DeclKind::TypeAlias: {
       swift::TypeAliasDecl *alias_decl =
           swift::cast<swift::TypeAliasDecl>(decl);
-      if (alias_decl->hasInterfaceType()) {
-        swift::Type swift_type = swift::TypeAliasType::get(
-            alias_decl, swift::Type(), swift::SubstitutionMap(),
-            alias_decl->getUnderlyingType());
-        return {swift_type.getPointer()};
-      }
-      break;
+      swift::Type swift_type = swift::TypeAliasType::get(
+          alias_decl, swift::Type(), swift::SubstitutionMap(),
+          alias_decl->getUnderlyingType());
+      return {swift_type.getPointer()};
     }
 
     case swift::DeclKind::Enum:
@@ -4385,11 +4382,9 @@ static CompilerType ValueDeclToType(swift::ValueDecl *decl,
     case swift::DeclKind::Class: {
       swift::NominalTypeDecl *nominal_decl =
           swift::cast<swift::NominalTypeDecl>(decl);
-      if (nominal_decl->hasInterfaceType()) {
-        swift::Type swift_type = nominal_decl->getDeclaredType();
-        return {swift_type.getPointer()};
-      }
-    } break;
+      swift::Type swift_type = nominal_decl->getDeclaredType();
+      return {swift_type.getPointer()};
+    }
 
     default:
       break;
@@ -4432,24 +4427,20 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
     case swift::DeclKind::TypeAlias: {
       swift::TypeAliasDecl *alias_decl =
           swift::cast<swift::TypeAliasDecl>(decl);
-      if (alias_decl->hasInterfaceType()) {
-        swift::Type swift_type = swift::TypeAliasType::get(
-            alias_decl, swift::Type(), swift::SubstitutionMap(),
-            alias_decl->getUnderlyingType());
-        return CompilerType(swift_type.getPointer());
-      }
-    } break;
+      swift::Type swift_type = swift::TypeAliasType::get(
+          alias_decl, swift::Type(), swift::SubstitutionMap(),
+          alias_decl->getUnderlyingType());
+      return CompilerType(swift_type.getPointer());
+    }
     case swift::DeclKind::Enum:
     case swift::DeclKind::Struct:
     case swift::DeclKind::Class:
     case swift::DeclKind::Protocol: {
       swift::NominalTypeDecl *nominal_decl =
           swift::cast<swift::NominalTypeDecl>(decl);
-      if (nominal_decl->hasInterfaceType()) {
-        swift::Type swift_type = nominal_decl->getDeclaredType();
-        return CompilerType(swift_type.getPointer());
-      }
-    } break;
+      swift::Type swift_type = nominal_decl->getDeclaredType();
+      return CompilerType(swift_type.getPointer());
+    }
 
     case swift::DeclKind::Func:
     case swift::DeclKind::Var:
@@ -4552,16 +4543,9 @@ size_t SwiftASTContext::FindTypes(const char *name,
         [this](swift::Decl *decl) -> CompilerType {
           if (swift::ValueDecl *value_decl =
                   swift::dyn_cast_or_null<swift::ValueDecl>(decl)) {
-            if (value_decl->hasInterfaceType()) {
-              swift::Type swift_type = value_decl->getInterfaceType();
-              swift::MetatypeType *meta_type =
-                  swift_type->getAs<swift::MetatypeType>();
-              swift::ASTContext *ast = GetASTContext();
-              if (meta_type)
-                return {meta_type->getInstanceType().getPointer()};
-              else
-                return {swift_type.getPointer()};
-            }
+            swift::Type swift_type = value_decl->getInterfaceType();
+            if (swift_type)
+              return {swift_type->getMetatypeInstanceType()};
           }
           return CompilerType();
         });


### PR DESCRIPTION
Checking hasInterfaceType() is no longer necessary or correct,
because getInterfaceType() will lazily compute the type for you,
even for some imported and deserialized decls.

However, this requires a type checker instance (even for
deserialized and imported decls).