### PR TITLE
Revert StringPrinterChanges

### DIFF
--- a/include/lldb/DataFormatters/StringPrinter.h
+++ b/include/lldb/DataFormatters/StringPrinter.h
@@ -133,9 +133,6 @@ public:
       return m_language_type;
     }
 
-    void SetHasSourceSize(bool e) { m_has_source_size = e; }
-
-    bool HasSourceSize() const { return m_has_source_size; }
   private:
     uint64_t m_location;
     lldb::ProcessSP m_process_sp;
@@ -149,7 +146,6 @@ public:
     bool m_ignore_max_length;
     bool m_zero_is_terminator;
     lldb::LanguageType m_language_type;
-    bool m_has_source_size = false;
   };
 
   class ReadBufferAndDumpToStreamOptions {
@@ -249,10 +245,6 @@ public:
       return m_language_type;
     }
 
-    void SetHasSourceSize(bool e) { m_has_source_size = e; }
-
-    bool HasSourceSize() const { return m_has_source_size; }
-
   private:
     DataExtractor m_data;
     Stream *m_stream;
@@ -264,7 +256,6 @@ public:
     bool m_zero_is_terminator;
     bool m_is_truncated;
     lldb::LanguageType m_language_type;
-    bool m_has_source_size = false;
   };
 
   // I can't use a std::unique_ptr for this because the Deleter is a template

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/nsstring/TestDataFormatterNSString.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/nsstring/TestDataFormatterNSString.py
@@ -77,9 +77,8 @@ class NSStringDataFormatterTestCase(TestBase):
         self.expect('frame variable hebrew', substrs=['לילה טוב'])
 
     def nsstring_data_formatter_commands(self):
-        self.expect('frame variable empty str0 str1 str2 str3 str4 str5 str6 str8 str9 str10 str11 label1 label2 processName str12',
-                    substrs=['(NSString *) empty = ', ' @""',
-                             '(NSString *) str1 = ', ' @"A rather short ASCII NSString object is here"',
+        self.expect('frame variable str0 str1 str2 str3 str4 str5 str6 str8 str9 str10 str11 label1 label2 processName str12',
+                    substrs=['(NSString *) str1 = ', ' @"A rather short ASCII NSString object is here"',
                              # '(NSString *) str0 = ',' @"255"',
                              '(NSString *) str1 = ', ' @"A rather short ASCII NSString object is here"',
                              '(NSString *) str2 = ', ' @"A rather short UTF8 NSString object is here"',
@@ -106,8 +105,6 @@ class NSStringDataFormatterTestCase(TestBase):
 
         self.expect('expr -d run-target -- path', substrs=['usr/blah/stuff'])
         self.expect('frame variable path', substrs=['usr/blah/stuff'])
-        self.expect('expr -d run-target -- empty_path', substrs=['@""'])
-        self.expect('frame variable empty_path', substrs=['@""'])
 
     def nsstring_withNULs_commands(self):
         """Check that the NSString formatter supports embedded NULs in the text"""

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/nsstring/main.m
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-objc/nsstring/main.m
@@ -24,7 +24,7 @@ int main (int argc, const char * argv[])
 {
     
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-	    NSString *empty = @"";
+
 	    NSString *str0 = [[NSNumber numberWithUnsignedLongLong:0xFF] stringValue];
 	    NSString *str1 = [NSString stringWithCString:"A rather short ASCII NSString object is here" encoding:NSASCIIStringEncoding];
 	    NSString *str2 = [NSString stringWithUTF8String:"A rather short UTF8 NSString object is here"];
@@ -77,7 +77,6 @@ int main (int argc, const char * argv[])
 
 	NSArray *components = @[@"usr", @"blah", @"stuff"];
 	NSString *path = [NSString pathWithComponents: components];
-	NSString *empty_path = [empty stringByDeletingPathExtension];
 
   const unichar someOfTheseAreNUL[] = {'a',' ', 'v','e','r','y',' ',
       'm','u','c','h',' ','b','o','r','i','n','g',' ','t','a','s','k',

--- a/source/DataFormatters/StringPrinter.cpp
+++ b/source/DataFormatters/StringPrinter.cpp
@@ -537,33 +537,27 @@ static bool ReadUTFBufferAndDumpToStream(
   if (!options.GetStream())
     return false;
 
-  uint32_t sourceSize;
+  uint32_t sourceSize = options.GetSourceSize();
   bool needs_zero_terminator = options.GetNeedsZeroTermination();
 
   bool is_truncated = false;
   const auto max_size = process_sp->GetTarget().GetMaximumSizeOfStringSummary();
 
-  if (options.HasSourceSize()) {
-    sourceSize = options.GetSourceSize();
-    if (!options.GetIgnoreMaxLength()) {
-      if (sourceSize > max_size) {
-        sourceSize = max_size;
-        is_truncated = true;
-      }
-    }
-  } else {
+  if (!sourceSize) {
     sourceSize = max_size;
     needs_zero_terminator = true;
+  } else if (!options.GetIgnoreMaxLength()) {
+    if (sourceSize > max_size) {
+      sourceSize = max_size;
+      is_truncated = true;
+    }
   }
 
   const int bufferSPSize = sourceSize * type_width;
 
   lldb::DataBufferSP buffer_sp(new DataBufferHeap(bufferSPSize, 0));
 
-  // Check if we got bytes. We never get any bytes if we have an empty
-  // string, but we still continue so that we end up actually printing
-  // an empty string ("").
-  if (sourceSize != 0 && !buffer_sp->GetBytes())
+  if (!buffer_sp->GetBytes())
     return false;
 
   Status error;

--- a/source/Plugins/Language/ObjC/NSString.cpp
+++ b/source/Plugins/Language/ObjC/NSString.cpp
@@ -171,7 +171,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
       options.SetStream(&stream);
       options.SetQuote('"');
       options.SetSourceSize(explicit_length);
-      options.SetHasSourceSize(has_explicit_length);
       options.SetNeedsZeroTermination(false);
       options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                  TypeSummaryCapping::eTypeSummaryUncapped);
@@ -184,7 +183,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
       options.SetProcessSP(process_sp);
       options.SetStream(&stream);
       options.SetSourceSize(explicit_length);
-      options.SetHasSourceSize(has_explicit_length);
       options.SetNeedsZeroTermination(false);
       options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                  TypeSummaryCapping::eTypeSummaryUncapped);
@@ -202,7 +200,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
     options.SetStream(&stream);
     options.SetQuote('"');
     options.SetSourceSize(explicit_length);
-    options.SetHasSourceSize(has_explicit_length);
     options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                TypeSummaryCapping::eTypeSummaryUncapped);
     options.SetLanguage(summary_options.GetLanguage());
@@ -225,7 +222,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
     options.SetStream(&stream);
     options.SetQuote('"');
     options.SetSourceSize(explicit_length);
-    options.SetHasSourceSize(has_explicit_length);
     options.SetNeedsZeroTermination(!has_explicit_length);
     options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                TypeSummaryCapping::eTypeSummaryUncapped);
@@ -246,7 +242,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
     options.SetStream(&stream);
     options.SetQuote('"');
     options.SetSourceSize(explicit_length);
-    options.SetHasSourceSize(has_explicit_length);
     options.SetNeedsZeroTermination(!has_explicit_length);
     options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                TypeSummaryCapping::eTypeSummaryUncapped);
@@ -269,7 +264,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
     options.SetProcessSP(process_sp);
     options.SetStream(&stream);
     options.SetSourceSize(explicit_length);
-    options.SetHasSourceSize(has_explicit_length);
     options.SetNeedsZeroTermination(!has_explicit_length);
     options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                TypeSummaryCapping::eTypeSummaryUncapped);
@@ -293,7 +287,6 @@ bool lldb_private::formatters::NSStringSummaryProvider(
     options.SetProcessSP(process_sp);
     options.SetStream(&stream);
     options.SetSourceSize(explicit_length);
-    options.SetHasSourceSize(has_explicit_length);
     options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                TypeSummaryCapping::eTypeSummaryUncapped);
     options.SetLanguage(summary_options.GetLanguage());

--- a/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -81,7 +81,6 @@ static bool readStringFromAddress(
   read_options.SetProcessSP(process);
   read_options.SetStream(&stream);
   read_options.SetSourceSize(length);
-  read_options.SetHasSourceSize(true);
   read_options.SetNeedsZeroTermination(false);
   read_options.SetIgnoreMaxLength(summary_options.GetCapping() ==
                                   lldb::eTypeSummaryUncapped);
@@ -283,7 +282,7 @@ bool lldb_private::formatters::swift::StringGuts_SummaryProvider(
         .SetSourceSize(count)
         .SetBinaryZeroIsTerminator(false)
         .SetLanguage(lldb::eLanguageTypeSwift);
-    options.SetHasSourceSize(true);
+
     return StringPrinter::ReadBufferAndDumpToStream<
         StringPrinter::StringElementType::UTF8>(options);
 
@@ -411,7 +410,6 @@ bool lldb_private::formatters::swift::StaticString_SummaryProvider(
   read_options.SetProcessSP(process_sp);
   read_options.SetLocation(start_ptr);
   read_options.SetSourceSize(size);
-  read_options.SetHasSourceSize(true);
   read_options.SetBinaryZeroIsTerminator(false);
   read_options.SetNeedsZeroTermination(false);
   read_options.SetStream(&stream);


### PR DESCRIPTION
This reverts commit cd8589942065314c7123a6d9874ab157481cc661 and 969980b6b4d1ed2f8c0da3861909a3993f4a11c1.
These commits were breaking swift-lldb on ubuntu. I'll revert the changes until I know how to fix those tests.