### PR TITLE
Regenerate Swig bindings.

### DIFF
--- a/scripts/Python/static-binding/LLDBWrapPython.cpp
+++ b/scripts/Python/static-binding/LLDBWrapPython.cpp
@@ -1633,17 +1633,6 @@ SwigPyObject_repr(SwigPyObject *v, PyObject *args)
   return repr;  
 }
 
-<<<<<<< HEAD
-/* We need a version taking two PyObject* parameters so it's a valid
- * PyCFunction to use in swigobject_methods[]. */
-SWIGRUNTIME PyObject *
-SwigPyObject_repr2(PyObject *v, PyObject *SWIGUNUSEDPARM(args))
-{
-  return SwigPyObject_repr((SwigPyObject*)v);
-}
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 SWIGRUNTIME int
 SwigPyObject_compare(SwigPyObject *v, SwigPyObject *w)
 {
@@ -1773,7 +1762,11 @@ SwigPyObject_append(PyObject* v, PyObject* next)
 }
 
 SWIGRUNTIME PyObject* 
+#ifdef METH_NOARGS
+SwigPyObject_next(PyObject* v)
+#else
 SwigPyObject_next(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
+#endif
 {
   SwigPyObject *sobj = (SwigPyObject *) v;
   if (sobj->next) {    
@@ -1807,20 +1800,6 @@ SwigPyObject_acquire(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
   sobj->own = SWIG_POINTER_OWN;
   return SWIG_Py_Void();
 }
-
-#ifdef METH_NOARGS
-static PyObject*
-SwigPyObject_disown2(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
-{
-  return SwigPyObject_disown(v);
-}
-
-static PyObject*
-SwigPyObject_acquire2(PyObject* v, PyObject *SWIGUNUSEDPARM(args))
-{
-  return SwigPyObject_acquire(v);
-}
-#endif
 
 SWIGINTERN PyObject*
 SwigPyObject_own(PyObject *v, PyObject *args)
@@ -1862,17 +1841,12 @@ SwigPyObject_own(PyObject *v, PyObject *args)
 #ifdef METH_O
 static PyMethodDef
 swigobject_methods[] = {
-<<<<<<< HEAD
-  {(char *)"disown",  (PyCFunction)SwigPyObject_disown2, METH_NOARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire2,METH_NOARGS,  (char *)"acquires ownership of the pointer"},
-=======
   {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
   {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"acquires ownership of the pointer"},
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
   {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
   {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_O,       (char *)"appends another 'this' object"},
   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr2,   METH_NOARGS,  (char *)"returns object representation"},
+  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #else
@@ -1883,7 +1857,7 @@ swigobject_methods[] = {
   {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
   {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
   {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_VARARGS,  (char *)"returns object representation"},
+  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #endif
@@ -2675,7 +2649,6 @@ SWIG_Python_NewPointerObj(PyObject *self, void *ptr, swig_type_info *type, int f
 #ifdef SWIGPYTHON_BUILTIN
       newobj->dict = 0;
 #endif
-<<<<<<< HEAD
     }
     if (newobj) {
       newobj->ptr = ptr;
@@ -2684,16 +2657,6 @@ SWIG_Python_NewPointerObj(PyObject *self, void *ptr, swig_type_info *type, int f
       newobj->next = 0;
       return (PyObject*) newobj;
     }
-=======
-    }
-    if (newobj) {
-      newobj->ptr = ptr;
-      newobj->ty = type;
-      newobj->own = own;
-      newobj->next = 0;
-      return (PyObject*) newobj;
-    }
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     return SWIG_Py_Void();
   }
 
@@ -2997,7 +2960,6 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
   } else {
     Py_INCREF(name);
   }
-<<<<<<< HEAD
 
   if (!tp->tp_dict) {
     if (PyType_Ready(tp) < 0)
@@ -3028,38 +2990,6 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #endif
 
 
-=======
-
-  if (!tp->tp_dict) {
-    if (PyType_Ready(tp) < 0)
-      goto done;
-  }
-
-  descr = _PyType_Lookup(tp, name);
-  f = NULL;
-  if (descr != NULL)
-    f = descr->ob_type->tp_descr_set;
-  if (!f) {
-    if (PyString_Check(name)) {
-      encoded_name = name;
-      Py_INCREF(name);
-    } else {
-      encoded_name = PyUnicode_AsUTF8String(name);
-    }
-    PyErr_Format(PyExc_AttributeError, "'%.100s' object has no attribute '%.200s'", tp->tp_name, PyString_AsString(encoded_name));
-    Py_DECREF(encoded_name);
-  } else {
-    res = f(descr, obj, value);
-  }
-  
-  done:
-  Py_DECREF(name);
-  return res;
-}
-#endif
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 #ifdef __cplusplus
 }
 #endif
@@ -3122,7 +3052,6 @@ void LLDBSwigPythonCallPythonLogOutputCallback(const char *str, void *baton);
 #define SWIGTYPE_p_lldb__SBCommandReturnObject swig_types[18]
 #define SWIGTYPE_p_lldb__SBCommunication swig_types[19]
 #define SWIGTYPE_p_lldb__SBCompileUnit swig_types[20]
-<<<<<<< HEAD
 #define SWIGTYPE_p_lldb__SBCompletionMatch swig_types[21]
 #define SWIGTYPE_p_lldb__SBCompletionResponse swig_types[22]
 #define SWIGTYPE_p_lldb__SBData swig_types[23]
@@ -3362,245 +3291,6 @@ void LLDBSwigPythonCallPythonLogOutputCallback(const char *str, void *baton);
 #define SWIGTYPE_p_void swig_types[257]
 static swig_type_info *swig_types[259];
 static swig_module_info swig_module = {swig_types, 258, 0, 0, 0, 0};
-=======
-#define SWIGTYPE_p_lldb__SBData swig_types[21]
-#define SWIGTYPE_p_lldb__SBDebugger swig_types[22]
-#define SWIGTYPE_p_lldb__SBDeclaration swig_types[23]
-#define SWIGTYPE_p_lldb__SBError swig_types[24]
-#define SWIGTYPE_p_lldb__SBEvent swig_types[25]
-#define SWIGTYPE_p_lldb__SBExecutionContext swig_types[26]
-#define SWIGTYPE_p_lldb__SBExpressionOptions swig_types[27]
-#define SWIGTYPE_p_lldb__SBFileSpec swig_types[28]
-#define SWIGTYPE_p_lldb__SBFileSpecList swig_types[29]
-#define SWIGTYPE_p_lldb__SBFrame swig_types[30]
-#define SWIGTYPE_p_lldb__SBFunction swig_types[31]
-#define SWIGTYPE_p_lldb__SBHostOS swig_types[32]
-#define SWIGTYPE_p_lldb__SBInstruction swig_types[33]
-#define SWIGTYPE_p_lldb__SBInstructionList swig_types[34]
-#define SWIGTYPE_p_lldb__SBLanguageRuntime swig_types[35]
-#define SWIGTYPE_p_lldb__SBLaunchInfo swig_types[36]
-#define SWIGTYPE_p_lldb__SBLineEntry swig_types[37]
-#define SWIGTYPE_p_lldb__SBListener swig_types[38]
-#define SWIGTYPE_p_lldb__SBMemoryRegionInfo swig_types[39]
-#define SWIGTYPE_p_lldb__SBMemoryRegionInfoList swig_types[40]
-#define SWIGTYPE_p_lldb__SBModule swig_types[41]
-#define SWIGTYPE_p_lldb__SBModuleSpec swig_types[42]
-#define SWIGTYPE_p_lldb__SBModuleSpecList swig_types[43]
-#define SWIGTYPE_p_lldb__SBPlatform swig_types[44]
-#define SWIGTYPE_p_lldb__SBPlatformConnectOptions swig_types[45]
-#define SWIGTYPE_p_lldb__SBPlatformShellCommand swig_types[46]
-#define SWIGTYPE_p_lldb__SBProcess swig_types[47]
-#define SWIGTYPE_p_lldb__SBProcessInfo swig_types[48]
-#define SWIGTYPE_p_lldb__SBQueue swig_types[49]
-#define SWIGTYPE_p_lldb__SBQueueItem swig_types[50]
-#define SWIGTYPE_p_lldb__SBSection swig_types[51]
-#define SWIGTYPE_p_lldb__SBSourceManager swig_types[52]
-#define SWIGTYPE_p_lldb__SBStream swig_types[53]
-#define SWIGTYPE_p_lldb__SBStringList swig_types[54]
-#define SWIGTYPE_p_lldb__SBStructuredData swig_types[55]
-#define SWIGTYPE_p_lldb__SBSymbol swig_types[56]
-#define SWIGTYPE_p_lldb__SBSymbolContext swig_types[57]
-#define SWIGTYPE_p_lldb__SBSymbolContextList swig_types[58]
-#define SWIGTYPE_p_lldb__SBTarget swig_types[59]
-#define SWIGTYPE_p_lldb__SBThread swig_types[60]
-#define SWIGTYPE_p_lldb__SBThreadCollection swig_types[61]
-#define SWIGTYPE_p_lldb__SBThreadPlan swig_types[62]
-#define SWIGTYPE_p_lldb__SBTrace swig_types[63]
-#define SWIGTYPE_p_lldb__SBTraceOptions swig_types[64]
-#define SWIGTYPE_p_lldb__SBType swig_types[65]
-#define SWIGTYPE_p_lldb__SBTypeCategory swig_types[66]
-#define SWIGTYPE_p_lldb__SBTypeEnumMember swig_types[67]
-#define SWIGTYPE_p_lldb__SBTypeEnumMemberList swig_types[68]
-#define SWIGTYPE_p_lldb__SBTypeFilter swig_types[69]
-#define SWIGTYPE_p_lldb__SBTypeFormat swig_types[70]
-#define SWIGTYPE_p_lldb__SBTypeList swig_types[71]
-#define SWIGTYPE_p_lldb__SBTypeMember swig_types[72]
-#define SWIGTYPE_p_lldb__SBTypeMemberFunction swig_types[73]
-#define SWIGTYPE_p_lldb__SBTypeNameSpecifier swig_types[74]
-#define SWIGTYPE_p_lldb__SBTypeSummary swig_types[75]
-#define SWIGTYPE_p_lldb__SBTypeSummaryOptions swig_types[76]
-#define SWIGTYPE_p_lldb__SBTypeSynthetic swig_types[77]
-#define SWIGTYPE_p_lldb__SBUnixSignals swig_types[78]
-#define SWIGTYPE_p_lldb__SBValue swig_types[79]
-#define SWIGTYPE_p_lldb__SBValueList swig_types[80]
-#define SWIGTYPE_p_lldb__SBVariablesOptions swig_types[81]
-#define SWIGTYPE_p_lldb__SBWatchpoint swig_types[82]
-#define SWIGTYPE_p_lldb_private__SharingPtrT_lldb_private__ValueObject_t swig_types[83]
-#define SWIGTYPE_p_long_double swig_types[84]
-#define SWIGTYPE_p_long_long swig_types[85]
-#define SWIGTYPE_p_p_void swig_types[86]
-#define SWIGTYPE_p_pthread_rwlock_t swig_types[87]
-#define SWIGTYPE_p_pthread_t swig_types[88]
-#define SWIGTYPE_p_short swig_types[89]
-#define SWIGTYPE_p_signed_char swig_types[90]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ABI_t swig_types[91]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Baton_t swig_types[92]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Block_t swig_types[93]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__BreakpointLocation_t swig_types[94]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__BreakpointPrecondition_t swig_types[95]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__BreakpointResolver_t swig_types[96]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__BreakpointSite_t swig_types[97]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Breakpoint_t swig_types[98]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__BroadcasterManager_t swig_types[99]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Broadcaster_t swig_types[100]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ClangASTImporter_t swig_types[101]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__CommandObject_t swig_types[102]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Communication_t swig_types[103]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__CompileUnit_t swig_types[104]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Connection_t swig_types[105]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__DataBuffer_t swig_types[106]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__DataExtractor_t swig_types[107]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Debugger_t swig_types[108]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Disassembler_t swig_types[109]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__DynamicLoader_t swig_types[110]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__EventDataStructuredData_t swig_types[111]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__EventData_t swig_types[112]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Event_t swig_types[113]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ExecutionContextRef_t swig_types[114]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ExpressionVariable_t swig_types[115]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__File_t swig_types[116]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__FuncUnwinders_t swig_types[117]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__FunctionCaller_t swig_types[118]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Function_t swig_types[119]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__IOHandler_t swig_types[120]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__IOObject_t swig_types[121]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__IRExecutionUnit_t swig_types[122]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__InlineFunctionInfo_t swig_types[123]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Instruction_t swig_types[124]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__InstrumentationRuntime_t swig_types[125]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__JITLoader_t swig_types[126]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__LanguageRuntime_t swig_types[127]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__LineTable_t swig_types[128]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Listener_t swig_types[129]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__MemoryHistory_t swig_types[130]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Module_t swig_types[131]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ObjectFileJITDelegate_t swig_types[132]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ObjectFile_t swig_types[133]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueArch_t swig_types[134]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueArgs_t swig_types[135]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueArray_t swig_types[136]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueBoolean_t swig_types[137]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueDictionary_t swig_types[138]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueFileSpecList_t swig_types[139]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueFileSpec_t swig_types[140]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueFormat_t swig_types[141]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValuePathMappings_t swig_types[142]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueProperties_t swig_types[143]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueRegex_t swig_types[144]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueSInt64_t swig_types[145]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueString_t swig_types[146]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueUInt64_t swig_types[147]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValueUUID_t swig_types[148]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__OptionValue_t swig_types[149]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Platform_t swig_types[150]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ProcessAttachInfo_t swig_types[151]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ProcessLaunchInfo_t swig_types[152]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Process_t swig_types[153]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Property_t swig_types[154]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__QueueItem_t swig_types[155]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Queue_t swig_types[156]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__REPL_t swig_types[157]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__RecognizedStackFrame_t swig_types[158]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__RegisterCheckpoint_t swig_types[159]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__RegisterContext_t swig_types[160]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__RegularExpression_t swig_types[161]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ScriptInterpreter_t swig_types[162]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ScriptSummaryFormat_t swig_types[163]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ScriptedSyntheticChildren_t swig_types[164]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SearchFilter_t swig_types[165]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SectionLoadList_t swig_types[166]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Section_t swig_types[167]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Settings_t swig_types[168]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StackFrameList_t swig_types[169]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StackFrameRecognizer_t swig_types[170]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StackFrame_t swig_types[171]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StopInfo_t swig_types[172]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StoppointLocation_t swig_types[173]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StreamFile_t swig_types[174]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Stream_t swig_types[175]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StringSummaryFormat_t swig_types[176]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__StructuredDataPlugin_t swig_types[177]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SwiftASTContext_t swig_types[178]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SymbolContextSpecifier_t swig_types[179]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SymbolFileType_t swig_types[180]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SymbolFile_t swig_types[181]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SyntheticChildrenFrontEnd_t swig_types[182]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SyntheticChildren_t swig_types[183]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__SystemRuntime_t swig_types[184]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TargetProperties_t swig_types[185]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Target_t swig_types[186]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ThreadCollection_t swig_types[187]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ThreadPlanTracer_t swig_types[188]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ThreadPlan_t swig_types[189]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Thread_t swig_types[190]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TraceOptions_t swig_types[191]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeCategoryImpl_t swig_types[192]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeEnumMemberImpl_t swig_types[193]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeFilterImpl_t swig_types[194]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeFormatImpl_t swig_types[195]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeImpl_t swig_types[196]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeMemberFunctionImpl_t swig_types[197]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeNameSpecifierImpl_t swig_types[198]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeSummaryImpl_t swig_types[199]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeSummaryOptions_t swig_types[200]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeSystem_t swig_types[201]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__TypeValidatorImpl_t swig_types[202]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Type_t swig_types[203]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__UnixSignals_t swig_types[204]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__UnwindAssembly_t swig_types[205]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__UnwindPlan_t swig_types[206]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__UserExpression_t swig_types[207]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__UtilityFunction_t swig_types[208]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ValueList_t swig_types[209]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__ValueObjectList_t swig_types[210]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Value_t swig_types[211]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__VariableList_t swig_types[212]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Variable_t swig_types[213]
-#define SWIGTYPE_p_std__shared_ptrT_lldb_private__Watchpoint_t swig_types[214]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__ClangASTContext_t swig_types[215]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__ClangModulesDeclVendor_t swig_types[216]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__ClangPersistentVariables_t swig_types[217]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__DynamicCheckerFunctions_t swig_types[218]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__DynamicLoader_t swig_types[219]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__JITLoaderList_t swig_types[220]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__MemoryRegionInfo_t swig_types[221]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__OperatingSystem_t swig_types[222]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__ScriptInterpreter_t swig_types[223]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__SectionList_t swig_types[224]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__SourceManager_t swig_types[225]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__StackFrame_t swig_types[226]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__StructuredDataImpl_t swig_types[227]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__SymbolVendor_t swig_types[228]
-#define SWIGTYPE_p_std__unique_ptrT_lldb_private__SystemRuntime_t swig_types[229]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__BreakpointLocation_t swig_types[230]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__BreakpointSite_t swig_types[231]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Breakpoint_t swig_types[232]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__BroadcasterManager_t swig_types[233]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Debugger_t swig_types[234]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Listener_t swig_types[235]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Module_t swig_types[236]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__ObjectFileJITDelegate_t swig_types[237]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__ObjectFile_t swig_types[238]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__OptionValue_t swig_types[239]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Process_t swig_types[240]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Queue_t swig_types[241]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Section_t swig_types[242]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__StackFrame_t swig_types[243]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Stream_t swig_types[244]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__StructuredDataPlugin_t swig_types[245]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__SymbolFileType_t swig_types[246]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Target_t swig_types[247]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Thread_t swig_types[248]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__Type_t swig_types[249]
-#define SWIGTYPE_p_std__weak_ptrT_lldb_private__UnixSignals_t swig_types[250]
-#define SWIGTYPE_p_unsigned_char swig_types[251]
-#define SWIGTYPE_p_unsigned_int swig_types[252]
-#define SWIGTYPE_p_unsigned_long_long swig_types[253]
-#define SWIGTYPE_p_unsigned_short swig_types[254]
-#define SWIGTYPE_p_void swig_types[255]
-static swig_type_info *swig_types[257];
-static swig_module_info swig_module = {swig_types, 256, 0, 0, 0, 0};
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -5324,8 +5014,6 @@ fail:
 }
 
 
-<<<<<<< HEAD
-=======
 SWIGINTERN PyObject *_wrap_SBAddress___ne__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBAddress *arg1 = (lldb::SBAddress *) 0 ;
@@ -5364,7 +5052,6 @@ fail:
 }
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 SWIGINTERN PyObject *_wrap_SBAddress_Clear(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBAddress *arg1 = (lldb::SBAddress *) 0 ;
@@ -59029,7 +58716,6 @@ fail:
     "    lldb::SBTarget::EvaluateExpression(char const *)\n"
     "    lldb::SBTarget::EvaluateExpression(char const *,lldb::SBExpressionOptions const &)\n");
   return 0;
-<<<<<<< HEAD
 }
 
 
@@ -59086,8 +58772,6 @@ SWIGINTERN PyObject *_wrap_SBTarget_CompleteCode(PyObject *SWIGUNUSEDPARM(self),
 fail:
   if (alloc4 == SWIG_NEWOBJ) delete[] buf4;
   return NULL;
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 }
 
 
@@ -75918,8 +75602,6 @@ fail:
     "    lldb::SBValue::GetExpressionPath(lldb::SBStream &)\n"
     "    lldb::SBValue::GetExpressionPath(lldb::SBStream &,bool)\n");
   return 0;
-<<<<<<< HEAD
-=======
 }
 
 
@@ -75958,7 +75640,6 @@ SWIGINTERN PyObject *_wrap_SBValue_EvaluateExpression__SWIG_0(PyObject *SWIGUNUS
 fail:
   if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
   return NULL;
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 }
 
 
@@ -77394,8 +77075,6 @@ fail:
 }
 
 
-<<<<<<< HEAD
-=======
 SWIGINTERN PyObject *_wrap_SBWatchpoint___eq__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBWatchpoint *arg1 = (lldb::SBWatchpoint *) 0 ;
@@ -77472,7 +77151,6 @@ fail:
 }
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 SWIGINTERN PyObject *_wrap_SBWatchpoint_GetError(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBWatchpoint *arg1 = (lldb::SBWatchpoint *) 0 ;
@@ -79555,39 +79233,13 @@ void LLDBSwigPythonCallPythonLogOutputCallback(const char *str, void *baton) {
 }
 
 static PyMethodDef SwigMethods[] = {
-	 { "SWIG_PyInstanceMethod_New", SWIG_PyInstanceMethod_New, METH_O, NULL},
-	 { "new_SBAddress", _wrap_new_SBAddress, METH_VARARGS, (char *)"\n"
+	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
+	 { (char *)"new_SBAddress", _wrap_new_SBAddress, METH_VARARGS, (char *)"\n"
 		"SBAddress()\n"
 		"SBAddress(SBAddress rhs)\n"
 		"SBAddress(SBSection section, lldb::addr_t offset)\n"
 		"new_SBAddress(lldb::addr_t load_addr, SBTarget target) -> SBAddress\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBAddress", _wrap_delete_SBAddress, METH_VARARGS, (char *)"delete_SBAddress(SBAddress self)"},
-	 { "SBAddress_IsValid", _wrap_SBAddress_IsValid, METH_VARARGS, (char *)"SBAddress_IsValid(SBAddress self) -> bool"},
-	 { "SBAddress___nonzero__", _wrap_SBAddress___nonzero__, METH_VARARGS, (char *)"SBAddress___nonzero__(SBAddress self) -> bool"},
-	 { "SBAddress_Clear", _wrap_SBAddress_Clear, METH_VARARGS, (char *)"SBAddress_Clear(SBAddress self)"},
-	 { "SBAddress_GetFileAddress", _wrap_SBAddress_GetFileAddress, METH_VARARGS, (char *)"SBAddress_GetFileAddress(SBAddress self) -> lldb::addr_t"},
-	 { "SBAddress_GetLoadAddress", _wrap_SBAddress_GetLoadAddress, METH_VARARGS, (char *)"SBAddress_GetLoadAddress(SBAddress self, SBTarget target) -> lldb::addr_t"},
-	 { "SBAddress_SetLoadAddress", _wrap_SBAddress_SetLoadAddress, METH_VARARGS, (char *)"SBAddress_SetLoadAddress(SBAddress self, lldb::addr_t load_addr, SBTarget target)"},
-	 { "SBAddress_OffsetAddress", _wrap_SBAddress_OffsetAddress, METH_VARARGS, (char *)"SBAddress_OffsetAddress(SBAddress self, lldb::addr_t offset) -> bool"},
-	 { "SBAddress_GetDescription", _wrap_SBAddress_GetDescription, METH_VARARGS, (char *)"SBAddress_GetDescription(SBAddress self, SBStream description) -> bool"},
-	 { "SBAddress_GetSection", _wrap_SBAddress_GetSection, METH_VARARGS, (char *)"SBAddress_GetSection(SBAddress self) -> SBSection"},
-	 { "SBAddress_GetOffset", _wrap_SBAddress_GetOffset, METH_VARARGS, (char *)"SBAddress_GetOffset(SBAddress self) -> lldb::addr_t"},
-	 { "SBAddress_SetAddress", _wrap_SBAddress_SetAddress, METH_VARARGS, (char *)"SBAddress_SetAddress(SBAddress self, SBSection section, lldb::addr_t offset)"},
-	 { "SBAddress_GetSymbolContext", _wrap_SBAddress_GetSymbolContext, METH_VARARGS, (char *)"\n"
-		"SBAddress_GetSymbolContext(SBAddress self, uint32_t resolve_scope) -> SBSymbolContext\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// GetSymbolContext() and the following can lookup symbol information for a given address.\n"
-		"/// An address might refer to code or data from an existing module, or it\n"
-		"/// might refer to something on the stack or heap. The following functions\n"
-		"/// will only return valid values if the address has been resolved to a code\n"
-		"/// or data address using 'void SBAddress::SetLoadAddress(...)' or \n"
-		"/// 'lldb::SBAddress SBTarget::ResolveLoadAddress (...)'. \n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"delete_SBAddress", _wrap_delete_SBAddress, METH_VARARGS, (char *)"delete_SBAddress(SBAddress self)"},
 	 { (char *)"SBAddress_IsValid", _wrap_SBAddress_IsValid, METH_VARARGS, (char *)"SBAddress_IsValid(SBAddress self) -> bool"},
 	 { (char *)"SBAddress___nonzero__", _wrap_SBAddress___nonzero__, METH_VARARGS, (char *)"SBAddress___nonzero__(SBAddress self) -> bool"},
@@ -79604,7 +79256,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBAddress_GetSymbolContext", _wrap_SBAddress_GetSymbolContext, METH_VARARGS, (char *)"\n"
 		"SBAddress_GetSymbolContext(SBAddress self, uint32_t resolve_scope) -> SBSymbolContext\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"GetSymbolContext() and the following can lookup symbol information for a given address.\n"
 		"An address might refer to code or data from an existing module, or it\n"
@@ -79613,23 +79264,9 @@ static PyMethodDef SwigMethods[] = {
 		"or data address using 'void SBAddress::SetLoadAddress(...)' or\n"
 		"'lldb::SBAddress SBTarget::ResolveLoadAddress (...)'.\n"
 		""},
-	 { "SBAddress_GetModule", _wrap_SBAddress_GetModule, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBAddress_GetModule", _wrap_SBAddress_GetModule, METH_VARARGS, (char *)"\n"
 		"SBAddress_GetModule(SBAddress self) -> SBModule\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// GetModule() and the following grab individual objects for a given address and\n"
-		"/// are less efficient if you want more than one symbol related objects. \n"
-		"/// Use one of the following when you want multiple debug symbol related \n"
-		"/// objects for an address:\n"
-		"///    lldb::SBSymbolContext SBAddress::GetSymbolContext (uint32_t resolve_scope);\n"
-		"///    lldb::SBSymbolContext SBTarget::ResolveSymbolContextForAddress (const SBAddress &addr, uint32_t resolve_scope);\n"
-		"/// One or more bits from the SymbolContextItem enumerations can be logically\n"
-		"/// OR'ed together to more efficiently retrieve multiple symbol objects.\n"
-		"//------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"GetModule() and the following grab individual objects for a given address and\n"
 		"are less efficient if you want more than one symbol related objects.\n"
@@ -79640,16 +79277,6 @@ static PyMethodDef SwigMethods[] = {
 		"One or more bits from the SymbolContextItem enumerations can be logically\n"
 		"OR'ed together to more efficiently retrieve multiple symbol objects.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBAddress_GetCompileUnit", _wrap_SBAddress_GetCompileUnit, METH_VARARGS, (char *)"SBAddress_GetCompileUnit(SBAddress self) -> SBCompileUnit"},
-	 { "SBAddress_GetFunction", _wrap_SBAddress_GetFunction, METH_VARARGS, (char *)"SBAddress_GetFunction(SBAddress self) -> SBFunction"},
-	 { "SBAddress_GetBlock", _wrap_SBAddress_GetBlock, METH_VARARGS, (char *)"SBAddress_GetBlock(SBAddress self) -> SBBlock"},
-	 { "SBAddress_GetSymbol", _wrap_SBAddress_GetSymbol, METH_VARARGS, (char *)"SBAddress_GetSymbol(SBAddress self) -> SBSymbol"},
-	 { "SBAddress_GetLineEntry", _wrap_SBAddress_GetLineEntry, METH_VARARGS, (char *)"SBAddress_GetLineEntry(SBAddress self) -> SBLineEntry"},
-	 { "SBAddress___str__", _wrap_SBAddress___str__, METH_VARARGS, (char *)"SBAddress___str__(SBAddress self) -> PyObject *"},
-	 { "SBAddress_swigregister", SBAddress_swigregister, METH_VARARGS, NULL},
-	 { "new_SBAttachInfo", _wrap_new_SBAttachInfo, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBAddress_GetCompileUnit", _wrap_SBAddress_GetCompileUnit, METH_VARARGS, (char *)"SBAddress_GetCompileUnit(SBAddress self) -> SBCompileUnit"},
 	 { (char *)"SBAddress_GetFunction", _wrap_SBAddress_GetFunction, METH_VARARGS, (char *)"SBAddress_GetFunction(SBAddress self) -> SBFunction"},
 	 { (char *)"SBAddress_GetBlock", _wrap_SBAddress_GetBlock, METH_VARARGS, (char *)"SBAddress_GetBlock(SBAddress self) -> SBBlock"},
@@ -79658,58 +79285,23 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBAddress___str__", _wrap_SBAddress___str__, METH_VARARGS, (char *)"SBAddress___str__(SBAddress self) -> PyObject *"},
 	 { (char *)"SBAddress_swigregister", SBAddress_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBAttachInfo", _wrap_new_SBAttachInfo, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBAttachInfo()\n"
 		"SBAttachInfo(lldb::pid_t pid)\n"
 		"SBAttachInfo(char const * path, bool wait_for)\n"
 		"SBAttachInfo(char const * path, bool wait_for, bool async)\n"
 		"new_SBAttachInfo(SBAttachInfo rhs) -> SBAttachInfo\n"
 		""},
-<<<<<<< HEAD
-	 { "SBAttachInfo_GetProcessID", _wrap_SBAttachInfo_GetProcessID, METH_VARARGS, (char *)"SBAttachInfo_GetProcessID(SBAttachInfo self) -> lldb::pid_t"},
-	 { "SBAttachInfo_SetProcessID", _wrap_SBAttachInfo_SetProcessID, METH_VARARGS, (char *)"SBAttachInfo_SetProcessID(SBAttachInfo self, lldb::pid_t pid)"},
-	 { "SBAttachInfo_SetExecutable", _wrap_SBAttachInfo_SetExecutable, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBAttachInfo_GetProcessID", _wrap_SBAttachInfo_GetProcessID, METH_VARARGS, (char *)"SBAttachInfo_GetProcessID(SBAttachInfo self) -> lldb::pid_t"},
 	 { (char *)"SBAttachInfo_SetProcessID", _wrap_SBAttachInfo_SetProcessID, METH_VARARGS, (char *)"SBAttachInfo_SetProcessID(SBAttachInfo self, lldb::pid_t pid)"},
 	 { (char *)"SBAttachInfo_SetExecutable", _wrap_SBAttachInfo_SetExecutable, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetExecutable(char const * path)\n"
 		"SBAttachInfo_SetExecutable(SBAttachInfo self, SBFileSpec exe_file)\n"
 		""},
-	 { "SBAttachInfo_GetWaitForLaunch", _wrap_SBAttachInfo_GetWaitForLaunch, METH_VARARGS, (char *)"SBAttachInfo_GetWaitForLaunch(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_SetWaitForLaunch", _wrap_SBAttachInfo_SetWaitForLaunch, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBAttachInfo_GetWaitForLaunch", _wrap_SBAttachInfo_GetWaitForLaunch, METH_VARARGS, (char *)"SBAttachInfo_GetWaitForLaunch(SBAttachInfo self) -> bool"},
+	 { (char *)"SBAttachInfo_SetWaitForLaunch", _wrap_SBAttachInfo_SetWaitForLaunch, METH_VARARGS, (char *)"\n"
 		"SetWaitForLaunch(bool b)\n"
 		"SBAttachInfo_SetWaitForLaunch(SBAttachInfo self, bool b, bool async)\n"
 		""},
-<<<<<<< HEAD
-	 { "SBAttachInfo_GetIgnoreExisting", _wrap_SBAttachInfo_GetIgnoreExisting, METH_VARARGS, (char *)"SBAttachInfo_GetIgnoreExisting(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_SetIgnoreExisting", _wrap_SBAttachInfo_SetIgnoreExisting, METH_VARARGS, (char *)"SBAttachInfo_SetIgnoreExisting(SBAttachInfo self, bool b)"},
-	 { "SBAttachInfo_GetResumeCount", _wrap_SBAttachInfo_GetResumeCount, METH_VARARGS, (char *)"SBAttachInfo_GetResumeCount(SBAttachInfo self) -> uint32_t"},
-	 { "SBAttachInfo_SetResumeCount", _wrap_SBAttachInfo_SetResumeCount, METH_VARARGS, (char *)"SBAttachInfo_SetResumeCount(SBAttachInfo self, uint32_t c)"},
-	 { "SBAttachInfo_GetProcessPluginName", _wrap_SBAttachInfo_GetProcessPluginName, METH_VARARGS, (char *)"SBAttachInfo_GetProcessPluginName(SBAttachInfo self) -> char const *"},
-	 { "SBAttachInfo_SetProcessPluginName", _wrap_SBAttachInfo_SetProcessPluginName, METH_VARARGS, (char *)"SBAttachInfo_SetProcessPluginName(SBAttachInfo self, char const * plugin_name)"},
-	 { "SBAttachInfo_GetUserID", _wrap_SBAttachInfo_GetUserID, METH_VARARGS, (char *)"SBAttachInfo_GetUserID(SBAttachInfo self) -> uint32_t"},
-	 { "SBAttachInfo_GetGroupID", _wrap_SBAttachInfo_GetGroupID, METH_VARARGS, (char *)"SBAttachInfo_GetGroupID(SBAttachInfo self) -> uint32_t"},
-	 { "SBAttachInfo_UserIDIsValid", _wrap_SBAttachInfo_UserIDIsValid, METH_VARARGS, (char *)"SBAttachInfo_UserIDIsValid(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_GroupIDIsValid", _wrap_SBAttachInfo_GroupIDIsValid, METH_VARARGS, (char *)"SBAttachInfo_GroupIDIsValid(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_SetUserID", _wrap_SBAttachInfo_SetUserID, METH_VARARGS, (char *)"SBAttachInfo_SetUserID(SBAttachInfo self, uint32_t uid)"},
-	 { "SBAttachInfo_SetGroupID", _wrap_SBAttachInfo_SetGroupID, METH_VARARGS, (char *)"SBAttachInfo_SetGroupID(SBAttachInfo self, uint32_t gid)"},
-	 { "SBAttachInfo_GetEffectiveUserID", _wrap_SBAttachInfo_GetEffectiveUserID, METH_VARARGS, (char *)"SBAttachInfo_GetEffectiveUserID(SBAttachInfo self) -> uint32_t"},
-	 { "SBAttachInfo_GetEffectiveGroupID", _wrap_SBAttachInfo_GetEffectiveGroupID, METH_VARARGS, (char *)"SBAttachInfo_GetEffectiveGroupID(SBAttachInfo self) -> uint32_t"},
-	 { "SBAttachInfo_EffectiveUserIDIsValid", _wrap_SBAttachInfo_EffectiveUserIDIsValid, METH_VARARGS, (char *)"SBAttachInfo_EffectiveUserIDIsValid(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_EffectiveGroupIDIsValid", _wrap_SBAttachInfo_EffectiveGroupIDIsValid, METH_VARARGS, (char *)"SBAttachInfo_EffectiveGroupIDIsValid(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_SetEffectiveUserID", _wrap_SBAttachInfo_SetEffectiveUserID, METH_VARARGS, (char *)"SBAttachInfo_SetEffectiveUserID(SBAttachInfo self, uint32_t uid)"},
-	 { "SBAttachInfo_SetEffectiveGroupID", _wrap_SBAttachInfo_SetEffectiveGroupID, METH_VARARGS, (char *)"SBAttachInfo_SetEffectiveGroupID(SBAttachInfo self, uint32_t gid)"},
-	 { "SBAttachInfo_GetParentProcessID", _wrap_SBAttachInfo_GetParentProcessID, METH_VARARGS, (char *)"SBAttachInfo_GetParentProcessID(SBAttachInfo self) -> lldb::pid_t"},
-	 { "SBAttachInfo_SetParentProcessID", _wrap_SBAttachInfo_SetParentProcessID, METH_VARARGS, (char *)"SBAttachInfo_SetParentProcessID(SBAttachInfo self, lldb::pid_t pid)"},
-	 { "SBAttachInfo_ParentProcessIDIsValid", _wrap_SBAttachInfo_ParentProcessIDIsValid, METH_VARARGS, (char *)"SBAttachInfo_ParentProcessIDIsValid(SBAttachInfo self) -> bool"},
-	 { "SBAttachInfo_GetListener", _wrap_SBAttachInfo_GetListener, METH_VARARGS, (char *)"SBAttachInfo_GetListener(SBAttachInfo self) -> SBListener"},
-	 { "SBAttachInfo_SetListener", _wrap_SBAttachInfo_SetListener, METH_VARARGS, (char *)"SBAttachInfo_SetListener(SBAttachInfo self, SBListener listener)"},
-	 { "delete_SBAttachInfo", _wrap_delete_SBAttachInfo, METH_VARARGS, (char *)"delete_SBAttachInfo(SBAttachInfo self)"},
-	 { "SBAttachInfo_swigregister", SBAttachInfo_swigregister, METH_VARARGS, NULL},
-	 { "new_SBBlock", _wrap_new_SBBlock, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBAttachInfo_GetIgnoreExisting", _wrap_SBAttachInfo_GetIgnoreExisting, METH_VARARGS, (char *)"SBAttachInfo_GetIgnoreExisting(SBAttachInfo self) -> bool"},
 	 { (char *)"SBAttachInfo_SetIgnoreExisting", _wrap_SBAttachInfo_SetIgnoreExisting, METH_VARARGS, (char *)"SBAttachInfo_SetIgnoreExisting(SBAttachInfo self, bool b)"},
 	 { (char *)"SBAttachInfo_GetResumeCount", _wrap_SBAttachInfo_GetResumeCount, METH_VARARGS, (char *)"SBAttachInfo_GetResumeCount(SBAttachInfo self) -> uint32_t"},
@@ -79736,109 +79328,65 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"delete_SBAttachInfo", _wrap_delete_SBAttachInfo, METH_VARARGS, (char *)"delete_SBAttachInfo(SBAttachInfo self)"},
 	 { (char *)"SBAttachInfo_swigregister", SBAttachInfo_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBBlock", _wrap_new_SBBlock, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBBlock()\n"
 		"new_SBBlock(SBBlock rhs) -> SBBlock\n"
 		""},
-	 { "delete_SBBlock", _wrap_delete_SBBlock, METH_VARARGS, (char *)"delete_SBBlock(SBBlock self)"},
-	 { "SBBlock_IsInlined", _wrap_SBBlock_IsInlined, METH_VARARGS, (char *)"\n"
+	 { (char *)"delete_SBBlock", _wrap_delete_SBBlock, METH_VARARGS, (char *)"delete_SBBlock(SBBlock self)"},
+	 { (char *)"SBBlock_IsInlined", _wrap_SBBlock_IsInlined, METH_VARARGS, (char *)"\n"
 		"SBBlock_IsInlined(SBBlock self) -> bool\n"
 		"\n"
 		"Does this block represent an inlined function?\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBlock_IsValid", _wrap_SBBlock_IsValid, METH_VARARGS, (char *)"SBBlock_IsValid(SBBlock self) -> bool"},
-	 { "SBBlock___nonzero__", _wrap_SBBlock___nonzero__, METH_VARARGS, (char *)"SBBlock___nonzero__(SBBlock self) -> bool"},
-	 { "SBBlock_GetInlinedName", _wrap_SBBlock_GetInlinedName, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBBlock_IsValid", _wrap_SBBlock_IsValid, METH_VARARGS, (char *)"SBBlock_IsValid(SBBlock self) -> bool"},
 	 { (char *)"SBBlock___nonzero__", _wrap_SBBlock___nonzero__, METH_VARARGS, (char *)"SBBlock___nonzero__(SBBlock self) -> bool"},
 	 { (char *)"SBBlock_GetInlinedName", _wrap_SBBlock_GetInlinedName, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBBlock_GetInlinedName(SBBlock self) -> char const *\n"
 		"\n"
 		"\n"
 		"Get the function name if this block represents an inlined function;\n"
 		"otherwise, return None.\n"
 		""},
-	 { "SBBlock_GetInlinedCallSiteFile", _wrap_SBBlock_GetInlinedCallSiteFile, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetInlinedCallSiteFile", _wrap_SBBlock_GetInlinedCallSiteFile, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetInlinedCallSiteFile(SBBlock self) -> SBFileSpec\n"
 		"\n"
 		"\n"
 		"Get the call site file if this block represents an inlined function;\n"
 		"otherwise, return an invalid file spec.\n"
 		""},
-	 { "SBBlock_GetInlinedCallSiteLine", _wrap_SBBlock_GetInlinedCallSiteLine, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetInlinedCallSiteLine", _wrap_SBBlock_GetInlinedCallSiteLine, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetInlinedCallSiteLine(SBBlock self) -> uint32_t\n"
 		"\n"
 		"\n"
 		"Get the call site line if this block represents an inlined function;\n"
 		"otherwise, return 0.\n"
 		""},
-	 { "SBBlock_GetInlinedCallSiteColumn", _wrap_SBBlock_GetInlinedCallSiteColumn, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetInlinedCallSiteColumn", _wrap_SBBlock_GetInlinedCallSiteColumn, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetInlinedCallSiteColumn(SBBlock self) -> uint32_t\n"
 		"\n"
 		"\n"
 		"Get the call site column if this block represents an inlined function;\n"
 		"otherwise, return 0.\n"
 		""},
-	 { "SBBlock_GetParent", _wrap_SBBlock_GetParent, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetParent", _wrap_SBBlock_GetParent, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetParent(SBBlock self) -> SBBlock\n"
 		"\n"
 		"Get the parent block.\n"
 		""},
-	 { "SBBlock_GetContainingInlinedBlock", _wrap_SBBlock_GetContainingInlinedBlock, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetContainingInlinedBlock", _wrap_SBBlock_GetContainingInlinedBlock, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetContainingInlinedBlock(SBBlock self) -> SBBlock\n"
 		"\n"
 		"Get the inlined block that is or contains this block.\n"
 		""},
-	 { "SBBlock_GetSibling", _wrap_SBBlock_GetSibling, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetSibling", _wrap_SBBlock_GetSibling, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetSibling(SBBlock self) -> SBBlock\n"
 		"\n"
 		"Get the sibling block for this block.\n"
 		""},
-	 { "SBBlock_GetFirstChild", _wrap_SBBlock_GetFirstChild, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBBlock_GetFirstChild", _wrap_SBBlock_GetFirstChild, METH_VARARGS, (char *)"\n"
 		"SBBlock_GetFirstChild(SBBlock self) -> SBBlock\n"
 		"\n"
 		"Get the first child block.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBlock_GetNumRanges", _wrap_SBBlock_GetNumRanges, METH_VARARGS, (char *)"SBBlock_GetNumRanges(SBBlock self) -> uint32_t"},
-	 { "SBBlock_GetRangeStartAddress", _wrap_SBBlock_GetRangeStartAddress, METH_VARARGS, (char *)"SBBlock_GetRangeStartAddress(SBBlock self, uint32_t idx) -> SBAddress"},
-	 { "SBBlock_GetRangeEndAddress", _wrap_SBBlock_GetRangeEndAddress, METH_VARARGS, (char *)"SBBlock_GetRangeEndAddress(SBBlock self, uint32_t idx) -> SBAddress"},
-	 { "SBBlock_GetRangeIndexForBlockAddress", _wrap_SBBlock_GetRangeIndexForBlockAddress, METH_VARARGS, (char *)"SBBlock_GetRangeIndexForBlockAddress(SBBlock self, SBAddress block_addr) -> uint32_t"},
-	 { "SBBlock_GetDescription", _wrap_SBBlock_GetDescription, METH_VARARGS, (char *)"SBBlock_GetDescription(SBBlock self, SBStream description) -> bool"},
-	 { "SBBlock_GetVariables", _wrap_SBBlock_GetVariables, METH_VARARGS, (char *)"\n"
-		"GetVariables(SBFrame frame, bool arguments, bool locals, bool statics, lldb::DynamicValueType use_dynamic) -> SBValueList\n"
-		"SBBlock_GetVariables(SBBlock self, SBTarget target, bool arguments, bool locals, bool statics) -> SBValueList\n"
-		""},
-	 { "SBBlock___str__", _wrap_SBBlock___str__, METH_VARARGS, (char *)"SBBlock___str__(SBBlock self) -> PyObject *"},
-	 { "SBBlock_swigregister", SBBlock_swigregister, METH_VARARGS, NULL},
-	 { "new_SBBreakpoint", _wrap_new_SBBreakpoint, METH_VARARGS, (char *)"\n"
-		"SBBreakpoint()\n"
-		"new_SBBreakpoint(SBBreakpoint rhs) -> SBBreakpoint\n"
-		""},
-	 { "delete_SBBreakpoint", _wrap_delete_SBBreakpoint, METH_VARARGS, (char *)"delete_SBBreakpoint(SBBreakpoint self)"},
-	 { "SBBreakpoint_GetID", _wrap_SBBreakpoint_GetID, METH_VARARGS, (char *)"SBBreakpoint_GetID(SBBreakpoint self) -> lldb::break_id_t"},
-	 { "SBBreakpoint_IsValid", _wrap_SBBreakpoint_IsValid, METH_VARARGS, (char *)"SBBreakpoint_IsValid(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint___nonzero__", _wrap_SBBreakpoint___nonzero__, METH_VARARGS, (char *)"SBBreakpoint___nonzero__(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint_ClearAllBreakpointSites", _wrap_SBBreakpoint_ClearAllBreakpointSites, METH_VARARGS, (char *)"SBBreakpoint_ClearAllBreakpointSites(SBBreakpoint self)"},
-	 { "SBBreakpoint_FindLocationByAddress", _wrap_SBBreakpoint_FindLocationByAddress, METH_VARARGS, (char *)"SBBreakpoint_FindLocationByAddress(SBBreakpoint self, lldb::addr_t vm_addr) -> SBBreakpointLocation"},
-	 { "SBBreakpoint_FindLocationIDByAddress", _wrap_SBBreakpoint_FindLocationIDByAddress, METH_VARARGS, (char *)"SBBreakpoint_FindLocationIDByAddress(SBBreakpoint self, lldb::addr_t vm_addr) -> lldb::break_id_t"},
-	 { "SBBreakpoint_FindLocationByID", _wrap_SBBreakpoint_FindLocationByID, METH_VARARGS, (char *)"SBBreakpoint_FindLocationByID(SBBreakpoint self, lldb::break_id_t bp_loc_id) -> SBBreakpointLocation"},
-	 { "SBBreakpoint_GetLocationAtIndex", _wrap_SBBreakpoint_GetLocationAtIndex, METH_VARARGS, (char *)"SBBreakpoint_GetLocationAtIndex(SBBreakpoint self, uint32_t index) -> SBBreakpointLocation"},
-	 { "SBBreakpoint_SetEnabled", _wrap_SBBreakpoint_SetEnabled, METH_VARARGS, (char *)"SBBreakpoint_SetEnabled(SBBreakpoint self, bool enable)"},
-	 { "SBBreakpoint_IsEnabled", _wrap_SBBreakpoint_IsEnabled, METH_VARARGS, (char *)"SBBreakpoint_IsEnabled(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint_SetOneShot", _wrap_SBBreakpoint_SetOneShot, METH_VARARGS, (char *)"SBBreakpoint_SetOneShot(SBBreakpoint self, bool one_shot)"},
-	 { "SBBreakpoint_IsOneShot", _wrap_SBBreakpoint_IsOneShot, METH_VARARGS, (char *)"SBBreakpoint_IsOneShot(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint_IsInternal", _wrap_SBBreakpoint_IsInternal, METH_VARARGS, (char *)"SBBreakpoint_IsInternal(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint_GetHitCount", _wrap_SBBreakpoint_GetHitCount, METH_VARARGS, (char *)"SBBreakpoint_GetHitCount(SBBreakpoint self) -> uint32_t"},
-	 { "SBBreakpoint_SetIgnoreCount", _wrap_SBBreakpoint_SetIgnoreCount, METH_VARARGS, (char *)"SBBreakpoint_SetIgnoreCount(SBBreakpoint self, uint32_t count)"},
-	 { "SBBreakpoint_GetIgnoreCount", _wrap_SBBreakpoint_GetIgnoreCount, METH_VARARGS, (char *)"SBBreakpoint_GetIgnoreCount(SBBreakpoint self) -> uint32_t"},
-	 { "SBBreakpoint_SetCondition", _wrap_SBBreakpoint_SetCondition, METH_VARARGS, (char *)"\n"
-		"SBBreakpoint_SetCondition(SBBreakpoint self, char const * condition)\n"
-		"\n"
-=======
 	 { (char *)"SBBlock_GetNumRanges", _wrap_SBBlock_GetNumRanges, METH_VARARGS, (char *)"SBBlock_GetNumRanges(SBBlock self) -> uint32_t"},
 	 { (char *)"SBBlock_GetRangeStartAddress", _wrap_SBBlock_GetRangeStartAddress, METH_VARARGS, (char *)"SBBlock_GetRangeStartAddress(SBBlock self, uint32_t idx) -> SBAddress"},
 	 { (char *)"SBBlock_GetRangeEndAddress", _wrap_SBBlock_GetRangeEndAddress, METH_VARARGS, (char *)"SBBlock_GetRangeEndAddress(SBBlock self, uint32_t idx) -> SBAddress"},
@@ -79875,38 +79423,16 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBBreakpoint_GetIgnoreCount", _wrap_SBBreakpoint_GetIgnoreCount, METH_VARARGS, (char *)"SBBreakpoint_GetIgnoreCount(SBBreakpoint self) -> uint32_t"},
 	 { (char *)"SBBreakpoint_SetCondition", _wrap_SBBreakpoint_SetCondition, METH_VARARGS, (char *)"\n"
 		"SBBreakpoint_SetCondition(SBBreakpoint self, char const * condition)\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"The breakpoint stops only if the condition expression evaluates to true.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpoint_GetCondition", _wrap_SBBreakpoint_GetCondition, METH_VARARGS, (char *)"\n"
-		"SBBreakpoint_GetCondition(SBBreakpoint self) -> char const *\n"
-		"\n"
-=======
 	 { (char *)"SBBreakpoint_GetCondition", _wrap_SBBreakpoint_GetCondition, METH_VARARGS, (char *)"\n"
 		"SBBreakpoint_GetCondition(SBBreakpoint self) -> char const *\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Get the condition expression for the breakpoint.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpoint_SetAutoContinue", _wrap_SBBreakpoint_SetAutoContinue, METH_VARARGS, (char *)"SBBreakpoint_SetAutoContinue(SBBreakpoint self, bool auto_continue)"},
-	 { "SBBreakpoint_GetAutoContinue", _wrap_SBBreakpoint_GetAutoContinue, METH_VARARGS, (char *)"SBBreakpoint_GetAutoContinue(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint_SetThreadID", _wrap_SBBreakpoint_SetThreadID, METH_VARARGS, (char *)"SBBreakpoint_SetThreadID(SBBreakpoint self, lldb::tid_t sb_thread_id)"},
-	 { "SBBreakpoint_GetThreadID", _wrap_SBBreakpoint_GetThreadID, METH_VARARGS, (char *)"SBBreakpoint_GetThreadID(SBBreakpoint self) -> lldb::tid_t"},
-	 { "SBBreakpoint_SetThreadIndex", _wrap_SBBreakpoint_SetThreadIndex, METH_VARARGS, (char *)"SBBreakpoint_SetThreadIndex(SBBreakpoint self, uint32_t index)"},
-	 { "SBBreakpoint_GetThreadIndex", _wrap_SBBreakpoint_GetThreadIndex, METH_VARARGS, (char *)"SBBreakpoint_GetThreadIndex(SBBreakpoint self) -> uint32_t"},
-	 { "SBBreakpoint_SetThreadName", _wrap_SBBreakpoint_SetThreadName, METH_VARARGS, (char *)"SBBreakpoint_SetThreadName(SBBreakpoint self, char const * thread_name)"},
-	 { "SBBreakpoint_GetThreadName", _wrap_SBBreakpoint_GetThreadName, METH_VARARGS, (char *)"SBBreakpoint_GetThreadName(SBBreakpoint self) -> char const *"},
-	 { "SBBreakpoint_SetQueueName", _wrap_SBBreakpoint_SetQueueName, METH_VARARGS, (char *)"SBBreakpoint_SetQueueName(SBBreakpoint self, char const * queue_name)"},
-	 { "SBBreakpoint_GetQueueName", _wrap_SBBreakpoint_GetQueueName, METH_VARARGS, (char *)"SBBreakpoint_GetQueueName(SBBreakpoint self) -> char const *"},
-	 { "SBBreakpoint_SetScriptCallbackFunction", _wrap_SBBreakpoint_SetScriptCallbackFunction, METH_VARARGS, (char *)"\n"
-		"SBBreakpoint_SetScriptCallbackFunction(SBBreakpoint self, char const * callback_function_name)\n"
-		"\n"
-=======
 	 { (char *)"SBBreakpoint_SetAutoContinue", _wrap_SBBreakpoint_SetAutoContinue, METH_VARARGS, (char *)"SBBreakpoint_SetAutoContinue(SBBreakpoint self, bool auto_continue)"},
 	 { (char *)"SBBreakpoint_GetAutoContinue", _wrap_SBBreakpoint_GetAutoContinue, METH_VARARGS, (char *)"SBBreakpoint_GetAutoContinue(SBBreakpoint self) -> bool"},
 	 { (char *)"SBBreakpoint_SetThreadID", _wrap_SBBreakpoint_SetThreadID, METH_VARARGS, (char *)"SBBreakpoint_SetThreadID(SBBreakpoint self, lldb::tid_t sb_thread_id)"},
@@ -79919,19 +79445,12 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBBreakpoint_GetQueueName", _wrap_SBBreakpoint_GetQueueName, METH_VARARGS, (char *)"SBBreakpoint_GetQueueName(SBBreakpoint self) -> char const *"},
 	 { (char *)"SBBreakpoint_SetScriptCallbackFunction", _wrap_SBBreakpoint_SetScriptCallbackFunction, METH_VARARGS, (char *)"\n"
 		"SBBreakpoint_SetScriptCallbackFunction(SBBreakpoint self, char const * callback_function_name)\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Set the name of the script function to be called when the breakpoint is hit.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpoint_SetScriptCallbackBody", _wrap_SBBreakpoint_SetScriptCallbackBody, METH_VARARGS, (char *)"\n"
-		"SBBreakpoint_SetScriptCallbackBody(SBBreakpoint self, char const * script_body_text) -> SBError\n"
-		"\n"
-=======
 	 { (char *)"SBBreakpoint_SetScriptCallbackBody", _wrap_SBBreakpoint_SetScriptCallbackBody, METH_VARARGS, (char *)"\n"
 		"SBBreakpoint_SetScriptCallbackBody(SBBreakpoint self, char const * script_body_text) -> SBError\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Provide the body for the script function to be called when the breakpoint is hit.\n"
@@ -79943,59 +79462,6 @@ static PyMethodDef SwigMethods[] = {
 		"compilation diagnostics.\n"
 		"Returns true if the body compiles successfully, false if not.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpoint_SetCommandLineCommands", _wrap_SBBreakpoint_SetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpoint_SetCommandLineCommands(SBBreakpoint self, SBStringList commands)"},
-	 { "SBBreakpoint_GetCommandLineCommands", _wrap_SBBreakpoint_GetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpoint_GetCommandLineCommands(SBBreakpoint self, SBStringList commands) -> bool"},
-	 { "SBBreakpoint_AddName", _wrap_SBBreakpoint_AddName, METH_VARARGS, (char *)"SBBreakpoint_AddName(SBBreakpoint self, char const * new_name) -> bool"},
-	 { "SBBreakpoint_RemoveName", _wrap_SBBreakpoint_RemoveName, METH_VARARGS, (char *)"SBBreakpoint_RemoveName(SBBreakpoint self, char const * name_to_remove)"},
-	 { "SBBreakpoint_MatchesName", _wrap_SBBreakpoint_MatchesName, METH_VARARGS, (char *)"SBBreakpoint_MatchesName(SBBreakpoint self, char const * name) -> bool"},
-	 { "SBBreakpoint_GetNames", _wrap_SBBreakpoint_GetNames, METH_VARARGS, (char *)"SBBreakpoint_GetNames(SBBreakpoint self, SBStringList names)"},
-	 { "SBBreakpoint_GetNumResolvedLocations", _wrap_SBBreakpoint_GetNumResolvedLocations, METH_VARARGS, (char *)"SBBreakpoint_GetNumResolvedLocations(SBBreakpoint self) -> size_t"},
-	 { "SBBreakpoint_GetNumLocations", _wrap_SBBreakpoint_GetNumLocations, METH_VARARGS, (char *)"SBBreakpoint_GetNumLocations(SBBreakpoint self) -> size_t"},
-	 { "SBBreakpoint_GetDescription", _wrap_SBBreakpoint_GetDescription, METH_VARARGS, (char *)"\n"
-		"GetDescription(SBStream description) -> bool\n"
-		"SBBreakpoint_GetDescription(SBBreakpoint self, SBStream description, bool include_locations) -> bool\n"
-		""},
-	 { "SBBreakpoint_AddLocation", _wrap_SBBreakpoint_AddLocation, METH_VARARGS, (char *)"SBBreakpoint_AddLocation(SBBreakpoint self, SBAddress address) -> SBError"},
-	 { "SBBreakpoint___eq__", _wrap_SBBreakpoint___eq__, METH_VARARGS, (char *)"SBBreakpoint___eq__(SBBreakpoint self, SBBreakpoint rhs) -> bool"},
-	 { "SBBreakpoint___ne__", _wrap_SBBreakpoint___ne__, METH_VARARGS, (char *)"SBBreakpoint___ne__(SBBreakpoint self, SBBreakpoint rhs) -> bool"},
-	 { "SBBreakpoint_EventIsBreakpointEvent", _wrap_SBBreakpoint_EventIsBreakpointEvent, METH_VARARGS, (char *)"SBBreakpoint_EventIsBreakpointEvent(SBEvent event) -> bool"},
-	 { "SBBreakpoint_GetBreakpointEventTypeFromEvent", _wrap_SBBreakpoint_GetBreakpointEventTypeFromEvent, METH_VARARGS, (char *)"SBBreakpoint_GetBreakpointEventTypeFromEvent(SBEvent event) -> lldb::BreakpointEventType"},
-	 { "SBBreakpoint_GetBreakpointFromEvent", _wrap_SBBreakpoint_GetBreakpointFromEvent, METH_VARARGS, (char *)"SBBreakpoint_GetBreakpointFromEvent(SBEvent event) -> SBBreakpoint"},
-	 { "SBBreakpoint_GetBreakpointLocationAtIndexFromEvent", _wrap_SBBreakpoint_GetBreakpointLocationAtIndexFromEvent, METH_VARARGS, (char *)"SBBreakpoint_GetBreakpointLocationAtIndexFromEvent(SBEvent event, uint32_t loc_idx) -> SBBreakpointLocation"},
-	 { "SBBreakpoint_GetNumBreakpointLocationsFromEvent", _wrap_SBBreakpoint_GetNumBreakpointLocationsFromEvent, METH_VARARGS, (char *)"SBBreakpoint_GetNumBreakpointLocationsFromEvent(SBEvent event_sp) -> uint32_t"},
-	 { "SBBreakpoint_IsHardware", _wrap_SBBreakpoint_IsHardware, METH_VARARGS, (char *)"SBBreakpoint_IsHardware(SBBreakpoint self) -> bool"},
-	 { "SBBreakpoint___str__", _wrap_SBBreakpoint___str__, METH_VARARGS, (char *)"SBBreakpoint___str__(SBBreakpoint self) -> PyObject *"},
-	 { "SBBreakpoint_swigregister", SBBreakpoint_swigregister, METH_VARARGS, NULL},
-	 { "new_SBBreakpointList", _wrap_new_SBBreakpointList, METH_VARARGS, (char *)"new_SBBreakpointList(SBTarget target) -> SBBreakpointList"},
-	 { "delete_SBBreakpointList", _wrap_delete_SBBreakpointList, METH_VARARGS, (char *)"delete_SBBreakpointList(SBBreakpointList self)"},
-	 { "SBBreakpointList_GetSize", _wrap_SBBreakpointList_GetSize, METH_VARARGS, (char *)"SBBreakpointList_GetSize(SBBreakpointList self) -> size_t"},
-	 { "SBBreakpointList_GetBreakpointAtIndex", _wrap_SBBreakpointList_GetBreakpointAtIndex, METH_VARARGS, (char *)"SBBreakpointList_GetBreakpointAtIndex(SBBreakpointList self, size_t idx) -> SBBreakpoint"},
-	 { "SBBreakpointList_FindBreakpointByID", _wrap_SBBreakpointList_FindBreakpointByID, METH_VARARGS, (char *)"SBBreakpointList_FindBreakpointByID(SBBreakpointList self, lldb::break_id_t arg3) -> SBBreakpoint"},
-	 { "SBBreakpointList_Append", _wrap_SBBreakpointList_Append, METH_VARARGS, (char *)"SBBreakpointList_Append(SBBreakpointList self, SBBreakpoint sb_bkpt)"},
-	 { "SBBreakpointList_AppendIfUnique", _wrap_SBBreakpointList_AppendIfUnique, METH_VARARGS, (char *)"SBBreakpointList_AppendIfUnique(SBBreakpointList self, SBBreakpoint sb_bkpt) -> bool"},
-	 { "SBBreakpointList_AppendByID", _wrap_SBBreakpointList_AppendByID, METH_VARARGS, (char *)"SBBreakpointList_AppendByID(SBBreakpointList self, lldb::break_id_t id)"},
-	 { "SBBreakpointList_Clear", _wrap_SBBreakpointList_Clear, METH_VARARGS, (char *)"SBBreakpointList_Clear(SBBreakpointList self)"},
-	 { "SBBreakpointList_swigregister", SBBreakpointList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBBreakpointLocation", _wrap_new_SBBreakpointLocation, METH_VARARGS, (char *)"\n"
-		"SBBreakpointLocation()\n"
-		"new_SBBreakpointLocation(SBBreakpointLocation rhs) -> SBBreakpointLocation\n"
-		""},
-	 { "delete_SBBreakpointLocation", _wrap_delete_SBBreakpointLocation, METH_VARARGS, (char *)"delete_SBBreakpointLocation(SBBreakpointLocation self)"},
-	 { "SBBreakpointLocation_GetID", _wrap_SBBreakpointLocation_GetID, METH_VARARGS, (char *)"SBBreakpointLocation_GetID(SBBreakpointLocation self) -> lldb::break_id_t"},
-	 { "SBBreakpointLocation_IsValid", _wrap_SBBreakpointLocation_IsValid, METH_VARARGS, (char *)"SBBreakpointLocation_IsValid(SBBreakpointLocation self) -> bool"},
-	 { "SBBreakpointLocation___nonzero__", _wrap_SBBreakpointLocation___nonzero__, METH_VARARGS, (char *)"SBBreakpointLocation___nonzero__(SBBreakpointLocation self) -> bool"},
-	 { "SBBreakpointLocation_GetAddress", _wrap_SBBreakpointLocation_GetAddress, METH_VARARGS, (char *)"SBBreakpointLocation_GetAddress(SBBreakpointLocation self) -> SBAddress"},
-	 { "SBBreakpointLocation_GetLoadAddress", _wrap_SBBreakpointLocation_GetLoadAddress, METH_VARARGS, (char *)"SBBreakpointLocation_GetLoadAddress(SBBreakpointLocation self) -> lldb::addr_t"},
-	 { "SBBreakpointLocation_SetEnabled", _wrap_SBBreakpointLocation_SetEnabled, METH_VARARGS, (char *)"SBBreakpointLocation_SetEnabled(SBBreakpointLocation self, bool enabled)"},
-	 { "SBBreakpointLocation_IsEnabled", _wrap_SBBreakpointLocation_IsEnabled, METH_VARARGS, (char *)"SBBreakpointLocation_IsEnabled(SBBreakpointLocation self) -> bool"},
-	 { "SBBreakpointLocation_GetHitCount", _wrap_SBBreakpointLocation_GetHitCount, METH_VARARGS, (char *)"SBBreakpointLocation_GetHitCount(SBBreakpointLocation self) -> uint32_t"},
-	 { "SBBreakpointLocation_GetIgnoreCount", _wrap_SBBreakpointLocation_GetIgnoreCount, METH_VARARGS, (char *)"SBBreakpointLocation_GetIgnoreCount(SBBreakpointLocation self) -> uint32_t"},
-	 { "SBBreakpointLocation_SetIgnoreCount", _wrap_SBBreakpointLocation_SetIgnoreCount, METH_VARARGS, (char *)"SBBreakpointLocation_SetIgnoreCount(SBBreakpointLocation self, uint32_t n)"},
-	 { "SBBreakpointLocation_SetCondition", _wrap_SBBreakpointLocation_SetCondition, METH_VARARGS, (char *)"\n"
-		"SBBreakpointLocation_SetCondition(SBBreakpointLocation self, char const * condition)\n"
-		"\n"
-=======
 	 { (char *)"SBBreakpoint_SetCommandLineCommands", _wrap_SBBreakpoint_SetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpoint_SetCommandLineCommands(SBBreakpoint self, SBStringList commands)"},
 	 { (char *)"SBBreakpoint_GetCommandLineCommands", _wrap_SBBreakpoint_GetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpoint_GetCommandLineCommands(SBBreakpoint self, SBStringList commands) -> bool"},
 	 { (char *)"SBBreakpoint_AddName", _wrap_SBBreakpoint_AddName, METH_VARARGS, (char *)"SBBreakpoint_AddName(SBBreakpoint self, char const * new_name) -> bool"},
@@ -80044,45 +79510,26 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBBreakpointLocation_SetIgnoreCount", _wrap_SBBreakpointLocation_SetIgnoreCount, METH_VARARGS, (char *)"SBBreakpointLocation_SetIgnoreCount(SBBreakpointLocation self, uint32_t n)"},
 	 { (char *)"SBBreakpointLocation_SetCondition", _wrap_SBBreakpointLocation_SetCondition, METH_VARARGS, (char *)"\n"
 		"SBBreakpointLocation_SetCondition(SBBreakpointLocation self, char const * condition)\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"The breakpoint location stops only if the condition expression evaluates\n"
 		"to true.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpointLocation_GetCondition", _wrap_SBBreakpointLocation_GetCondition, METH_VARARGS, (char *)"\n"
-		"SBBreakpointLocation_GetCondition(SBBreakpointLocation self) -> char const *\n"
-		"\n"
-=======
 	 { (char *)"SBBreakpointLocation_GetCondition", _wrap_SBBreakpointLocation_GetCondition, METH_VARARGS, (char *)"\n"
 		"SBBreakpointLocation_GetCondition(SBBreakpointLocation self) -> char const *\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Get the condition expression for the breakpoint location.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpointLocation_GetAutoContinue", _wrap_SBBreakpointLocation_GetAutoContinue, METH_VARARGS, (char *)"SBBreakpointLocation_GetAutoContinue(SBBreakpointLocation self) -> bool"},
-	 { "SBBreakpointLocation_SetAutoContinue", _wrap_SBBreakpointLocation_SetAutoContinue, METH_VARARGS, (char *)"SBBreakpointLocation_SetAutoContinue(SBBreakpointLocation self, bool auto_continue)"},
-	 { "SBBreakpointLocation_SetScriptCallbackFunction", _wrap_SBBreakpointLocation_SetScriptCallbackFunction, METH_VARARGS, (char *)"\n"
-		"SBBreakpointLocation_SetScriptCallbackFunction(SBBreakpointLocation self, char const * callback_function_name)\n"
-		"\n"
-=======
 	 { (char *)"SBBreakpointLocation_GetAutoContinue", _wrap_SBBreakpointLocation_GetAutoContinue, METH_VARARGS, (char *)"SBBreakpointLocation_GetAutoContinue(SBBreakpointLocation self) -> bool"},
 	 { (char *)"SBBreakpointLocation_SetAutoContinue", _wrap_SBBreakpointLocation_SetAutoContinue, METH_VARARGS, (char *)"SBBreakpointLocation_SetAutoContinue(SBBreakpointLocation self, bool auto_continue)"},
 	 { (char *)"SBBreakpointLocation_SetScriptCallbackFunction", _wrap_SBBreakpointLocation_SetScriptCallbackFunction, METH_VARARGS, (char *)"\n"
 		"SBBreakpointLocation_SetScriptCallbackFunction(SBBreakpointLocation self, char const * callback_function_name)\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Set the callback to the given Python function name.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpointLocation_SetScriptCallbackBody", _wrap_SBBreakpointLocation_SetScriptCallbackBody, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBBreakpointLocation_SetScriptCallbackBody", _wrap_SBBreakpointLocation_SetScriptCallbackBody, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBBreakpointLocation_SetScriptCallbackBody(SBBreakpointLocation self, char const * script_body_text) -> SBError\n"
 		"\n"
 		"\n"
@@ -80095,24 +79542,6 @@ static PyMethodDef SwigMethods[] = {
 		"compilation diagnostics.\n"
 		"Returns true if the body compiles successfully, false if not.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBBreakpointLocation_SetCommandLineCommands", _wrap_SBBreakpointLocation_SetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpointLocation_SetCommandLineCommands(SBBreakpointLocation self, SBStringList commands)"},
-	 { "SBBreakpointLocation_GetCommandLineCommands", _wrap_SBBreakpointLocation_GetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpointLocation_GetCommandLineCommands(SBBreakpointLocation self, SBStringList commands) -> bool"},
-	 { "SBBreakpointLocation_SetThreadID", _wrap_SBBreakpointLocation_SetThreadID, METH_VARARGS, (char *)"SBBreakpointLocation_SetThreadID(SBBreakpointLocation self, lldb::tid_t sb_thread_id)"},
-	 { "SBBreakpointLocation_GetThreadID", _wrap_SBBreakpointLocation_GetThreadID, METH_VARARGS, (char *)"SBBreakpointLocation_GetThreadID(SBBreakpointLocation self) -> lldb::tid_t"},
-	 { "SBBreakpointLocation_SetThreadIndex", _wrap_SBBreakpointLocation_SetThreadIndex, METH_VARARGS, (char *)"SBBreakpointLocation_SetThreadIndex(SBBreakpointLocation self, uint32_t index)"},
-	 { "SBBreakpointLocation_GetThreadIndex", _wrap_SBBreakpointLocation_GetThreadIndex, METH_VARARGS, (char *)"SBBreakpointLocation_GetThreadIndex(SBBreakpointLocation self) -> uint32_t"},
-	 { "SBBreakpointLocation_SetThreadName", _wrap_SBBreakpointLocation_SetThreadName, METH_VARARGS, (char *)"SBBreakpointLocation_SetThreadName(SBBreakpointLocation self, char const * thread_name)"},
-	 { "SBBreakpointLocation_GetThreadName", _wrap_SBBreakpointLocation_GetThreadName, METH_VARARGS, (char *)"SBBreakpointLocation_GetThreadName(SBBreakpointLocation self) -> char const *"},
-	 { "SBBreakpointLocation_SetQueueName", _wrap_SBBreakpointLocation_SetQueueName, METH_VARARGS, (char *)"SBBreakpointLocation_SetQueueName(SBBreakpointLocation self, char const * queue_name)"},
-	 { "SBBreakpointLocation_GetQueueName", _wrap_SBBreakpointLocation_GetQueueName, METH_VARARGS, (char *)"SBBreakpointLocation_GetQueueName(SBBreakpointLocation self) -> char const *"},
-	 { "SBBreakpointLocation_IsResolved", _wrap_SBBreakpointLocation_IsResolved, METH_VARARGS, (char *)"SBBreakpointLocation_IsResolved(SBBreakpointLocation self) -> bool"},
-	 { "SBBreakpointLocation_GetDescription", _wrap_SBBreakpointLocation_GetDescription, METH_VARARGS, (char *)"SBBreakpointLocation_GetDescription(SBBreakpointLocation self, SBStream description, lldb::DescriptionLevel level) -> bool"},
-	 { "SBBreakpointLocation_GetBreakpoint", _wrap_SBBreakpointLocation_GetBreakpoint, METH_VARARGS, (char *)"SBBreakpointLocation_GetBreakpoint(SBBreakpointLocation self) -> SBBreakpoint"},
-	 { "SBBreakpointLocation___str__", _wrap_SBBreakpointLocation___str__, METH_VARARGS, (char *)"SBBreakpointLocation___str__(SBBreakpointLocation self) -> PyObject *"},
-	 { "SBBreakpointLocation_swigregister", SBBreakpointLocation_swigregister, METH_VARARGS, NULL},
-	 { "new_SBBreakpointName", _wrap_new_SBBreakpointName, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBBreakpointLocation_SetCommandLineCommands", _wrap_SBBreakpointLocation_SetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpointLocation_SetCommandLineCommands(SBBreakpointLocation self, SBStringList commands)"},
 	 { (char *)"SBBreakpointLocation_GetCommandLineCommands", _wrap_SBBreakpointLocation_GetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpointLocation_GetCommandLineCommands(SBBreakpointLocation self, SBStringList commands) -> bool"},
 	 { (char *)"SBBreakpointLocation_SetThreadID", _wrap_SBBreakpointLocation_SetThreadID, METH_VARARGS, (char *)"SBBreakpointLocation_SetThreadID(SBBreakpointLocation self, lldb::tid_t sb_thread_id)"},
@@ -80129,54 +79558,11 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBBreakpointLocation___str__", _wrap_SBBreakpointLocation___str__, METH_VARARGS, (char *)"SBBreakpointLocation___str__(SBBreakpointLocation self) -> PyObject *"},
 	 { (char *)"SBBreakpointLocation_swigregister", SBBreakpointLocation_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBBreakpointName", _wrap_new_SBBreakpointName, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBBreakpointName()\n"
 		"SBBreakpointName(SBTarget target, char const * name)\n"
 		"SBBreakpointName(SBBreakpoint bkpt, char const * name)\n"
 		"new_SBBreakpointName(SBBreakpointName rhs) -> SBBreakpointName\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBBreakpointName", _wrap_delete_SBBreakpointName, METH_VARARGS, (char *)"delete_SBBreakpointName(SBBreakpointName self)"},
-	 { "SBBreakpointName___eq__", _wrap_SBBreakpointName___eq__, METH_VARARGS, (char *)"SBBreakpointName___eq__(SBBreakpointName self, SBBreakpointName rhs) -> bool"},
-	 { "SBBreakpointName___ne__", _wrap_SBBreakpointName___ne__, METH_VARARGS, (char *)"SBBreakpointName___ne__(SBBreakpointName self, SBBreakpointName rhs) -> bool"},
-	 { "SBBreakpointName___nonzero__", _wrap_SBBreakpointName___nonzero__, METH_VARARGS, (char *)"SBBreakpointName___nonzero__(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_IsValid", _wrap_SBBreakpointName_IsValid, METH_VARARGS, (char *)"SBBreakpointName_IsValid(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_GetName", _wrap_SBBreakpointName_GetName, METH_VARARGS, (char *)"SBBreakpointName_GetName(SBBreakpointName self) -> char const *"},
-	 { "SBBreakpointName_SetEnabled", _wrap_SBBreakpointName_SetEnabled, METH_VARARGS, (char *)"SBBreakpointName_SetEnabled(SBBreakpointName self, bool enable)"},
-	 { "SBBreakpointName_IsEnabled", _wrap_SBBreakpointName_IsEnabled, METH_VARARGS, (char *)"SBBreakpointName_IsEnabled(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_SetOneShot", _wrap_SBBreakpointName_SetOneShot, METH_VARARGS, (char *)"SBBreakpointName_SetOneShot(SBBreakpointName self, bool one_shot)"},
-	 { "SBBreakpointName_IsOneShot", _wrap_SBBreakpointName_IsOneShot, METH_VARARGS, (char *)"SBBreakpointName_IsOneShot(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_SetIgnoreCount", _wrap_SBBreakpointName_SetIgnoreCount, METH_VARARGS, (char *)"SBBreakpointName_SetIgnoreCount(SBBreakpointName self, uint32_t count)"},
-	 { "SBBreakpointName_GetIgnoreCount", _wrap_SBBreakpointName_GetIgnoreCount, METH_VARARGS, (char *)"SBBreakpointName_GetIgnoreCount(SBBreakpointName self) -> uint32_t"},
-	 { "SBBreakpointName_SetCondition", _wrap_SBBreakpointName_SetCondition, METH_VARARGS, (char *)"SBBreakpointName_SetCondition(SBBreakpointName self, char const * condition)"},
-	 { "SBBreakpointName_GetCondition", _wrap_SBBreakpointName_GetCondition, METH_VARARGS, (char *)"SBBreakpointName_GetCondition(SBBreakpointName self) -> char const *"},
-	 { "SBBreakpointName_SetAutoContinue", _wrap_SBBreakpointName_SetAutoContinue, METH_VARARGS, (char *)"SBBreakpointName_SetAutoContinue(SBBreakpointName self, bool auto_continue)"},
-	 { "SBBreakpointName_GetAutoContinue", _wrap_SBBreakpointName_GetAutoContinue, METH_VARARGS, (char *)"SBBreakpointName_GetAutoContinue(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_SetThreadID", _wrap_SBBreakpointName_SetThreadID, METH_VARARGS, (char *)"SBBreakpointName_SetThreadID(SBBreakpointName self, lldb::tid_t sb_thread_id)"},
-	 { "SBBreakpointName_GetThreadID", _wrap_SBBreakpointName_GetThreadID, METH_VARARGS, (char *)"SBBreakpointName_GetThreadID(SBBreakpointName self) -> lldb::tid_t"},
-	 { "SBBreakpointName_SetThreadIndex", _wrap_SBBreakpointName_SetThreadIndex, METH_VARARGS, (char *)"SBBreakpointName_SetThreadIndex(SBBreakpointName self, uint32_t index)"},
-	 { "SBBreakpointName_GetThreadIndex", _wrap_SBBreakpointName_GetThreadIndex, METH_VARARGS, (char *)"SBBreakpointName_GetThreadIndex(SBBreakpointName self) -> uint32_t"},
-	 { "SBBreakpointName_SetThreadName", _wrap_SBBreakpointName_SetThreadName, METH_VARARGS, (char *)"SBBreakpointName_SetThreadName(SBBreakpointName self, char const * thread_name)"},
-	 { "SBBreakpointName_GetThreadName", _wrap_SBBreakpointName_GetThreadName, METH_VARARGS, (char *)"SBBreakpointName_GetThreadName(SBBreakpointName self) -> char const *"},
-	 { "SBBreakpointName_SetQueueName", _wrap_SBBreakpointName_SetQueueName, METH_VARARGS, (char *)"SBBreakpointName_SetQueueName(SBBreakpointName self, char const * queue_name)"},
-	 { "SBBreakpointName_GetQueueName", _wrap_SBBreakpointName_GetQueueName, METH_VARARGS, (char *)"SBBreakpointName_GetQueueName(SBBreakpointName self) -> char const *"},
-	 { "SBBreakpointName_SetScriptCallbackFunction", _wrap_SBBreakpointName_SetScriptCallbackFunction, METH_VARARGS, (char *)"SBBreakpointName_SetScriptCallbackFunction(SBBreakpointName self, char const * callback_function_name)"},
-	 { "SBBreakpointName_SetCommandLineCommands", _wrap_SBBreakpointName_SetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpointName_SetCommandLineCommands(SBBreakpointName self, SBStringList commands)"},
-	 { "SBBreakpointName_GetCommandLineCommands", _wrap_SBBreakpointName_GetCommandLineCommands, METH_VARARGS, (char *)"SBBreakpointName_GetCommandLineCommands(SBBreakpointName self, SBStringList commands) -> bool"},
-	 { "SBBreakpointName_SetScriptCallbackBody", _wrap_SBBreakpointName_SetScriptCallbackBody, METH_VARARGS, (char *)"SBBreakpointName_SetScriptCallbackBody(SBBreakpointName self, char const * script_body_text) -> SBError"},
-	 { "SBBreakpointName_GetHelpString", _wrap_SBBreakpointName_GetHelpString, METH_VARARGS, (char *)"SBBreakpointName_GetHelpString(SBBreakpointName self) -> char const *"},
-	 { "SBBreakpointName_SetHelpString", _wrap_SBBreakpointName_SetHelpString, METH_VARARGS, (char *)"SBBreakpointName_SetHelpString(SBBreakpointName self, char const * help_string)"},
-	 { "SBBreakpointName_GetAllowList", _wrap_SBBreakpointName_GetAllowList, METH_VARARGS, (char *)"SBBreakpointName_GetAllowList(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_SetAllowList", _wrap_SBBreakpointName_SetAllowList, METH_VARARGS, (char *)"SBBreakpointName_SetAllowList(SBBreakpointName self, bool value)"},
-	 { "SBBreakpointName_GetAllowDelete", _wrap_SBBreakpointName_GetAllowDelete, METH_VARARGS, (char *)"SBBreakpointName_GetAllowDelete(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_SetAllowDelete", _wrap_SBBreakpointName_SetAllowDelete, METH_VARARGS, (char *)"SBBreakpointName_SetAllowDelete(SBBreakpointName self, bool value)"},
-	 { "SBBreakpointName_GetAllowDisable", _wrap_SBBreakpointName_GetAllowDisable, METH_VARARGS, (char *)"SBBreakpointName_GetAllowDisable(SBBreakpointName self) -> bool"},
-	 { "SBBreakpointName_SetAllowDisable", _wrap_SBBreakpointName_SetAllowDisable, METH_VARARGS, (char *)"SBBreakpointName_SetAllowDisable(SBBreakpointName self, bool value)"},
-	 { "SBBreakpointName_GetDescription", _wrap_SBBreakpointName_GetDescription, METH_VARARGS, (char *)"SBBreakpointName_GetDescription(SBBreakpointName self, SBStream description) -> bool"},
-	 { "SBBreakpointName___str__", _wrap_SBBreakpointName___str__, METH_VARARGS, (char *)"SBBreakpointName___str__(SBBreakpointName self) -> PyObject *"},
-	 { "SBBreakpointName_swigregister", SBBreakpointName_swigregister, METH_VARARGS, NULL},
-	 { "new_SBBroadcaster", _wrap_new_SBBroadcaster, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBBreakpointName", _wrap_delete_SBBreakpointName, METH_VARARGS, (char *)"delete_SBBreakpointName(SBBreakpointName self)"},
 	 { (char *)"SBBreakpointName___eq__", _wrap_SBBreakpointName___eq__, METH_VARARGS, (char *)"SBBreakpointName___eq__(SBBreakpointName self, SBBreakpointName rhs) -> bool"},
 	 { (char *)"SBBreakpointName___ne__", _wrap_SBBreakpointName___ne__, METH_VARARGS, (char *)"SBBreakpointName___ne__(SBBreakpointName self, SBBreakpointName rhs) -> bool"},
@@ -80217,77 +79603,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBBreakpointName___str__", _wrap_SBBreakpointName___str__, METH_VARARGS, (char *)"SBBreakpointName___str__(SBBreakpointName self) -> PyObject *"},
 	 { (char *)"SBBreakpointName_swigregister", SBBreakpointName_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBBroadcaster", _wrap_new_SBBroadcaster, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBBroadcaster()\n"
 		"SBBroadcaster(char const * name)\n"
 		"new_SBBroadcaster(SBBroadcaster rhs) -> SBBroadcaster\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBBroadcaster", _wrap_delete_SBBroadcaster, METH_VARARGS, (char *)"delete_SBBroadcaster(SBBroadcaster self)"},
-	 { "SBBroadcaster_IsValid", _wrap_SBBroadcaster_IsValid, METH_VARARGS, (char *)"SBBroadcaster_IsValid(SBBroadcaster self) -> bool"},
-	 { "SBBroadcaster___nonzero__", _wrap_SBBroadcaster___nonzero__, METH_VARARGS, (char *)"SBBroadcaster___nonzero__(SBBroadcaster self) -> bool"},
-	 { "SBBroadcaster_Clear", _wrap_SBBroadcaster_Clear, METH_VARARGS, (char *)"SBBroadcaster_Clear(SBBroadcaster self)"},
-	 { "SBBroadcaster_BroadcastEventByType", _wrap_SBBroadcaster_BroadcastEventByType, METH_VARARGS, (char *)"\n"
-		"BroadcastEventByType(uint32_t event_type, bool unique=False)\n"
-		"SBBroadcaster_BroadcastEventByType(SBBroadcaster self, uint32_t event_type)\n"
-		""},
-	 { "SBBroadcaster_BroadcastEvent", _wrap_SBBroadcaster_BroadcastEvent, METH_VARARGS, (char *)"\n"
-		"BroadcastEvent(SBEvent event, bool unique=False)\n"
-		"SBBroadcaster_BroadcastEvent(SBBroadcaster self, SBEvent event)\n"
-		""},
-	 { "SBBroadcaster_AddInitialEventsToListener", _wrap_SBBroadcaster_AddInitialEventsToListener, METH_VARARGS, (char *)"SBBroadcaster_AddInitialEventsToListener(SBBroadcaster self, SBListener listener, uint32_t requested_events)"},
-	 { "SBBroadcaster_AddListener", _wrap_SBBroadcaster_AddListener, METH_VARARGS, (char *)"SBBroadcaster_AddListener(SBBroadcaster self, SBListener listener, uint32_t event_mask) -> uint32_t"},
-	 { "SBBroadcaster_GetName", _wrap_SBBroadcaster_GetName, METH_VARARGS, (char *)"SBBroadcaster_GetName(SBBroadcaster self) -> char const *"},
-	 { "SBBroadcaster_EventTypeHasListeners", _wrap_SBBroadcaster_EventTypeHasListeners, METH_VARARGS, (char *)"SBBroadcaster_EventTypeHasListeners(SBBroadcaster self, uint32_t event_type) -> bool"},
-	 { "SBBroadcaster_RemoveListener", _wrap_SBBroadcaster_RemoveListener, METH_VARARGS, (char *)"\n"
-		"RemoveListener(SBListener listener, uint32_t event_mask=4294967295) -> bool\n"
-		"SBBroadcaster_RemoveListener(SBBroadcaster self, SBListener listener) -> bool\n"
-		""},
-	 { "SBBroadcaster___eq__", _wrap_SBBroadcaster___eq__, METH_VARARGS, (char *)"SBBroadcaster___eq__(SBBroadcaster self, SBBroadcaster rhs) -> bool"},
-	 { "SBBroadcaster___ne__", _wrap_SBBroadcaster___ne__, METH_VARARGS, (char *)"SBBroadcaster___ne__(SBBroadcaster self, SBBroadcaster rhs) -> bool"},
-	 { "SBBroadcaster_swigregister", SBBroadcaster_swigregister, METH_VARARGS, NULL},
-	 { "new_SBCommandInterpreterRunOptions", _wrap_new_SBCommandInterpreterRunOptions, METH_VARARGS, (char *)"new_SBCommandInterpreterRunOptions() -> SBCommandInterpreterRunOptions"},
-	 { "delete_SBCommandInterpreterRunOptions", _wrap_delete_SBCommandInterpreterRunOptions, METH_VARARGS, (char *)"delete_SBCommandInterpreterRunOptions(SBCommandInterpreterRunOptions self)"},
-	 { "SBCommandInterpreterRunOptions_GetStopOnContinue", _wrap_SBCommandInterpreterRunOptions_GetStopOnContinue, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_GetStopOnContinue(SBCommandInterpreterRunOptions self) -> bool"},
-	 { "SBCommandInterpreterRunOptions_SetStopOnContinue", _wrap_SBCommandInterpreterRunOptions_SetStopOnContinue, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_SetStopOnContinue(SBCommandInterpreterRunOptions self, bool arg3)"},
-	 { "SBCommandInterpreterRunOptions_GetStopOnError", _wrap_SBCommandInterpreterRunOptions_GetStopOnError, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_GetStopOnError(SBCommandInterpreterRunOptions self) -> bool"},
-	 { "SBCommandInterpreterRunOptions_SetStopOnError", _wrap_SBCommandInterpreterRunOptions_SetStopOnError, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_SetStopOnError(SBCommandInterpreterRunOptions self, bool arg3)"},
-	 { "SBCommandInterpreterRunOptions_GetStopOnCrash", _wrap_SBCommandInterpreterRunOptions_GetStopOnCrash, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_GetStopOnCrash(SBCommandInterpreterRunOptions self) -> bool"},
-	 { "SBCommandInterpreterRunOptions_SetStopOnCrash", _wrap_SBCommandInterpreterRunOptions_SetStopOnCrash, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_SetStopOnCrash(SBCommandInterpreterRunOptions self, bool arg3)"},
-	 { "SBCommandInterpreterRunOptions_GetEchoCommands", _wrap_SBCommandInterpreterRunOptions_GetEchoCommands, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_GetEchoCommands(SBCommandInterpreterRunOptions self) -> bool"},
-	 { "SBCommandInterpreterRunOptions_SetEchoCommands", _wrap_SBCommandInterpreterRunOptions_SetEchoCommands, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_SetEchoCommands(SBCommandInterpreterRunOptions self, bool arg3)"},
-	 { "SBCommandInterpreterRunOptions_GetPrintResults", _wrap_SBCommandInterpreterRunOptions_GetPrintResults, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_GetPrintResults(SBCommandInterpreterRunOptions self) -> bool"},
-	 { "SBCommandInterpreterRunOptions_SetPrintResults", _wrap_SBCommandInterpreterRunOptions_SetPrintResults, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_SetPrintResults(SBCommandInterpreterRunOptions self, bool arg3)"},
-	 { "SBCommandInterpreterRunOptions_GetAddToHistory", _wrap_SBCommandInterpreterRunOptions_GetAddToHistory, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_GetAddToHistory(SBCommandInterpreterRunOptions self) -> bool"},
-	 { "SBCommandInterpreterRunOptions_SetAddToHistory", _wrap_SBCommandInterpreterRunOptions_SetAddToHistory, METH_VARARGS, (char *)"SBCommandInterpreterRunOptions_SetAddToHistory(SBCommandInterpreterRunOptions self, bool arg3)"},
-	 { "SBCommandInterpreterRunOptions_swigregister", SBCommandInterpreterRunOptions_swigregister, METH_VARARGS, NULL},
-	 { "new_SBCommandInterpreter", _wrap_new_SBCommandInterpreter, METH_VARARGS, (char *)"new_SBCommandInterpreter(SBCommandInterpreter rhs) -> SBCommandInterpreter"},
-	 { "delete_SBCommandInterpreter", _wrap_delete_SBCommandInterpreter, METH_VARARGS, (char *)"delete_SBCommandInterpreter(SBCommandInterpreter self)"},
-	 { "SBCommandInterpreter_GetArgumentTypeAsCString", _wrap_SBCommandInterpreter_GetArgumentTypeAsCString, METH_VARARGS, (char *)"SBCommandInterpreter_GetArgumentTypeAsCString(lldb::CommandArgumentType const arg_type) -> char const *"},
-	 { "SBCommandInterpreter_GetArgumentDescriptionAsCString", _wrap_SBCommandInterpreter_GetArgumentDescriptionAsCString, METH_VARARGS, (char *)"SBCommandInterpreter_GetArgumentDescriptionAsCString(lldb::CommandArgumentType const arg_type) -> char const *"},
-	 { "SBCommandInterpreter_EventIsCommandInterpreterEvent", _wrap_SBCommandInterpreter_EventIsCommandInterpreterEvent, METH_VARARGS, (char *)"SBCommandInterpreter_EventIsCommandInterpreterEvent(SBEvent event) -> bool"},
-	 { "SBCommandInterpreter_IsValid", _wrap_SBCommandInterpreter_IsValid, METH_VARARGS, (char *)"SBCommandInterpreter_IsValid(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter___nonzero__", _wrap_SBCommandInterpreter___nonzero__, METH_VARARGS, (char *)"SBCommandInterpreter___nonzero__(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_GetIOHandlerControlSequence", _wrap_SBCommandInterpreter_GetIOHandlerControlSequence, METH_VARARGS, (char *)"SBCommandInterpreter_GetIOHandlerControlSequence(SBCommandInterpreter self, char ch) -> char const *"},
-	 { "SBCommandInterpreter_GetPromptOnQuit", _wrap_SBCommandInterpreter_GetPromptOnQuit, METH_VARARGS, (char *)"SBCommandInterpreter_GetPromptOnQuit(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_SetPromptOnQuit", _wrap_SBCommandInterpreter_SetPromptOnQuit, METH_VARARGS, (char *)"SBCommandInterpreter_SetPromptOnQuit(SBCommandInterpreter self, bool b)"},
-	 { "SBCommandInterpreter_AllowExitCodeOnQuit", _wrap_SBCommandInterpreter_AllowExitCodeOnQuit, METH_VARARGS, (char *)"SBCommandInterpreter_AllowExitCodeOnQuit(SBCommandInterpreter self, bool b)"},
-	 { "SBCommandInterpreter_HasCustomQuitExitCode", _wrap_SBCommandInterpreter_HasCustomQuitExitCode, METH_VARARGS, (char *)"SBCommandInterpreter_HasCustomQuitExitCode(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_GetQuitStatus", _wrap_SBCommandInterpreter_GetQuitStatus, METH_VARARGS, (char *)"SBCommandInterpreter_GetQuitStatus(SBCommandInterpreter self) -> int"},
-	 { "SBCommandInterpreter_ResolveCommand", _wrap_SBCommandInterpreter_ResolveCommand, METH_VARARGS, (char *)"SBCommandInterpreter_ResolveCommand(SBCommandInterpreter self, char const * command_line, SBCommandReturnObject result)"},
-	 { "SBCommandInterpreter_CommandExists", _wrap_SBCommandInterpreter_CommandExists, METH_VARARGS, (char *)"SBCommandInterpreter_CommandExists(SBCommandInterpreter self, char const * cmd) -> bool"},
-	 { "SBCommandInterpreter_AliasExists", _wrap_SBCommandInterpreter_AliasExists, METH_VARARGS, (char *)"SBCommandInterpreter_AliasExists(SBCommandInterpreter self, char const * cmd) -> bool"},
-	 { "SBCommandInterpreter_GetBroadcaster", _wrap_SBCommandInterpreter_GetBroadcaster, METH_VARARGS, (char *)"SBCommandInterpreter_GetBroadcaster(SBCommandInterpreter self) -> SBBroadcaster"},
-	 { "SBCommandInterpreter_GetBroadcasterClass", _wrap_SBCommandInterpreter_GetBroadcasterClass, METH_VARARGS, (char *)"SBCommandInterpreter_GetBroadcasterClass() -> char const *"},
-	 { "SBCommandInterpreter_HasCommands", _wrap_SBCommandInterpreter_HasCommands, METH_VARARGS, (char *)"SBCommandInterpreter_HasCommands(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_HasAliases", _wrap_SBCommandInterpreter_HasAliases, METH_VARARGS, (char *)"SBCommandInterpreter_HasAliases(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_HasAliasOptions", _wrap_SBCommandInterpreter_HasAliasOptions, METH_VARARGS, (char *)"SBCommandInterpreter_HasAliasOptions(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_GetProcess", _wrap_SBCommandInterpreter_GetProcess, METH_VARARGS, (char *)"SBCommandInterpreter_GetProcess(SBCommandInterpreter self) -> SBProcess"},
-	 { "SBCommandInterpreter_GetDebugger", _wrap_SBCommandInterpreter_GetDebugger, METH_VARARGS, (char *)"SBCommandInterpreter_GetDebugger(SBCommandInterpreter self) -> SBDebugger"},
-	 { "SBCommandInterpreter_SourceInitFileInHomeDirectory", _wrap_SBCommandInterpreter_SourceInitFileInHomeDirectory, METH_VARARGS, (char *)"SBCommandInterpreter_SourceInitFileInHomeDirectory(SBCommandInterpreter self, SBCommandReturnObject result)"},
-	 { "SBCommandInterpreter_SourceInitFileInCurrentWorkingDirectory", _wrap_SBCommandInterpreter_SourceInitFileInCurrentWorkingDirectory, METH_VARARGS, (char *)"SBCommandInterpreter_SourceInitFileInCurrentWorkingDirectory(SBCommandInterpreter self, SBCommandReturnObject result)"},
-	 { "SBCommandInterpreter_HandleCommand", _wrap_SBCommandInterpreter_HandleCommand, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBBroadcaster", _wrap_delete_SBBroadcaster, METH_VARARGS, (char *)"delete_SBBroadcaster(SBBroadcaster self)"},
 	 { (char *)"SBBroadcaster_IsValid", _wrap_SBBroadcaster_IsValid, METH_VARARGS, (char *)"SBBroadcaster_IsValid(SBBroadcaster self) -> bool"},
 	 { (char *)"SBBroadcaster___nonzero__", _wrap_SBBroadcaster___nonzero__, METH_VARARGS, (char *)"SBBroadcaster___nonzero__(SBBroadcaster self) -> bool"},
@@ -80352,42 +79671,11 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBCommandInterpreter_SourceInitFileInHomeDirectory", _wrap_SBCommandInterpreter_SourceInitFileInHomeDirectory, METH_VARARGS, (char *)"SBCommandInterpreter_SourceInitFileInHomeDirectory(SBCommandInterpreter self, SBCommandReturnObject result)"},
 	 { (char *)"SBCommandInterpreter_SourceInitFileInCurrentWorkingDirectory", _wrap_SBCommandInterpreter_SourceInitFileInCurrentWorkingDirectory, METH_VARARGS, (char *)"SBCommandInterpreter_SourceInitFileInCurrentWorkingDirectory(SBCommandInterpreter self, SBCommandReturnObject result)"},
 	 { (char *)"SBCommandInterpreter_HandleCommand", _wrap_SBCommandInterpreter_HandleCommand, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"HandleCommand(char const * command_line, SBCommandReturnObject result, bool add_to_history=False) -> lldb::ReturnStatus\n"
 		"HandleCommand(char const * command_line, SBCommandReturnObject result) -> lldb::ReturnStatus\n"
 		"HandleCommand(char const * command_line, SBExecutionContext exe_ctx, SBCommandReturnObject result, bool add_to_history=False) -> lldb::ReturnStatus\n"
 		"SBCommandInterpreter_HandleCommand(SBCommandInterpreter self, char const * command_line, SBExecutionContext exe_ctx, SBCommandReturnObject result) -> lldb::ReturnStatus\n"
 		""},
-<<<<<<< HEAD
-	 { "SBCommandInterpreter_HandleCommandsFromFile", _wrap_SBCommandInterpreter_HandleCommandsFromFile, METH_VARARGS, (char *)"SBCommandInterpreter_HandleCommandsFromFile(SBCommandInterpreter self, SBFileSpec file, SBExecutionContext override_context, SBCommandInterpreterRunOptions options, SBCommandReturnObject result)"},
-	 { "SBCommandInterpreter_HandleCompletion", _wrap_SBCommandInterpreter_HandleCompletion, METH_VARARGS, (char *)"SBCommandInterpreter_HandleCompletion(SBCommandInterpreter self, char const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches) -> int"},
-	 { "SBCommandInterpreter_HandleCompletionWithDescriptions", _wrap_SBCommandInterpreter_HandleCompletionWithDescriptions, METH_VARARGS, (char *)"SBCommandInterpreter_HandleCompletionWithDescriptions(SBCommandInterpreter self, char const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches, SBStringList descriptions) -> int"},
-	 { "SBCommandInterpreter_IsActive", _wrap_SBCommandInterpreter_IsActive, METH_VARARGS, (char *)"SBCommandInterpreter_IsActive(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_WasInterrupted", _wrap_SBCommandInterpreter_WasInterrupted, METH_VARARGS, (char *)"SBCommandInterpreter_WasInterrupted(SBCommandInterpreter self) -> bool"},
-	 { "SBCommandInterpreter_swigregister", SBCommandInterpreter_swigregister, METH_VARARGS, NULL},
-	 { "new_SBCommandReturnObject", _wrap_new_SBCommandReturnObject, METH_VARARGS, (char *)"\n"
-		"SBCommandReturnObject()\n"
-		"new_SBCommandReturnObject(SBCommandReturnObject rhs) -> SBCommandReturnObject\n"
-		""},
-	 { "delete_SBCommandReturnObject", _wrap_delete_SBCommandReturnObject, METH_VARARGS, (char *)"delete_SBCommandReturnObject(SBCommandReturnObject self)"},
-	 { "SBCommandReturnObject_IsValid", _wrap_SBCommandReturnObject_IsValid, METH_VARARGS, (char *)"SBCommandReturnObject_IsValid(SBCommandReturnObject self) -> bool"},
-	 { "SBCommandReturnObject___nonzero__", _wrap_SBCommandReturnObject___nonzero__, METH_VARARGS, (char *)"SBCommandReturnObject___nonzero__(SBCommandReturnObject self) -> bool"},
-	 { "SBCommandReturnObject_GetOutputSize", _wrap_SBCommandReturnObject_GetOutputSize, METH_VARARGS, (char *)"SBCommandReturnObject_GetOutputSize(SBCommandReturnObject self) -> size_t"},
-	 { "SBCommandReturnObject_GetErrorSize", _wrap_SBCommandReturnObject_GetErrorSize, METH_VARARGS, (char *)"SBCommandReturnObject_GetErrorSize(SBCommandReturnObject self) -> size_t"},
-	 { "SBCommandReturnObject_GetOutput", _wrap_SBCommandReturnObject_GetOutput, METH_VARARGS, (char *)"\n"
-		"GetOutput() -> char const\n"
-		"SBCommandReturnObject_GetOutput(SBCommandReturnObject self, bool only_if_no_immediate) -> char const *\n"
-		""},
-	 { "SBCommandReturnObject_GetError", _wrap_SBCommandReturnObject_GetError, METH_VARARGS, (char *)"\n"
-		"GetError() -> char const\n"
-		"SBCommandReturnObject_GetError(SBCommandReturnObject self, bool if_no_immediate) -> char const *\n"
-		""},
-	 { "SBCommandReturnObject_PutOutput", _wrap_SBCommandReturnObject_PutOutput, METH_VARARGS, (char *)"SBCommandReturnObject_PutOutput(SBCommandReturnObject self, FILE * fh) -> size_t"},
-	 { "SBCommandReturnObject_PutError", _wrap_SBCommandReturnObject_PutError, METH_VARARGS, (char *)"SBCommandReturnObject_PutError(SBCommandReturnObject self, FILE * fh) -> size_t"},
-	 { "SBCommandReturnObject_Clear", _wrap_SBCommandReturnObject_Clear, METH_VARARGS, (char *)"SBCommandReturnObject_Clear(SBCommandReturnObject self)"},
-	 { "SBCommandReturnObject_SetStatus", _wrap_SBCommandReturnObject_SetStatus, METH_VARARGS, (char *)"SBCommandReturnObject_SetStatus(SBCommandReturnObject self, lldb::ReturnStatus status)"},
-	 { "SBCommandReturnObject_SetError", _wrap_SBCommandReturnObject_SetError, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBCommandInterpreter_HandleCommandsFromFile", _wrap_SBCommandInterpreter_HandleCommandsFromFile, METH_VARARGS, (char *)"SBCommandInterpreter_HandleCommandsFromFile(SBCommandInterpreter self, SBFileSpec file, SBExecutionContext override_context, SBCommandInterpreterRunOptions options, SBCommandReturnObject result)"},
 	 { (char *)"SBCommandInterpreter_HandleCompletion", _wrap_SBCommandInterpreter_HandleCompletion, METH_VARARGS, (char *)"SBCommandInterpreter_HandleCompletion(SBCommandInterpreter self, char const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches) -> int"},
 	 { (char *)"SBCommandInterpreter_HandleCompletionWithDescriptions", _wrap_SBCommandInterpreter_HandleCompletionWithDescriptions, METH_VARARGS, (char *)"SBCommandInterpreter_HandleCompletionWithDescriptions(SBCommandInterpreter self, char const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches, SBStringList descriptions) -> int"},
@@ -80416,86 +79704,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBCommandReturnObject_Clear", _wrap_SBCommandReturnObject_Clear, METH_VARARGS, (char *)"SBCommandReturnObject_Clear(SBCommandReturnObject self)"},
 	 { (char *)"SBCommandReturnObject_SetStatus", _wrap_SBCommandReturnObject_SetStatus, METH_VARARGS, (char *)"SBCommandReturnObject_SetStatus(SBCommandReturnObject self, lldb::ReturnStatus status)"},
 	 { (char *)"SBCommandReturnObject_SetError", _wrap_SBCommandReturnObject_SetError, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetError(SBError error, char const * fallback_error_cstr=None)\n"
 		"SetError(SBError error)\n"
 		"SBCommandReturnObject_SetError(SBCommandReturnObject self, char const * error_cstr)\n"
 		""},
-<<<<<<< HEAD
-	 { "SBCommandReturnObject_GetStatus", _wrap_SBCommandReturnObject_GetStatus, METH_VARARGS, (char *)"SBCommandReturnObject_GetStatus(SBCommandReturnObject self) -> lldb::ReturnStatus"},
-	 { "SBCommandReturnObject_Succeeded", _wrap_SBCommandReturnObject_Succeeded, METH_VARARGS, (char *)"SBCommandReturnObject_Succeeded(SBCommandReturnObject self) -> bool"},
-	 { "SBCommandReturnObject_HasResult", _wrap_SBCommandReturnObject_HasResult, METH_VARARGS, (char *)"SBCommandReturnObject_HasResult(SBCommandReturnObject self) -> bool"},
-	 { "SBCommandReturnObject_AppendMessage", _wrap_SBCommandReturnObject_AppendMessage, METH_VARARGS, (char *)"SBCommandReturnObject_AppendMessage(SBCommandReturnObject self, char const * message)"},
-	 { "SBCommandReturnObject_AppendWarning", _wrap_SBCommandReturnObject_AppendWarning, METH_VARARGS, (char *)"SBCommandReturnObject_AppendWarning(SBCommandReturnObject self, char const * message)"},
-	 { "SBCommandReturnObject_GetDescription", _wrap_SBCommandReturnObject_GetDescription, METH_VARARGS, (char *)"SBCommandReturnObject_GetDescription(SBCommandReturnObject self, SBStream description) -> bool"},
-	 { "SBCommandReturnObject_SetImmediateOutputFile", _wrap_SBCommandReturnObject_SetImmediateOutputFile, METH_VARARGS, (char *)"SBCommandReturnObject_SetImmediateOutputFile(SBCommandReturnObject self, FILE * fh)"},
-	 { "SBCommandReturnObject_SetImmediateErrorFile", _wrap_SBCommandReturnObject_SetImmediateErrorFile, METH_VARARGS, (char *)"SBCommandReturnObject_SetImmediateErrorFile(SBCommandReturnObject self, FILE * fh)"},
-	 { "SBCommandReturnObject_PutCString", _wrap_SBCommandReturnObject_PutCString, METH_VARARGS, (char *)"SBCommandReturnObject_PutCString(SBCommandReturnObject self, char const * string)"},
-	 { "SBCommandReturnObject_Print", _wrap_SBCommandReturnObject_Print, METH_VARARGS, (char *)"SBCommandReturnObject_Print(SBCommandReturnObject self, char const * str)"},
-	 { "SBCommandReturnObject___str__", _wrap_SBCommandReturnObject___str__, METH_VARARGS, (char *)"SBCommandReturnObject___str__(SBCommandReturnObject self) -> PyObject *"},
-	 { "SBCommandReturnObject_write", _wrap_SBCommandReturnObject_write, METH_VARARGS, (char *)"SBCommandReturnObject_write(SBCommandReturnObject self, char const * str)"},
-	 { "SBCommandReturnObject_flush", _wrap_SBCommandReturnObject_flush, METH_VARARGS, (char *)"SBCommandReturnObject_flush(SBCommandReturnObject self)"},
-	 { "SBCommandReturnObject_swigregister", SBCommandReturnObject_swigregister, METH_VARARGS, NULL},
-	 { "new_SBCommunication", _wrap_new_SBCommunication, METH_VARARGS, (char *)"\n"
-		"SBCommunication()\n"
-		"new_SBCommunication(char const * broadcaster_name) -> SBCommunication\n"
-		""},
-	 { "delete_SBCommunication", _wrap_delete_SBCommunication, METH_VARARGS, (char *)"delete_SBCommunication(SBCommunication self)"},
-	 { "SBCommunication_IsValid", _wrap_SBCommunication_IsValid, METH_VARARGS, (char *)"SBCommunication_IsValid(SBCommunication self) -> bool"},
-	 { "SBCommunication___nonzero__", _wrap_SBCommunication___nonzero__, METH_VARARGS, (char *)"SBCommunication___nonzero__(SBCommunication self) -> bool"},
-	 { "SBCommunication_GetBroadcaster", _wrap_SBCommunication_GetBroadcaster, METH_VARARGS, (char *)"SBCommunication_GetBroadcaster(SBCommunication self) -> SBBroadcaster"},
-	 { "SBCommunication_GetBroadcasterClass", _wrap_SBCommunication_GetBroadcasterClass, METH_VARARGS, (char *)"SBCommunication_GetBroadcasterClass() -> char const *"},
-	 { "SBCommunication_AdoptFileDesriptor", _wrap_SBCommunication_AdoptFileDesriptor, METH_VARARGS, (char *)"SBCommunication_AdoptFileDesriptor(SBCommunication self, int fd, bool owns_fd) -> lldb::ConnectionStatus"},
-	 { "SBCommunication_Connect", _wrap_SBCommunication_Connect, METH_VARARGS, (char *)"SBCommunication_Connect(SBCommunication self, char const * url) -> lldb::ConnectionStatus"},
-	 { "SBCommunication_Disconnect", _wrap_SBCommunication_Disconnect, METH_VARARGS, (char *)"SBCommunication_Disconnect(SBCommunication self) -> lldb::ConnectionStatus"},
-	 { "SBCommunication_IsConnected", _wrap_SBCommunication_IsConnected, METH_VARARGS, (char *)"SBCommunication_IsConnected(SBCommunication self) -> bool"},
-	 { "SBCommunication_GetCloseOnEOF", _wrap_SBCommunication_GetCloseOnEOF, METH_VARARGS, (char *)"SBCommunication_GetCloseOnEOF(SBCommunication self) -> bool"},
-	 { "SBCommunication_SetCloseOnEOF", _wrap_SBCommunication_SetCloseOnEOF, METH_VARARGS, (char *)"SBCommunication_SetCloseOnEOF(SBCommunication self, bool b)"},
-	 { "SBCommunication_Read", _wrap_SBCommunication_Read, METH_VARARGS, (char *)"SBCommunication_Read(SBCommunication self, void * dst, size_t dst_len, uint32_t timeout_usec, lldb::ConnectionStatus & status) -> size_t"},
-	 { "SBCommunication_Write", _wrap_SBCommunication_Write, METH_VARARGS, (char *)"SBCommunication_Write(SBCommunication self, void const * src, size_t src_len, lldb::ConnectionStatus & status) -> size_t"},
-	 { "SBCommunication_ReadThreadStart", _wrap_SBCommunication_ReadThreadStart, METH_VARARGS, (char *)"SBCommunication_ReadThreadStart(SBCommunication self) -> bool"},
-	 { "SBCommunication_ReadThreadStop", _wrap_SBCommunication_ReadThreadStop, METH_VARARGS, (char *)"SBCommunication_ReadThreadStop(SBCommunication self) -> bool"},
-	 { "SBCommunication_ReadThreadIsRunning", _wrap_SBCommunication_ReadThreadIsRunning, METH_VARARGS, (char *)"SBCommunication_ReadThreadIsRunning(SBCommunication self) -> bool"},
-	 { "SBCommunication_SetReadThreadBytesReceivedCallback", _wrap_SBCommunication_SetReadThreadBytesReceivedCallback, METH_VARARGS, (char *)"SBCommunication_SetReadThreadBytesReceivedCallback(SBCommunication self, lldb::SBCommunication::ReadThreadBytesReceived callback, void * callback_baton) -> bool"},
-	 { "SBCommunication_swigregister", SBCommunication_swigregister, METH_VARARGS, NULL},
-	 { "new_SBCompileUnit", _wrap_new_SBCompileUnit, METH_VARARGS, (char *)"\n"
-		"SBCompileUnit()\n"
-		"new_SBCompileUnit(SBCompileUnit rhs) -> SBCompileUnit\n"
-		""},
-	 { "delete_SBCompileUnit", _wrap_delete_SBCompileUnit, METH_VARARGS, (char *)"delete_SBCompileUnit(SBCompileUnit self)"},
-	 { "SBCompileUnit_IsValid", _wrap_SBCompileUnit_IsValid, METH_VARARGS, (char *)"SBCompileUnit_IsValid(SBCompileUnit self) -> bool"},
-	 { "SBCompileUnit___nonzero__", _wrap_SBCompileUnit___nonzero__, METH_VARARGS, (char *)"SBCompileUnit___nonzero__(SBCompileUnit self) -> bool"},
-	 { "SBCompileUnit_GetFileSpec", _wrap_SBCompileUnit_GetFileSpec, METH_VARARGS, (char *)"SBCompileUnit_GetFileSpec(SBCompileUnit self) -> SBFileSpec"},
-	 { "SBCompileUnit_GetNumLineEntries", _wrap_SBCompileUnit_GetNumLineEntries, METH_VARARGS, (char *)"SBCompileUnit_GetNumLineEntries(SBCompileUnit self) -> uint32_t"},
-	 { "SBCompileUnit_GetLineEntryAtIndex", _wrap_SBCompileUnit_GetLineEntryAtIndex, METH_VARARGS, (char *)"SBCompileUnit_GetLineEntryAtIndex(SBCompileUnit self, uint32_t idx) -> SBLineEntry"},
-	 { "SBCompileUnit_FindLineEntryIndex", _wrap_SBCompileUnit_FindLineEntryIndex, METH_VARARGS, (char *)"\n"
-		"FindLineEntryIndex(uint32_t start_idx, uint32_t line, SBFileSpec inline_file_spec) -> uint32_t\n"
-		"SBCompileUnit_FindLineEntryIndex(SBCompileUnit self, uint32_t start_idx, uint32_t line, SBFileSpec inline_file_spec, bool exact) -> uint32_t\n"
-		""},
-	 { "SBCompileUnit_GetSupportFileAtIndex", _wrap_SBCompileUnit_GetSupportFileAtIndex, METH_VARARGS, (char *)"SBCompileUnit_GetSupportFileAtIndex(SBCompileUnit self, uint32_t idx) -> SBFileSpec"},
-	 { "SBCompileUnit_GetNumSupportFiles", _wrap_SBCompileUnit_GetNumSupportFiles, METH_VARARGS, (char *)"SBCompileUnit_GetNumSupportFiles(SBCompileUnit self) -> uint32_t"},
-	 { "SBCompileUnit_FindSupportFileIndex", _wrap_SBCompileUnit_FindSupportFileIndex, METH_VARARGS, (char *)"SBCompileUnit_FindSupportFileIndex(SBCompileUnit self, uint32_t start_idx, SBFileSpec sb_file, bool full) -> uint32_t"},
-	 { "SBCompileUnit_GetTypes", _wrap_SBCompileUnit_GetTypes, METH_VARARGS, (char *)"\n"
-		"GetTypes(uint32_t type_mask) -> SBTypeList\n"
-		"SBCompileUnit_GetTypes(SBCompileUnit self) -> SBTypeList\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Get all types matching  type_mask from debug info in this\n"
-		"/// compile unit.\n"
-		"///\n"
-		"/// @param[in] type_mask\n"
-		"///    A bitfield that consists of one or more bits logically OR'ed\n"
-		"///    together from the lldb::TypeClass enumeration. This allows\n"
-		"///    you to request only structure types, or only class, struct\n"
-		"///    and union types. Passing in lldb::eTypeClassAny will return\n"
-		"///    all types found in the debug information for this compile\n"
-		"///    unit.\n"
-		"///\n"
-		"/// @return\n"
-		"///    A list of types in this compile unit that match  type_mask\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBCommandReturnObject_GetStatus", _wrap_SBCommandReturnObject_GetStatus, METH_VARARGS, (char *)"SBCommandReturnObject_GetStatus(SBCommandReturnObject self) -> lldb::ReturnStatus"},
 	 { (char *)"SBCommandReturnObject_Succeeded", _wrap_SBCommandReturnObject_Succeeded, METH_VARARGS, (char *)"SBCommandReturnObject_Succeeded(SBCommandReturnObject self) -> bool"},
 	 { (char *)"SBCommandReturnObject_HasResult", _wrap_SBCommandReturnObject_HasResult, METH_VARARGS, (char *)"SBCommandReturnObject_HasResult(SBCommandReturnObject self) -> bool"},
@@ -80553,7 +79765,6 @@ static PyMethodDef SwigMethods[] = {
 		"GetTypes(uint32_t type_mask) -> SBTypeList\n"
 		"SBCompileUnit_GetTypes(SBCompileUnit self) -> SBTypeList\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get all types matching type_mask from debug info in this\n"
 		"compile unit.\n"
@@ -80569,14 +79780,13 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"   A list of types in this compile unit that match type_mask\n"
 		""},
-<<<<<<< HEAD
-	 { "SBCompileUnit_GetLanguage", _wrap_SBCompileUnit_GetLanguage, METH_VARARGS, (char *)"SBCompileUnit_GetLanguage(SBCompileUnit self) -> lldb::LanguageType"},
-	 { "SBCompileUnit_GetDescription", _wrap_SBCompileUnit_GetDescription, METH_VARARGS, (char *)"SBCompileUnit_GetDescription(SBCompileUnit self, SBStream description) -> bool"},
-	 { "SBCompileUnit___eq__", _wrap_SBCompileUnit___eq__, METH_VARARGS, (char *)"SBCompileUnit___eq__(SBCompileUnit self, SBCompileUnit rhs) -> bool"},
-	 { "SBCompileUnit___ne__", _wrap_SBCompileUnit___ne__, METH_VARARGS, (char *)"SBCompileUnit___ne__(SBCompileUnit self, SBCompileUnit rhs) -> bool"},
-	 { "SBCompileUnit___str__", _wrap_SBCompileUnit___str__, METH_VARARGS, (char *)"SBCompileUnit___str__(SBCompileUnit self) -> PyObject *"},
-	 { "SBCompileUnit_swigregister", SBCompileUnit_swigregister, METH_VARARGS, NULL},
-	 { "SBCompletionMatch_GetDisplay", _wrap_SBCompletionMatch_GetDisplay, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBCompileUnit_GetLanguage", _wrap_SBCompileUnit_GetLanguage, METH_VARARGS, (char *)"SBCompileUnit_GetLanguage(SBCompileUnit self) -> lldb::LanguageType"},
+	 { (char *)"SBCompileUnit_GetDescription", _wrap_SBCompileUnit_GetDescription, METH_VARARGS, (char *)"SBCompileUnit_GetDescription(SBCompileUnit self, SBStream description) -> bool"},
+	 { (char *)"SBCompileUnit___eq__", _wrap_SBCompileUnit___eq__, METH_VARARGS, (char *)"SBCompileUnit___eq__(SBCompileUnit self, SBCompileUnit rhs) -> bool"},
+	 { (char *)"SBCompileUnit___ne__", _wrap_SBCompileUnit___ne__, METH_VARARGS, (char *)"SBCompileUnit___ne__(SBCompileUnit self, SBCompileUnit rhs) -> bool"},
+	 { (char *)"SBCompileUnit___str__", _wrap_SBCompileUnit___str__, METH_VARARGS, (char *)"SBCompileUnit___str__(SBCompileUnit self) -> PyObject *"},
+	 { (char *)"SBCompileUnit_swigregister", SBCompileUnit_swigregister, METH_VARARGS, NULL},
+	 { (char *)"SBCompletionMatch_GetDisplay", _wrap_SBCompletionMatch_GetDisplay, METH_VARARGS, (char *)"\n"
 		"SBCompletionMatch_GetDisplay(SBCompletionMatch self) -> char const *\n"
 		"\n"
 		"\n"
@@ -80587,17 +79797,17 @@ static PyMethodDef SwigMethods[] = {
 		"code.\n"
 		"\n"
 		""},
-	 { "SBCompletionMatch_GetInsertable", _wrap_SBCompletionMatch_GetInsertable, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBCompletionMatch_GetInsertable", _wrap_SBCompletionMatch_GetInsertable, METH_VARARGS, (char *)"\n"
 		"SBCompletionMatch_GetInsertable(SBCompletionMatch self) -> char const *\n"
 		"\n"
 		"\n"
 		"Returns a string that can be inserted into the code.\n"
 		"\n"
 		""},
-	 { "new_SBCompletionMatch", _wrap_new_SBCompletionMatch, METH_VARARGS, (char *)"new_SBCompletionMatch() -> SBCompletionMatch"},
-	 { "delete_SBCompletionMatch", _wrap_delete_SBCompletionMatch, METH_VARARGS, (char *)"delete_SBCompletionMatch(SBCompletionMatch self)"},
-	 { "SBCompletionMatch_swigregister", SBCompletionMatch_swigregister, METH_VARARGS, NULL},
-	 { "SBCompletionResponse_GetErrorMessage", _wrap_SBCompletionResponse_GetErrorMessage, METH_VARARGS, (char *)"\n"
+	 { (char *)"new_SBCompletionMatch", _wrap_new_SBCompletionMatch, METH_VARARGS, (char *)"new_SBCompletionMatch() -> SBCompletionMatch"},
+	 { (char *)"delete_SBCompletionMatch", _wrap_delete_SBCompletionMatch, METH_VARARGS, (char *)"delete_SBCompletionMatch(SBCompletionMatch self)"},
+	 { (char *)"SBCompletionMatch_swigregister", SBCompletionMatch_swigregister, METH_VARARGS, NULL},
+	 { (char *)"SBCompletionResponse_GetErrorMessage", _wrap_SBCompletionResponse_GetErrorMessage, METH_VARARGS, (char *)"\n"
 		"SBCompletionResponse_GetErrorMessage(SBCompletionResponse self) -> char const *\n"
 		"\n"
 		"\n"
@@ -80605,7 +79815,7 @@ static PyMethodDef SwigMethods[] = {
 		"completion calculation was a success.\n"
 		"\n"
 		""},
-	 { "SBCompletionResponse_GetPrefix", _wrap_SBCompletionResponse_GetPrefix, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBCompletionResponse_GetPrefix", _wrap_SBCompletionResponse_GetPrefix, METH_VARARGS, (char *)"\n"
 		"SBCompletionResponse_GetPrefix(SBCompletionResponse self) -> char const *\n"
 		"\n"
 		"\n"
@@ -80613,72 +79823,17 @@ static PyMethodDef SwigMethods[] = {
 		"code for which the completion was requested.\n"
 		"\n"
 		""},
-	 { "SBCompletionResponse_GetNumMatches", _wrap_SBCompletionResponse_GetNumMatches, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBCompletionResponse_GetNumMatches", _wrap_SBCompletionResponse_GetNumMatches, METH_VARARGS, (char *)"\n"
 		"SBCompletionResponse_GetNumMatches(SBCompletionResponse self) -> uint32_t\n"
 		"\n"
 		"\n"
 		"Returns the number of matches that this response contains.\n"
 		"\n"
 		""},
-	 { "SBCompletionResponse_GetMatchAtIndex", _wrap_SBCompletionResponse_GetMatchAtIndex, METH_VARARGS, (char *)"SBCompletionResponse_GetMatchAtIndex(SBCompletionResponse self, size_t idx) -> SBCompletionMatch"},
-	 { "new_SBCompletionResponse", _wrap_new_SBCompletionResponse, METH_VARARGS, (char *)"new_SBCompletionResponse() -> SBCompletionResponse"},
-	 { "delete_SBCompletionResponse", _wrap_delete_SBCompletionResponse, METH_VARARGS, (char *)"delete_SBCompletionResponse(SBCompletionResponse self)"},
-	 { "SBCompletionResponse_swigregister", SBCompletionResponse_swigregister, METH_VARARGS, NULL},
-	 { "new_SBData", _wrap_new_SBData, METH_VARARGS, (char *)"\n"
-		"SBData()\n"
-		"new_SBData(SBData rhs) -> SBData\n"
-		""},
-	 { "delete_SBData", _wrap_delete_SBData, METH_VARARGS, (char *)"delete_SBData(SBData self)"},
-	 { "SBData_GetAddressByteSize", _wrap_SBData_GetAddressByteSize, METH_VARARGS, (char *)"SBData_GetAddressByteSize(SBData self) -> uint8_t"},
-	 { "SBData_SetAddressByteSize", _wrap_SBData_SetAddressByteSize, METH_VARARGS, (char *)"SBData_SetAddressByteSize(SBData self, uint8_t addr_byte_size)"},
-	 { "SBData_Clear", _wrap_SBData_Clear, METH_VARARGS, (char *)"SBData_Clear(SBData self)"},
-	 { "SBData_IsValid", _wrap_SBData_IsValid, METH_VARARGS, (char *)"SBData_IsValid(SBData self) -> bool"},
-	 { "SBData___nonzero__", _wrap_SBData___nonzero__, METH_VARARGS, (char *)"SBData___nonzero__(SBData self) -> bool"},
-	 { "SBData_GetByteSize", _wrap_SBData_GetByteSize, METH_VARARGS, (char *)"SBData_GetByteSize(SBData self) -> size_t"},
-	 { "SBData_GetByteOrder", _wrap_SBData_GetByteOrder, METH_VARARGS, (char *)"SBData_GetByteOrder(SBData self) -> lldb::ByteOrder"},
-	 { "SBData_SetByteOrder", _wrap_SBData_SetByteOrder, METH_VARARGS, (char *)"SBData_SetByteOrder(SBData self, lldb::ByteOrder endian)"},
-	 { "SBData_GetFloat", _wrap_SBData_GetFloat, METH_VARARGS, (char *)"SBData_GetFloat(SBData self, SBError error, lldb::offset_t offset) -> float"},
-	 { "SBData_GetDouble", _wrap_SBData_GetDouble, METH_VARARGS, (char *)"SBData_GetDouble(SBData self, SBError error, lldb::offset_t offset) -> double"},
-	 { "SBData_GetLongDouble", _wrap_SBData_GetLongDouble, METH_VARARGS, (char *)"SBData_GetLongDouble(SBData self, SBError error, lldb::offset_t offset) -> long double"},
-	 { "SBData_GetAddress", _wrap_SBData_GetAddress, METH_VARARGS, (char *)"SBData_GetAddress(SBData self, SBError error, lldb::offset_t offset) -> lldb::addr_t"},
-	 { "SBData_GetUnsignedInt8", _wrap_SBData_GetUnsignedInt8, METH_VARARGS, (char *)"SBData_GetUnsignedInt8(SBData self, SBError error, lldb::offset_t offset) -> uint8_t"},
-	 { "SBData_GetUnsignedInt16", _wrap_SBData_GetUnsignedInt16, METH_VARARGS, (char *)"SBData_GetUnsignedInt16(SBData self, SBError error, lldb::offset_t offset) -> uint16_t"},
-	 { "SBData_GetUnsignedInt32", _wrap_SBData_GetUnsignedInt32, METH_VARARGS, (char *)"SBData_GetUnsignedInt32(SBData self, SBError error, lldb::offset_t offset) -> uint32_t"},
-	 { "SBData_GetUnsignedInt64", _wrap_SBData_GetUnsignedInt64, METH_VARARGS, (char *)"SBData_GetUnsignedInt64(SBData self, SBError error, lldb::offset_t offset) -> uint64_t"},
-	 { "SBData_GetSignedInt8", _wrap_SBData_GetSignedInt8, METH_VARARGS, (char *)"SBData_GetSignedInt8(SBData self, SBError error, lldb::offset_t offset) -> int8_t"},
-	 { "SBData_GetSignedInt16", _wrap_SBData_GetSignedInt16, METH_VARARGS, (char *)"SBData_GetSignedInt16(SBData self, SBError error, lldb::offset_t offset) -> int16_t"},
-	 { "SBData_GetSignedInt32", _wrap_SBData_GetSignedInt32, METH_VARARGS, (char *)"SBData_GetSignedInt32(SBData self, SBError error, lldb::offset_t offset) -> int32_t"},
-	 { "SBData_GetSignedInt64", _wrap_SBData_GetSignedInt64, METH_VARARGS, (char *)"SBData_GetSignedInt64(SBData self, SBError error, lldb::offset_t offset) -> int64_t"},
-	 { "SBData_GetString", _wrap_SBData_GetString, METH_VARARGS, (char *)"SBData_GetString(SBData self, SBError error, lldb::offset_t offset) -> char const *"},
-	 { "SBData_GetDescription", _wrap_SBData_GetDescription, METH_VARARGS, (char *)"SBData_GetDescription(SBData self, SBStream description, lldb::addr_t base_addr) -> bool"},
-	 { "SBData_ReadRawData", _wrap_SBData_ReadRawData, METH_VARARGS, (char *)"SBData_ReadRawData(SBData self, SBError error, lldb::offset_t offset, void * buf) -> size_t"},
-	 { "SBData_SetData", _wrap_SBData_SetData, METH_VARARGS, (char *)"SBData_SetData(SBData self, SBError error, void const * buf, lldb::ByteOrder endian, uint8_t addr_size)"},
-	 { "SBData_Append", _wrap_SBData_Append, METH_VARARGS, (char *)"SBData_Append(SBData self, SBData rhs) -> bool"},
-	 { "SBData_CreateDataFromCString", _wrap_SBData_CreateDataFromCString, METH_VARARGS, (char *)"SBData_CreateDataFromCString(lldb::ByteOrder endian, uint32_t addr_byte_size, char const * data) -> SBData"},
-	 { "SBData_CreateDataFromUInt64Array", _wrap_SBData_CreateDataFromUInt64Array, METH_VARARGS, (char *)"SBData_CreateDataFromUInt64Array(lldb::ByteOrder endian, uint32_t addr_byte_size, uint64_t * array) -> SBData"},
-	 { "SBData_CreateDataFromUInt32Array", _wrap_SBData_CreateDataFromUInt32Array, METH_VARARGS, (char *)"SBData_CreateDataFromUInt32Array(lldb::ByteOrder endian, uint32_t addr_byte_size, uint32_t * array) -> SBData"},
-	 { "SBData_CreateDataFromSInt64Array", _wrap_SBData_CreateDataFromSInt64Array, METH_VARARGS, (char *)"SBData_CreateDataFromSInt64Array(lldb::ByteOrder endian, uint32_t addr_byte_size, int64_t * array) -> SBData"},
-	 { "SBData_CreateDataFromSInt32Array", _wrap_SBData_CreateDataFromSInt32Array, METH_VARARGS, (char *)"SBData_CreateDataFromSInt32Array(lldb::ByteOrder endian, uint32_t addr_byte_size, int32_t * array) -> SBData"},
-	 { "SBData_CreateDataFromDoubleArray", _wrap_SBData_CreateDataFromDoubleArray, METH_VARARGS, (char *)"SBData_CreateDataFromDoubleArray(lldb::ByteOrder endian, uint32_t addr_byte_size, double * array) -> SBData"},
-	 { "SBData_SetDataFromCString", _wrap_SBData_SetDataFromCString, METH_VARARGS, (char *)"SBData_SetDataFromCString(SBData self, char const * data) -> bool"},
-	 { "SBData_SetDataFromUInt64Array", _wrap_SBData_SetDataFromUInt64Array, METH_VARARGS, (char *)"SBData_SetDataFromUInt64Array(SBData self, uint64_t * array) -> bool"},
-	 { "SBData_SetDataFromUInt32Array", _wrap_SBData_SetDataFromUInt32Array, METH_VARARGS, (char *)"SBData_SetDataFromUInt32Array(SBData self, uint32_t * array) -> bool"},
-	 { "SBData_SetDataFromSInt64Array", _wrap_SBData_SetDataFromSInt64Array, METH_VARARGS, (char *)"SBData_SetDataFromSInt64Array(SBData self, int64_t * array) -> bool"},
-	 { "SBData_SetDataFromSInt32Array", _wrap_SBData_SetDataFromSInt32Array, METH_VARARGS, (char *)"SBData_SetDataFromSInt32Array(SBData self, int32_t * array) -> bool"},
-	 { "SBData_SetDataFromDoubleArray", _wrap_SBData_SetDataFromDoubleArray, METH_VARARGS, (char *)"SBData_SetDataFromDoubleArray(SBData self, double * array) -> bool"},
-	 { "SBData___str__", _wrap_SBData___str__, METH_VARARGS, (char *)"SBData___str__(SBData self) -> PyObject *"},
-	 { "SBData_swigregister", SBData_swigregister, METH_VARARGS, NULL},
-	 { "SBDebugger_Initialize", _wrap_SBDebugger_Initialize, METH_VARARGS, (char *)"SBDebugger_Initialize()"},
-	 { "SBDebugger_InitializeWithErrorHandling", _wrap_SBDebugger_InitializeWithErrorHandling, METH_VARARGS, (char *)"SBDebugger_InitializeWithErrorHandling() -> SBError"},
-	 { "SBDebugger_Terminate", _wrap_SBDebugger_Terminate, METH_VARARGS, (char *)"SBDebugger_Terminate()"},
-	 { "SBDebugger_Create", _wrap_SBDebugger_Create, METH_VARARGS, (char *)"\n"
-=======
-	 { (char *)"SBCompileUnit_GetLanguage", _wrap_SBCompileUnit_GetLanguage, METH_VARARGS, (char *)"SBCompileUnit_GetLanguage(SBCompileUnit self) -> lldb::LanguageType"},
-	 { (char *)"SBCompileUnit_GetDescription", _wrap_SBCompileUnit_GetDescription, METH_VARARGS, (char *)"SBCompileUnit_GetDescription(SBCompileUnit self, SBStream description) -> bool"},
-	 { (char *)"SBCompileUnit___eq__", _wrap_SBCompileUnit___eq__, METH_VARARGS, (char *)"SBCompileUnit___eq__(SBCompileUnit self, SBCompileUnit rhs) -> bool"},
-	 { (char *)"SBCompileUnit___ne__", _wrap_SBCompileUnit___ne__, METH_VARARGS, (char *)"SBCompileUnit___ne__(SBCompileUnit self, SBCompileUnit rhs) -> bool"},
-	 { (char *)"SBCompileUnit___str__", _wrap_SBCompileUnit___str__, METH_VARARGS, (char *)"SBCompileUnit___str__(SBCompileUnit self) -> PyObject *"},
-	 { (char *)"SBCompileUnit_swigregister", SBCompileUnit_swigregister, METH_VARARGS, NULL},
+	 { (char *)"SBCompletionResponse_GetMatchAtIndex", _wrap_SBCompletionResponse_GetMatchAtIndex, METH_VARARGS, (char *)"SBCompletionResponse_GetMatchAtIndex(SBCompletionResponse self, size_t idx) -> SBCompletionMatch"},
+	 { (char *)"new_SBCompletionResponse", _wrap_new_SBCompletionResponse, METH_VARARGS, (char *)"new_SBCompletionResponse() -> SBCompletionResponse"},
+	 { (char *)"delete_SBCompletionResponse", _wrap_delete_SBCompletionResponse, METH_VARARGS, (char *)"delete_SBCompletionResponse(SBCompletionResponse self)"},
+	 { (char *)"SBCompletionResponse_swigregister", SBCompletionResponse_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBData", _wrap_new_SBData, METH_VARARGS, (char *)"\n"
 		"SBData()\n"
 		"new_SBData(SBData rhs) -> SBData\n"
@@ -80727,39 +79882,16 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBDebugger_InitializeWithErrorHandling", _wrap_SBDebugger_InitializeWithErrorHandling, METH_VARARGS, (char *)"SBDebugger_InitializeWithErrorHandling() -> SBError"},
 	 { (char *)"SBDebugger_Terminate", _wrap_SBDebugger_Terminate, METH_VARARGS, (char *)"SBDebugger_Terminate()"},
 	 { (char *)"SBDebugger_Create", _wrap_SBDebugger_Create, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"Create() -> SBDebugger\n"
 		"Create(bool source_init_files) -> SBDebugger\n"
 		"SBDebugger_Create(bool source_init_files, lldb::LogOutputCallback log_callback) -> SBDebugger\n"
 		""},
-	 { "SBDebugger_Destroy", _wrap_SBDebugger_Destroy, METH_VARARGS, (char *)"SBDebugger_Destroy(SBDebugger debugger)"},
-	 { "SBDebugger_MemoryPressureDetected", _wrap_SBDebugger_MemoryPressureDetected, METH_VARARGS, (char *)"SBDebugger_MemoryPressureDetected()"},
-	 { "new_SBDebugger", _wrap_new_SBDebugger, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBDebugger_Destroy", _wrap_SBDebugger_Destroy, METH_VARARGS, (char *)"SBDebugger_Destroy(SBDebugger debugger)"},
+	 { (char *)"SBDebugger_MemoryPressureDetected", _wrap_SBDebugger_MemoryPressureDetected, METH_VARARGS, (char *)"SBDebugger_MemoryPressureDetected()"},
+	 { (char *)"new_SBDebugger", _wrap_new_SBDebugger, METH_VARARGS, (char *)"\n"
 		"SBDebugger()\n"
 		"new_SBDebugger(SBDebugger rhs) -> SBDebugger\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBDebugger", _wrap_delete_SBDebugger, METH_VARARGS, (char *)"delete_SBDebugger(SBDebugger self)"},
-	 { "SBDebugger_IsValid", _wrap_SBDebugger_IsValid, METH_VARARGS, (char *)"SBDebugger_IsValid(SBDebugger self) -> bool"},
-	 { "SBDebugger___nonzero__", _wrap_SBDebugger___nonzero__, METH_VARARGS, (char *)"SBDebugger___nonzero__(SBDebugger self) -> bool"},
-	 { "SBDebugger_Clear", _wrap_SBDebugger_Clear, METH_VARARGS, (char *)"SBDebugger_Clear(SBDebugger self)"},
-	 { "SBDebugger_SetAsync", _wrap_SBDebugger_SetAsync, METH_VARARGS, (char *)"SBDebugger_SetAsync(SBDebugger self, bool b)"},
-	 { "SBDebugger_GetAsync", _wrap_SBDebugger_GetAsync, METH_VARARGS, (char *)"SBDebugger_GetAsync(SBDebugger self) -> bool"},
-	 { "SBDebugger_SkipLLDBInitFiles", _wrap_SBDebugger_SkipLLDBInitFiles, METH_VARARGS, (char *)"SBDebugger_SkipLLDBInitFiles(SBDebugger self, bool b)"},
-	 { "SBDebugger_SetInputFileHandle", _wrap_SBDebugger_SetInputFileHandle, METH_VARARGS, (char *)"SBDebugger_SetInputFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"},
-	 { "SBDebugger_SetOutputFileHandle", _wrap_SBDebugger_SetOutputFileHandle, METH_VARARGS, (char *)"SBDebugger_SetOutputFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"},
-	 { "SBDebugger_SetErrorFileHandle", _wrap_SBDebugger_SetErrorFileHandle, METH_VARARGS, (char *)"SBDebugger_SetErrorFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"},
-	 { "SBDebugger_GetInputFileHandle", _wrap_SBDebugger_GetInputFileHandle, METH_VARARGS, (char *)"SBDebugger_GetInputFileHandle(SBDebugger self) -> FILE *"},
-	 { "SBDebugger_GetOutputFileHandle", _wrap_SBDebugger_GetOutputFileHandle, METH_VARARGS, (char *)"SBDebugger_GetOutputFileHandle(SBDebugger self) -> FILE *"},
-	 { "SBDebugger_GetErrorFileHandle", _wrap_SBDebugger_GetErrorFileHandle, METH_VARARGS, (char *)"SBDebugger_GetErrorFileHandle(SBDebugger self) -> FILE *"},
-	 { "SBDebugger_GetCommandInterpreter", _wrap_SBDebugger_GetCommandInterpreter, METH_VARARGS, (char *)"SBDebugger_GetCommandInterpreter(SBDebugger self) -> SBCommandInterpreter"},
-	 { "SBDebugger_HandleCommand", _wrap_SBDebugger_HandleCommand, METH_VARARGS, (char *)"SBDebugger_HandleCommand(SBDebugger self, char const * command)"},
-	 { "SBDebugger_GetListener", _wrap_SBDebugger_GetListener, METH_VARARGS, (char *)"SBDebugger_GetListener(SBDebugger self) -> SBListener"},
-	 { "SBDebugger_HandleProcessEvent", _wrap_SBDebugger_HandleProcessEvent, METH_VARARGS, (char *)"SBDebugger_HandleProcessEvent(SBDebugger self, SBProcess process, SBEvent event, FILE * out, FILE * err)"},
-	 { "SBDebugger_CreateTargetWithFileAndTargetTriple", _wrap_SBDebugger_CreateTargetWithFileAndTargetTriple, METH_VARARGS, (char *)"SBDebugger_CreateTargetWithFileAndTargetTriple(SBDebugger self, char const * filename, char const * target_triple) -> SBTarget"},
-	 { "SBDebugger_CreateTargetWithFileAndArch", _wrap_SBDebugger_CreateTargetWithFileAndArch, METH_VARARGS, (char *)"SBDebugger_CreateTargetWithFileAndArch(SBDebugger self, char const * filename, char const * archname) -> SBTarget"},
-	 { "SBDebugger_CreateTarget", _wrap_SBDebugger_CreateTarget, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBDebugger", _wrap_delete_SBDebugger, METH_VARARGS, (char *)"delete_SBDebugger(SBDebugger self)"},
 	 { (char *)"SBDebugger_IsValid", _wrap_SBDebugger_IsValid, METH_VARARGS, (char *)"SBDebugger_IsValid(SBDebugger self) -> bool"},
 	 { (char *)"SBDebugger___nonzero__", _wrap_SBDebugger___nonzero__, METH_VARARGS, (char *)"SBDebugger___nonzero__(SBDebugger self) -> bool"},
@@ -80780,32 +79912,19 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBDebugger_CreateTargetWithFileAndTargetTriple", _wrap_SBDebugger_CreateTargetWithFileAndTargetTriple, METH_VARARGS, (char *)"SBDebugger_CreateTargetWithFileAndTargetTriple(SBDebugger self, char const * filename, char const * target_triple) -> SBTarget"},
 	 { (char *)"SBDebugger_CreateTargetWithFileAndArch", _wrap_SBDebugger_CreateTargetWithFileAndArch, METH_VARARGS, (char *)"SBDebugger_CreateTargetWithFileAndArch(SBDebugger self, char const * filename, char const * archname) -> SBTarget"},
 	 { (char *)"SBDebugger_CreateTarget", _wrap_SBDebugger_CreateTarget, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"CreateTarget(char const * filename, char const * target_triple, char const * platform_name, bool add_dependent_modules, SBError sb_error) -> SBTarget\n"
 		"SBDebugger_CreateTarget(SBDebugger self, char const * filename) -> SBTarget\n"
 		""},
-	 { "SBDebugger_GetDummyTarget", _wrap_SBDebugger_GetDummyTarget, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBDebugger_GetDummyTarget", _wrap_SBDebugger_GetDummyTarget, METH_VARARGS, (char *)"\n"
 		"SBDebugger_GetDummyTarget(SBDebugger self) -> SBTarget\n"
 		"\n"
 		"The dummy target holds breakpoints and breakpoint names that will prime newly created targets.\n"
 		""},
-	 { "SBDebugger_DeleteTarget", _wrap_SBDebugger_DeleteTarget, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBDebugger_DeleteTarget", _wrap_SBDebugger_DeleteTarget, METH_VARARGS, (char *)"\n"
 		"SBDebugger_DeleteTarget(SBDebugger self, SBTarget target) -> bool\n"
 		"\n"
 		"Return true if target is deleted from the target list of the debugger.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBDebugger_GetTargetAtIndex", _wrap_SBDebugger_GetTargetAtIndex, METH_VARARGS, (char *)"SBDebugger_GetTargetAtIndex(SBDebugger self, uint32_t idx) -> SBTarget"},
-	 { "SBDebugger_GetIndexOfTarget", _wrap_SBDebugger_GetIndexOfTarget, METH_VARARGS, (char *)"SBDebugger_GetIndexOfTarget(SBDebugger self, SBTarget target) -> uint32_t"},
-	 { "SBDebugger_FindTargetWithProcessID", _wrap_SBDebugger_FindTargetWithProcessID, METH_VARARGS, (char *)"SBDebugger_FindTargetWithProcessID(SBDebugger self, lldb::pid_t pid) -> SBTarget"},
-	 { "SBDebugger_FindTargetWithFileAndArch", _wrap_SBDebugger_FindTargetWithFileAndArch, METH_VARARGS, (char *)"SBDebugger_FindTargetWithFileAndArch(SBDebugger self, char const * filename, char const * arch) -> SBTarget"},
-	 { "SBDebugger_GetNumTargets", _wrap_SBDebugger_GetNumTargets, METH_VARARGS, (char *)"SBDebugger_GetNumTargets(SBDebugger self) -> uint32_t"},
-	 { "SBDebugger_GetSelectedTarget", _wrap_SBDebugger_GetSelectedTarget, METH_VARARGS, (char *)"SBDebugger_GetSelectedTarget(SBDebugger self) -> SBTarget"},
-	 { "SBDebugger_SetSelectedTarget", _wrap_SBDebugger_SetSelectedTarget, METH_VARARGS, (char *)"SBDebugger_SetSelectedTarget(SBDebugger self, SBTarget target)"},
-	 { "SBDebugger_GetSelectedPlatform", _wrap_SBDebugger_GetSelectedPlatform, METH_VARARGS, (char *)"SBDebugger_GetSelectedPlatform(SBDebugger self) -> SBPlatform"},
-	 { "SBDebugger_SetSelectedPlatform", _wrap_SBDebugger_SetSelectedPlatform, METH_VARARGS, (char *)"SBDebugger_SetSelectedPlatform(SBDebugger self, SBPlatform platform)"},
-	 { "SBDebugger_GetNumPlatforms", _wrap_SBDebugger_GetNumPlatforms, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBDebugger_GetTargetAtIndex", _wrap_SBDebugger_GetTargetAtIndex, METH_VARARGS, (char *)"SBDebugger_GetTargetAtIndex(SBDebugger self, uint32_t idx) -> SBTarget"},
 	 { (char *)"SBDebugger_GetIndexOfTarget", _wrap_SBDebugger_GetIndexOfTarget, METH_VARARGS, (char *)"SBDebugger_GetIndexOfTarget(SBDebugger self, SBTarget target) -> uint32_t"},
 	 { (char *)"SBDebugger_FindTargetWithProcessID", _wrap_SBDebugger_FindTargetWithProcessID, METH_VARARGS, (char *)"SBDebugger_FindTargetWithProcessID(SBDebugger self, lldb::pid_t pid) -> SBTarget"},
@@ -80816,22 +79935,21 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBDebugger_GetSelectedPlatform", _wrap_SBDebugger_GetSelectedPlatform, METH_VARARGS, (char *)"SBDebugger_GetSelectedPlatform(SBDebugger self) -> SBPlatform"},
 	 { (char *)"SBDebugger_SetSelectedPlatform", _wrap_SBDebugger_SetSelectedPlatform, METH_VARARGS, (char *)"SBDebugger_SetSelectedPlatform(SBDebugger self, SBPlatform platform)"},
 	 { (char *)"SBDebugger_GetNumPlatforms", _wrap_SBDebugger_GetNumPlatforms, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBDebugger_GetNumPlatforms(SBDebugger self) -> uint32_t\n"
 		"\n"
 		"Get the number of currently active platforms.\n"
 		""},
-	 { "SBDebugger_GetPlatformAtIndex", _wrap_SBDebugger_GetPlatformAtIndex, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBDebugger_GetPlatformAtIndex", _wrap_SBDebugger_GetPlatformAtIndex, METH_VARARGS, (char *)"\n"
 		"SBDebugger_GetPlatformAtIndex(SBDebugger self, uint32_t idx) -> SBPlatform\n"
 		"\n"
 		"Get one of the currently active platforms.\n"
 		""},
-	 { "SBDebugger_GetNumAvailablePlatforms", _wrap_SBDebugger_GetNumAvailablePlatforms, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBDebugger_GetNumAvailablePlatforms", _wrap_SBDebugger_GetNumAvailablePlatforms, METH_VARARGS, (char *)"\n"
 		"SBDebugger_GetNumAvailablePlatforms(SBDebugger self) -> uint32_t\n"
 		"\n"
 		"Get the number of available platforms.\n"
 		""},
-	 { "SBDebugger_GetAvailablePlatformInfoAtIndex", _wrap_SBDebugger_GetAvailablePlatformInfoAtIndex, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBDebugger_GetAvailablePlatformInfoAtIndex", _wrap_SBDebugger_GetAvailablePlatformInfoAtIndex, METH_VARARGS, (char *)"\n"
 		"SBDebugger_GetAvailablePlatformInfoAtIndex(SBDebugger self, uint32_t idx) -> SBStructuredData\n"
 		"\n"
 		"\n"
@@ -80841,94 +79959,6 @@ static PyMethodDef SwigMethods[] = {
 		"           retrieved, must be less than the value returned by\n"
 		"           GetNumAvailablePlatforms().\n"
 		""},
-<<<<<<< HEAD
-	 { "SBDebugger_GetSourceManager", _wrap_SBDebugger_GetSourceManager, METH_VARARGS, (char *)"SBDebugger_GetSourceManager(SBDebugger self) -> SBSourceManager"},
-	 { "SBDebugger_SetCurrentPlatform", _wrap_SBDebugger_SetCurrentPlatform, METH_VARARGS, (char *)"SBDebugger_SetCurrentPlatform(SBDebugger self, char const * platform_name) -> SBError"},
-	 { "SBDebugger_SetCurrentPlatformSDKRoot", _wrap_SBDebugger_SetCurrentPlatformSDKRoot, METH_VARARGS, (char *)"SBDebugger_SetCurrentPlatformSDKRoot(SBDebugger self, char const * sysroot) -> bool"},
-	 { "SBDebugger_SetUseExternalEditor", _wrap_SBDebugger_SetUseExternalEditor, METH_VARARGS, (char *)"SBDebugger_SetUseExternalEditor(SBDebugger self, bool input) -> bool"},
-	 { "SBDebugger_GetUseExternalEditor", _wrap_SBDebugger_GetUseExternalEditor, METH_VARARGS, (char *)"SBDebugger_GetUseExternalEditor(SBDebugger self) -> bool"},
-	 { "SBDebugger_SetUseColor", _wrap_SBDebugger_SetUseColor, METH_VARARGS, (char *)"SBDebugger_SetUseColor(SBDebugger self, bool use_color) -> bool"},
-	 { "SBDebugger_GetUseColor", _wrap_SBDebugger_GetUseColor, METH_VARARGS, (char *)"SBDebugger_GetUseColor(SBDebugger self) -> bool"},
-	 { "SBDebugger_GetDefaultArchitecture", _wrap_SBDebugger_GetDefaultArchitecture, METH_VARARGS, (char *)"SBDebugger_GetDefaultArchitecture(char * arch_name, size_t arch_name_len) -> bool"},
-	 { "SBDebugger_SetDefaultArchitecture", _wrap_SBDebugger_SetDefaultArchitecture, METH_VARARGS, (char *)"SBDebugger_SetDefaultArchitecture(char const * arch_name) -> bool"},
-	 { "SBDebugger_GetScriptingLanguage", _wrap_SBDebugger_GetScriptingLanguage, METH_VARARGS, (char *)"SBDebugger_GetScriptingLanguage(SBDebugger self, char const * script_language_name) -> lldb::ScriptLanguage"},
-	 { "SBDebugger_GetVersionString", _wrap_SBDebugger_GetVersionString, METH_VARARGS, (char *)"SBDebugger_GetVersionString() -> char const *"},
-	 { "SBDebugger_StateAsCString", _wrap_SBDebugger_StateAsCString, METH_VARARGS, (char *)"SBDebugger_StateAsCString(lldb::StateType state) -> char const *"},
-	 { "SBDebugger_GetBuildConfiguration", _wrap_SBDebugger_GetBuildConfiguration, METH_VARARGS, (char *)"SBDebugger_GetBuildConfiguration() -> SBStructuredData"},
-	 { "SBDebugger_StateIsRunningState", _wrap_SBDebugger_StateIsRunningState, METH_VARARGS, (char *)"SBDebugger_StateIsRunningState(lldb::StateType state) -> bool"},
-	 { "SBDebugger_StateIsStoppedState", _wrap_SBDebugger_StateIsStoppedState, METH_VARARGS, (char *)"SBDebugger_StateIsStoppedState(lldb::StateType state) -> bool"},
-	 { "SBDebugger_EnableLog", _wrap_SBDebugger_EnableLog, METH_VARARGS, (char *)"SBDebugger_EnableLog(SBDebugger self, char const * channel, char const ** types) -> bool"},
-	 { "SBDebugger_SetLoggingCallback", _wrap_SBDebugger_SetLoggingCallback, METH_VARARGS, (char *)"SBDebugger_SetLoggingCallback(SBDebugger self, lldb::LogOutputCallback log_callback)"},
-	 { "SBDebugger_DispatchInput", _wrap_SBDebugger_DispatchInput, METH_VARARGS, (char *)"SBDebugger_DispatchInput(SBDebugger self, void const * data)"},
-	 { "SBDebugger_DispatchInputInterrupt", _wrap_SBDebugger_DispatchInputInterrupt, METH_VARARGS, (char *)"SBDebugger_DispatchInputInterrupt(SBDebugger self)"},
-	 { "SBDebugger_DispatchInputEndOfFile", _wrap_SBDebugger_DispatchInputEndOfFile, METH_VARARGS, (char *)"SBDebugger_DispatchInputEndOfFile(SBDebugger self)"},
-	 { "SBDebugger_GetInstanceName", _wrap_SBDebugger_GetInstanceName, METH_VARARGS, (char *)"SBDebugger_GetInstanceName(SBDebugger self) -> char const *"},
-	 { "SBDebugger_FindDebuggerWithID", _wrap_SBDebugger_FindDebuggerWithID, METH_VARARGS, (char *)"SBDebugger_FindDebuggerWithID(int id) -> SBDebugger"},
-	 { "SBDebugger_SetInternalVariable", _wrap_SBDebugger_SetInternalVariable, METH_VARARGS, (char *)"SBDebugger_SetInternalVariable(char const * var_name, char const * value, char const * debugger_instance_name) -> SBError"},
-	 { "SBDebugger_GetInternalVariableValue", _wrap_SBDebugger_GetInternalVariableValue, METH_VARARGS, (char *)"SBDebugger_GetInternalVariableValue(char const * var_name, char const * debugger_instance_name) -> SBStringList"},
-	 { "SBDebugger_GetDescription", _wrap_SBDebugger_GetDescription, METH_VARARGS, (char *)"SBDebugger_GetDescription(SBDebugger self, SBStream description) -> bool"},
-	 { "SBDebugger_GetTerminalWidth", _wrap_SBDebugger_GetTerminalWidth, METH_VARARGS, (char *)"SBDebugger_GetTerminalWidth(SBDebugger self) -> uint32_t"},
-	 { "SBDebugger_SetTerminalWidth", _wrap_SBDebugger_SetTerminalWidth, METH_VARARGS, (char *)"SBDebugger_SetTerminalWidth(SBDebugger self, uint32_t term_width)"},
-	 { "SBDebugger_GetID", _wrap_SBDebugger_GetID, METH_VARARGS, (char *)"SBDebugger_GetID(SBDebugger self) -> lldb::user_id_t"},
-	 { "SBDebugger_GetPrompt", _wrap_SBDebugger_GetPrompt, METH_VARARGS, (char *)"SBDebugger_GetPrompt(SBDebugger self) -> char const *"},
-	 { "SBDebugger_SetPrompt", _wrap_SBDebugger_SetPrompt, METH_VARARGS, (char *)"SBDebugger_SetPrompt(SBDebugger self, char const * prompt)"},
-	 { "SBDebugger_GetReproducerPath", _wrap_SBDebugger_GetReproducerPath, METH_VARARGS, (char *)"SBDebugger_GetReproducerPath(SBDebugger self) -> char const *"},
-	 { "SBDebugger_GetScriptLanguage", _wrap_SBDebugger_GetScriptLanguage, METH_VARARGS, (char *)"SBDebugger_GetScriptLanguage(SBDebugger self) -> lldb::ScriptLanguage"},
-	 { "SBDebugger_SetScriptLanguage", _wrap_SBDebugger_SetScriptLanguage, METH_VARARGS, (char *)"SBDebugger_SetScriptLanguage(SBDebugger self, lldb::ScriptLanguage script_lang)"},
-	 { "SBDebugger_GetCloseInputOnEOF", _wrap_SBDebugger_GetCloseInputOnEOF, METH_VARARGS, (char *)"SBDebugger_GetCloseInputOnEOF(SBDebugger self) -> bool"},
-	 { "SBDebugger_SetCloseInputOnEOF", _wrap_SBDebugger_SetCloseInputOnEOF, METH_VARARGS, (char *)"SBDebugger_SetCloseInputOnEOF(SBDebugger self, bool b)"},
-	 { "SBDebugger_GetCategory", _wrap_SBDebugger_GetCategory, METH_VARARGS, (char *)"\n"
-		"GetCategory(char const * category_name) -> SBTypeCategory\n"
-		"SBDebugger_GetCategory(SBDebugger self, lldb::LanguageType lang_type) -> SBTypeCategory\n"
-		""},
-	 { "SBDebugger_CreateCategory", _wrap_SBDebugger_CreateCategory, METH_VARARGS, (char *)"SBDebugger_CreateCategory(SBDebugger self, char const * category_name) -> SBTypeCategory"},
-	 { "SBDebugger_DeleteCategory", _wrap_SBDebugger_DeleteCategory, METH_VARARGS, (char *)"SBDebugger_DeleteCategory(SBDebugger self, char const * category_name) -> bool"},
-	 { "SBDebugger_GetNumCategories", _wrap_SBDebugger_GetNumCategories, METH_VARARGS, (char *)"SBDebugger_GetNumCategories(SBDebugger self) -> uint32_t"},
-	 { "SBDebugger_GetCategoryAtIndex", _wrap_SBDebugger_GetCategoryAtIndex, METH_VARARGS, (char *)"SBDebugger_GetCategoryAtIndex(SBDebugger self, uint32_t arg3) -> SBTypeCategory"},
-	 { "SBDebugger_GetDefaultCategory", _wrap_SBDebugger_GetDefaultCategory, METH_VARARGS, (char *)"SBDebugger_GetDefaultCategory(SBDebugger self) -> SBTypeCategory"},
-	 { "SBDebugger_GetFormatForType", _wrap_SBDebugger_GetFormatForType, METH_VARARGS, (char *)"SBDebugger_GetFormatForType(SBDebugger self, SBTypeNameSpecifier arg3) -> SBTypeFormat"},
-	 { "SBDebugger_GetSummaryForType", _wrap_SBDebugger_GetSummaryForType, METH_VARARGS, (char *)"SBDebugger_GetSummaryForType(SBDebugger self, SBTypeNameSpecifier arg3) -> SBTypeSummary"},
-	 { "SBDebugger_GetFilterForType", _wrap_SBDebugger_GetFilterForType, METH_VARARGS, (char *)"SBDebugger_GetFilterForType(SBDebugger self, SBTypeNameSpecifier arg3) -> SBTypeFilter"},
-	 { "SBDebugger_GetSyntheticForType", _wrap_SBDebugger_GetSyntheticForType, METH_VARARGS, (char *)"SBDebugger_GetSyntheticForType(SBDebugger self, SBTypeNameSpecifier arg3) -> SBTypeSynthetic"},
-	 { "SBDebugger_RunCommandInterpreter", _wrap_SBDebugger_RunCommandInterpreter, METH_VARARGS, (char *)"SBDebugger_RunCommandInterpreter(SBDebugger self, bool auto_handle_events, bool spawn_thread, SBCommandInterpreterRunOptions options, int & num_errors, bool & quit_requested, bool & stopped_for_crash)"},
-	 { "SBDebugger_RunREPL", _wrap_SBDebugger_RunREPL, METH_VARARGS, (char *)"SBDebugger_RunREPL(SBDebugger self, lldb::LanguageType language, char const * repl_options) -> SBError"},
-	 { "SBDebugger___str__", _wrap_SBDebugger___str__, METH_VARARGS, (char *)"SBDebugger___str__(SBDebugger self) -> PyObject *"},
-	 { "SBDebugger_swigregister", SBDebugger_swigregister, METH_VARARGS, NULL},
-	 { "new_SBDeclaration", _wrap_new_SBDeclaration, METH_VARARGS, (char *)"\n"
-		"SBDeclaration()\n"
-		"new_SBDeclaration(SBDeclaration rhs) -> SBDeclaration\n"
-		""},
-	 { "delete_SBDeclaration", _wrap_delete_SBDeclaration, METH_VARARGS, (char *)"delete_SBDeclaration(SBDeclaration self)"},
-	 { "SBDeclaration_IsValid", _wrap_SBDeclaration_IsValid, METH_VARARGS, (char *)"SBDeclaration_IsValid(SBDeclaration self) -> bool"},
-	 { "SBDeclaration___nonzero__", _wrap_SBDeclaration___nonzero__, METH_VARARGS, (char *)"SBDeclaration___nonzero__(SBDeclaration self) -> bool"},
-	 { "SBDeclaration_GetFileSpec", _wrap_SBDeclaration_GetFileSpec, METH_VARARGS, (char *)"SBDeclaration_GetFileSpec(SBDeclaration self) -> SBFileSpec"},
-	 { "SBDeclaration_GetLine", _wrap_SBDeclaration_GetLine, METH_VARARGS, (char *)"SBDeclaration_GetLine(SBDeclaration self) -> uint32_t"},
-	 { "SBDeclaration_GetColumn", _wrap_SBDeclaration_GetColumn, METH_VARARGS, (char *)"SBDeclaration_GetColumn(SBDeclaration self) -> uint32_t"},
-	 { "SBDeclaration_GetDescription", _wrap_SBDeclaration_GetDescription, METH_VARARGS, (char *)"SBDeclaration_GetDescription(SBDeclaration self, SBStream description) -> bool"},
-	 { "SBDeclaration_SetFileSpec", _wrap_SBDeclaration_SetFileSpec, METH_VARARGS, (char *)"SBDeclaration_SetFileSpec(SBDeclaration self, SBFileSpec filespec)"},
-	 { "SBDeclaration_SetLine", _wrap_SBDeclaration_SetLine, METH_VARARGS, (char *)"SBDeclaration_SetLine(SBDeclaration self, uint32_t line)"},
-	 { "SBDeclaration_SetColumn", _wrap_SBDeclaration_SetColumn, METH_VARARGS, (char *)"SBDeclaration_SetColumn(SBDeclaration self, uint32_t column)"},
-	 { "SBDeclaration___eq__", _wrap_SBDeclaration___eq__, METH_VARARGS, (char *)"SBDeclaration___eq__(SBDeclaration self, SBDeclaration rhs) -> bool"},
-	 { "SBDeclaration___ne__", _wrap_SBDeclaration___ne__, METH_VARARGS, (char *)"SBDeclaration___ne__(SBDeclaration self, SBDeclaration rhs) -> bool"},
-	 { "SBDeclaration___str__", _wrap_SBDeclaration___str__, METH_VARARGS, (char *)"SBDeclaration___str__(SBDeclaration self) -> PyObject *"},
-	 { "SBDeclaration_swigregister", SBDeclaration_swigregister, METH_VARARGS, NULL},
-	 { "new_SBError", _wrap_new_SBError, METH_VARARGS, (char *)"\n"
-		"SBError()\n"
-		"new_SBError(SBError rhs) -> SBError\n"
-		""},
-	 { "delete_SBError", _wrap_delete_SBError, METH_VARARGS, (char *)"delete_SBError(SBError self)"},
-	 { "SBError_GetCString", _wrap_SBError_GetCString, METH_VARARGS, (char *)"SBError_GetCString(SBError self) -> char const *"},
-	 { "SBError_Clear", _wrap_SBError_Clear, METH_VARARGS, (char *)"SBError_Clear(SBError self)"},
-	 { "SBError_Fail", _wrap_SBError_Fail, METH_VARARGS, (char *)"SBError_Fail(SBError self) -> bool"},
-	 { "SBError_Success", _wrap_SBError_Success, METH_VARARGS, (char *)"SBError_Success(SBError self) -> bool"},
-	 { "SBError_GetError", _wrap_SBError_GetError, METH_VARARGS, (char *)"SBError_GetError(SBError self) -> uint32_t"},
-	 { "SBError_GetType", _wrap_SBError_GetType, METH_VARARGS, (char *)"SBError_GetType(SBError self) -> lldb::ErrorType"},
-	 { "SBError_SetError", _wrap_SBError_SetError, METH_VARARGS, (char *)"SBError_SetError(SBError self, uint32_t err, lldb::ErrorType type)"},
-	 { "SBError_SetErrorToErrno", _wrap_SBError_SetErrorToErrno, METH_VARARGS, (char *)"SBError_SetErrorToErrno(SBError self)"},
-	 { "SBError_SetErrorToGenericError", _wrap_SBError_SetErrorToGenericError, METH_VARARGS, (char *)"SBError_SetErrorToGenericError(SBError self)"},
-	 { "SBError_SetErrorString", _wrap_SBError_SetErrorString, METH_VARARGS, (char *)"SBError_SetErrorString(SBError self, char const * err_str)"},
-	 { "SBError_SetErrorStringWithFormat", _wrap_SBError_SetErrorStringWithFormat, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBDebugger_GetSourceManager", _wrap_SBDebugger_GetSourceManager, METH_VARARGS, (char *)"SBDebugger_GetSourceManager(SBDebugger self) -> SBSourceManager"},
 	 { (char *)"SBDebugger_SetCurrentPlatform", _wrap_SBDebugger_SetCurrentPlatform, METH_VARARGS, (char *)"SBDebugger_SetCurrentPlatform(SBDebugger self, char const * platform_name) -> SBError"},
 	 { (char *)"SBDebugger_SetCurrentPlatformSDKRoot", _wrap_SBDebugger_SetCurrentPlatformSDKRoot, METH_VARARGS, (char *)"SBDebugger_SetCurrentPlatformSDKRoot(SBDebugger self, char const * sysroot) -> bool"},
@@ -81040,46 +80070,21 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBError_SetErrorToGenericError", _wrap_SBError_SetErrorToGenericError, METH_VARARGS, (char *)"SBError_SetErrorToGenericError(SBError self)"},
 	 { (char *)"SBError_SetErrorString", _wrap_SBError_SetErrorString, METH_VARARGS, (char *)"SBError_SetErrorString(SBError self, char const * err_str)"},
 	 { (char *)"SBError_SetErrorStringWithFormat", _wrap_SBError_SetErrorStringWithFormat, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetErrorStringWithFormat(char const * format, char * str1=None, char * str2=None, char * str3=None) -> int\n"
 		"SetErrorStringWithFormat(char const * format, char * str1=None, char * str2=None) -> int\n"
 		"SetErrorStringWithFormat(char const * format, char * str1=None) -> int\n"
 		"SBError_SetErrorStringWithFormat(SBError self, char const * format) -> int\n"
 		""},
-<<<<<<< HEAD
-	 { "SBError_IsValid", _wrap_SBError_IsValid, METH_VARARGS, (char *)"SBError_IsValid(SBError self) -> bool"},
-	 { "SBError___nonzero__", _wrap_SBError___nonzero__, METH_VARARGS, (char *)"SBError___nonzero__(SBError self) -> bool"},
-	 { "SBError_GetDescription", _wrap_SBError_GetDescription, METH_VARARGS, (char *)"SBError_GetDescription(SBError self, SBStream description) -> bool"},
-	 { "SBError___str__", _wrap_SBError___str__, METH_VARARGS, (char *)"SBError___str__(SBError self) -> PyObject *"},
-	 { "SBError_swigregister", SBError_swigregister, METH_VARARGS, NULL},
-	 { "new_SBEvent", _wrap_new_SBEvent, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBError_IsValid", _wrap_SBError_IsValid, METH_VARARGS, (char *)"SBError_IsValid(SBError self) -> bool"},
 	 { (char *)"SBError___nonzero__", _wrap_SBError___nonzero__, METH_VARARGS, (char *)"SBError___nonzero__(SBError self) -> bool"},
 	 { (char *)"SBError_GetDescription", _wrap_SBError_GetDescription, METH_VARARGS, (char *)"SBError_GetDescription(SBError self, SBStream description) -> bool"},
 	 { (char *)"SBError___str__", _wrap_SBError___str__, METH_VARARGS, (char *)"SBError___str__(SBError self) -> PyObject *"},
 	 { (char *)"SBError_swigregister", SBError_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBEvent", _wrap_new_SBEvent, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBEvent()\n"
 		"SBEvent(SBEvent rhs)\n"
 		"__init__(self, int type, str data) -> SBEvent (make an event that contains a C string)\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBEvent", _wrap_delete_SBEvent, METH_VARARGS, (char *)"delete_SBEvent(SBEvent self)"},
-	 { "SBEvent_IsValid", _wrap_SBEvent_IsValid, METH_VARARGS, (char *)"SBEvent_IsValid(SBEvent self) -> bool"},
-	 { "SBEvent___nonzero__", _wrap_SBEvent___nonzero__, METH_VARARGS, (char *)"SBEvent___nonzero__(SBEvent self) -> bool"},
-	 { "SBEvent_GetDataFlavor", _wrap_SBEvent_GetDataFlavor, METH_VARARGS, (char *)"SBEvent_GetDataFlavor(SBEvent self) -> char const *"},
-	 { "SBEvent_GetType", _wrap_SBEvent_GetType, METH_VARARGS, (char *)"SBEvent_GetType(SBEvent self) -> uint32_t"},
-	 { "SBEvent_GetBroadcaster", _wrap_SBEvent_GetBroadcaster, METH_VARARGS, (char *)"SBEvent_GetBroadcaster(SBEvent self) -> SBBroadcaster"},
-	 { "SBEvent_GetBroadcasterClass", _wrap_SBEvent_GetBroadcasterClass, METH_VARARGS, (char *)"SBEvent_GetBroadcasterClass(SBEvent self) -> char const *"},
-	 { "SBEvent_BroadcasterMatchesRef", _wrap_SBEvent_BroadcasterMatchesRef, METH_VARARGS, (char *)"SBEvent_BroadcasterMatchesRef(SBEvent self, SBBroadcaster broadcaster) -> bool"},
-	 { "SBEvent_Clear", _wrap_SBEvent_Clear, METH_VARARGS, (char *)"SBEvent_Clear(SBEvent self)"},
-	 { "SBEvent_GetCStringFromEvent", _wrap_SBEvent_GetCStringFromEvent, METH_VARARGS, (char *)"SBEvent_GetCStringFromEvent(SBEvent event) -> char const *"},
-	 { "SBEvent_GetDescription", _wrap_SBEvent_GetDescription, METH_VARARGS, (char *)"SBEvent_GetDescription(SBEvent self, SBStream description) -> bool"},
-	 { "SBEvent_swigregister", SBEvent_swigregister, METH_VARARGS, NULL},
-	 { "new_SBExecutionContext", _wrap_new_SBExecutionContext, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBEvent", _wrap_delete_SBEvent, METH_VARARGS, (char *)"delete_SBEvent(SBEvent self)"},
 	 { (char *)"SBEvent_IsValid", _wrap_SBEvent_IsValid, METH_VARARGS, (char *)"SBEvent_IsValid(SBEvent self) -> bool"},
 	 { (char *)"SBEvent___nonzero__", _wrap_SBEvent___nonzero__, METH_VARARGS, (char *)"SBEvent___nonzero__(SBEvent self) -> bool"},
@@ -81093,7 +80098,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBEvent_GetDescription", _wrap_SBEvent_GetDescription, METH_VARARGS, (char *)"SBEvent_GetDescription(SBEvent self, SBStream description) -> bool"},
 	 { (char *)"SBEvent_swigregister", SBEvent_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBExecutionContext", _wrap_new_SBExecutionContext, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBExecutionContext()\n"
 		"SBExecutionContext(SBExecutionContext rhs)\n"
 		"SBExecutionContext(SBTarget target)\n"
@@ -81101,51 +80105,31 @@ static PyMethodDef SwigMethods[] = {
 		"SBExecutionContext(SBThread thread)\n"
 		"new_SBExecutionContext(SBFrame frame) -> SBExecutionContext\n"
 		""},
-	 { "delete_SBExecutionContext", _wrap_delete_SBExecutionContext, METH_VARARGS, (char *)"delete_SBExecutionContext(SBExecutionContext self)"},
-	 { "SBExecutionContext_GetTarget", _wrap_SBExecutionContext_GetTarget, METH_VARARGS, (char *)"SBExecutionContext_GetTarget(SBExecutionContext self) -> SBTarget"},
-	 { "SBExecutionContext_GetProcess", _wrap_SBExecutionContext_GetProcess, METH_VARARGS, (char *)"SBExecutionContext_GetProcess(SBExecutionContext self) -> SBProcess"},
-	 { "SBExecutionContext_GetThread", _wrap_SBExecutionContext_GetThread, METH_VARARGS, (char *)"SBExecutionContext_GetThread(SBExecutionContext self) -> SBThread"},
-	 { "SBExecutionContext_GetFrame", _wrap_SBExecutionContext_GetFrame, METH_VARARGS, (char *)"SBExecutionContext_GetFrame(SBExecutionContext self) -> SBFrame"},
-	 { "SBExecutionContext_swigregister", SBExecutionContext_swigregister, METH_VARARGS, NULL},
-	 { "new_SBExpressionOptions", _wrap_new_SBExpressionOptions, METH_VARARGS, (char *)"\n"
+	 { (char *)"delete_SBExecutionContext", _wrap_delete_SBExecutionContext, METH_VARARGS, (char *)"delete_SBExecutionContext(SBExecutionContext self)"},
+	 { (char *)"SBExecutionContext_GetTarget", _wrap_SBExecutionContext_GetTarget, METH_VARARGS, (char *)"SBExecutionContext_GetTarget(SBExecutionContext self) -> SBTarget"},
+	 { (char *)"SBExecutionContext_GetProcess", _wrap_SBExecutionContext_GetProcess, METH_VARARGS, (char *)"SBExecutionContext_GetProcess(SBExecutionContext self) -> SBProcess"},
+	 { (char *)"SBExecutionContext_GetThread", _wrap_SBExecutionContext_GetThread, METH_VARARGS, (char *)"SBExecutionContext_GetThread(SBExecutionContext self) -> SBThread"},
+	 { (char *)"SBExecutionContext_GetFrame", _wrap_SBExecutionContext_GetFrame, METH_VARARGS, (char *)"SBExecutionContext_GetFrame(SBExecutionContext self) -> SBFrame"},
+	 { (char *)"SBExecutionContext_swigregister", SBExecutionContext_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_SBExpressionOptions", _wrap_new_SBExpressionOptions, METH_VARARGS, (char *)"\n"
 		"SBExpressionOptions()\n"
 		"new_SBExpressionOptions(SBExpressionOptions rhs) -> SBExpressionOptions\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBExpressionOptions", _wrap_delete_SBExpressionOptions, METH_VARARGS, (char *)"delete_SBExpressionOptions(SBExpressionOptions self)"},
-	 { "SBExpressionOptions_GetCoerceResultToId", _wrap_SBExpressionOptions_GetCoerceResultToId, METH_VARARGS, (char *)"SBExpressionOptions_GetCoerceResultToId(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetCoerceResultToId", _wrap_SBExpressionOptions_SetCoerceResultToId, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBExpressionOptions", _wrap_delete_SBExpressionOptions, METH_VARARGS, (char *)"delete_SBExpressionOptions(SBExpressionOptions self)"},
 	 { (char *)"SBExpressionOptions_GetCoerceResultToId", _wrap_SBExpressionOptions_GetCoerceResultToId, METH_VARARGS, (char *)"SBExpressionOptions_GetCoerceResultToId(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetCoerceResultToId", _wrap_SBExpressionOptions_SetCoerceResultToId, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetCoerceResultToId(bool coerce=True)\n"
 		"SBExpressionOptions_SetCoerceResultToId(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to coerce the expression result to ObjC id type after evaluation.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetUnwindOnError", _wrap_SBExpressionOptions_GetUnwindOnError, METH_VARARGS, (char *)"SBExpressionOptions_GetUnwindOnError(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetUnwindOnError", _wrap_SBExpressionOptions_SetUnwindOnError, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetUnwindOnError", _wrap_SBExpressionOptions_GetUnwindOnError, METH_VARARGS, (char *)"SBExpressionOptions_GetUnwindOnError(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetUnwindOnError", _wrap_SBExpressionOptions_SetUnwindOnError, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetUnwindOnError(bool unwind=True)\n"
 		"SBExpressionOptions_SetUnwindOnError(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to unwind the expression stack on error.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetIgnoreBreakpoints", _wrap_SBExpressionOptions_GetIgnoreBreakpoints, METH_VARARGS, (char *)"SBExpressionOptions_GetIgnoreBreakpoints(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetIgnoreBreakpoints", _wrap_SBExpressionOptions_SetIgnoreBreakpoints, METH_VARARGS, (char *)"\n"
-		"SetIgnoreBreakpoints(bool ignore=True)\n"
-		"SBExpressionOptions_SetIgnoreBreakpoints(SBExpressionOptions self)\n"
-		""},
-	 { "SBExpressionOptions_GetFetchDynamicValue", _wrap_SBExpressionOptions_GetFetchDynamicValue, METH_VARARGS, (char *)"SBExpressionOptions_GetFetchDynamicValue(SBExpressionOptions self) -> lldb::DynamicValueType"},
-	 { "SBExpressionOptions_SetFetchDynamicValue", _wrap_SBExpressionOptions_SetFetchDynamicValue, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetIgnoreBreakpoints", _wrap_SBExpressionOptions_GetIgnoreBreakpoints, METH_VARARGS, (char *)"SBExpressionOptions_GetIgnoreBreakpoints(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetIgnoreBreakpoints", _wrap_SBExpressionOptions_SetIgnoreBreakpoints, METH_VARARGS, (char *)"\n"
 		"SetIgnoreBreakpoints(bool ignore=True)\n"
@@ -81153,33 +80137,18 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { (char *)"SBExpressionOptions_GetFetchDynamicValue", _wrap_SBExpressionOptions_GetFetchDynamicValue, METH_VARARGS, (char *)"SBExpressionOptions_GetFetchDynamicValue(SBExpressionOptions self) -> lldb::DynamicValueType"},
 	 { (char *)"SBExpressionOptions_SetFetchDynamicValue", _wrap_SBExpressionOptions_SetFetchDynamicValue, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetFetchDynamicValue(lldb::DynamicValueType dynamic)\n"
 		"SBExpressionOptions_SetFetchDynamicValue(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to cast the expression result to its dynamic type.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetTimeoutInMicroSeconds", _wrap_SBExpressionOptions_GetTimeoutInMicroSeconds, METH_VARARGS, (char *)"SBExpressionOptions_GetTimeoutInMicroSeconds(SBExpressionOptions self) -> uint32_t"},
-	 { "SBExpressionOptions_SetTimeoutInMicroSeconds", _wrap_SBExpressionOptions_SetTimeoutInMicroSeconds, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetTimeoutInMicroSeconds", _wrap_SBExpressionOptions_GetTimeoutInMicroSeconds, METH_VARARGS, (char *)"SBExpressionOptions_GetTimeoutInMicroSeconds(SBExpressionOptions self) -> uint32_t"},
 	 { (char *)"SBExpressionOptions_SetTimeoutInMicroSeconds", _wrap_SBExpressionOptions_SetTimeoutInMicroSeconds, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetTimeoutInMicroSeconds(uint32_t timeout=0)\n"
 		"SBExpressionOptions_SetTimeoutInMicroSeconds(SBExpressionOptions self)\n"
 		"\n"
 		"Sets the timeout in microseconds to run the expression for. If try all threads is set to true and the expression doesn't complete within the specified timeout, all threads will be resumed for the same timeout to see if the expresson will finish.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetOneThreadTimeoutInMicroSeconds", _wrap_SBExpressionOptions_GetOneThreadTimeoutInMicroSeconds, METH_VARARGS, (char *)"SBExpressionOptions_GetOneThreadTimeoutInMicroSeconds(SBExpressionOptions self) -> uint32_t"},
-	 { "SBExpressionOptions_SetOneThreadTimeoutInMicroSeconds", _wrap_SBExpressionOptions_SetOneThreadTimeoutInMicroSeconds, METH_VARARGS, (char *)"\n"
-		"SetOneThreadTimeoutInMicroSeconds(uint32_t timeout=0)\n"
-		"SBExpressionOptions_SetOneThreadTimeoutInMicroSeconds(SBExpressionOptions self)\n"
-		""},
-	 { "SBExpressionOptions_GetTryAllThreads", _wrap_SBExpressionOptions_GetTryAllThreads, METH_VARARGS, (char *)"SBExpressionOptions_GetTryAllThreads(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetTryAllThreads", _wrap_SBExpressionOptions_SetTryAllThreads, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetOneThreadTimeoutInMicroSeconds", _wrap_SBExpressionOptions_GetOneThreadTimeoutInMicroSeconds, METH_VARARGS, (char *)"SBExpressionOptions_GetOneThreadTimeoutInMicroSeconds(SBExpressionOptions self) -> uint32_t"},
 	 { (char *)"SBExpressionOptions_SetOneThreadTimeoutInMicroSeconds", _wrap_SBExpressionOptions_SetOneThreadTimeoutInMicroSeconds, METH_VARARGS, (char *)"\n"
 		"SetOneThreadTimeoutInMicroSeconds(uint32_t timeout=0)\n"
@@ -81187,35 +80156,11 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { (char *)"SBExpressionOptions_GetTryAllThreads", _wrap_SBExpressionOptions_GetTryAllThreads, METH_VARARGS, (char *)"SBExpressionOptions_GetTryAllThreads(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetTryAllThreads", _wrap_SBExpressionOptions_SetTryAllThreads, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetTryAllThreads(bool run_others=True)\n"
 		"SBExpressionOptions_SetTryAllThreads(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to run all threads if the expression does not complete on one thread.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetStopOthers", _wrap_SBExpressionOptions_GetStopOthers, METH_VARARGS, (char *)"SBExpressionOptions_GetStopOthers(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetStopOthers", _wrap_SBExpressionOptions_SetStopOthers, METH_VARARGS, (char *)"\n"
-		"SetStopOthers(bool stop_others=True)\n"
-		"SBExpressionOptions_SetStopOthers(SBExpressionOptions self)\n"
-		""},
-	 { "SBExpressionOptions_GetTrapExceptions", _wrap_SBExpressionOptions_GetTrapExceptions, METH_VARARGS, (char *)"SBExpressionOptions_GetTrapExceptions(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetTrapExceptions", _wrap_SBExpressionOptions_SetTrapExceptions, METH_VARARGS, (char *)"\n"
-		"SetTrapExceptions(bool trap_exceptions=True)\n"
-		"SBExpressionOptions_SetTrapExceptions(SBExpressionOptions self)\n"
-		""},
-	 { "SBExpressionOptions_GetPlaygroundTransformEnabled", _wrap_SBExpressionOptions_GetPlaygroundTransformEnabled, METH_VARARGS, (char *)"SBExpressionOptions_GetPlaygroundTransformEnabled(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetPlaygroundTransformEnabled", _wrap_SBExpressionOptions_SetPlaygroundTransformEnabled, METH_VARARGS, (char *)"\n"
-		"SetPlaygroundTransformEnabled(bool enable_playground_transform=True)\n"
-		"SBExpressionOptions_SetPlaygroundTransformEnabled(SBExpressionOptions self)\n"
-		""},
-	 { "SBExpressionOptions_GetREPLMode", _wrap_SBExpressionOptions_GetREPLMode, METH_VARARGS, (char *)"SBExpressionOptions_GetREPLMode(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetREPLMode", _wrap_SBExpressionOptions_SetREPLMode, METH_VARARGS, (char *)"\n"
-		"SetREPLMode(bool enable_repl=True)\n"
-		"SBExpressionOptions_SetREPLMode(SBExpressionOptions self)\n"
-		""},
-	 { "SBExpressionOptions_SetLanguage", _wrap_SBExpressionOptions_SetLanguage, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetStopOthers", _wrap_SBExpressionOptions_GetStopOthers, METH_VARARGS, (char *)"SBExpressionOptions_GetStopOthers(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetStopOthers", _wrap_SBExpressionOptions_SetStopOthers, METH_VARARGS, (char *)"\n"
 		"SetStopOthers(bool stop_others=True)\n"
@@ -81237,135 +80182,67 @@ static PyMethodDef SwigMethods[] = {
 		"SBExpressionOptions_SetREPLMode(SBExpressionOptions self)\n"
 		""},
 	 { (char *)"SBExpressionOptions_SetLanguage", _wrap_SBExpressionOptions_SetLanguage, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBExpressionOptions_SetLanguage(SBExpressionOptions self, lldb::LanguageType language)\n"
 		"\n"
 		"Sets the language that LLDB should assume the expression is written in\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetGenerateDebugInfo", _wrap_SBExpressionOptions_GetGenerateDebugInfo, METH_VARARGS, (char *)"SBExpressionOptions_GetGenerateDebugInfo(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetGenerateDebugInfo", _wrap_SBExpressionOptions_SetGenerateDebugInfo, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetGenerateDebugInfo", _wrap_SBExpressionOptions_GetGenerateDebugInfo, METH_VARARGS, (char *)"SBExpressionOptions_GetGenerateDebugInfo(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetGenerateDebugInfo", _wrap_SBExpressionOptions_SetGenerateDebugInfo, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetGenerateDebugInfo(bool b=True)\n"
 		"SBExpressionOptions_SetGenerateDebugInfo(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to generate debug information for the expression and also controls if a SBModule is generated.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetSuppressPersistentResult", _wrap_SBExpressionOptions_GetSuppressPersistentResult, METH_VARARGS, (char *)"SBExpressionOptions_GetSuppressPersistentResult(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetSuppressPersistentResult", _wrap_SBExpressionOptions_SetSuppressPersistentResult, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetSuppressPersistentResult", _wrap_SBExpressionOptions_GetSuppressPersistentResult, METH_VARARGS, (char *)"SBExpressionOptions_GetSuppressPersistentResult(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetSuppressPersistentResult", _wrap_SBExpressionOptions_SetSuppressPersistentResult, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetSuppressPersistentResult(bool b=False)\n"
 		"SBExpressionOptions_SetSuppressPersistentResult(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to produce a persistent result that can be used in future expressions.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetPrefix", _wrap_SBExpressionOptions_GetPrefix, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetPrefix", _wrap_SBExpressionOptions_GetPrefix, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBExpressionOptions_GetPrefix(SBExpressionOptions self) -> char const *\n"
 		"\n"
 		"Gets the prefix to use for this expression.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_SetPrefix", _wrap_SBExpressionOptions_SetPrefix, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_SetPrefix", _wrap_SBExpressionOptions_SetPrefix, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBExpressionOptions_SetPrefix(SBExpressionOptions self, char const * prefix)\n"
 		"\n"
 		"Sets the prefix to use for this expression. This prefix gets inserted after the 'target.expr-prefix' prefix contents, but before the wrapped expression function body.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_SetAutoApplyFixIts", _wrap_SBExpressionOptions_SetAutoApplyFixIts, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_SetAutoApplyFixIts", _wrap_SBExpressionOptions_SetAutoApplyFixIts, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetAutoApplyFixIts(bool b=True)\n"
 		"SBExpressionOptions_SetAutoApplyFixIts(SBExpressionOptions self)\n"
 		"\n"
 		"Sets whether to auto-apply fix-it hints to the expression being evaluated.\n"
 		""},
-	 { "SBExpressionOptions_GetAutoApplyFixIts", _wrap_SBExpressionOptions_GetAutoApplyFixIts, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBExpressionOptions_GetAutoApplyFixIts", _wrap_SBExpressionOptions_GetAutoApplyFixIts, METH_VARARGS, (char *)"\n"
 		"SBExpressionOptions_GetAutoApplyFixIts(SBExpressionOptions self) -> bool\n"
 		"\n"
 		"Gets whether to auto-apply fix-it hints to an expression.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBExpressionOptions_GetTopLevel", _wrap_SBExpressionOptions_GetTopLevel, METH_VARARGS, (char *)"SBExpressionOptions_GetTopLevel(SBExpressionOptions self) -> bool"},
-	 { "SBExpressionOptions_SetTopLevel", _wrap_SBExpressionOptions_SetTopLevel, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBExpressionOptions_GetTopLevel", _wrap_SBExpressionOptions_GetTopLevel, METH_VARARGS, (char *)"SBExpressionOptions_GetTopLevel(SBExpressionOptions self) -> bool"},
 	 { (char *)"SBExpressionOptions_SetTopLevel", _wrap_SBExpressionOptions_SetTopLevel, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetTopLevel(bool b=True)\n"
 		"SBExpressionOptions_SetTopLevel(SBExpressionOptions self)\n"
 		""},
-	 { "SBExpressionOptions_GetAllowJIT", _wrap_SBExpressionOptions_GetAllowJIT, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBExpressionOptions_GetAllowJIT", _wrap_SBExpressionOptions_GetAllowJIT, METH_VARARGS, (char *)"\n"
 		"SBExpressionOptions_GetAllowJIT(SBExpressionOptions self) -> bool\n"
 		"\n"
 		"Gets whether to JIT an expression if it cannot be interpreted.\n"
 		""},
-	 { "SBExpressionOptions_SetAllowJIT", _wrap_SBExpressionOptions_SetAllowJIT, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBExpressionOptions_SetAllowJIT", _wrap_SBExpressionOptions_SetAllowJIT, METH_VARARGS, (char *)"\n"
 		"SBExpressionOptions_SetAllowJIT(SBExpressionOptions self, bool allow)\n"
 		"\n"
 		"Sets whether to JIT an expression if it cannot be interpreted.\n"
 		""},
-	 { "SBExpressionOptions_swigregister", SBExpressionOptions_swigregister, METH_VARARGS, NULL},
-	 { "new_SBFileSpec", _wrap_new_SBFileSpec, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBExpressionOptions_swigregister", SBExpressionOptions_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_SBFileSpec", _wrap_new_SBFileSpec, METH_VARARGS, (char *)"\n"
 		"SBFileSpec()\n"
 		"SBFileSpec(SBFileSpec rhs)\n"
 		"SBFileSpec(char const * path)\n"
 		"new_SBFileSpec(char const * path, bool resolve) -> SBFileSpec\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBFileSpec", _wrap_delete_SBFileSpec, METH_VARARGS, (char *)"delete_SBFileSpec(SBFileSpec self)"},
-	 { "SBFileSpec_IsValid", _wrap_SBFileSpec_IsValid, METH_VARARGS, (char *)"SBFileSpec_IsValid(SBFileSpec self) -> bool"},
-	 { "SBFileSpec___nonzero__", _wrap_SBFileSpec___nonzero__, METH_VARARGS, (char *)"SBFileSpec___nonzero__(SBFileSpec self) -> bool"},
-	 { "SBFileSpec_Exists", _wrap_SBFileSpec_Exists, METH_VARARGS, (char *)"SBFileSpec_Exists(SBFileSpec self) -> bool"},
-	 { "SBFileSpec_ResolveExecutableLocation", _wrap_SBFileSpec_ResolveExecutableLocation, METH_VARARGS, (char *)"SBFileSpec_ResolveExecutableLocation(SBFileSpec self) -> bool"},
-	 { "SBFileSpec_GetFilename", _wrap_SBFileSpec_GetFilename, METH_VARARGS, (char *)"SBFileSpec_GetFilename(SBFileSpec self) -> char const *"},
-	 { "SBFileSpec_GetDirectory", _wrap_SBFileSpec_GetDirectory, METH_VARARGS, (char *)"SBFileSpec_GetDirectory(SBFileSpec self) -> char const *"},
-	 { "SBFileSpec_SetFilename", _wrap_SBFileSpec_SetFilename, METH_VARARGS, (char *)"SBFileSpec_SetFilename(SBFileSpec self, char const * filename)"},
-	 { "SBFileSpec_SetDirectory", _wrap_SBFileSpec_SetDirectory, METH_VARARGS, (char *)"SBFileSpec_SetDirectory(SBFileSpec self, char const * directory)"},
-	 { "SBFileSpec_GetPath", _wrap_SBFileSpec_GetPath, METH_VARARGS, (char *)"SBFileSpec_GetPath(SBFileSpec self, char * dst_path, size_t dst_len) -> uint32_t"},
-	 { "SBFileSpec_ResolvePath", _wrap_SBFileSpec_ResolvePath, METH_VARARGS, (char *)"SBFileSpec_ResolvePath(char const * src_path, char * dst_path, size_t dst_len) -> int"},
-	 { "SBFileSpec_GetDescription", _wrap_SBFileSpec_GetDescription, METH_VARARGS, (char *)"SBFileSpec_GetDescription(SBFileSpec self, SBStream description) -> bool"},
-	 { "SBFileSpec_AppendPathComponent", _wrap_SBFileSpec_AppendPathComponent, METH_VARARGS, (char *)"SBFileSpec_AppendPathComponent(SBFileSpec self, char const * file_or_directory)"},
-	 { "SBFileSpec___str__", _wrap_SBFileSpec___str__, METH_VARARGS, (char *)"SBFileSpec___str__(SBFileSpec self) -> PyObject *"},
-	 { "SBFileSpec_swigregister", SBFileSpec_swigregister, METH_VARARGS, NULL},
-	 { "new_SBFileSpecList", _wrap_new_SBFileSpecList, METH_VARARGS, (char *)"\n"
-		"SBFileSpecList()\n"
-		"new_SBFileSpecList(SBFileSpecList rhs) -> SBFileSpecList\n"
-		""},
-	 { "delete_SBFileSpecList", _wrap_delete_SBFileSpecList, METH_VARARGS, (char *)"delete_SBFileSpecList(SBFileSpecList self)"},
-	 { "SBFileSpecList_GetSize", _wrap_SBFileSpecList_GetSize, METH_VARARGS, (char *)"SBFileSpecList_GetSize(SBFileSpecList self) -> uint32_t"},
-	 { "SBFileSpecList_GetDescription", _wrap_SBFileSpecList_GetDescription, METH_VARARGS, (char *)"SBFileSpecList_GetDescription(SBFileSpecList self, SBStream description) -> bool"},
-	 { "SBFileSpecList_Append", _wrap_SBFileSpecList_Append, METH_VARARGS, (char *)"SBFileSpecList_Append(SBFileSpecList self, SBFileSpec sb_file)"},
-	 { "SBFileSpecList_AppendIfUnique", _wrap_SBFileSpecList_AppendIfUnique, METH_VARARGS, (char *)"SBFileSpecList_AppendIfUnique(SBFileSpecList self, SBFileSpec sb_file) -> bool"},
-	 { "SBFileSpecList_Clear", _wrap_SBFileSpecList_Clear, METH_VARARGS, (char *)"SBFileSpecList_Clear(SBFileSpecList self)"},
-	 { "SBFileSpecList_FindFileIndex", _wrap_SBFileSpecList_FindFileIndex, METH_VARARGS, (char *)"SBFileSpecList_FindFileIndex(SBFileSpecList self, uint32_t idx, SBFileSpec sb_file, bool full) -> uint32_t"},
-	 { "SBFileSpecList_GetFileSpecAtIndex", _wrap_SBFileSpecList_GetFileSpecAtIndex, METH_VARARGS, (char *)"SBFileSpecList_GetFileSpecAtIndex(SBFileSpecList self, uint32_t idx) -> SBFileSpec"},
-	 { "SBFileSpecList_swigregister", SBFileSpecList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBFrame", _wrap_new_SBFrame, METH_VARARGS, (char *)"\n"
-		"SBFrame()\n"
-		"new_SBFrame(SBFrame rhs) -> SBFrame\n"
-		""},
-	 { "delete_SBFrame", _wrap_delete_SBFrame, METH_VARARGS, (char *)"delete_SBFrame(SBFrame self)"},
-	 { "SBFrame_IsEqual", _wrap_SBFrame_IsEqual, METH_VARARGS, (char *)"SBFrame_IsEqual(SBFrame self, SBFrame rhs) -> bool"},
-	 { "SBFrame_IsValid", _wrap_SBFrame_IsValid, METH_VARARGS, (char *)"SBFrame_IsValid(SBFrame self) -> bool"},
-	 { "SBFrame___nonzero__", _wrap_SBFrame___nonzero__, METH_VARARGS, (char *)"SBFrame___nonzero__(SBFrame self) -> bool"},
-	 { "SBFrame_GetFrameID", _wrap_SBFrame_GetFrameID, METH_VARARGS, (char *)"SBFrame_GetFrameID(SBFrame self) -> uint32_t"},
-	 { "SBFrame_GetCFA", _wrap_SBFrame_GetCFA, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBFileSpec", _wrap_delete_SBFileSpec, METH_VARARGS, (char *)"delete_SBFileSpec(SBFileSpec self)"},
 	 { (char *)"SBFileSpec___eq__", _wrap_SBFileSpec___eq__, METH_VARARGS, (char *)"SBFileSpec___eq__(SBFileSpec self, SBFileSpec rhs) -> bool"},
 	 { (char *)"SBFileSpec___ne__", _wrap_SBFileSpec___ne__, METH_VARARGS, (char *)"SBFileSpec___ne__(SBFileSpec self, SBFileSpec rhs) -> bool"},
@@ -81406,7 +80283,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBFrame___nonzero__", _wrap_SBFrame___nonzero__, METH_VARARGS, (char *)"SBFrame___nonzero__(SBFrame self) -> bool"},
 	 { (char *)"SBFrame_GetFrameID", _wrap_SBFrame_GetFrameID, METH_VARARGS, (char *)"SBFrame_GetFrameID(SBFrame self) -> uint32_t"},
 	 { (char *)"SBFrame_GetCFA", _wrap_SBFrame_GetCFA, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBFrame_GetCFA(SBFrame self) -> lldb::addr_t\n"
 		"\n"
 		"\n"
@@ -81416,25 +80292,6 @@ static PyMethodDef SwigMethods[] = {
 		"Returns an lldb::addr_t stack address, or LLDB_INVALID_ADDRESS if\n"
 		"the CFA cannot be determined.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_GetPC", _wrap_SBFrame_GetPC, METH_VARARGS, (char *)"SBFrame_GetPC(SBFrame self) -> lldb::addr_t"},
-	 { "SBFrame_SetPC", _wrap_SBFrame_SetPC, METH_VARARGS, (char *)"SBFrame_SetPC(SBFrame self, lldb::addr_t new_pc) -> bool"},
-	 { "SBFrame_GetSP", _wrap_SBFrame_GetSP, METH_VARARGS, (char *)"SBFrame_GetSP(SBFrame self) -> lldb::addr_t"},
-	 { "SBFrame_GetFP", _wrap_SBFrame_GetFP, METH_VARARGS, (char *)"SBFrame_GetFP(SBFrame self) -> lldb::addr_t"},
-	 { "SBFrame_GetPCAddress", _wrap_SBFrame_GetPCAddress, METH_VARARGS, (char *)"SBFrame_GetPCAddress(SBFrame self) -> SBAddress"},
-	 { "SBFrame_GetSymbolContext", _wrap_SBFrame_GetSymbolContext, METH_VARARGS, (char *)"SBFrame_GetSymbolContext(SBFrame self, uint32_t resolve_scope) -> SBSymbolContext"},
-	 { "SBFrame_GetModule", _wrap_SBFrame_GetModule, METH_VARARGS, (char *)"SBFrame_GetModule(SBFrame self) -> SBModule"},
-	 { "SBFrame_GetCompileUnit", _wrap_SBFrame_GetCompileUnit, METH_VARARGS, (char *)"SBFrame_GetCompileUnit(SBFrame self) -> SBCompileUnit"},
-	 { "SBFrame_GetFunction", _wrap_SBFrame_GetFunction, METH_VARARGS, (char *)"SBFrame_GetFunction(SBFrame self) -> SBFunction"},
-	 { "SBFrame_GetSymbol", _wrap_SBFrame_GetSymbol, METH_VARARGS, (char *)"SBFrame_GetSymbol(SBFrame self) -> SBSymbol"},
-	 { "SBFrame_GetBlock", _wrap_SBFrame_GetBlock, METH_VARARGS, (char *)"\n"
-		"SBFrame_GetBlock(SBFrame self) -> SBBlock\n"
-		"\n"
-		"\n"
-		"/// Gets the deepest block that contains the frame PC.\n"
-		"///\n"
-		"/// See also GetFrameBlock().\n"
-=======
 	 { (char *)"SBFrame_GetPC", _wrap_SBFrame_GetPC, METH_VARARGS, (char *)"SBFrame_GetPC(SBFrame self) -> lldb::addr_t"},
 	 { (char *)"SBFrame_SetPC", _wrap_SBFrame_SetPC, METH_VARARGS, (char *)"SBFrame_SetPC(SBFrame self, lldb::addr_t new_pc) -> bool"},
 	 { (char *)"SBFrame_GetSP", _wrap_SBFrame_GetSP, METH_VARARGS, (char *)"SBFrame_GetSP(SBFrame self) -> lldb::addr_t"},
@@ -81448,19 +80305,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBFrame_GetBlock", _wrap_SBFrame_GetBlock, METH_VARARGS, (char *)"\n"
 		"SBFrame_GetBlock(SBFrame self) -> SBBlock\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Gets the deepest block that contains the frame PC.\n"
 		"\n"
 		"See also GetFrameBlock().\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_GetDisplayFunctionName", _wrap_SBFrame_GetDisplayFunctionName, METH_VARARGS, (char *)"SBFrame_GetDisplayFunctionName(SBFrame self) -> char const *"},
-	 { "SBFrame_GetFunctionName", _wrap_SBFrame_GetFunctionName, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBFrame_GetDisplayFunctionName", _wrap_SBFrame_GetDisplayFunctionName, METH_VARARGS, (char *)"SBFrame_GetDisplayFunctionName(SBFrame self) -> char const *"},
 	 { (char *)"SBFrame_GetFunctionName", _wrap_SBFrame_GetFunctionName, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"GetFunctionName() -> char const\n"
 		"SBFrame_GetFunctionName(SBFrame self) -> char const *\n"
 		"\n"
@@ -81479,90 +80330,46 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"See also IsInlined().\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_GuessLanguage", _wrap_SBFrame_GuessLanguage, METH_VARARGS, (char *)"\n"
-		"SBFrame_GuessLanguage(SBFrame self) -> lldb::LanguageType\n"
-		"\n"
-=======
 	 { (char *)"SBFrame_GuessLanguage", _wrap_SBFrame_GuessLanguage, METH_VARARGS, (char *)"\n"
 		"SBFrame_GuessLanguage(SBFrame self) -> lldb::LanguageType\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Returns the language of the frame's SBFunction, or if there.\n"
 		"is no SBFunction, guess the language from the mangled name.\n"
 		".\n"
 		""},
-	 { "SBFrame_IsSwiftThunk", _wrap_SBFrame_IsSwiftThunk, METH_VARARGS, (char *)"SBFrame_IsSwiftThunk(SBFrame self) -> bool"},
-	 { "SBFrame_IsInlined", _wrap_SBFrame_IsInlined, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBFrame_IsSwiftThunk", _wrap_SBFrame_IsSwiftThunk, METH_VARARGS, (char *)"SBFrame_IsSwiftThunk(SBFrame self) -> bool"},
+	 { (char *)"SBFrame_IsInlined", _wrap_SBFrame_IsInlined, METH_VARARGS, (char *)"\n"
 		"IsInlined() -> bool\n"
 		"SBFrame_IsInlined(SBFrame self) -> bool\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"/// Return true if this frame represents an inlined function.\n"
-		"///\n"
-		"/// See also GetFunctionName().\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return true if this frame represents an inlined function.\n"
 		"\n"
 		"See also GetFunctionName().\n"
 		""},
-	 { "SBFrame_IsArtificial", _wrap_SBFrame_IsArtificial, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBFrame_IsArtificial", _wrap_SBFrame_IsArtificial, METH_VARARGS, (char *)"\n"
 		"IsArtificial() -> bool\n"
 		"SBFrame_IsArtificial(SBFrame self) -> bool\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"/// Return true if this frame is artificial (e.g a frame synthesized to\n"
-		"/// capture a tail call). Local variables may not be available in an artificial\n"
-		"/// frame.\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return true if this frame is artificial (e.g a frame synthesized to\n"
 		"capture a tail call). Local variables may not be available in an artificial\n"
 		"frame.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_EvaluateExpression", _wrap_SBFrame_EvaluateExpression, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBFrame_EvaluateExpression", _wrap_SBFrame_EvaluateExpression, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"EvaluateExpression(char const * expr) -> SBValue\n"
 		"EvaluateExpression(char const * expr, lldb::DynamicValueType use_dynamic) -> SBValue\n"
 		"EvaluateExpression(char const * expr, lldb::DynamicValueType use_dynamic, bool unwind_on_error) -> SBValue\n"
 		"SBFrame_EvaluateExpression(SBFrame self, char const * expr, SBExpressionOptions options) -> SBValue\n"
-<<<<<<< HEAD
-		"\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"The version that doesn't supply a 'use_dynamic' value will use the\n"
 		"target's default.\n"
 		""},
-	 { "SBFrame_GetFrameBlock", _wrap_SBFrame_GetFrameBlock, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBFrame_GetFrameBlock", _wrap_SBFrame_GetFrameBlock, METH_VARARGS, (char *)"\n"
 		"SBFrame_GetFrameBlock(SBFrame self) -> SBBlock\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"/// Gets the lexical block that defines the stack frame. Another way to think\n"
-		"/// of this is it will return the block that contains all of the variables\n"
-		"/// for a stack frame. Inlined functions are represented as SBBlock objects\n"
-		"/// that have inlined function information: the name of the inlined function,\n"
-		"/// where it was called from. The block that is returned will be the first \n"
-		"/// block at or above the block for the PC (SBFrame::GetBlock()) that defines\n"
-		"/// the scope of the frame. When a function contains no inlined functions,\n"
-		"/// this will be the top most lexical block that defines the function. \n"
-		"/// When a function has inlined functions and the PC is currently\n"
-		"/// in one of those inlined functions, this method will return the inlined\n"
-		"/// block that defines this frame. If the PC isn't currently in an inlined\n"
-		"/// function, the lexical block that defines the function is returned.\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Gets the lexical block that defines the stack frame. Another way to think\n"
 		"of this is it will return the block that contains all of the variables\n"
@@ -81577,13 +80384,6 @@ static PyMethodDef SwigMethods[] = {
 		"block that defines this frame. If the PC isn't currently in an inlined\n"
 		"function, the lexical block that defines the function is returned.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_GetLineEntry", _wrap_SBFrame_GetLineEntry, METH_VARARGS, (char *)"SBFrame_GetLineEntry(SBFrame self) -> SBLineEntry"},
-	 { "SBFrame_GetThread", _wrap_SBFrame_GetThread, METH_VARARGS, (char *)"SBFrame_GetThread(SBFrame self) -> SBThread"},
-	 { "SBFrame_Disassemble", _wrap_SBFrame_Disassemble, METH_VARARGS, (char *)"SBFrame_Disassemble(SBFrame self) -> char const *"},
-	 { "SBFrame_Clear", _wrap_SBFrame_Clear, METH_VARARGS, (char *)"SBFrame_Clear(SBFrame self)"},
-	 { "SBFrame_GetVariables", _wrap_SBFrame_GetVariables, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBFrame_GetLineEntry", _wrap_SBFrame_GetLineEntry, METH_VARARGS, (char *)"SBFrame_GetLineEntry(SBFrame self) -> SBLineEntry"},
 	 { (char *)"SBFrame_GetThread", _wrap_SBFrame_GetThread, METH_VARARGS, (char *)"SBFrame_GetThread(SBFrame self) -> SBThread"},
 	 { (char *)"SBFrame_Disassemble", _wrap_SBFrame_Disassemble, METH_VARARGS, (char *)"SBFrame_Disassemble(SBFrame self) -> char const *"},
@@ -81591,45 +80391,23 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBFrame___eq__", _wrap_SBFrame___eq__, METH_VARARGS, (char *)"SBFrame___eq__(SBFrame self, SBFrame rhs) -> bool"},
 	 { (char *)"SBFrame___ne__", _wrap_SBFrame___ne__, METH_VARARGS, (char *)"SBFrame___ne__(SBFrame self, SBFrame rhs) -> bool"},
 	 { (char *)"SBFrame_GetVariables", _wrap_SBFrame_GetVariables, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"GetVariables(bool arguments, bool locals, bool statics, bool in_scope_only) -> SBValueList\n"
 		"GetVariables(bool arguments, bool locals, bool statics, bool in_scope_only, lldb::DynamicValueType use_dynamic) -> SBValueList\n"
 		"SBFrame_GetVariables(SBFrame self, SBVariablesOptions options) -> SBValueList\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"/// The version that doesn't supply a 'use_dynamic' value will use the\n"
-		"/// target's default.\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"The version that doesn't supply a 'use_dynamic' value will use the\n"
 		"target's default.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_GetRegisters", _wrap_SBFrame_GetRegisters, METH_VARARGS, (char *)"SBFrame_GetRegisters(SBFrame self) -> SBValueList"},
-	 { "SBFrame_FindVariable", _wrap_SBFrame_FindVariable, METH_VARARGS, (char *)"\n"
-		"FindVariable(char const * var_name) -> SBValue\n"
-		"SBFrame_FindVariable(SBFrame self, char const * var_name, lldb::DynamicValueType use_dynamic) -> SBValue\n"
-		"\n"
-=======
 	 { (char *)"SBFrame_GetRegisters", _wrap_SBFrame_GetRegisters, METH_VARARGS, (char *)"SBFrame_GetRegisters(SBFrame self) -> SBValueList"},
 	 { (char *)"SBFrame_FindVariable", _wrap_SBFrame_FindVariable, METH_VARARGS, (char *)"\n"
 		"FindVariable(char const * var_name) -> SBValue\n"
 		"SBFrame_FindVariable(SBFrame self, char const * var_name, lldb::DynamicValueType use_dynamic) -> SBValue\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"The version that doesn't supply a 'use_dynamic' value will use the\n"
 		"target's default.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_FindRegister", _wrap_SBFrame_FindRegister, METH_VARARGS, (char *)"SBFrame_FindRegister(SBFrame self, char const * name) -> SBValue"},
-	 { "SBFrame_GetValueForVariablePath", _wrap_SBFrame_GetValueForVariablePath, METH_VARARGS, (char *)"\n"
-		"GetValueForVariablePath(char const * var_path) -> SBValue\n"
-		"SBFrame_GetValueForVariablePath(SBFrame self, char const * var_path, lldb::DynamicValueType use_dynamic) -> SBValue\n"
-		"\n"
-=======
 	 { (char *)"SBFrame_FindRegister", _wrap_SBFrame_FindRegister, METH_VARARGS, (char *)"SBFrame_FindRegister(SBFrame self, char const * name) -> SBValue"},
 	 { (char *)"SBFrame_GetValueForVariablePath", _wrap_SBFrame_GetValueForVariablePath, METH_VARARGS, (char *)"\n"
 		"GetValueForVariablePath(char const * var_path) -> SBValue\n"
@@ -81637,7 +80415,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"\n"
 		"Get a lldb.SBValue for a variable path.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Variable paths can include access to pointer or instance members:\n"
 		"    rect_ptr->origin.y\n"
@@ -81658,16 +80435,9 @@ static PyMethodDef SwigMethods[] = {
 		"track the current value of the value as execution progresses\n"
 		"in the current frame.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_FindValue", _wrap_SBFrame_FindValue, METH_VARARGS, (char *)"\n"
-		"FindValue(char const * name, lldb::ValueType value_type) -> SBValue\n"
-		"SBFrame_FindValue(SBFrame self, char const * name, lldb::ValueType value_type, lldb::DynamicValueType use_dynamic) -> SBValue\n"
-		"\n"
-=======
 	 { (char *)"SBFrame_FindValue", _wrap_SBFrame_FindValue, METH_VARARGS, (char *)"\n"
 		"FindValue(char const * name, lldb::ValueType value_type) -> SBValue\n"
 		"SBFrame_FindValue(SBFrame self, char const * name, lldb::ValueType value_type, lldb::DynamicValueType use_dynamic) -> SBValue\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Find variables, register sets, registers, or persistent variables using\n"
@@ -81676,33 +80446,6 @@ static PyMethodDef SwigMethods[] = {
 		"The version that doesn't supply a 'use_dynamic' value will use the\n"
 		"target's default.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFrame_GetDescription", _wrap_SBFrame_GetDescription, METH_VARARGS, (char *)"SBFrame_GetDescription(SBFrame self, SBStream description) -> bool"},
-	 { "SBFrame___str__", _wrap_SBFrame___str__, METH_VARARGS, (char *)"SBFrame___str__(SBFrame self) -> PyObject *"},
-	 { "SBFrame_swigregister", SBFrame_swigregister, METH_VARARGS, NULL},
-	 { "new_SBFunction", _wrap_new_SBFunction, METH_VARARGS, (char *)"\n"
-		"SBFunction()\n"
-		"new_SBFunction(SBFunction rhs) -> SBFunction\n"
-		""},
-	 { "delete_SBFunction", _wrap_delete_SBFunction, METH_VARARGS, (char *)"delete_SBFunction(SBFunction self)"},
-	 { "SBFunction_IsValid", _wrap_SBFunction_IsValid, METH_VARARGS, (char *)"SBFunction_IsValid(SBFunction self) -> bool"},
-	 { "SBFunction___nonzero__", _wrap_SBFunction___nonzero__, METH_VARARGS, (char *)"SBFunction___nonzero__(SBFunction self) -> bool"},
-	 { "SBFunction_GetName", _wrap_SBFunction_GetName, METH_VARARGS, (char *)"SBFunction_GetName(SBFunction self) -> char const *"},
-	 { "SBFunction_GetDisplayName", _wrap_SBFunction_GetDisplayName, METH_VARARGS, (char *)"SBFunction_GetDisplayName(SBFunction self) -> char const *"},
-	 { "SBFunction_GetMangledName", _wrap_SBFunction_GetMangledName, METH_VARARGS, (char *)"SBFunction_GetMangledName(SBFunction self) -> char const *"},
-	 { "SBFunction_GetInstructions", _wrap_SBFunction_GetInstructions, METH_VARARGS, (char *)"\n"
-		"GetInstructions(SBTarget target) -> SBInstructionList\n"
-		"SBFunction_GetInstructions(SBFunction self, SBTarget target, char const * flavor) -> SBInstructionList\n"
-		""},
-	 { "SBFunction_GetStartAddress", _wrap_SBFunction_GetStartAddress, METH_VARARGS, (char *)"SBFunction_GetStartAddress(SBFunction self) -> SBAddress"},
-	 { "SBFunction_GetEndAddress", _wrap_SBFunction_GetEndAddress, METH_VARARGS, (char *)"SBFunction_GetEndAddress(SBFunction self) -> SBAddress"},
-	 { "SBFunction_GetArgumentName", _wrap_SBFunction_GetArgumentName, METH_VARARGS, (char *)"SBFunction_GetArgumentName(SBFunction self, uint32_t arg_idx) -> char const *"},
-	 { "SBFunction_GetPrologueByteSize", _wrap_SBFunction_GetPrologueByteSize, METH_VARARGS, (char *)"SBFunction_GetPrologueByteSize(SBFunction self) -> uint32_t"},
-	 { "SBFunction_GetType", _wrap_SBFunction_GetType, METH_VARARGS, (char *)"SBFunction_GetType(SBFunction self) -> SBType"},
-	 { "SBFunction_GetBlock", _wrap_SBFunction_GetBlock, METH_VARARGS, (char *)"SBFunction_GetBlock(SBFunction self) -> SBBlock"},
-	 { "SBFunction_GetLanguage", _wrap_SBFunction_GetLanguage, METH_VARARGS, (char *)"SBFunction_GetLanguage(SBFunction self) -> lldb::LanguageType"},
-	 { "SBFunction_GetIsOptimized", _wrap_SBFunction_GetIsOptimized, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBFrame_GetDescription", _wrap_SBFrame_GetDescription, METH_VARARGS, (char *)"SBFrame_GetDescription(SBFrame self, SBStream description) -> bool"},
 	 { (char *)"SBFrame___str__", _wrap_SBFrame___str__, METH_VARARGS, (char *)"SBFrame___str__(SBFrame self) -> PyObject *"},
 	 { (char *)"SBFrame_swigregister", SBFrame_swigregister, METH_VARARGS, NULL},
@@ -81728,7 +80471,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBFunction_GetBlock", _wrap_SBFunction_GetBlock, METH_VARARGS, (char *)"SBFunction_GetBlock(SBFunction self) -> SBBlock"},
 	 { (char *)"SBFunction_GetLanguage", _wrap_SBFunction_GetLanguage, METH_VARARGS, (char *)"SBFunction_GetLanguage(SBFunction self) -> lldb::LanguageType"},
 	 { (char *)"SBFunction_GetIsOptimized", _wrap_SBFunction_GetIsOptimized, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBFunction_GetIsOptimized(SBFunction self) -> bool\n"
 		"\n"
 		"\n"
@@ -81739,133 +80481,6 @@ static PyMethodDef SwigMethods[] = {
 		"provide some guidance to the user about this.\n"
 		"Returns false if unoptimized, or unknown.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBFunction_GetCanThrow", _wrap_SBFunction_GetCanThrow, METH_VARARGS, (char *)"SBFunction_GetCanThrow(SBFunction self) -> bool"},
-	 { "SBFunction_GetDescription", _wrap_SBFunction_GetDescription, METH_VARARGS, (char *)"SBFunction_GetDescription(SBFunction self, SBStream description) -> bool"},
-	 { "SBFunction___eq__", _wrap_SBFunction___eq__, METH_VARARGS, (char *)"SBFunction___eq__(SBFunction self, SBFunction rhs) -> bool"},
-	 { "SBFunction___ne__", _wrap_SBFunction___ne__, METH_VARARGS, (char *)"SBFunction___ne__(SBFunction self, SBFunction rhs) -> bool"},
-	 { "SBFunction___str__", _wrap_SBFunction___str__, METH_VARARGS, (char *)"SBFunction___str__(SBFunction self) -> PyObject *"},
-	 { "SBFunction_swigregister", SBFunction_swigregister, METH_VARARGS, NULL},
-	 { "SBHostOS_GetProgramFileSpec", _wrap_SBHostOS_GetProgramFileSpec, METH_VARARGS, (char *)"SBHostOS_GetProgramFileSpec() -> SBFileSpec"},
-	 { "SBHostOS_GetLLDBPythonPath", _wrap_SBHostOS_GetLLDBPythonPath, METH_VARARGS, (char *)"SBHostOS_GetLLDBPythonPath() -> SBFileSpec"},
-	 { "SBHostOS_GetLLDBPath", _wrap_SBHostOS_GetLLDBPath, METH_VARARGS, (char *)"SBHostOS_GetLLDBPath(lldb::PathType path_type) -> SBFileSpec"},
-	 { "SBHostOS_GetUserHomeDirectory", _wrap_SBHostOS_GetUserHomeDirectory, METH_VARARGS, (char *)"SBHostOS_GetUserHomeDirectory() -> SBFileSpec"},
-	 { "SBHostOS_ThreadCreated", _wrap_SBHostOS_ThreadCreated, METH_VARARGS, (char *)"SBHostOS_ThreadCreated(char const * name)"},
-	 { "SBHostOS_ThreadCreate", _wrap_SBHostOS_ThreadCreate, METH_VARARGS, (char *)"SBHostOS_ThreadCreate(char const * name, lldb::thread_func_t arg3, void * thread_arg, SBError err) -> lldb::thread_t"},
-	 { "SBHostOS_ThreadCancel", _wrap_SBHostOS_ThreadCancel, METH_VARARGS, (char *)"SBHostOS_ThreadCancel(lldb::thread_t thread, SBError err) -> bool"},
-	 { "SBHostOS_ThreadDetach", _wrap_SBHostOS_ThreadDetach, METH_VARARGS, (char *)"SBHostOS_ThreadDetach(lldb::thread_t thread, SBError err) -> bool"},
-	 { "SBHostOS_ThreadJoin", _wrap_SBHostOS_ThreadJoin, METH_VARARGS, (char *)"SBHostOS_ThreadJoin(lldb::thread_t thread, lldb::thread_result_t * result, SBError err) -> bool"},
-	 { "new_SBHostOS", _wrap_new_SBHostOS, METH_VARARGS, (char *)"new_SBHostOS() -> SBHostOS"},
-	 { "delete_SBHostOS", _wrap_delete_SBHostOS, METH_VARARGS, (char *)"delete_SBHostOS(SBHostOS self)"},
-	 { "SBHostOS_swigregister", SBHostOS_swigregister, METH_VARARGS, NULL},
-	 { "new_SBInstruction", _wrap_new_SBInstruction, METH_VARARGS, (char *)"\n"
-		"SBInstruction()\n"
-		"new_SBInstruction(SBInstruction rhs) -> SBInstruction\n"
-		""},
-	 { "delete_SBInstruction", _wrap_delete_SBInstruction, METH_VARARGS, (char *)"delete_SBInstruction(SBInstruction self)"},
-	 { "SBInstruction_IsValid", _wrap_SBInstruction_IsValid, METH_VARARGS, (char *)"SBInstruction_IsValid(SBInstruction self) -> bool"},
-	 { "SBInstruction___nonzero__", _wrap_SBInstruction___nonzero__, METH_VARARGS, (char *)"SBInstruction___nonzero__(SBInstruction self) -> bool"},
-	 { "SBInstruction_GetAddress", _wrap_SBInstruction_GetAddress, METH_VARARGS, (char *)"SBInstruction_GetAddress(SBInstruction self) -> SBAddress"},
-	 { "SBInstruction_GetMnemonic", _wrap_SBInstruction_GetMnemonic, METH_VARARGS, (char *)"SBInstruction_GetMnemonic(SBInstruction self, SBTarget target) -> char const *"},
-	 { "SBInstruction_GetOperands", _wrap_SBInstruction_GetOperands, METH_VARARGS, (char *)"SBInstruction_GetOperands(SBInstruction self, SBTarget target) -> char const *"},
-	 { "SBInstruction_GetComment", _wrap_SBInstruction_GetComment, METH_VARARGS, (char *)"SBInstruction_GetComment(SBInstruction self, SBTarget target) -> char const *"},
-	 { "SBInstruction_GetData", _wrap_SBInstruction_GetData, METH_VARARGS, (char *)"SBInstruction_GetData(SBInstruction self, SBTarget target) -> SBData"},
-	 { "SBInstruction_GetByteSize", _wrap_SBInstruction_GetByteSize, METH_VARARGS, (char *)"SBInstruction_GetByteSize(SBInstruction self) -> size_t"},
-	 { "SBInstruction_DoesBranch", _wrap_SBInstruction_DoesBranch, METH_VARARGS, (char *)"SBInstruction_DoesBranch(SBInstruction self) -> bool"},
-	 { "SBInstruction_HasDelaySlot", _wrap_SBInstruction_HasDelaySlot, METH_VARARGS, (char *)"SBInstruction_HasDelaySlot(SBInstruction self) -> bool"},
-	 { "SBInstruction_CanSetBreakpoint", _wrap_SBInstruction_CanSetBreakpoint, METH_VARARGS, (char *)"SBInstruction_CanSetBreakpoint(SBInstruction self) -> bool"},
-	 { "SBInstruction_Print", _wrap_SBInstruction_Print, METH_VARARGS, (char *)"SBInstruction_Print(SBInstruction self, FILE * out)"},
-	 { "SBInstruction_GetDescription", _wrap_SBInstruction_GetDescription, METH_VARARGS, (char *)"SBInstruction_GetDescription(SBInstruction self, SBStream description) -> bool"},
-	 { "SBInstruction_EmulateWithFrame", _wrap_SBInstruction_EmulateWithFrame, METH_VARARGS, (char *)"SBInstruction_EmulateWithFrame(SBInstruction self, SBFrame frame, uint32_t evaluate_options) -> bool"},
-	 { "SBInstruction_DumpEmulation", _wrap_SBInstruction_DumpEmulation, METH_VARARGS, (char *)"SBInstruction_DumpEmulation(SBInstruction self, char const * triple) -> bool"},
-	 { "SBInstruction_TestEmulation", _wrap_SBInstruction_TestEmulation, METH_VARARGS, (char *)"SBInstruction_TestEmulation(SBInstruction self, SBStream output_stream, char const * test_file) -> bool"},
-	 { "SBInstruction___str__", _wrap_SBInstruction___str__, METH_VARARGS, (char *)"SBInstruction___str__(SBInstruction self) -> PyObject *"},
-	 { "SBInstruction_swigregister", SBInstruction_swigregister, METH_VARARGS, NULL},
-	 { "new_SBInstructionList", _wrap_new_SBInstructionList, METH_VARARGS, (char *)"\n"
-		"SBInstructionList()\n"
-		"new_SBInstructionList(SBInstructionList rhs) -> SBInstructionList\n"
-		""},
-	 { "delete_SBInstructionList", _wrap_delete_SBInstructionList, METH_VARARGS, (char *)"delete_SBInstructionList(SBInstructionList self)"},
-	 { "SBInstructionList_IsValid", _wrap_SBInstructionList_IsValid, METH_VARARGS, (char *)"SBInstructionList_IsValid(SBInstructionList self) -> bool"},
-	 { "SBInstructionList___nonzero__", _wrap_SBInstructionList___nonzero__, METH_VARARGS, (char *)"SBInstructionList___nonzero__(SBInstructionList self) -> bool"},
-	 { "SBInstructionList_GetSize", _wrap_SBInstructionList_GetSize, METH_VARARGS, (char *)"SBInstructionList_GetSize(SBInstructionList self) -> size_t"},
-	 { "SBInstructionList_GetInstructionAtIndex", _wrap_SBInstructionList_GetInstructionAtIndex, METH_VARARGS, (char *)"SBInstructionList_GetInstructionAtIndex(SBInstructionList self, uint32_t idx) -> SBInstruction"},
-	 { "SBInstructionList_GetInstructionsCount", _wrap_SBInstructionList_GetInstructionsCount, METH_VARARGS, (char *)"SBInstructionList_GetInstructionsCount(SBInstructionList self, SBAddress start, SBAddress end, bool canSetBreakpoint) -> size_t"},
-	 { "SBInstructionList_Clear", _wrap_SBInstructionList_Clear, METH_VARARGS, (char *)"SBInstructionList_Clear(SBInstructionList self)"},
-	 { "SBInstructionList_AppendInstruction", _wrap_SBInstructionList_AppendInstruction, METH_VARARGS, (char *)"SBInstructionList_AppendInstruction(SBInstructionList self, SBInstruction inst)"},
-	 { "SBInstructionList_Print", _wrap_SBInstructionList_Print, METH_VARARGS, (char *)"SBInstructionList_Print(SBInstructionList self, FILE * out)"},
-	 { "SBInstructionList_GetDescription", _wrap_SBInstructionList_GetDescription, METH_VARARGS, (char *)"SBInstructionList_GetDescription(SBInstructionList self, SBStream description) -> bool"},
-	 { "SBInstructionList_DumpEmulationForAllInstructions", _wrap_SBInstructionList_DumpEmulationForAllInstructions, METH_VARARGS, (char *)"SBInstructionList_DumpEmulationForAllInstructions(SBInstructionList self, char const * triple) -> bool"},
-	 { "SBInstructionList___str__", _wrap_SBInstructionList___str__, METH_VARARGS, (char *)"SBInstructionList___str__(SBInstructionList self) -> PyObject *"},
-	 { "SBInstructionList_swigregister", SBInstructionList_swigregister, METH_VARARGS, NULL},
-	 { "SBLanguageRuntime_GetLanguageTypeFromString", _wrap_SBLanguageRuntime_GetLanguageTypeFromString, METH_VARARGS, (char *)"SBLanguageRuntime_GetLanguageTypeFromString(char const * string) -> lldb::LanguageType"},
-	 { "SBLanguageRuntime_GetNameForLanguageType", _wrap_SBLanguageRuntime_GetNameForLanguageType, METH_VARARGS, (char *)"SBLanguageRuntime_GetNameForLanguageType(lldb::LanguageType language) -> char const *"},
-	 { "new_SBLanguageRuntime", _wrap_new_SBLanguageRuntime, METH_VARARGS, (char *)"new_SBLanguageRuntime() -> SBLanguageRuntime"},
-	 { "delete_SBLanguageRuntime", _wrap_delete_SBLanguageRuntime, METH_VARARGS, (char *)"delete_SBLanguageRuntime(SBLanguageRuntime self)"},
-	 { "SBLanguageRuntime_swigregister", SBLanguageRuntime_swigregister, METH_VARARGS, NULL},
-	 { "new_SBLaunchInfo", _wrap_new_SBLaunchInfo, METH_VARARGS, (char *)"new_SBLaunchInfo(char const ** argv) -> SBLaunchInfo"},
-	 { "SBLaunchInfo_GetProcessID", _wrap_SBLaunchInfo_GetProcessID, METH_VARARGS, (char *)"SBLaunchInfo_GetProcessID(SBLaunchInfo self) -> lldb::pid_t"},
-	 { "SBLaunchInfo_GetUserID", _wrap_SBLaunchInfo_GetUserID, METH_VARARGS, (char *)"SBLaunchInfo_GetUserID(SBLaunchInfo self) -> uint32_t"},
-	 { "SBLaunchInfo_GetGroupID", _wrap_SBLaunchInfo_GetGroupID, METH_VARARGS, (char *)"SBLaunchInfo_GetGroupID(SBLaunchInfo self) -> uint32_t"},
-	 { "SBLaunchInfo_UserIDIsValid", _wrap_SBLaunchInfo_UserIDIsValid, METH_VARARGS, (char *)"SBLaunchInfo_UserIDIsValid(SBLaunchInfo self) -> bool"},
-	 { "SBLaunchInfo_GroupIDIsValid", _wrap_SBLaunchInfo_GroupIDIsValid, METH_VARARGS, (char *)"SBLaunchInfo_GroupIDIsValid(SBLaunchInfo self) -> bool"},
-	 { "SBLaunchInfo_SetUserID", _wrap_SBLaunchInfo_SetUserID, METH_VARARGS, (char *)"SBLaunchInfo_SetUserID(SBLaunchInfo self, uint32_t uid)"},
-	 { "SBLaunchInfo_SetGroupID", _wrap_SBLaunchInfo_SetGroupID, METH_VARARGS, (char *)"SBLaunchInfo_SetGroupID(SBLaunchInfo self, uint32_t gid)"},
-	 { "SBLaunchInfo_GetExecutableFile", _wrap_SBLaunchInfo_GetExecutableFile, METH_VARARGS, (char *)"SBLaunchInfo_GetExecutableFile(SBLaunchInfo self) -> SBFileSpec"},
-	 { "SBLaunchInfo_SetExecutableFile", _wrap_SBLaunchInfo_SetExecutableFile, METH_VARARGS, (char *)"SBLaunchInfo_SetExecutableFile(SBLaunchInfo self, SBFileSpec exe_file, bool add_as_first_arg)"},
-	 { "SBLaunchInfo_GetListener", _wrap_SBLaunchInfo_GetListener, METH_VARARGS, (char *)"SBLaunchInfo_GetListener(SBLaunchInfo self) -> SBListener"},
-	 { "SBLaunchInfo_SetListener", _wrap_SBLaunchInfo_SetListener, METH_VARARGS, (char *)"SBLaunchInfo_SetListener(SBLaunchInfo self, SBListener listener)"},
-	 { "SBLaunchInfo_GetNumArguments", _wrap_SBLaunchInfo_GetNumArguments, METH_VARARGS, (char *)"SBLaunchInfo_GetNumArguments(SBLaunchInfo self) -> uint32_t"},
-	 { "SBLaunchInfo_GetArgumentAtIndex", _wrap_SBLaunchInfo_GetArgumentAtIndex, METH_VARARGS, (char *)"SBLaunchInfo_GetArgumentAtIndex(SBLaunchInfo self, uint32_t idx) -> char const *"},
-	 { "SBLaunchInfo_SetArguments", _wrap_SBLaunchInfo_SetArguments, METH_VARARGS, (char *)"SBLaunchInfo_SetArguments(SBLaunchInfo self, char const ** argv, bool append)"},
-	 { "SBLaunchInfo_GetNumEnvironmentEntries", _wrap_SBLaunchInfo_GetNumEnvironmentEntries, METH_VARARGS, (char *)"SBLaunchInfo_GetNumEnvironmentEntries(SBLaunchInfo self) -> uint32_t"},
-	 { "SBLaunchInfo_GetEnvironmentEntryAtIndex", _wrap_SBLaunchInfo_GetEnvironmentEntryAtIndex, METH_VARARGS, (char *)"SBLaunchInfo_GetEnvironmentEntryAtIndex(SBLaunchInfo self, uint32_t idx) -> char const *"},
-	 { "SBLaunchInfo_SetEnvironmentEntries", _wrap_SBLaunchInfo_SetEnvironmentEntries, METH_VARARGS, (char *)"SBLaunchInfo_SetEnvironmentEntries(SBLaunchInfo self, char const ** envp, bool append)"},
-	 { "SBLaunchInfo_Clear", _wrap_SBLaunchInfo_Clear, METH_VARARGS, (char *)"SBLaunchInfo_Clear(SBLaunchInfo self)"},
-	 { "SBLaunchInfo_GetWorkingDirectory", _wrap_SBLaunchInfo_GetWorkingDirectory, METH_VARARGS, (char *)"SBLaunchInfo_GetWorkingDirectory(SBLaunchInfo self) -> char const *"},
-	 { "SBLaunchInfo_SetWorkingDirectory", _wrap_SBLaunchInfo_SetWorkingDirectory, METH_VARARGS, (char *)"SBLaunchInfo_SetWorkingDirectory(SBLaunchInfo self, char const * working_dir)"},
-	 { "SBLaunchInfo_GetLaunchFlags", _wrap_SBLaunchInfo_GetLaunchFlags, METH_VARARGS, (char *)"SBLaunchInfo_GetLaunchFlags(SBLaunchInfo self) -> uint32_t"},
-	 { "SBLaunchInfo_SetLaunchFlags", _wrap_SBLaunchInfo_SetLaunchFlags, METH_VARARGS, (char *)"SBLaunchInfo_SetLaunchFlags(SBLaunchInfo self, uint32_t flags)"},
-	 { "SBLaunchInfo_GetProcessPluginName", _wrap_SBLaunchInfo_GetProcessPluginName, METH_VARARGS, (char *)"SBLaunchInfo_GetProcessPluginName(SBLaunchInfo self) -> char const *"},
-	 { "SBLaunchInfo_SetProcessPluginName", _wrap_SBLaunchInfo_SetProcessPluginName, METH_VARARGS, (char *)"SBLaunchInfo_SetProcessPluginName(SBLaunchInfo self, char const * plugin_name)"},
-	 { "SBLaunchInfo_GetShell", _wrap_SBLaunchInfo_GetShell, METH_VARARGS, (char *)"SBLaunchInfo_GetShell(SBLaunchInfo self) -> char const *"},
-	 { "SBLaunchInfo_SetShell", _wrap_SBLaunchInfo_SetShell, METH_VARARGS, (char *)"SBLaunchInfo_SetShell(SBLaunchInfo self, char const * path)"},
-	 { "SBLaunchInfo_GetShellExpandArguments", _wrap_SBLaunchInfo_GetShellExpandArguments, METH_VARARGS, (char *)"SBLaunchInfo_GetShellExpandArguments(SBLaunchInfo self) -> bool"},
-	 { "SBLaunchInfo_SetShellExpandArguments", _wrap_SBLaunchInfo_SetShellExpandArguments, METH_VARARGS, (char *)"SBLaunchInfo_SetShellExpandArguments(SBLaunchInfo self, bool expand)"},
-	 { "SBLaunchInfo_GetResumeCount", _wrap_SBLaunchInfo_GetResumeCount, METH_VARARGS, (char *)"SBLaunchInfo_GetResumeCount(SBLaunchInfo self) -> uint32_t"},
-	 { "SBLaunchInfo_SetResumeCount", _wrap_SBLaunchInfo_SetResumeCount, METH_VARARGS, (char *)"SBLaunchInfo_SetResumeCount(SBLaunchInfo self, uint32_t c)"},
-	 { "SBLaunchInfo_AddCloseFileAction", _wrap_SBLaunchInfo_AddCloseFileAction, METH_VARARGS, (char *)"SBLaunchInfo_AddCloseFileAction(SBLaunchInfo self, int fd) -> bool"},
-	 { "SBLaunchInfo_AddDuplicateFileAction", _wrap_SBLaunchInfo_AddDuplicateFileAction, METH_VARARGS, (char *)"SBLaunchInfo_AddDuplicateFileAction(SBLaunchInfo self, int fd, int dup_fd) -> bool"},
-	 { "SBLaunchInfo_AddOpenFileAction", _wrap_SBLaunchInfo_AddOpenFileAction, METH_VARARGS, (char *)"SBLaunchInfo_AddOpenFileAction(SBLaunchInfo self, int fd, char const * path, bool read, bool write) -> bool"},
-	 { "SBLaunchInfo_AddSuppressFileAction", _wrap_SBLaunchInfo_AddSuppressFileAction, METH_VARARGS, (char *)"SBLaunchInfo_AddSuppressFileAction(SBLaunchInfo self, int fd, bool read, bool write) -> bool"},
-	 { "SBLaunchInfo_SetLaunchEventData", _wrap_SBLaunchInfo_SetLaunchEventData, METH_VARARGS, (char *)"SBLaunchInfo_SetLaunchEventData(SBLaunchInfo self, char const * data)"},
-	 { "SBLaunchInfo_GetLaunchEventData", _wrap_SBLaunchInfo_GetLaunchEventData, METH_VARARGS, (char *)"SBLaunchInfo_GetLaunchEventData(SBLaunchInfo self) -> char const *"},
-	 { "SBLaunchInfo_GetDetachOnError", _wrap_SBLaunchInfo_GetDetachOnError, METH_VARARGS, (char *)"SBLaunchInfo_GetDetachOnError(SBLaunchInfo self) -> bool"},
-	 { "SBLaunchInfo_SetDetachOnError", _wrap_SBLaunchInfo_SetDetachOnError, METH_VARARGS, (char *)"SBLaunchInfo_SetDetachOnError(SBLaunchInfo self, bool enable)"},
-	 { "delete_SBLaunchInfo", _wrap_delete_SBLaunchInfo, METH_VARARGS, (char *)"delete_SBLaunchInfo(SBLaunchInfo self)"},
-	 { "SBLaunchInfo_swigregister", SBLaunchInfo_swigregister, METH_VARARGS, NULL},
-	 { "new_SBLineEntry", _wrap_new_SBLineEntry, METH_VARARGS, (char *)"\n"
-		"SBLineEntry()\n"
-		"new_SBLineEntry(SBLineEntry rhs) -> SBLineEntry\n"
-		""},
-	 { "delete_SBLineEntry", _wrap_delete_SBLineEntry, METH_VARARGS, (char *)"delete_SBLineEntry(SBLineEntry self)"},
-	 { "SBLineEntry_GetStartAddress", _wrap_SBLineEntry_GetStartAddress, METH_VARARGS, (char *)"SBLineEntry_GetStartAddress(SBLineEntry self) -> SBAddress"},
-	 { "SBLineEntry_GetEndAddress", _wrap_SBLineEntry_GetEndAddress, METH_VARARGS, (char *)"SBLineEntry_GetEndAddress(SBLineEntry self) -> SBAddress"},
-	 { "SBLineEntry_IsValid", _wrap_SBLineEntry_IsValid, METH_VARARGS, (char *)"SBLineEntry_IsValid(SBLineEntry self) -> bool"},
-	 { "SBLineEntry___nonzero__", _wrap_SBLineEntry___nonzero__, METH_VARARGS, (char *)"SBLineEntry___nonzero__(SBLineEntry self) -> bool"},
-	 { "SBLineEntry_GetFileSpec", _wrap_SBLineEntry_GetFileSpec, METH_VARARGS, (char *)"SBLineEntry_GetFileSpec(SBLineEntry self) -> SBFileSpec"},
-	 { "SBLineEntry_GetLine", _wrap_SBLineEntry_GetLine, METH_VARARGS, (char *)"SBLineEntry_GetLine(SBLineEntry self) -> uint32_t"},
-	 { "SBLineEntry_GetColumn", _wrap_SBLineEntry_GetColumn, METH_VARARGS, (char *)"SBLineEntry_GetColumn(SBLineEntry self) -> uint32_t"},
-	 { "SBLineEntry_GetDescription", _wrap_SBLineEntry_GetDescription, METH_VARARGS, (char *)"SBLineEntry_GetDescription(SBLineEntry self, SBStream description) -> bool"},
-	 { "SBLineEntry_SetFileSpec", _wrap_SBLineEntry_SetFileSpec, METH_VARARGS, (char *)"SBLineEntry_SetFileSpec(SBLineEntry self, SBFileSpec filespec)"},
-	 { "SBLineEntry_SetLine", _wrap_SBLineEntry_SetLine, METH_VARARGS, (char *)"SBLineEntry_SetLine(SBLineEntry self, uint32_t line)"},
-	 { "SBLineEntry_SetColumn", _wrap_SBLineEntry_SetColumn, METH_VARARGS, (char *)"SBLineEntry_SetColumn(SBLineEntry self, uint32_t column)"},
-	 { "SBLineEntry___eq__", _wrap_SBLineEntry___eq__, METH_VARARGS, (char *)"SBLineEntry___eq__(SBLineEntry self, SBLineEntry rhs) -> bool"},
-	 { "SBLineEntry___ne__", _wrap_SBLineEntry___ne__, METH_VARARGS, (char *)"SBLineEntry___ne__(SBLineEntry self, SBLineEntry rhs) -> bool"},
-	 { "SBLineEntry___str__", _wrap_SBLineEntry___str__, METH_VARARGS, (char *)"SBLineEntry___str__(SBLineEntry self) -> PyObject *"},
-	 { "SBLineEntry_swigregister", SBLineEntry_swigregister, METH_VARARGS, NULL},
-	 { "new_SBListener", _wrap_new_SBListener, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBFunction_GetCanThrow", _wrap_SBFunction_GetCanThrow, METH_VARARGS, (char *)"SBFunction_GetCanThrow(SBFunction self) -> bool"},
 	 { (char *)"SBFunction_GetDescription", _wrap_SBFunction_GetDescription, METH_VARARGS, (char *)"SBFunction_GetDescription(SBFunction self, SBStream description) -> bool"},
 	 { (char *)"SBFunction___eq__", _wrap_SBFunction___eq__, METH_VARARGS, (char *)"SBFunction___eq__(SBFunction self, SBFunction rhs) -> bool"},
@@ -81991,52 +80606,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBLineEntry___str__", _wrap_SBLineEntry___str__, METH_VARARGS, (char *)"SBLineEntry___str__(SBLineEntry self) -> PyObject *"},
 	 { (char *)"SBLineEntry_swigregister", SBLineEntry_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBListener", _wrap_new_SBListener, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBListener()\n"
 		"SBListener(char const * name)\n"
 		"new_SBListener(SBListener rhs) -> SBListener\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBListener", _wrap_delete_SBListener, METH_VARARGS, (char *)"delete_SBListener(SBListener self)"},
-	 { "SBListener_AddEvent", _wrap_SBListener_AddEvent, METH_VARARGS, (char *)"SBListener_AddEvent(SBListener self, SBEvent event)"},
-	 { "SBListener_Clear", _wrap_SBListener_Clear, METH_VARARGS, (char *)"SBListener_Clear(SBListener self)"},
-	 { "SBListener_IsValid", _wrap_SBListener_IsValid, METH_VARARGS, (char *)"SBListener_IsValid(SBListener self) -> bool"},
-	 { "SBListener___nonzero__", _wrap_SBListener___nonzero__, METH_VARARGS, (char *)"SBListener___nonzero__(SBListener self) -> bool"},
-	 { "SBListener_StartListeningForEventClass", _wrap_SBListener_StartListeningForEventClass, METH_VARARGS, (char *)"SBListener_StartListeningForEventClass(SBListener self, SBDebugger debugger, char const * broadcaster_class, uint32_t event_mask) -> uint32_t"},
-	 { "SBListener_StopListeningForEventClass", _wrap_SBListener_StopListeningForEventClass, METH_VARARGS, (char *)"SBListener_StopListeningForEventClass(SBListener self, SBDebugger debugger, char const * broadcaster_class, uint32_t event_mask) -> uint32_t"},
-	 { "SBListener_StartListeningForEvents", _wrap_SBListener_StartListeningForEvents, METH_VARARGS, (char *)"SBListener_StartListeningForEvents(SBListener self, SBBroadcaster broadcaster, uint32_t event_mask) -> uint32_t"},
-	 { "SBListener_StopListeningForEvents", _wrap_SBListener_StopListeningForEvents, METH_VARARGS, (char *)"SBListener_StopListeningForEvents(SBListener self, SBBroadcaster broadcaster, uint32_t event_mask) -> bool"},
-	 { "SBListener_WaitForEvent", _wrap_SBListener_WaitForEvent, METH_VARARGS, (char *)"SBListener_WaitForEvent(SBListener self, uint32_t num_seconds, SBEvent event) -> bool"},
-	 { "SBListener_WaitForEventForBroadcaster", _wrap_SBListener_WaitForEventForBroadcaster, METH_VARARGS, (char *)"SBListener_WaitForEventForBroadcaster(SBListener self, uint32_t num_seconds, SBBroadcaster broadcaster, SBEvent sb_event) -> bool"},
-	 { "SBListener_WaitForEventForBroadcasterWithType", _wrap_SBListener_WaitForEventForBroadcasterWithType, METH_VARARGS, (char *)"SBListener_WaitForEventForBroadcasterWithType(SBListener self, uint32_t num_seconds, SBBroadcaster broadcaster, uint32_t event_type_mask, SBEvent sb_event) -> bool"},
-	 { "SBListener_PeekAtNextEvent", _wrap_SBListener_PeekAtNextEvent, METH_VARARGS, (char *)"SBListener_PeekAtNextEvent(SBListener self, SBEvent sb_event) -> bool"},
-	 { "SBListener_PeekAtNextEventForBroadcaster", _wrap_SBListener_PeekAtNextEventForBroadcaster, METH_VARARGS, (char *)"SBListener_PeekAtNextEventForBroadcaster(SBListener self, SBBroadcaster broadcaster, SBEvent sb_event) -> bool"},
-	 { "SBListener_PeekAtNextEventForBroadcasterWithType", _wrap_SBListener_PeekAtNextEventForBroadcasterWithType, METH_VARARGS, (char *)"SBListener_PeekAtNextEventForBroadcasterWithType(SBListener self, SBBroadcaster broadcaster, uint32_t event_type_mask, SBEvent sb_event) -> bool"},
-	 { "SBListener_GetNextEvent", _wrap_SBListener_GetNextEvent, METH_VARARGS, (char *)"SBListener_GetNextEvent(SBListener self, SBEvent sb_event) -> bool"},
-	 { "SBListener_GetNextEventForBroadcaster", _wrap_SBListener_GetNextEventForBroadcaster, METH_VARARGS, (char *)"SBListener_GetNextEventForBroadcaster(SBListener self, SBBroadcaster broadcaster, SBEvent sb_event) -> bool"},
-	 { "SBListener_GetNextEventForBroadcasterWithType", _wrap_SBListener_GetNextEventForBroadcasterWithType, METH_VARARGS, (char *)"SBListener_GetNextEventForBroadcasterWithType(SBListener self, SBBroadcaster broadcaster, uint32_t event_type_mask, SBEvent sb_event) -> bool"},
-	 { "SBListener_HandleBroadcastEvent", _wrap_SBListener_HandleBroadcastEvent, METH_VARARGS, (char *)"SBListener_HandleBroadcastEvent(SBListener self, SBEvent event) -> bool"},
-	 { "SBListener_swigregister", SBListener_swigregister, METH_VARARGS, NULL},
-	 { "new_SBMemoryRegionInfo", _wrap_new_SBMemoryRegionInfo, METH_VARARGS, (char *)"\n"
-		"SBMemoryRegionInfo()\n"
-		"new_SBMemoryRegionInfo(SBMemoryRegionInfo rhs) -> SBMemoryRegionInfo\n"
-		""},
-	 { "delete_SBMemoryRegionInfo", _wrap_delete_SBMemoryRegionInfo, METH_VARARGS, (char *)"delete_SBMemoryRegionInfo(SBMemoryRegionInfo self)"},
-	 { "SBMemoryRegionInfo_Clear", _wrap_SBMemoryRegionInfo_Clear, METH_VARARGS, (char *)"SBMemoryRegionInfo_Clear(SBMemoryRegionInfo self)"},
-	 { "SBMemoryRegionInfo_GetRegionBase", _wrap_SBMemoryRegionInfo_GetRegionBase, METH_VARARGS, (char *)"SBMemoryRegionInfo_GetRegionBase(SBMemoryRegionInfo self) -> lldb::addr_t"},
-	 { "SBMemoryRegionInfo_GetRegionEnd", _wrap_SBMemoryRegionInfo_GetRegionEnd, METH_VARARGS, (char *)"SBMemoryRegionInfo_GetRegionEnd(SBMemoryRegionInfo self) -> lldb::addr_t"},
-	 { "SBMemoryRegionInfo_IsReadable", _wrap_SBMemoryRegionInfo_IsReadable, METH_VARARGS, (char *)"SBMemoryRegionInfo_IsReadable(SBMemoryRegionInfo self) -> bool"},
-	 { "SBMemoryRegionInfo_IsWritable", _wrap_SBMemoryRegionInfo_IsWritable, METH_VARARGS, (char *)"SBMemoryRegionInfo_IsWritable(SBMemoryRegionInfo self) -> bool"},
-	 { "SBMemoryRegionInfo_IsExecutable", _wrap_SBMemoryRegionInfo_IsExecutable, METH_VARARGS, (char *)"SBMemoryRegionInfo_IsExecutable(SBMemoryRegionInfo self) -> bool"},
-	 { "SBMemoryRegionInfo_IsMapped", _wrap_SBMemoryRegionInfo_IsMapped, METH_VARARGS, (char *)"SBMemoryRegionInfo_IsMapped(SBMemoryRegionInfo self) -> bool"},
-	 { "SBMemoryRegionInfo_GetName", _wrap_SBMemoryRegionInfo_GetName, METH_VARARGS, (char *)"SBMemoryRegionInfo_GetName(SBMemoryRegionInfo self) -> char const *"},
-	 { "SBMemoryRegionInfo___eq__", _wrap_SBMemoryRegionInfo___eq__, METH_VARARGS, (char *)"SBMemoryRegionInfo___eq__(SBMemoryRegionInfo self, SBMemoryRegionInfo rhs) -> bool"},
-	 { "SBMemoryRegionInfo___ne__", _wrap_SBMemoryRegionInfo___ne__, METH_VARARGS, (char *)"SBMemoryRegionInfo___ne__(SBMemoryRegionInfo self, SBMemoryRegionInfo rhs) -> bool"},
-	 { "SBMemoryRegionInfo_GetDescription", _wrap_SBMemoryRegionInfo_GetDescription, METH_VARARGS, (char *)"SBMemoryRegionInfo_GetDescription(SBMemoryRegionInfo self, SBStream description) -> bool"},
-	 { "SBMemoryRegionInfo___str__", _wrap_SBMemoryRegionInfo___str__, METH_VARARGS, (char *)"SBMemoryRegionInfo___str__(SBMemoryRegionInfo self) -> PyObject *"},
-	 { "SBMemoryRegionInfo_swigregister", SBMemoryRegionInfo_swigregister, METH_VARARGS, NULL},
-	 { "new_SBMemoryRegionInfoList", _wrap_new_SBMemoryRegionInfoList, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBListener", _wrap_delete_SBListener, METH_VARARGS, (char *)"delete_SBListener(SBListener self)"},
 	 { (char *)"SBListener_AddEvent", _wrap_SBListener_AddEvent, METH_VARARGS, (char *)"SBListener_AddEvent(SBListener self, SBEvent event)"},
 	 { (char *)"SBListener_Clear", _wrap_SBListener_Clear, METH_VARARGS, (char *)"SBListener_Clear(SBListener self)"},
@@ -82076,45 +80649,24 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBMemoryRegionInfo___str__", _wrap_SBMemoryRegionInfo___str__, METH_VARARGS, (char *)"SBMemoryRegionInfo___str__(SBMemoryRegionInfo self) -> PyObject *"},
 	 { (char *)"SBMemoryRegionInfo_swigregister", SBMemoryRegionInfo_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBMemoryRegionInfoList", _wrap_new_SBMemoryRegionInfoList, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBMemoryRegionInfoList()\n"
 		"new_SBMemoryRegionInfoList(SBMemoryRegionInfoList rhs) -> SBMemoryRegionInfoList\n"
 		""},
-	 { "delete_SBMemoryRegionInfoList", _wrap_delete_SBMemoryRegionInfoList, METH_VARARGS, (char *)"delete_SBMemoryRegionInfoList(SBMemoryRegionInfoList self)"},
-	 { "SBMemoryRegionInfoList_GetSize", _wrap_SBMemoryRegionInfoList_GetSize, METH_VARARGS, (char *)"SBMemoryRegionInfoList_GetSize(SBMemoryRegionInfoList self) -> uint32_t"},
-	 { "SBMemoryRegionInfoList_GetMemoryRegionAtIndex", _wrap_SBMemoryRegionInfoList_GetMemoryRegionAtIndex, METH_VARARGS, (char *)"SBMemoryRegionInfoList_GetMemoryRegionAtIndex(SBMemoryRegionInfoList self, uint32_t idx, SBMemoryRegionInfo region_info) -> bool"},
-	 { "SBMemoryRegionInfoList_Append", _wrap_SBMemoryRegionInfoList_Append, METH_VARARGS, (char *)"\n"
+	 { (char *)"delete_SBMemoryRegionInfoList", _wrap_delete_SBMemoryRegionInfoList, METH_VARARGS, (char *)"delete_SBMemoryRegionInfoList(SBMemoryRegionInfoList self)"},
+	 { (char *)"SBMemoryRegionInfoList_GetSize", _wrap_SBMemoryRegionInfoList_GetSize, METH_VARARGS, (char *)"SBMemoryRegionInfoList_GetSize(SBMemoryRegionInfoList self) -> uint32_t"},
+	 { (char *)"SBMemoryRegionInfoList_GetMemoryRegionAtIndex", _wrap_SBMemoryRegionInfoList_GetMemoryRegionAtIndex, METH_VARARGS, (char *)"SBMemoryRegionInfoList_GetMemoryRegionAtIndex(SBMemoryRegionInfoList self, uint32_t idx, SBMemoryRegionInfo region_info) -> bool"},
+	 { (char *)"SBMemoryRegionInfoList_Append", _wrap_SBMemoryRegionInfoList_Append, METH_VARARGS, (char *)"\n"
 		"Append(SBMemoryRegionInfo region)\n"
 		"SBMemoryRegionInfoList_Append(SBMemoryRegionInfoList self, SBMemoryRegionInfoList region_list)\n"
 		""},
-	 { "SBMemoryRegionInfoList_Clear", _wrap_SBMemoryRegionInfoList_Clear, METH_VARARGS, (char *)"SBMemoryRegionInfoList_Clear(SBMemoryRegionInfoList self)"},
-	 { "SBMemoryRegionInfoList_swigregister", SBMemoryRegionInfoList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBModule", _wrap_new_SBModule, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBMemoryRegionInfoList_Clear", _wrap_SBMemoryRegionInfoList_Clear, METH_VARARGS, (char *)"SBMemoryRegionInfoList_Clear(SBMemoryRegionInfoList self)"},
+	 { (char *)"SBMemoryRegionInfoList_swigregister", SBMemoryRegionInfoList_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_SBModule", _wrap_new_SBModule, METH_VARARGS, (char *)"\n"
 		"SBModule()\n"
 		"SBModule(SBModule rhs)\n"
 		"SBModule(SBModuleSpec module_spec)\n"
 		"new_SBModule(SBProcess process, lldb::addr_t header_addr) -> SBModule\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBModule", _wrap_delete_SBModule, METH_VARARGS, (char *)"delete_SBModule(SBModule self)"},
-	 { "SBModule_IsValid", _wrap_SBModule_IsValid, METH_VARARGS, (char *)"SBModule_IsValid(SBModule self) -> bool"},
-	 { "SBModule___nonzero__", _wrap_SBModule___nonzero__, METH_VARARGS, (char *)"SBModule___nonzero__(SBModule self) -> bool"},
-	 { "SBModule_Clear", _wrap_SBModule_Clear, METH_VARARGS, (char *)"SBModule_Clear(SBModule self)"},
-	 { "SBModule_GetFileSpec", _wrap_SBModule_GetFileSpec, METH_VARARGS, (char *)"\n"
-		"SBModule_GetFileSpec(SBModule self) -> SBFileSpec\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Get const accessor for the module file specification.\n"
-		"///\n"
-		"/// This function returns the file for the module on the host system\n"
-		"/// that is running LLDB. This can differ from the path on the \n"
-		"/// platform since we might be doing remote debugging.\n"
-		"///\n"
-		"/// @return\n"
-		"///     A const reference to the file specification object.\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"delete_SBModule", _wrap_delete_SBModule, METH_VARARGS, (char *)"delete_SBModule(SBModule self)"},
 	 { (char *)"SBModule_IsValid", _wrap_SBModule_IsValid, METH_VARARGS, (char *)"SBModule_IsValid(SBModule self) -> bool"},
 	 { (char *)"SBModule___nonzero__", _wrap_SBModule___nonzero__, METH_VARARGS, (char *)"SBModule___nonzero__(SBModule self) -> bool"},
@@ -82122,7 +80674,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBModule_GetFileSpec", _wrap_SBModule_GetFileSpec, METH_VARARGS, (char *)"\n"
 		"SBModule_GetFileSpec(SBModule self) -> SBFileSpec\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get const accessor for the module file specification.\n"
 		"\n"
@@ -82133,28 +80684,9 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    A const reference to the file specification object.\n"
 		""},
-	 { "SBModule_GetPlatformFileSpec", _wrap_SBModule_GetPlatformFileSpec, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBModule_GetPlatformFileSpec", _wrap_SBModule_GetPlatformFileSpec, METH_VARARGS, (char *)"\n"
 		"SBModule_GetPlatformFileSpec(SBModule self) -> SBFileSpec\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Get accessor for the module platform file specification.\n"
-		"///\n"
-		"/// Platform file refers to the path of the module as it is known on\n"
-		"/// the remote system on which it is being debugged. For local \n"
-		"/// debugging this is always the same as Module::GetFileSpec(). But\n"
-		"/// remote debugging might mention a file '/usr/lib/liba.dylib'\n"
-		"/// which might be locally downloaded and cached. In this case the\n"
-		"/// platform file could be something like:\n"
-		"/// '/tmp/lldb/platform-cache/remote.host.computer/usr/lib/liba.dylib'\n"
-		"/// The file could also be cached in a local developer kit directory.\n"
-		"///\n"
-		"/// @return\n"
-		"///     A const reference to the file specification object.\n"
-		"//------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get accessor for the module platform file specification.\n"
 		"\n"
@@ -82170,45 +80702,14 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    A const reference to the file specification object.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_SetPlatformFileSpec", _wrap_SBModule_SetPlatformFileSpec, METH_VARARGS, (char *)"SBModule_SetPlatformFileSpec(SBModule self, SBFileSpec platform_file) -> bool"},
-	 { "SBModule_GetRemoteInstallFileSpec", _wrap_SBModule_GetRemoteInstallFileSpec, METH_VARARGS, (char *)"SBModule_GetRemoteInstallFileSpec(SBModule self) -> SBFileSpec"},
-	 { "SBModule_SetRemoteInstallFileSpec", _wrap_SBModule_SetRemoteInstallFileSpec, METH_VARARGS, (char *)"SBModule_SetRemoteInstallFileSpec(SBModule self, SBFileSpec file) -> bool"},
-	 { "SBModule_GetUUIDString", _wrap_SBModule_GetUUIDString, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBModule_SetPlatformFileSpec", _wrap_SBModule_SetPlatformFileSpec, METH_VARARGS, (char *)"SBModule_SetPlatformFileSpec(SBModule self, SBFileSpec platform_file) -> bool"},
 	 { (char *)"SBModule_GetRemoteInstallFileSpec", _wrap_SBModule_GetRemoteInstallFileSpec, METH_VARARGS, (char *)"SBModule_GetRemoteInstallFileSpec(SBModule self) -> SBFileSpec"},
 	 { (char *)"SBModule_SetRemoteInstallFileSpec", _wrap_SBModule_SetRemoteInstallFileSpec, METH_VARARGS, (char *)"SBModule_SetRemoteInstallFileSpec(SBModule self, SBFileSpec file) -> bool"},
 	 { (char *)"SBModule_GetUUIDString", _wrap_SBModule_GetUUIDString, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBModule_GetUUIDString(SBModule self) -> char const *\n"
 		"\n"
 		"Returns the UUID of the module as a Python string.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_FindSection", _wrap_SBModule_FindSection, METH_VARARGS, (char *)"SBModule_FindSection(SBModule self, char const * sect_name) -> SBSection"},
-	 { "SBModule_ResolveFileAddress", _wrap_SBModule_ResolveFileAddress, METH_VARARGS, (char *)"SBModule_ResolveFileAddress(SBModule self, lldb::addr_t vm_addr) -> SBAddress"},
-	 { "SBModule_ResolveSymbolContextForAddress", _wrap_SBModule_ResolveSymbolContextForAddress, METH_VARARGS, (char *)"SBModule_ResolveSymbolContextForAddress(SBModule self, SBAddress addr, uint32_t resolve_scope) -> SBSymbolContext"},
-	 { "SBModule_GetDescription", _wrap_SBModule_GetDescription, METH_VARARGS, (char *)"SBModule_GetDescription(SBModule self, SBStream description) -> bool"},
-	 { "SBModule_GetNumCompileUnits", _wrap_SBModule_GetNumCompileUnits, METH_VARARGS, (char *)"SBModule_GetNumCompileUnits(SBModule self) -> uint32_t"},
-	 { "SBModule_GetCompileUnitAtIndex", _wrap_SBModule_GetCompileUnitAtIndex, METH_VARARGS, (char *)"SBModule_GetCompileUnitAtIndex(SBModule self, uint32_t arg3) -> SBCompileUnit"},
-	 { "SBModule_FindCompileUnits", _wrap_SBModule_FindCompileUnits, METH_VARARGS, (char *)"\n"
-		"SBModule_FindCompileUnits(SBModule self, SBFileSpec sb_file_spec) -> SBSymbolContextList\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Find compile units related to *this module and passed source\n"
-		"/// file.\n"
-		"///\n"
-		"/// @param[in] sb_file_spec\n"
-		"///     A lldb::SBFileSpec object that contains source file\n"
-		"///     specification.\n"
-		"///\n"
-		"/// @return\n"
-		"///     A lldb::SBSymbolContextList that gets filled in with all of\n"
-		"///     the symbol contexts for all the matches.\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBModule___eq__", _wrap_SBModule___eq__, METH_VARARGS, (char *)"SBModule___eq__(SBModule self, SBModule rhs) -> bool"},
 	 { (char *)"SBModule___ne__", _wrap_SBModule___ne__, METH_VARARGS, (char *)"SBModule___ne__(SBModule self, SBModule rhs) -> bool"},
 	 { (char *)"SBModule_FindSection", _wrap_SBModule_FindSection, METH_VARARGS, (char *)"SBModule_FindSection(SBModule self, char const * sect_name) -> SBSection"},
@@ -82220,7 +80721,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBModule_FindCompileUnits", _wrap_SBModule_FindCompileUnits, METH_VARARGS, (char *)"\n"
 		"SBModule_FindCompileUnits(SBModule self, SBFileSpec sb_file_spec) -> SBSymbolContextList\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Find compile units related to *this module and passed source\n"
 		"file.\n"
@@ -82233,21 +80733,6 @@ static PyMethodDef SwigMethods[] = {
 		"    A lldb::SBSymbolContextList that gets filled in with all of\n"
 		"    the symbol contexts for all the matches.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_GetNumSymbols", _wrap_SBModule_GetNumSymbols, METH_VARARGS, (char *)"SBModule_GetNumSymbols(SBModule self) -> size_t"},
-	 { "SBModule_GetSymbolAtIndex", _wrap_SBModule_GetSymbolAtIndex, METH_VARARGS, (char *)"SBModule_GetSymbolAtIndex(SBModule self, size_t idx) -> SBSymbol"},
-	 { "SBModule_FindSymbol", _wrap_SBModule_FindSymbol, METH_VARARGS, (char *)"\n"
-		"FindSymbol(char const * name, lldb::SymbolType type) -> SBSymbol\n"
-		"SBModule_FindSymbol(SBModule self, char const * name) -> SBSymbol\n"
-		""},
-	 { "SBModule_FindSymbols", _wrap_SBModule_FindSymbols, METH_VARARGS, (char *)"\n"
-		"FindSymbols(char const * name, lldb::SymbolType type) -> SBSymbolContextList\n"
-		"SBModule_FindSymbols(SBModule self, char const * name) -> SBSymbolContextList\n"
-		""},
-	 { "SBModule_GetNumSections", _wrap_SBModule_GetNumSections, METH_VARARGS, (char *)"SBModule_GetNumSections(SBModule self) -> size_t"},
-	 { "SBModule_GetSectionAtIndex", _wrap_SBModule_GetSectionAtIndex, METH_VARARGS, (char *)"SBModule_GetSectionAtIndex(SBModule self, size_t idx) -> SBSection"},
-	 { "SBModule_FindFunctions", _wrap_SBModule_FindFunctions, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBModule_GetNumSymbols", _wrap_SBModule_GetNumSymbols, METH_VARARGS, (char *)"SBModule_GetNumSymbols(SBModule self) -> size_t"},
 	 { (char *)"SBModule_GetSymbolAtIndex", _wrap_SBModule_GetSymbolAtIndex, METH_VARARGS, (char *)"SBModule_GetSymbolAtIndex(SBModule self, size_t idx) -> SBSymbol"},
 	 { (char *)"SBModule_FindSymbol", _wrap_SBModule_FindSymbol, METH_VARARGS, (char *)"\n"
@@ -82261,7 +80746,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBModule_GetNumSections", _wrap_SBModule_GetNumSections, METH_VARARGS, (char *)"SBModule_GetNumSections(SBModule self) -> size_t"},
 	 { (char *)"SBModule_GetSectionAtIndex", _wrap_SBModule_GetSectionAtIndex, METH_VARARGS, (char *)"SBModule_GetSectionAtIndex(SBModule self, size_t idx) -> SBSection"},
 	 { (char *)"SBModule_FindFunctions", _wrap_SBModule_FindFunctions, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"FindFunctions(char const * name, uint32_t name_type_mask) -> SBSymbolContextList\n"
 		"SBModule_FindFunctions(SBModule self, char const * name) -> SBSymbolContextList\n"
 		"\n"
@@ -82282,31 +80766,6 @@ static PyMethodDef SwigMethods[] = {
 		"    A symbol context list that gets filled in with all of the\n"
 		"    matches.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_FindFirstType", _wrap_SBModule_FindFirstType, METH_VARARGS, (char *)"SBModule_FindFirstType(SBModule self, char const * name) -> SBType"},
-	 { "SBModule_FindTypes", _wrap_SBModule_FindTypes, METH_VARARGS, (char *)"SBModule_FindTypes(SBModule self, char const * type) -> SBTypeList"},
-	 { "SBModule_GetTypeByID", _wrap_SBModule_GetTypeByID, METH_VARARGS, (char *)"SBModule_GetTypeByID(SBModule self, lldb::user_id_t uid) -> SBType"},
-	 { "SBModule_GetBasicType", _wrap_SBModule_GetBasicType, METH_VARARGS, (char *)"SBModule_GetBasicType(SBModule self, lldb::BasicType type) -> SBType"},
-	 { "SBModule_GetTypes", _wrap_SBModule_GetTypes, METH_VARARGS, (char *)"\n"
-		"GetTypes(uint32_t type_mask) -> SBTypeList\n"
-		"SBModule_GetTypes(SBModule self) -> SBTypeList\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Get all types matching  type_mask from debug info in this\n"
-		"/// module.\n"
-		"///\n"
-		"/// @param[in] type_mask\n"
-		"///     A bitfield that consists of one or more bits logically OR'ed\n"
-		"///     together from the lldb::TypeClass enumeration. This allows\n"
-		"///     you to request only structure types, or only class, struct\n"
-		"///     and union types. Passing in lldb::eTypeClassAny will return\n"
-		"///     all types found in the debug information for this module.\n"
-		"///\n"
-		"/// @return\n"
-		"///     A list of types in this module that match  type_mask\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBModule_FindFirstType", _wrap_SBModule_FindFirstType, METH_VARARGS, (char *)"SBModule_FindFirstType(SBModule self, char const * name) -> SBType"},
 	 { (char *)"SBModule_FindTypes", _wrap_SBModule_FindTypes, METH_VARARGS, (char *)"SBModule_FindTypes(SBModule self, char const * type) -> SBTypeList"},
 	 { (char *)"SBModule_GetTypeByID", _wrap_SBModule_GetTypeByID, METH_VARARGS, (char *)"SBModule_GetTypeByID(SBModule self, lldb::user_id_t uid) -> SBType"},
@@ -82315,7 +80774,6 @@ static PyMethodDef SwigMethods[] = {
 		"GetTypes(uint32_t type_mask) -> SBTypeList\n"
 		"SBModule_GetTypes(SBModule self) -> SBTypeList\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get all types matching type_mask from debug info in this\n"
 		"module.\n"
@@ -82330,11 +80788,6 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    A list of types in this module that match type_mask\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_FindGlobalVariables", _wrap_SBModule_FindGlobalVariables, METH_VARARGS, (char *)"\n"
-		"SBModule_FindGlobalVariables(SBModule self, SBTarget target, char const * name, uint32_t max_matches) -> SBValueList\n"
-		"\n"
-=======
 	 { (char *)"SBModule_FindGlobalVariables", _wrap_SBModule_FindGlobalVariables, METH_VARARGS, (char *)"\n"
 		"SBModule_FindGlobalVariables(SBModule self, SBTarget target, char const * name, uint32_t max_matches) -> SBValueList\n"
 		"\n"
@@ -82347,7 +80800,6 @@ static PyMethodDef SwigMethods[] = {
 		"@param[in] name\n"
 		"    The name of the global or static variable we are looking\n"
 		"    for.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[in] max_matches\n"
 		"    Allow the number of matches to be limited to max_matches.\n"
@@ -82355,14 +80807,8 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    A list of matched variables in an SBValueList.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_FindFirstGlobalVariable", _wrap_SBModule_FindFirstGlobalVariable, METH_VARARGS, (char *)"\n"
-		"SBModule_FindFirstGlobalVariable(SBModule self, SBTarget target, char const * name) -> SBValue\n"
-		"\n"
-=======
 	 { (char *)"SBModule_FindFirstGlobalVariable", _wrap_SBModule_FindFirstGlobalVariable, METH_VARARGS, (char *)"\n"
 		"SBModule_FindFirstGlobalVariable(SBModule self, SBTarget target, char const * name) -> SBValue\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Find the first global (or static) variable by name.\n"
@@ -82377,139 +80823,6 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    An SBValue that gets filled in with the found variable (if any).\n"
 		""},
-<<<<<<< HEAD
-	 { "SBModule_GetByteOrder", _wrap_SBModule_GetByteOrder, METH_VARARGS, (char *)"SBModule_GetByteOrder(SBModule self) -> lldb::ByteOrder"},
-	 { "SBModule_GetAddressByteSize", _wrap_SBModule_GetAddressByteSize, METH_VARARGS, (char *)"SBModule_GetAddressByteSize(SBModule self) -> uint32_t"},
-	 { "SBModule_GetTriple", _wrap_SBModule_GetTriple, METH_VARARGS, (char *)"SBModule_GetTriple(SBModule self) -> char const *"},
-	 { "SBModule_GetVersion", _wrap_SBModule_GetVersion, METH_VARARGS, (char *)"SBModule_GetVersion(SBModule self) -> uint32_t"},
-	 { "SBModule_GetSymbolFileSpec", _wrap_SBModule_GetSymbolFileSpec, METH_VARARGS, (char *)"SBModule_GetSymbolFileSpec(SBModule self) -> SBFileSpec"},
-	 { "SBModule_GetObjectFileHeaderAddress", _wrap_SBModule_GetObjectFileHeaderAddress, METH_VARARGS, (char *)"SBModule_GetObjectFileHeaderAddress(SBModule self) -> SBAddress"},
-	 { "SBModule_IsTypeSystemCompatible", _wrap_SBModule_IsTypeSystemCompatible, METH_VARARGS, (char *)"SBModule_IsTypeSystemCompatible(SBModule self, lldb::LanguageType language) -> SBError"},
-	 { "SBModule_GetObjectFileEntryPointAddress", _wrap_SBModule_GetObjectFileEntryPointAddress, METH_VARARGS, (char *)"SBModule_GetObjectFileEntryPointAddress(SBModule self) -> SBAddress"},
-	 { "SBModule___eq__", _wrap_SBModule___eq__, METH_VARARGS, (char *)"SBModule___eq__(SBModule self, SBModule rhs) -> bool"},
-	 { "SBModule___ne__", _wrap_SBModule___ne__, METH_VARARGS, (char *)"SBModule___ne__(SBModule self, SBModule rhs) -> bool"},
-	 { "SBModule___str__", _wrap_SBModule___str__, METH_VARARGS, (char *)"SBModule___str__(SBModule self) -> PyObject *"},
-	 { "SBModule_swigregister", SBModule_swigregister, METH_VARARGS, NULL},
-	 { "new_SBModuleSpec", _wrap_new_SBModuleSpec, METH_VARARGS, (char *)"\n"
-		"SBModuleSpec()\n"
-		"new_SBModuleSpec(SBModuleSpec rhs) -> SBModuleSpec\n"
-		""},
-	 { "delete_SBModuleSpec", _wrap_delete_SBModuleSpec, METH_VARARGS, (char *)"delete_SBModuleSpec(SBModuleSpec self)"},
-	 { "SBModuleSpec_IsValid", _wrap_SBModuleSpec_IsValid, METH_VARARGS, (char *)"SBModuleSpec_IsValid(SBModuleSpec self) -> bool"},
-	 { "SBModuleSpec___nonzero__", _wrap_SBModuleSpec___nonzero__, METH_VARARGS, (char *)"SBModuleSpec___nonzero__(SBModuleSpec self) -> bool"},
-	 { "SBModuleSpec_Clear", _wrap_SBModuleSpec_Clear, METH_VARARGS, (char *)"SBModuleSpec_Clear(SBModuleSpec self)"},
-	 { "SBModuleSpec_GetFileSpec", _wrap_SBModuleSpec_GetFileSpec, METH_VARARGS, (char *)"SBModuleSpec_GetFileSpec(SBModuleSpec self) -> SBFileSpec"},
-	 { "SBModuleSpec_SetFileSpec", _wrap_SBModuleSpec_SetFileSpec, METH_VARARGS, (char *)"SBModuleSpec_SetFileSpec(SBModuleSpec self, SBFileSpec fspec)"},
-	 { "SBModuleSpec_GetPlatformFileSpec", _wrap_SBModuleSpec_GetPlatformFileSpec, METH_VARARGS, (char *)"SBModuleSpec_GetPlatformFileSpec(SBModuleSpec self) -> SBFileSpec"},
-	 { "SBModuleSpec_SetPlatformFileSpec", _wrap_SBModuleSpec_SetPlatformFileSpec, METH_VARARGS, (char *)"SBModuleSpec_SetPlatformFileSpec(SBModuleSpec self, SBFileSpec fspec)"},
-	 { "SBModuleSpec_GetSymbolFileSpec", _wrap_SBModuleSpec_GetSymbolFileSpec, METH_VARARGS, (char *)"SBModuleSpec_GetSymbolFileSpec(SBModuleSpec self) -> SBFileSpec"},
-	 { "SBModuleSpec_SetSymbolFileSpec", _wrap_SBModuleSpec_SetSymbolFileSpec, METH_VARARGS, (char *)"SBModuleSpec_SetSymbolFileSpec(SBModuleSpec self, SBFileSpec fspec)"},
-	 { "SBModuleSpec_GetObjectName", _wrap_SBModuleSpec_GetObjectName, METH_VARARGS, (char *)"SBModuleSpec_GetObjectName(SBModuleSpec self) -> char const *"},
-	 { "SBModuleSpec_SetObjectName", _wrap_SBModuleSpec_SetObjectName, METH_VARARGS, (char *)"SBModuleSpec_SetObjectName(SBModuleSpec self, char const * name)"},
-	 { "SBModuleSpec_GetTriple", _wrap_SBModuleSpec_GetTriple, METH_VARARGS, (char *)"SBModuleSpec_GetTriple(SBModuleSpec self) -> char const *"},
-	 { "SBModuleSpec_SetTriple", _wrap_SBModuleSpec_SetTriple, METH_VARARGS, (char *)"SBModuleSpec_SetTriple(SBModuleSpec self, char const * triple)"},
-	 { "SBModuleSpec_GetUUIDBytes", _wrap_SBModuleSpec_GetUUIDBytes, METH_VARARGS, (char *)"SBModuleSpec_GetUUIDBytes(SBModuleSpec self) -> uint8_t const *"},
-	 { "SBModuleSpec_GetUUIDLength", _wrap_SBModuleSpec_GetUUIDLength, METH_VARARGS, (char *)"SBModuleSpec_GetUUIDLength(SBModuleSpec self) -> size_t"},
-	 { "SBModuleSpec_SetUUIDBytes", _wrap_SBModuleSpec_SetUUIDBytes, METH_VARARGS, (char *)"SBModuleSpec_SetUUIDBytes(SBModuleSpec self, uint8_t const * uuid, size_t uuid_len) -> bool"},
-	 { "SBModuleSpec_GetDescription", _wrap_SBModuleSpec_GetDescription, METH_VARARGS, (char *)"SBModuleSpec_GetDescription(SBModuleSpec self, SBStream description) -> bool"},
-	 { "SBModuleSpec___str__", _wrap_SBModuleSpec___str__, METH_VARARGS, (char *)"SBModuleSpec___str__(SBModuleSpec self) -> PyObject *"},
-	 { "SBModuleSpec_swigregister", SBModuleSpec_swigregister, METH_VARARGS, NULL},
-	 { "new_SBModuleSpecList", _wrap_new_SBModuleSpecList, METH_VARARGS, (char *)"\n"
-		"SBModuleSpecList()\n"
-		"new_SBModuleSpecList(SBModuleSpecList rhs) -> SBModuleSpecList\n"
-		""},
-	 { "delete_SBModuleSpecList", _wrap_delete_SBModuleSpecList, METH_VARARGS, (char *)"delete_SBModuleSpecList(SBModuleSpecList self)"},
-	 { "SBModuleSpecList_GetModuleSpecifications", _wrap_SBModuleSpecList_GetModuleSpecifications, METH_VARARGS, (char *)"SBModuleSpecList_GetModuleSpecifications(char const * path) -> SBModuleSpecList"},
-	 { "SBModuleSpecList_Append", _wrap_SBModuleSpecList_Append, METH_VARARGS, (char *)"\n"
-		"Append(SBModuleSpec spec)\n"
-		"SBModuleSpecList_Append(SBModuleSpecList self, SBModuleSpecList spec_list)\n"
-		""},
-	 { "SBModuleSpecList_FindFirstMatchingSpec", _wrap_SBModuleSpecList_FindFirstMatchingSpec, METH_VARARGS, (char *)"SBModuleSpecList_FindFirstMatchingSpec(SBModuleSpecList self, SBModuleSpec match_spec) -> SBModuleSpec"},
-	 { "SBModuleSpecList_FindMatchingSpecs", _wrap_SBModuleSpecList_FindMatchingSpecs, METH_VARARGS, (char *)"SBModuleSpecList_FindMatchingSpecs(SBModuleSpecList self, SBModuleSpec match_spec) -> SBModuleSpecList"},
-	 { "SBModuleSpecList_GetSize", _wrap_SBModuleSpecList_GetSize, METH_VARARGS, (char *)"SBModuleSpecList_GetSize(SBModuleSpecList self) -> size_t"},
-	 { "SBModuleSpecList_GetSpecAtIndex", _wrap_SBModuleSpecList_GetSpecAtIndex, METH_VARARGS, (char *)"SBModuleSpecList_GetSpecAtIndex(SBModuleSpecList self, size_t i) -> SBModuleSpec"},
-	 { "SBModuleSpecList_GetDescription", _wrap_SBModuleSpecList_GetDescription, METH_VARARGS, (char *)"SBModuleSpecList_GetDescription(SBModuleSpecList self, SBStream description) -> bool"},
-	 { "SBModuleSpecList___str__", _wrap_SBModuleSpecList___str__, METH_VARARGS, (char *)"SBModuleSpecList___str__(SBModuleSpecList self) -> PyObject *"},
-	 { "SBModuleSpecList_swigregister", SBModuleSpecList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBPlatformConnectOptions", _wrap_new_SBPlatformConnectOptions, METH_VARARGS, (char *)"\n"
-		"SBPlatformConnectOptions(char const * url)\n"
-		"new_SBPlatformConnectOptions(SBPlatformConnectOptions rhs) -> SBPlatformConnectOptions\n"
-		""},
-	 { "delete_SBPlatformConnectOptions", _wrap_delete_SBPlatformConnectOptions, METH_VARARGS, (char *)"delete_SBPlatformConnectOptions(SBPlatformConnectOptions self)"},
-	 { "SBPlatformConnectOptions_GetURL", _wrap_SBPlatformConnectOptions_GetURL, METH_VARARGS, (char *)"SBPlatformConnectOptions_GetURL(SBPlatformConnectOptions self) -> char const *"},
-	 { "SBPlatformConnectOptions_SetURL", _wrap_SBPlatformConnectOptions_SetURL, METH_VARARGS, (char *)"SBPlatformConnectOptions_SetURL(SBPlatformConnectOptions self, char const * url)"},
-	 { "SBPlatformConnectOptions_GetRsyncEnabled", _wrap_SBPlatformConnectOptions_GetRsyncEnabled, METH_VARARGS, (char *)"SBPlatformConnectOptions_GetRsyncEnabled(SBPlatformConnectOptions self) -> bool"},
-	 { "SBPlatformConnectOptions_EnableRsync", _wrap_SBPlatformConnectOptions_EnableRsync, METH_VARARGS, (char *)"SBPlatformConnectOptions_EnableRsync(SBPlatformConnectOptions self, char const * options, char const * remote_path_prefix, bool omit_remote_hostname)"},
-	 { "SBPlatformConnectOptions_DisableRsync", _wrap_SBPlatformConnectOptions_DisableRsync, METH_VARARGS, (char *)"SBPlatformConnectOptions_DisableRsync(SBPlatformConnectOptions self)"},
-	 { "SBPlatformConnectOptions_GetLocalCacheDirectory", _wrap_SBPlatformConnectOptions_GetLocalCacheDirectory, METH_VARARGS, (char *)"SBPlatformConnectOptions_GetLocalCacheDirectory(SBPlatformConnectOptions self) -> char const *"},
-	 { "SBPlatformConnectOptions_SetLocalCacheDirectory", _wrap_SBPlatformConnectOptions_SetLocalCacheDirectory, METH_VARARGS, (char *)"SBPlatformConnectOptions_SetLocalCacheDirectory(SBPlatformConnectOptions self, char const * path)"},
-	 { "SBPlatformConnectOptions_swigregister", SBPlatformConnectOptions_swigregister, METH_VARARGS, NULL},
-	 { "new_SBPlatformShellCommand", _wrap_new_SBPlatformShellCommand, METH_VARARGS, (char *)"\n"
-		"SBPlatformShellCommand(char const * shell_command)\n"
-		"new_SBPlatformShellCommand(SBPlatformShellCommand rhs) -> SBPlatformShellCommand\n"
-		""},
-	 { "delete_SBPlatformShellCommand", _wrap_delete_SBPlatformShellCommand, METH_VARARGS, (char *)"delete_SBPlatformShellCommand(SBPlatformShellCommand self)"},
-	 { "SBPlatformShellCommand_Clear", _wrap_SBPlatformShellCommand_Clear, METH_VARARGS, (char *)"SBPlatformShellCommand_Clear(SBPlatformShellCommand self)"},
-	 { "SBPlatformShellCommand_GetCommand", _wrap_SBPlatformShellCommand_GetCommand, METH_VARARGS, (char *)"SBPlatformShellCommand_GetCommand(SBPlatformShellCommand self) -> char const *"},
-	 { "SBPlatformShellCommand_SetCommand", _wrap_SBPlatformShellCommand_SetCommand, METH_VARARGS, (char *)"SBPlatformShellCommand_SetCommand(SBPlatformShellCommand self, char const * shell_command)"},
-	 { "SBPlatformShellCommand_GetWorkingDirectory", _wrap_SBPlatformShellCommand_GetWorkingDirectory, METH_VARARGS, (char *)"SBPlatformShellCommand_GetWorkingDirectory(SBPlatformShellCommand self) -> char const *"},
-	 { "SBPlatformShellCommand_SetWorkingDirectory", _wrap_SBPlatformShellCommand_SetWorkingDirectory, METH_VARARGS, (char *)"SBPlatformShellCommand_SetWorkingDirectory(SBPlatformShellCommand self, char const * path)"},
-	 { "SBPlatformShellCommand_GetTimeoutSeconds", _wrap_SBPlatformShellCommand_GetTimeoutSeconds, METH_VARARGS, (char *)"SBPlatformShellCommand_GetTimeoutSeconds(SBPlatformShellCommand self) -> uint32_t"},
-	 { "SBPlatformShellCommand_SetTimeoutSeconds", _wrap_SBPlatformShellCommand_SetTimeoutSeconds, METH_VARARGS, (char *)"SBPlatformShellCommand_SetTimeoutSeconds(SBPlatformShellCommand self, uint32_t sec)"},
-	 { "SBPlatformShellCommand_GetSignal", _wrap_SBPlatformShellCommand_GetSignal, METH_VARARGS, (char *)"SBPlatformShellCommand_GetSignal(SBPlatformShellCommand self) -> int"},
-	 { "SBPlatformShellCommand_GetStatus", _wrap_SBPlatformShellCommand_GetStatus, METH_VARARGS, (char *)"SBPlatformShellCommand_GetStatus(SBPlatformShellCommand self) -> int"},
-	 { "SBPlatformShellCommand_GetOutput", _wrap_SBPlatformShellCommand_GetOutput, METH_VARARGS, (char *)"SBPlatformShellCommand_GetOutput(SBPlatformShellCommand self) -> char const *"},
-	 { "SBPlatformShellCommand_swigregister", SBPlatformShellCommand_swigregister, METH_VARARGS, NULL},
-	 { "new_SBPlatform", _wrap_new_SBPlatform, METH_VARARGS, (char *)"\n"
-		"SBPlatform()\n"
-		"new_SBPlatform(char const * arg2) -> SBPlatform\n"
-		""},
-	 { "delete_SBPlatform", _wrap_delete_SBPlatform, METH_VARARGS, (char *)"delete_SBPlatform(SBPlatform self)"},
-	 { "SBPlatform_IsValid", _wrap_SBPlatform_IsValid, METH_VARARGS, (char *)"SBPlatform_IsValid(SBPlatform self) -> bool"},
-	 { "SBPlatform___nonzero__", _wrap_SBPlatform___nonzero__, METH_VARARGS, (char *)"SBPlatform___nonzero__(SBPlatform self) -> bool"},
-	 { "SBPlatform_Clear", _wrap_SBPlatform_Clear, METH_VARARGS, (char *)"SBPlatform_Clear(SBPlatform self)"},
-	 { "SBPlatform_GetWorkingDirectory", _wrap_SBPlatform_GetWorkingDirectory, METH_VARARGS, (char *)"SBPlatform_GetWorkingDirectory(SBPlatform self) -> char const *"},
-	 { "SBPlatform_SetWorkingDirectory", _wrap_SBPlatform_SetWorkingDirectory, METH_VARARGS, (char *)"SBPlatform_SetWorkingDirectory(SBPlatform self, char const * arg3) -> bool"},
-	 { "SBPlatform_GetName", _wrap_SBPlatform_GetName, METH_VARARGS, (char *)"SBPlatform_GetName(SBPlatform self) -> char const *"},
-	 { "SBPlatform_ConnectRemote", _wrap_SBPlatform_ConnectRemote, METH_VARARGS, (char *)"SBPlatform_ConnectRemote(SBPlatform self, SBPlatformConnectOptions connect_options) -> SBError"},
-	 { "SBPlatform_DisconnectRemote", _wrap_SBPlatform_DisconnectRemote, METH_VARARGS, (char *)"SBPlatform_DisconnectRemote(SBPlatform self)"},
-	 { "SBPlatform_IsConnected", _wrap_SBPlatform_IsConnected, METH_VARARGS, (char *)"SBPlatform_IsConnected(SBPlatform self) -> bool"},
-	 { "SBPlatform_GetTriple", _wrap_SBPlatform_GetTriple, METH_VARARGS, (char *)"SBPlatform_GetTriple(SBPlatform self) -> char const *"},
-	 { "SBPlatform_GetHostname", _wrap_SBPlatform_GetHostname, METH_VARARGS, (char *)"SBPlatform_GetHostname(SBPlatform self) -> char const *"},
-	 { "SBPlatform_GetOSBuild", _wrap_SBPlatform_GetOSBuild, METH_VARARGS, (char *)"SBPlatform_GetOSBuild(SBPlatform self) -> char const *"},
-	 { "SBPlatform_GetOSDescription", _wrap_SBPlatform_GetOSDescription, METH_VARARGS, (char *)"SBPlatform_GetOSDescription(SBPlatform self) -> char const *"},
-	 { "SBPlatform_GetOSMajorVersion", _wrap_SBPlatform_GetOSMajorVersion, METH_VARARGS, (char *)"SBPlatform_GetOSMajorVersion(SBPlatform self) -> uint32_t"},
-	 { "SBPlatform_GetOSMinorVersion", _wrap_SBPlatform_GetOSMinorVersion, METH_VARARGS, (char *)"SBPlatform_GetOSMinorVersion(SBPlatform self) -> uint32_t"},
-	 { "SBPlatform_GetOSUpdateVersion", _wrap_SBPlatform_GetOSUpdateVersion, METH_VARARGS, (char *)"SBPlatform_GetOSUpdateVersion(SBPlatform self) -> uint32_t"},
-	 { "SBPlatform_Get", _wrap_SBPlatform_Get, METH_VARARGS, (char *)"SBPlatform_Get(SBPlatform self, SBFileSpec src, SBFileSpec dst) -> SBError"},
-	 { "SBPlatform_Put", _wrap_SBPlatform_Put, METH_VARARGS, (char *)"SBPlatform_Put(SBPlatform self, SBFileSpec src, SBFileSpec dst) -> SBError"},
-	 { "SBPlatform_Install", _wrap_SBPlatform_Install, METH_VARARGS, (char *)"SBPlatform_Install(SBPlatform self, SBFileSpec src, SBFileSpec dst) -> SBError"},
-	 { "SBPlatform_Run", _wrap_SBPlatform_Run, METH_VARARGS, (char *)"SBPlatform_Run(SBPlatform self, SBPlatformShellCommand shell_command) -> SBError"},
-	 { "SBPlatform_Launch", _wrap_SBPlatform_Launch, METH_VARARGS, (char *)"SBPlatform_Launch(SBPlatform self, SBLaunchInfo launch_info) -> SBError"},
-	 { "SBPlatform_Kill", _wrap_SBPlatform_Kill, METH_VARARGS, (char *)"SBPlatform_Kill(SBPlatform self, lldb::pid_t const pid) -> SBError"},
-	 { "SBPlatform_MakeDirectory", _wrap_SBPlatform_MakeDirectory, METH_VARARGS, (char *)"\n"
-		"MakeDirectory(char const * path, uint32_t file_permissions) -> SBError\n"
-		"SBPlatform_MakeDirectory(SBPlatform self, char const * path) -> SBError\n"
-		""},
-	 { "SBPlatform_GetFilePermissions", _wrap_SBPlatform_GetFilePermissions, METH_VARARGS, (char *)"SBPlatform_GetFilePermissions(SBPlatform self, char const * path) -> uint32_t"},
-	 { "SBPlatform_SetFilePermissions", _wrap_SBPlatform_SetFilePermissions, METH_VARARGS, (char *)"SBPlatform_SetFilePermissions(SBPlatform self, char const * path, uint32_t file_permissions) -> SBError"},
-	 { "SBPlatform_GetUnixSignals", _wrap_SBPlatform_GetUnixSignals, METH_VARARGS, (char *)"SBPlatform_GetUnixSignals(SBPlatform self) -> SBUnixSignals"},
-	 { "SBPlatform_swigregister", SBPlatform_swigregister, METH_VARARGS, NULL},
-	 { "new_SBProcess", _wrap_new_SBProcess, METH_VARARGS, (char *)"\n"
-		"SBProcess()\n"
-		"new_SBProcess(SBProcess rhs) -> SBProcess\n"
-		""},
-	 { "delete_SBProcess", _wrap_delete_SBProcess, METH_VARARGS, (char *)"delete_SBProcess(SBProcess self)"},
-	 { "SBProcess_GetBroadcasterClassName", _wrap_SBProcess_GetBroadcasterClassName, METH_VARARGS, (char *)"SBProcess_GetBroadcasterClassName() -> char const *"},
-	 { "SBProcess_GetPluginName", _wrap_SBProcess_GetPluginName, METH_VARARGS, (char *)"SBProcess_GetPluginName(SBProcess self) -> char const *"},
-	 { "SBProcess_GetShortPluginName", _wrap_SBProcess_GetShortPluginName, METH_VARARGS, (char *)"SBProcess_GetShortPluginName(SBProcess self) -> char const *"},
-	 { "SBProcess_Clear", _wrap_SBProcess_Clear, METH_VARARGS, (char *)"SBProcess_Clear(SBProcess self)"},
-	 { "SBProcess_IsValid", _wrap_SBProcess_IsValid, METH_VARARGS, (char *)"SBProcess_IsValid(SBProcess self) -> bool"},
-	 { "SBProcess___nonzero__", _wrap_SBProcess___nonzero__, METH_VARARGS, (char *)"SBProcess___nonzero__(SBProcess self) -> bool"},
-	 { "SBProcess_GetTarget", _wrap_SBProcess_GetTarget, METH_VARARGS, (char *)"SBProcess_GetTarget(SBProcess self) -> SBTarget"},
-	 { "SBProcess_GetByteOrder", _wrap_SBProcess_GetByteOrder, METH_VARARGS, (char *)"SBProcess_GetByteOrder(SBProcess self) -> lldb::ByteOrder"},
-	 { "SBProcess_PutSTDIN", _wrap_SBProcess_PutSTDIN, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBModule_GetByteOrder", _wrap_SBModule_GetByteOrder, METH_VARARGS, (char *)"SBModule_GetByteOrder(SBModule self) -> lldb::ByteOrder"},
 	 { (char *)"SBModule_GetAddressByteSize", _wrap_SBModule_GetAddressByteSize, METH_VARARGS, (char *)"SBModule_GetAddressByteSize(SBModule self) -> uint32_t"},
 	 { (char *)"SBModule_GetTriple", _wrap_SBModule_GetTriple, METH_VARARGS, (char *)"SBModule_GetTriple(SBModule self) -> char const *"},
@@ -82668,126 +80981,62 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBProcess_GetTarget", _wrap_SBProcess_GetTarget, METH_VARARGS, (char *)"SBProcess_GetTarget(SBProcess self) -> SBTarget"},
 	 { (char *)"SBProcess_GetByteOrder", _wrap_SBProcess_GetByteOrder, METH_VARARGS, (char *)"SBProcess_GetByteOrder(SBProcess self) -> lldb::ByteOrder"},
 	 { (char *)"SBProcess_PutSTDIN", _wrap_SBProcess_PutSTDIN, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Writes data into the current process's stdin. API client specifies a Python\n"
 		"string as the only argument.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetSTDOUT", _wrap_SBProcess_GetSTDOUT, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_GetSTDOUT", _wrap_SBProcess_GetSTDOUT, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Reads data from the current process's stdout stream. API client specifies\n"
 		"the size of the buffer to read data into. It returns the byte buffer in a\n"
 		"Python string.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetSTDERR", _wrap_SBProcess_GetSTDERR, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_GetSTDERR", _wrap_SBProcess_GetSTDERR, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Reads data from the current process's stderr stream. API client specifies\n"
 		"the size of the buffer to read data into. It returns the byte buffer in a\n"
 		"Python string.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetAsyncProfileData", _wrap_SBProcess_GetAsyncProfileData, METH_VARARGS, (char *)"SBProcess_GetAsyncProfileData(SBProcess self, char * dst) -> size_t"},
-	 { "SBProcess_ReportEventState", _wrap_SBProcess_ReportEventState, METH_VARARGS, (char *)"SBProcess_ReportEventState(SBProcess self, SBEvent event, FILE * out)"},
-	 { "SBProcess_AppendEventStateReport", _wrap_SBProcess_AppendEventStateReport, METH_VARARGS, (char *)"SBProcess_AppendEventStateReport(SBProcess self, SBEvent event, SBCommandReturnObject result)"},
-	 { "SBProcess_RemoteAttachToProcessWithID", _wrap_SBProcess_RemoteAttachToProcessWithID, METH_VARARGS, (char *)"\n"
-		"SBProcess_RemoteAttachToProcessWithID(SBProcess self, lldb::pid_t pid, SBError error) -> bool\n"
-		"\n"
-=======
 	 { (char *)"SBProcess_GetAsyncProfileData", _wrap_SBProcess_GetAsyncProfileData, METH_VARARGS, (char *)"SBProcess_GetAsyncProfileData(SBProcess self, char * dst) -> size_t"},
 	 { (char *)"SBProcess_ReportEventState", _wrap_SBProcess_ReportEventState, METH_VARARGS, (char *)"SBProcess_ReportEventState(SBProcess self, SBEvent event, FILE * out)"},
 	 { (char *)"SBProcess_AppendEventStateReport", _wrap_SBProcess_AppendEventStateReport, METH_VARARGS, (char *)"SBProcess_AppendEventStateReport(SBProcess self, SBEvent event, SBCommandReturnObject result)"},
 	 { (char *)"SBProcess_RemoteAttachToProcessWithID", _wrap_SBProcess_RemoteAttachToProcessWithID, METH_VARARGS, (char *)"\n"
 		"SBProcess_RemoteAttachToProcessWithID(SBProcess self, lldb::pid_t pid, SBError error) -> bool\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Remote connection related functions. These will fail if the\n"
 		"process is not in eStateConnected. They are intended for use\n"
 		"when connecting to an externally managed debugserver instance.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_RemoteLaunch", _wrap_SBProcess_RemoteLaunch, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_RemoteLaunch", _wrap_SBProcess_RemoteLaunch, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBProcess_RemoteLaunch(SBProcess self, char const ** argv, char const ** envp, char const * stdin_path, char const * stdout_path, char const * stderr_path, char const * working_directory, uint32_t launch_flags, bool stop_at_entry, SBError error) -> bool\n"
 		"\n"
 		"See SBTarget.Launch for argument description and usage.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetNumThreads", _wrap_SBProcess_GetNumThreads, METH_VARARGS, (char *)"SBProcess_GetNumThreads(SBProcess self) -> uint32_t"},
-	 { "SBProcess_GetThreadAtIndex", _wrap_SBProcess_GetThreadAtIndex, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_GetNumThreads", _wrap_SBProcess_GetNumThreads, METH_VARARGS, (char *)"SBProcess_GetNumThreads(SBProcess self) -> uint32_t"},
 	 { (char *)"SBProcess_GetThreadAtIndex", _wrap_SBProcess_GetThreadAtIndex, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns the INDEX'th thread from the list of current threads.  The index\n"
 		"of a thread is only valid for the current stop.  For a persistent thread\n"
 		"identifier use either the thread ID or the IndexID.  See help on SBThread\n"
 		"for more details.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetThreadByID", _wrap_SBProcess_GetThreadByID, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Returns the thread with the given thread ID.\n"
-=======
 	 { (char *)"SBProcess_GetThreadByID", _wrap_SBProcess_GetThreadByID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns the thread with the given thread ID.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetThreadByIndexID", _wrap_SBProcess_GetThreadByIndexID, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Returns the thread with the given thread IndexID.\n"
-=======
 	 { (char *)"SBProcess_GetThreadByIndexID", _wrap_SBProcess_GetThreadByIndexID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns the thread with the given thread IndexID.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetSelectedThread", _wrap_SBProcess_GetSelectedThread, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Returns the currently selected thread.\n"
-=======
 	 { (char *)"SBProcess_GetSelectedThread", _wrap_SBProcess_GetSelectedThread, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns the currently selected thread.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_CreateOSPluginThread", _wrap_SBProcess_CreateOSPluginThread, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Lazily create a thread on demand through the current OperatingSystem plug-in, if the current OperatingSystem plug-in supports it.\n"
-=======
 	 { (char *)"SBProcess_CreateOSPluginThread", _wrap_SBProcess_CreateOSPluginThread, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Lazily create a thread on demand through the current OperatingSystem plug-in, if the current OperatingSystem plug-in supports it.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_SetSelectedThread", _wrap_SBProcess_SetSelectedThread, METH_VARARGS, (char *)"SBProcess_SetSelectedThread(SBProcess self, SBThread thread) -> bool"},
-	 { "SBProcess_SetSelectedThreadByID", _wrap_SBProcess_SetSelectedThreadByID, METH_VARARGS, (char *)"SBProcess_SetSelectedThreadByID(SBProcess self, lldb::tid_t tid) -> bool"},
-	 { "SBProcess_SetSelectedThreadByIndexID", _wrap_SBProcess_SetSelectedThreadByIndexID, METH_VARARGS, (char *)"SBProcess_SetSelectedThreadByIndexID(SBProcess self, uint32_t index_id) -> bool"},
-	 { "SBProcess_GetNumQueues", _wrap_SBProcess_GetNumQueues, METH_VARARGS, (char *)"SBProcess_GetNumQueues(SBProcess self) -> uint32_t"},
-	 { "SBProcess_GetQueueAtIndex", _wrap_SBProcess_GetQueueAtIndex, METH_VARARGS, (char *)"SBProcess_GetQueueAtIndex(SBProcess self, uint32_t index) -> SBQueue"},
-	 { "SBProcess_GetState", _wrap_SBProcess_GetState, METH_VARARGS, (char *)"SBProcess_GetState(SBProcess self) -> lldb::StateType"},
-	 { "SBProcess_GetExitStatus", _wrap_SBProcess_GetExitStatus, METH_VARARGS, (char *)"SBProcess_GetExitStatus(SBProcess self) -> int"},
-	 { "SBProcess_GetExitDescription", _wrap_SBProcess_GetExitDescription, METH_VARARGS, (char *)"SBProcess_GetExitDescription(SBProcess self) -> char const *"},
-	 { "SBProcess_GetProcessID", _wrap_SBProcess_GetProcessID, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Returns the process ID of the process.\n"
-=======
 	 { (char *)"SBProcess_SetSelectedThread", _wrap_SBProcess_SetSelectedThread, METH_VARARGS, (char *)"SBProcess_SetSelectedThread(SBProcess self, SBThread thread) -> bool"},
 	 { (char *)"SBProcess_SetSelectedThreadByID", _wrap_SBProcess_SetSelectedThreadByID, METH_VARARGS, (char *)"SBProcess_SetSelectedThreadByID(SBProcess self, lldb::tid_t tid) -> bool"},
 	 { (char *)"SBProcess_SetSelectedThreadByIndexID", _wrap_SBProcess_SetSelectedThreadByIndexID, METH_VARARGS, (char *)"SBProcess_SetSelectedThreadByIndexID(SBProcess self, uint32_t index_id) -> bool"},
@@ -82797,44 +81046,32 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBProcess_GetExitStatus", _wrap_SBProcess_GetExitStatus, METH_VARARGS, (char *)"SBProcess_GetExitStatus(SBProcess self) -> int"},
 	 { (char *)"SBProcess_GetExitDescription", _wrap_SBProcess_GetExitDescription, METH_VARARGS, (char *)"SBProcess_GetExitDescription(SBProcess self) -> char const *"},
 	 { (char *)"SBProcess_GetProcessID", _wrap_SBProcess_GetProcessID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns the process ID of the process.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetUniqueID", _wrap_SBProcess_GetUniqueID, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Returns an integer ID that is guaranteed to be unique across all process instances. This is not the process ID, just a unique integer for comparison and caching purposes.\n"
-=======
 	 { (char *)"SBProcess_GetUniqueID", _wrap_SBProcess_GetUniqueID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns an integer ID that is guaranteed to be unique across all process instances. This is not the process ID, just a unique integer for comparison and caching purposes.\n"
 		""},
-	 { "SBProcess_GetAddressByteSize", _wrap_SBProcess_GetAddressByteSize, METH_VARARGS, (char *)"SBProcess_GetAddressByteSize(SBProcess self) -> uint32_t"},
-	 { "SBProcess_Destroy", _wrap_SBProcess_Destroy, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBProcess_GetAddressByteSize", _wrap_SBProcess_GetAddressByteSize, METH_VARARGS, (char *)"SBProcess_GetAddressByteSize(SBProcess self) -> uint32_t"},
+	 { (char *)"SBProcess_Destroy", _wrap_SBProcess_Destroy, METH_VARARGS, (char *)"\n"
 		"SBProcess_Destroy(SBProcess self) -> SBError\n"
 		"\n"
 		"\n"
 		"Kills the process and shuts down all threads that were spawned to\n"
 		"track and monitor process.\n"
 		""},
-	 { "SBProcess_Continue", _wrap_SBProcess_Continue, METH_VARARGS, (char *)"SBProcess_Continue(SBProcess self) -> SBError"},
-	 { "SBProcess_Stop", _wrap_SBProcess_Stop, METH_VARARGS, (char *)"SBProcess_Stop(SBProcess self) -> SBError"},
-	 { "SBProcess_Kill", _wrap_SBProcess_Kill, METH_VARARGS, (char *)"SBProcess_Kill(SBProcess self) -> SBError"},
-	 { "SBProcess_Detach", _wrap_SBProcess_Detach, METH_VARARGS, (char *)"SBProcess_Detach(SBProcess self) -> SBError"},
-	 { "SBProcess_Signal", _wrap_SBProcess_Signal, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBProcess_Continue", _wrap_SBProcess_Continue, METH_VARARGS, (char *)"SBProcess_Continue(SBProcess self) -> SBError"},
+	 { (char *)"SBProcess_Stop", _wrap_SBProcess_Stop, METH_VARARGS, (char *)"SBProcess_Stop(SBProcess self) -> SBError"},
+	 { (char *)"SBProcess_Kill", _wrap_SBProcess_Kill, METH_VARARGS, (char *)"SBProcess_Kill(SBProcess self) -> SBError"},
+	 { (char *)"SBProcess_Detach", _wrap_SBProcess_Detach, METH_VARARGS, (char *)"SBProcess_Detach(SBProcess self) -> SBError"},
+	 { (char *)"SBProcess_Signal", _wrap_SBProcess_Signal, METH_VARARGS, (char *)"\n"
 		"SBProcess_Signal(SBProcess self, int signal) -> SBError\n"
 		"\n"
 		"Sends the process a unix signal.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetUnixSignals", _wrap_SBProcess_GetUnixSignals, METH_VARARGS, (char *)"SBProcess_GetUnixSignals(SBProcess self) -> SBUnixSignals"},
-	 { "SBProcess_GetStopID", _wrap_SBProcess_GetStopID, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_GetUnixSignals", _wrap_SBProcess_GetUnixSignals, METH_VARARGS, (char *)"SBProcess_GetUnixSignals(SBProcess self) -> SBUnixSignals"},
 	 { (char *)"SBProcess_GetStopID", _wrap_SBProcess_GetStopID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"GetStopID(bool include_expression_stops=False) -> uint32_t\n"
 		"SBProcess_GetStopID(SBProcess self) -> uint32_t\n"
 		"\n"
@@ -82845,13 +81082,8 @@ static PyMethodDef SwigMethods[] = {
 		"only increase when execution is continued explicitly by the user.  Note, the value\n"
 		"will always increase, but may increase by more than one per stop.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_SendAsyncInterrupt", _wrap_SBProcess_SendAsyncInterrupt, METH_VARARGS, (char *)"SBProcess_SendAsyncInterrupt(SBProcess self)"},
-	 { "SBProcess_ReadMemory", _wrap_SBProcess_ReadMemory, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_SendAsyncInterrupt", _wrap_SBProcess_SendAsyncInterrupt, METH_VARARGS, (char *)"SBProcess_SendAsyncInterrupt(SBProcess self)"},
 	 { (char *)"SBProcess_ReadMemory", _wrap_SBProcess_ReadMemory, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Reads memory from the current process's address space and removes any\n"
 		"traps that may have been inserted into the memory. It returns the byte\n"
@@ -82861,11 +81093,7 @@ static PyMethodDef SwigMethods[] = {
 		"content = process.ReadMemory(addr, 4, error)\n"
 		"new_bytes = bytearray(content)\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_WriteMemory", _wrap_SBProcess_WriteMemory, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_WriteMemory", _wrap_SBProcess_WriteMemory, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Writes memory to the current process's address space and maintains any\n"
 		"traps that might be present due to software breakpoints. Example:\n"
@@ -82876,11 +81104,7 @@ static PyMethodDef SwigMethods[] = {
 		"if not error.Success() or result != len(bytes):\n"
 		"    print('SBProcess.WriteMemory() failed!')\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_ReadCStringFromMemory", _wrap_SBProcess_ReadCStringFromMemory, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_ReadCStringFromMemory", _wrap_SBProcess_ReadCStringFromMemory, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Reads a NULL terminated C string from the current process's address space.\n"
 		"It returns a python string of the exact length, or truncates the string if\n"
@@ -82894,15 +81118,9 @@ static PyMethodDef SwigMethods[] = {
 		"else\n"
 		"    print('error: ', error)\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_ReadUnsignedFromMemory", _wrap_SBProcess_ReadUnsignedFromMemory, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Reads an unsigned integer from memory given a byte size and an address. \n"
-=======
 	 { (char *)"SBProcess_ReadUnsignedFromMemory", _wrap_SBProcess_ReadUnsignedFromMemory, METH_VARARGS, (char *)"\n"
 		"\n"
 		"Reads an unsigned integer from memory given a byte size and an address.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"Returns the unsigned integer that was read. Example:\n"
 		"\n"
 		"# Read a 4 byte unsigned integer from address 0x1000\n"
@@ -82913,11 +81131,7 @@ static PyMethodDef SwigMethods[] = {
 		"else\n"
 		"    print('error: ', error)\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_ReadPointerFromMemory", _wrap_SBProcess_ReadPointerFromMemory, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_ReadPointerFromMemory", _wrap_SBProcess_ReadPointerFromMemory, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Reads a pointer from memory from an address and returns the value. Example:\n"
 		"\n"
@@ -82929,22 +81143,6 @@ static PyMethodDef SwigMethods[] = {
 		"else\n"
 		"    print('error: ', error)\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetStateFromEvent", _wrap_SBProcess_GetStateFromEvent, METH_VARARGS, (char *)"SBProcess_GetStateFromEvent(SBEvent event) -> lldb::StateType"},
-	 { "SBProcess_GetRestartedFromEvent", _wrap_SBProcess_GetRestartedFromEvent, METH_VARARGS, (char *)"SBProcess_GetRestartedFromEvent(SBEvent event) -> bool"},
-	 { "SBProcess_GetNumRestartedReasonsFromEvent", _wrap_SBProcess_GetNumRestartedReasonsFromEvent, METH_VARARGS, (char *)"SBProcess_GetNumRestartedReasonsFromEvent(SBEvent event) -> size_t"},
-	 { "SBProcess_GetRestartedReasonAtIndexFromEvent", _wrap_SBProcess_GetRestartedReasonAtIndexFromEvent, METH_VARARGS, (char *)"SBProcess_GetRestartedReasonAtIndexFromEvent(SBEvent event, size_t idx) -> char const *"},
-	 { "SBProcess_GetProcessFromEvent", _wrap_SBProcess_GetProcessFromEvent, METH_VARARGS, (char *)"SBProcess_GetProcessFromEvent(SBEvent event) -> SBProcess"},
-	 { "SBProcess_GetInterruptedFromEvent", _wrap_SBProcess_GetInterruptedFromEvent, METH_VARARGS, (char *)"SBProcess_GetInterruptedFromEvent(SBEvent event) -> bool"},
-	 { "SBProcess_GetStructuredDataFromEvent", _wrap_SBProcess_GetStructuredDataFromEvent, METH_VARARGS, (char *)"SBProcess_GetStructuredDataFromEvent(SBEvent event) -> SBStructuredData"},
-	 { "SBProcess_EventIsProcessEvent", _wrap_SBProcess_EventIsProcessEvent, METH_VARARGS, (char *)"SBProcess_EventIsProcessEvent(SBEvent event) -> bool"},
-	 { "SBProcess_EventIsStructuredDataEvent", _wrap_SBProcess_EventIsStructuredDataEvent, METH_VARARGS, (char *)"SBProcess_EventIsStructuredDataEvent(SBEvent event) -> bool"},
-	 { "SBProcess_GetBroadcaster", _wrap_SBProcess_GetBroadcaster, METH_VARARGS, (char *)"SBProcess_GetBroadcaster(SBProcess self) -> SBBroadcaster"},
-	 { "SBProcess_GetDescription", _wrap_SBProcess_GetDescription, METH_VARARGS, (char *)"SBProcess_GetDescription(SBProcess self, SBStream description) -> bool"},
-	 { "SBProcess_GetNumSupportedHardwareWatchpoints", _wrap_SBProcess_GetNumSupportedHardwareWatchpoints, METH_VARARGS, (char *)"SBProcess_GetNumSupportedHardwareWatchpoints(SBProcess self, SBError error) -> uint32_t"},
-	 { "SBProcess_LoadImage", _wrap_SBProcess_LoadImage, METH_VARARGS, (char *)"SBProcess_LoadImage(SBProcess self, SBFileSpec image_spec, SBError error) -> uint32_t"},
-	 { "SBProcess_LoadImageUsingPaths", _wrap_SBProcess_LoadImageUsingPaths, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_GetStateFromEvent", _wrap_SBProcess_GetStateFromEvent, METH_VARARGS, (char *)"SBProcess_GetStateFromEvent(SBEvent event) -> lldb::StateType"},
 	 { (char *)"SBProcess_GetRestartedFromEvent", _wrap_SBProcess_GetRestartedFromEvent, METH_VARARGS, (char *)"SBProcess_GetRestartedFromEvent(SBEvent event) -> bool"},
 	 { (char *)"SBProcess_GetNumRestartedReasonsFromEvent", _wrap_SBProcess_GetNumRestartedReasonsFromEvent, METH_VARARGS, (char *)"SBProcess_GetNumRestartedReasonsFromEvent(SBEvent event) -> size_t"},
@@ -82959,7 +81157,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBProcess_GetNumSupportedHardwareWatchpoints", _wrap_SBProcess_GetNumSupportedHardwareWatchpoints, METH_VARARGS, (char *)"SBProcess_GetNumSupportedHardwareWatchpoints(SBProcess self, SBError error) -> uint32_t"},
 	 { (char *)"SBProcess_LoadImage", _wrap_SBProcess_LoadImage, METH_VARARGS, (char *)"SBProcess_LoadImage(SBProcess self, SBFileSpec image_spec, SBError error) -> uint32_t"},
 	 { (char *)"SBProcess_LoadImageUsingPaths", _wrap_SBProcess_LoadImageUsingPaths, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Load the library whose filename is given by image_spec looking in all the\n"
 		"paths supplied in the paths argument.  If successful, return a token that\n"
@@ -82967,15 +81164,9 @@ static PyMethodDef SwigMethods[] = {
 		"successfully loaded.  On failure, return\n"
 		"lldb.LLDB_INVALID_IMAGE_TOKEN.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_UnloadImage", _wrap_SBProcess_UnloadImage, METH_VARARGS, (char *)"SBProcess_UnloadImage(SBProcess self, uint32_t image_token) -> SBError"},
-	 { "SBProcess_SendEventData", _wrap_SBProcess_SendEventData, METH_VARARGS, (char *)"SBProcess_SendEventData(SBProcess self, char const * event_data) -> SBError"},
-	 { "SBProcess_GetNumExtendedBacktraceTypes", _wrap_SBProcess_GetNumExtendedBacktraceTypes, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_UnloadImage", _wrap_SBProcess_UnloadImage, METH_VARARGS, (char *)"SBProcess_UnloadImage(SBProcess self, uint32_t image_token) -> SBError"},
 	 { (char *)"SBProcess_SendEventData", _wrap_SBProcess_SendEventData, METH_VARARGS, (char *)"SBProcess_SendEventData(SBProcess self, char const * event_data) -> SBError"},
 	 { (char *)"SBProcess_GetNumExtendedBacktraceTypes", _wrap_SBProcess_GetNumExtendedBacktraceTypes, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the number of different thread-origin extended backtraces\n"
 		"this process can support as a uint32_t.\n"
@@ -82984,27 +81175,11 @@ static PyMethodDef SwigMethods[] = {
 		"or the work item was enqueued to it (in the case of a libdispatch\n"
 		"queue).\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetExtendedBacktraceTypeAtIndex", _wrap_SBProcess_GetExtendedBacktraceTypeAtIndex, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Takes an index argument, returns the name of one of the thread-origin \n"
-		"extended backtrace methods as a str.\n"
-=======
 	 { (char *)"SBProcess_GetExtendedBacktraceTypeAtIndex", _wrap_SBProcess_GetExtendedBacktraceTypeAtIndex, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Takes an index argument, returns the name of one of the thread-origin\n"
 		"extended backtrace methods as a str.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess_GetHistoryThreads", _wrap_SBProcess_GetHistoryThreads, METH_VARARGS, (char *)"SBProcess_GetHistoryThreads(SBProcess self, lldb::addr_t addr) -> SBThreadCollection"},
-	 { "SBProcess_IsInstrumentationRuntimePresent", _wrap_SBProcess_IsInstrumentationRuntimePresent, METH_VARARGS, (char *)"SBProcess_IsInstrumentationRuntimePresent(SBProcess self, lldb::InstrumentationRuntimeType type) -> bool"},
-	 { "SBProcess_SaveCore", _wrap_SBProcess_SaveCore, METH_VARARGS, (char *)"SBProcess_SaveCore(SBProcess self, char const * file_name) -> SBError"},
-	 { "SBProcess_StartTrace", _wrap_SBProcess_StartTrace, METH_VARARGS, (char *)"SBProcess_StartTrace(SBProcess self, SBTraceOptions options, SBError error) -> SBTrace"},
-	 { "SBProcess_GetMemoryRegionInfo", _wrap_SBProcess_GetMemoryRegionInfo, METH_VARARGS, (char *)"SBProcess_GetMemoryRegionInfo(SBProcess self, lldb::addr_t load_addr, SBMemoryRegionInfo region_info) -> SBError"},
-	 { "SBProcess_GetMemoryRegions", _wrap_SBProcess_GetMemoryRegions, METH_VARARGS, (char *)"SBProcess_GetMemoryRegions(SBProcess self) -> SBMemoryRegionInfoList"},
-	 { "SBProcess_GetProcessInfo", _wrap_SBProcess_GetProcessInfo, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess_GetHistoryThreads", _wrap_SBProcess_GetHistoryThreads, METH_VARARGS, (char *)"SBProcess_GetHistoryThreads(SBProcess self, lldb::addr_t addr) -> SBThreadCollection"},
 	 { (char *)"SBProcess_IsInstrumentationRuntimePresent", _wrap_SBProcess_IsInstrumentationRuntimePresent, METH_VARARGS, (char *)"SBProcess_IsInstrumentationRuntimePresent(SBProcess self, lldb::InstrumentationRuntimeType type) -> bool"},
 	 { (char *)"SBProcess_SaveCore", _wrap_SBProcess_SaveCore, METH_VARARGS, (char *)"SBProcess_SaveCore(SBProcess self, char const * file_name) -> SBError"},
@@ -83012,7 +81187,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBProcess_GetMemoryRegionInfo", _wrap_SBProcess_GetMemoryRegionInfo, METH_VARARGS, (char *)"SBProcess_GetMemoryRegionInfo(SBProcess self, lldb::addr_t load_addr, SBMemoryRegionInfo region_info) -> SBError"},
 	 { (char *)"SBProcess_GetMemoryRegions", _wrap_SBProcess_GetMemoryRegions, METH_VARARGS, (char *)"SBProcess_GetMemoryRegions(SBProcess self) -> SBMemoryRegionInfoList"},
 	 { (char *)"SBProcess_GetProcessInfo", _wrap_SBProcess_GetProcessInfo, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get information about the process.\n"
 		"Valid process info will only be returned when the process is alive,\n"
@@ -83022,40 +81196,6 @@ static PyMethodDef SwigMethods[] = {
 		"if process_info.IsValid():\n"
 		"    process_info.GetProcessID()\n"
 		""},
-<<<<<<< HEAD
-	 { "SBProcess___str__", _wrap_SBProcess___str__, METH_VARARGS, (char *)"SBProcess___str__(SBProcess self) -> PyObject *"},
-	 { "SBProcess_swigregister", SBProcess_swigregister, METH_VARARGS, NULL},
-	 { "new_SBProcessInfo", _wrap_new_SBProcessInfo, METH_VARARGS, (char *)"\n"
-		"SBProcessInfo()\n"
-		"new_SBProcessInfo(SBProcessInfo rhs) -> SBProcessInfo\n"
-		""},
-	 { "delete_SBProcessInfo", _wrap_delete_SBProcessInfo, METH_VARARGS, (char *)"delete_SBProcessInfo(SBProcessInfo self)"},
-	 { "SBProcessInfo_IsValid", _wrap_SBProcessInfo_IsValid, METH_VARARGS, (char *)"SBProcessInfo_IsValid(SBProcessInfo self) -> bool"},
-	 { "SBProcessInfo___nonzero__", _wrap_SBProcessInfo___nonzero__, METH_VARARGS, (char *)"SBProcessInfo___nonzero__(SBProcessInfo self) -> bool"},
-	 { "SBProcessInfo_GetName", _wrap_SBProcessInfo_GetName, METH_VARARGS, (char *)"SBProcessInfo_GetName(SBProcessInfo self) -> char const *"},
-	 { "SBProcessInfo_GetExecutableFile", _wrap_SBProcessInfo_GetExecutableFile, METH_VARARGS, (char *)"SBProcessInfo_GetExecutableFile(SBProcessInfo self) -> SBFileSpec"},
-	 { "SBProcessInfo_GetProcessID", _wrap_SBProcessInfo_GetProcessID, METH_VARARGS, (char *)"SBProcessInfo_GetProcessID(SBProcessInfo self) -> lldb::pid_t"},
-	 { "SBProcessInfo_GetUserID", _wrap_SBProcessInfo_GetUserID, METH_VARARGS, (char *)"SBProcessInfo_GetUserID(SBProcessInfo self) -> uint32_t"},
-	 { "SBProcessInfo_GetGroupID", _wrap_SBProcessInfo_GetGroupID, METH_VARARGS, (char *)"SBProcessInfo_GetGroupID(SBProcessInfo self) -> uint32_t"},
-	 { "SBProcessInfo_UserIDIsValid", _wrap_SBProcessInfo_UserIDIsValid, METH_VARARGS, (char *)"SBProcessInfo_UserIDIsValid(SBProcessInfo self) -> bool"},
-	 { "SBProcessInfo_GroupIDIsValid", _wrap_SBProcessInfo_GroupIDIsValid, METH_VARARGS, (char *)"SBProcessInfo_GroupIDIsValid(SBProcessInfo self) -> bool"},
-	 { "SBProcessInfo_GetEffectiveUserID", _wrap_SBProcessInfo_GetEffectiveUserID, METH_VARARGS, (char *)"SBProcessInfo_GetEffectiveUserID(SBProcessInfo self) -> uint32_t"},
-	 { "SBProcessInfo_GetEffectiveGroupID", _wrap_SBProcessInfo_GetEffectiveGroupID, METH_VARARGS, (char *)"SBProcessInfo_GetEffectiveGroupID(SBProcessInfo self) -> uint32_t"},
-	 { "SBProcessInfo_EffectiveUserIDIsValid", _wrap_SBProcessInfo_EffectiveUserIDIsValid, METH_VARARGS, (char *)"SBProcessInfo_EffectiveUserIDIsValid(SBProcessInfo self) -> bool"},
-	 { "SBProcessInfo_EffectiveGroupIDIsValid", _wrap_SBProcessInfo_EffectiveGroupIDIsValid, METH_VARARGS, (char *)"SBProcessInfo_EffectiveGroupIDIsValid(SBProcessInfo self) -> bool"},
-	 { "SBProcessInfo_GetParentProcessID", _wrap_SBProcessInfo_GetParentProcessID, METH_VARARGS, (char *)"SBProcessInfo_GetParentProcessID(SBProcessInfo self) -> lldb::pid_t"},
-	 { "SBProcessInfo_swigregister", SBProcessInfo_swigregister, METH_VARARGS, NULL},
-	 { "new_SBQueue", _wrap_new_SBQueue, METH_VARARGS, (char *)"\n"
-		"SBQueue()\n"
-		"new_SBQueue(lldb::QueueSP const & queue_sp) -> SBQueue\n"
-		""},
-	 { "delete_SBQueue", _wrap_delete_SBQueue, METH_VARARGS, (char *)"delete_SBQueue(SBQueue self)"},
-	 { "SBQueue_IsValid", _wrap_SBQueue_IsValid, METH_VARARGS, (char *)"SBQueue_IsValid(SBQueue self) -> bool"},
-	 { "SBQueue___nonzero__", _wrap_SBQueue___nonzero__, METH_VARARGS, (char *)"SBQueue___nonzero__(SBQueue self) -> bool"},
-	 { "SBQueue_Clear", _wrap_SBQueue_Clear, METH_VARARGS, (char *)"SBQueue_Clear(SBQueue self)"},
-	 { "SBQueue_GetProcess", _wrap_SBQueue_GetProcess, METH_VARARGS, (char *)"SBQueue_GetProcess(SBQueue self) -> SBProcess"},
-	 { "SBQueue_GetQueueID", _wrap_SBQueue_GetQueueID, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBProcess___str__", _wrap_SBProcess___str__, METH_VARARGS, (char *)"SBProcess___str__(SBProcess self) -> PyObject *"},
 	 { (char *)"SBProcess_swigregister", SBProcess_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBProcessInfo", _wrap_new_SBProcessInfo, METH_VARARGS, (char *)"\n"
@@ -83088,87 +81228,19 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBQueue_Clear", _wrap_SBQueue_Clear, METH_VARARGS, (char *)"SBQueue_Clear(SBQueue self)"},
 	 { (char *)"SBQueue_GetProcess", _wrap_SBQueue_GetProcess, METH_VARARGS, (char *)"SBQueue_GetProcess(SBQueue self) -> SBProcess"},
 	 { (char *)"SBQueue_GetQueueID", _wrap_SBQueue_GetQueueID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns an lldb::queue_id_t type unique identifier number for this\n"
 		"queue that will not be used by any other queue during this process'\n"
 		"execution.  These ID numbers often start at 1 with the first\n"
 		"system-created queues and increment from there.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBQueue_GetName", _wrap_SBQueue_GetName, METH_VARARGS, (char *)"SBQueue_GetName(SBQueue self) -> char const *"},
-	 { "SBQueue_GetKind", _wrap_SBQueue_GetKind, METH_VARARGS, (char *)"\n"
-		"\n"
-		"Returns an lldb::QueueKind enumerated value (e.g. eQueueKindUnknown, \n"
-=======
 	 { (char *)"SBQueue_GetName", _wrap_SBQueue_GetName, METH_VARARGS, (char *)"SBQueue_GetName(SBQueue self) -> char const *"},
 	 { (char *)"SBQueue_GetKind", _wrap_SBQueue_GetKind, METH_VARARGS, (char *)"\n"
 		"\n"
 		"Returns an lldb::QueueKind enumerated value (e.g. eQueueKindUnknown,\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"eQueueKindSerial, eQueueKindConcurrent) describing the type of this\n"
 		"queue.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBQueue_GetIndexID", _wrap_SBQueue_GetIndexID, METH_VARARGS, (char *)"SBQueue_GetIndexID(SBQueue self) -> uint32_t"},
-	 { "SBQueue_GetNumThreads", _wrap_SBQueue_GetNumThreads, METH_VARARGS, (char *)"SBQueue_GetNumThreads(SBQueue self) -> uint32_t"},
-	 { "SBQueue_GetThreadAtIndex", _wrap_SBQueue_GetThreadAtIndex, METH_VARARGS, (char *)"SBQueue_GetThreadAtIndex(SBQueue self, uint32_t arg3) -> SBThread"},
-	 { "SBQueue_GetNumPendingItems", _wrap_SBQueue_GetNumPendingItems, METH_VARARGS, (char *)"SBQueue_GetNumPendingItems(SBQueue self) -> uint32_t"},
-	 { "SBQueue_GetPendingItemAtIndex", _wrap_SBQueue_GetPendingItemAtIndex, METH_VARARGS, (char *)"SBQueue_GetPendingItemAtIndex(SBQueue self, uint32_t arg3) -> SBQueueItem"},
-	 { "SBQueue_GetNumRunningItems", _wrap_SBQueue_GetNumRunningItems, METH_VARARGS, (char *)"SBQueue_GetNumRunningItems(SBQueue self) -> uint32_t"},
-	 { "SBQueue_swigregister", SBQueue_swigregister, METH_VARARGS, NULL},
-	 { "new_SBQueueItem", _wrap_new_SBQueueItem, METH_VARARGS, (char *)"\n"
-		"SBQueueItem()\n"
-		"new_SBQueueItem(lldb::QueueItemSP const & queue_item_sp) -> SBQueueItem\n"
-		""},
-	 { "delete_SBQueueItem", _wrap_delete_SBQueueItem, METH_VARARGS, (char *)"delete_SBQueueItem(SBQueueItem self)"},
-	 { "SBQueueItem_IsValid", _wrap_SBQueueItem_IsValid, METH_VARARGS, (char *)"SBQueueItem_IsValid(SBQueueItem self) -> bool"},
-	 { "SBQueueItem___nonzero__", _wrap_SBQueueItem___nonzero__, METH_VARARGS, (char *)"SBQueueItem___nonzero__(SBQueueItem self) -> bool"},
-	 { "SBQueueItem_Clear", _wrap_SBQueueItem_Clear, METH_VARARGS, (char *)"SBQueueItem_Clear(SBQueueItem self)"},
-	 { "SBQueueItem_GetKind", _wrap_SBQueueItem_GetKind, METH_VARARGS, (char *)"SBQueueItem_GetKind(SBQueueItem self) -> lldb::QueueItemKind"},
-	 { "SBQueueItem_SetKind", _wrap_SBQueueItem_SetKind, METH_VARARGS, (char *)"SBQueueItem_SetKind(SBQueueItem self, lldb::QueueItemKind kind)"},
-	 { "SBQueueItem_GetAddress", _wrap_SBQueueItem_GetAddress, METH_VARARGS, (char *)"SBQueueItem_GetAddress(SBQueueItem self) -> SBAddress"},
-	 { "SBQueueItem_SetAddress", _wrap_SBQueueItem_SetAddress, METH_VARARGS, (char *)"SBQueueItem_SetAddress(SBQueueItem self, SBAddress addr)"},
-	 { "SBQueueItem_SetQueueItem", _wrap_SBQueueItem_SetQueueItem, METH_VARARGS, (char *)"SBQueueItem_SetQueueItem(SBQueueItem self, lldb::QueueItemSP const & queue_item_sp)"},
-	 { "SBQueueItem_GetExtendedBacktraceThread", _wrap_SBQueueItem_GetExtendedBacktraceThread, METH_VARARGS, (char *)"SBQueueItem_GetExtendedBacktraceThread(SBQueueItem self, char const * type) -> SBThread"},
-	 { "SBQueueItem_swigregister", SBQueueItem_swigregister, METH_VARARGS, NULL},
-	 { "new_SBSection", _wrap_new_SBSection, METH_VARARGS, (char *)"\n"
-		"SBSection()\n"
-		"new_SBSection(SBSection rhs) -> SBSection\n"
-		""},
-	 { "delete_SBSection", _wrap_delete_SBSection, METH_VARARGS, (char *)"delete_SBSection(SBSection self)"},
-	 { "SBSection_IsValid", _wrap_SBSection_IsValid, METH_VARARGS, (char *)"SBSection_IsValid(SBSection self) -> bool"},
-	 { "SBSection___nonzero__", _wrap_SBSection___nonzero__, METH_VARARGS, (char *)"SBSection___nonzero__(SBSection self) -> bool"},
-	 { "SBSection_GetName", _wrap_SBSection_GetName, METH_VARARGS, (char *)"SBSection_GetName(SBSection self) -> char const *"},
-	 { "SBSection_GetParent", _wrap_SBSection_GetParent, METH_VARARGS, (char *)"SBSection_GetParent(SBSection self) -> SBSection"},
-	 { "SBSection_FindSubSection", _wrap_SBSection_FindSubSection, METH_VARARGS, (char *)"SBSection_FindSubSection(SBSection self, char const * sect_name) -> SBSection"},
-	 { "SBSection_GetNumSubSections", _wrap_SBSection_GetNumSubSections, METH_VARARGS, (char *)"SBSection_GetNumSubSections(SBSection self) -> size_t"},
-	 { "SBSection_GetSubSectionAtIndex", _wrap_SBSection_GetSubSectionAtIndex, METH_VARARGS, (char *)"SBSection_GetSubSectionAtIndex(SBSection self, size_t idx) -> SBSection"},
-	 { "SBSection_GetFileAddress", _wrap_SBSection_GetFileAddress, METH_VARARGS, (char *)"SBSection_GetFileAddress(SBSection self) -> lldb::addr_t"},
-	 { "SBSection_GetLoadAddress", _wrap_SBSection_GetLoadAddress, METH_VARARGS, (char *)"SBSection_GetLoadAddress(SBSection self, SBTarget target) -> lldb::addr_t"},
-	 { "SBSection_GetByteSize", _wrap_SBSection_GetByteSize, METH_VARARGS, (char *)"SBSection_GetByteSize(SBSection self) -> lldb::addr_t"},
-	 { "SBSection_GetFileOffset", _wrap_SBSection_GetFileOffset, METH_VARARGS, (char *)"SBSection_GetFileOffset(SBSection self) -> uint64_t"},
-	 { "SBSection_GetFileByteSize", _wrap_SBSection_GetFileByteSize, METH_VARARGS, (char *)"SBSection_GetFileByteSize(SBSection self) -> uint64_t"},
-	 { "SBSection_GetSectionData", _wrap_SBSection_GetSectionData, METH_VARARGS, (char *)"\n"
-		"GetSectionData() -> SBData\n"
-		"SBSection_GetSectionData(SBSection self, uint64_t offset, uint64_t size) -> SBData\n"
-		""},
-	 { "SBSection_GetSectionType", _wrap_SBSection_GetSectionType, METH_VARARGS, (char *)"SBSection_GetSectionType(SBSection self) -> lldb::SectionType"},
-	 { "SBSection_GetPermissions", _wrap_SBSection_GetPermissions, METH_VARARGS, (char *)"SBSection_GetPermissions(SBSection self) -> uint32_t"},
-	 { "SBSection_GetTargetByteSize", _wrap_SBSection_GetTargetByteSize, METH_VARARGS, (char *)"\n"
-		"SBSection_GetTargetByteSize(SBSection self) -> uint32_t\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Return the size of a target's byte represented by this section\n"
-		"/// in numbers of host bytes. Note that certain architectures have\n"
-		"/// varying minimum addressable unit (i.e. byte) size for their \n"
-		"/// CODE or DATA buses.\n"
-		"///\n"
-		"/// @return\n"
-		"///     The number of host (8-bit) bytes needed to hold a target byte\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBQueue_GetIndexID", _wrap_SBQueue_GetIndexID, METH_VARARGS, (char *)"SBQueue_GetIndexID(SBQueue self) -> uint32_t"},
 	 { (char *)"SBQueue_GetNumThreads", _wrap_SBQueue_GetNumThreads, METH_VARARGS, (char *)"SBQueue_GetNumThreads(SBQueue self) -> uint32_t"},
 	 { (char *)"SBQueue_GetThreadAtIndex", _wrap_SBQueue_GetThreadAtIndex, METH_VARARGS, (char *)"SBQueue_GetThreadAtIndex(SBQueue self, uint32_t arg3) -> SBThread"},
@@ -83217,7 +81289,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBSection_GetTargetByteSize", _wrap_SBSection_GetTargetByteSize, METH_VARARGS, (char *)"\n"
 		"SBSection_GetTargetByteSize(SBSection self) -> uint32_t\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the size of a target's byte represented by this section\n"
 		"in numbers of host bytes. Note that certain architectures have\n"
@@ -83227,25 +81298,6 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    The number of host (8-bit) bytes needed to hold a target byte\n"
 		""},
-<<<<<<< HEAD
-	 { "SBSection_GetDescription", _wrap_SBSection_GetDescription, METH_VARARGS, (char *)"SBSection_GetDescription(SBSection self, SBStream description) -> bool"},
-	 { "SBSection___eq__", _wrap_SBSection___eq__, METH_VARARGS, (char *)"SBSection___eq__(SBSection self, SBSection rhs) -> bool"},
-	 { "SBSection___ne__", _wrap_SBSection___ne__, METH_VARARGS, (char *)"SBSection___ne__(SBSection self, SBSection rhs) -> bool"},
-	 { "SBSection___str__", _wrap_SBSection___str__, METH_VARARGS, (char *)"SBSection___str__(SBSection self) -> PyObject *"},
-	 { "SBSection_swigregister", SBSection_swigregister, METH_VARARGS, NULL},
-	 { "new_SBSourceManager", _wrap_new_SBSourceManager, METH_VARARGS, (char *)"new_SBSourceManager(SBSourceManager rhs) -> SBSourceManager"},
-	 { "delete_SBSourceManager", _wrap_delete_SBSourceManager, METH_VARARGS, (char *)"delete_SBSourceManager(SBSourceManager self)"},
-	 { "SBSourceManager_DisplaySourceLinesWithLineNumbers", _wrap_SBSourceManager_DisplaySourceLinesWithLineNumbers, METH_VARARGS, (char *)"SBSourceManager_DisplaySourceLinesWithLineNumbers(SBSourceManager self, SBFileSpec file, uint32_t line, uint32_t context_before, uint32_t context_after, char const * current_line_cstr, SBStream s) -> size_t"},
-	 { "SBSourceManager_DisplaySourceLinesWithLineNumbersAndColumn", _wrap_SBSourceManager_DisplaySourceLinesWithLineNumbersAndColumn, METH_VARARGS, (char *)"SBSourceManager_DisplaySourceLinesWithLineNumbersAndColumn(SBSourceManager self, SBFileSpec file, uint32_t line, uint32_t column, uint32_t context_before, uint32_t context_after, char const * current_line_cstr, SBStream s) -> size_t"},
-	 { "SBSourceManager_swigregister", SBSourceManager_swigregister, METH_VARARGS, NULL},
-	 { "new_SBStream", _wrap_new_SBStream, METH_VARARGS, (char *)"new_SBStream() -> SBStream"},
-	 { "delete_SBStream", _wrap_delete_SBStream, METH_VARARGS, (char *)"delete_SBStream(SBStream self)"},
-	 { "SBStream_IsValid", _wrap_SBStream_IsValid, METH_VARARGS, (char *)"SBStream_IsValid(SBStream self) -> bool"},
-	 { "SBStream___nonzero__", _wrap_SBStream___nonzero__, METH_VARARGS, (char *)"SBStream___nonzero__(SBStream self) -> bool"},
-	 { "SBStream_GetData", _wrap_SBStream_GetData, METH_VARARGS, (char *)"\n"
-		"SBStream_GetData(SBStream self) -> char const *\n"
-		"\n"
-=======
 	 { (char *)"SBSection_GetDescription", _wrap_SBSection_GetDescription, METH_VARARGS, (char *)"SBSection_GetDescription(SBSection self, SBStream description) -> bool"},
 	 { (char *)"SBSection___eq__", _wrap_SBSection___eq__, METH_VARARGS, (char *)"SBSection___eq__(SBSection self, SBSection rhs) -> bool"},
 	 { (char *)"SBSection___ne__", _wrap_SBSection___ne__, METH_VARARGS, (char *)"SBSection___ne__(SBSection self, SBSection rhs) -> bool"},
@@ -83262,44 +81314,19 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBStream___nonzero__", _wrap_SBStream___nonzero__, METH_VARARGS, (char *)"SBStream___nonzero__(SBStream self) -> bool"},
 	 { (char *)"SBStream_GetData", _wrap_SBStream_GetData, METH_VARARGS, (char *)"\n"
 		"SBStream_GetData(SBStream self) -> char const *\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"If this stream is not redirected to a file, it will maintain a local\n"
 		"cache for the stream data which can be accessed using this accessor.\n"
 		""},
-	 { "SBStream_GetSize", _wrap_SBStream_GetSize, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBStream_GetSize", _wrap_SBStream_GetSize, METH_VARARGS, (char *)"\n"
 		"SBStream_GetSize(SBStream self) -> size_t\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//--------------------------------------------------------------------------\n"
-		"/// If this stream is not redirected to a file, it will maintain a local\n"
-		"/// cache for the stream output whose length can be accessed using this \n"
-		"/// accessor.\n"
-		"//--------------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"If this stream is not redirected to a file, it will maintain a local\n"
 		"cache for the stream output whose length can be accessed using this\n"
 		"accessor.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBStream_Print", _wrap_SBStream_Print, METH_VARARGS, (char *)"SBStream_Print(SBStream self, char const * str)"},
-	 { "SBStream_RedirectToFile", _wrap_SBStream_RedirectToFile, METH_VARARGS, (char *)"SBStream_RedirectToFile(SBStream self, char const * path, bool append)"},
-	 { "SBStream_RedirectToFileHandle", _wrap_SBStream_RedirectToFileHandle, METH_VARARGS, (char *)"SBStream_RedirectToFileHandle(SBStream self, FILE * fh, bool transfer_fh_ownership)"},
-	 { "SBStream_RedirectToFileDescriptor", _wrap_SBStream_RedirectToFileDescriptor, METH_VARARGS, (char *)"SBStream_RedirectToFileDescriptor(SBStream self, int fd, bool transfer_fh_ownership)"},
-	 { "SBStream_Clear", _wrap_SBStream_Clear, METH_VARARGS, (char *)"\n"
-		"SBStream_Clear(SBStream self)\n"
-		"\n"
-		"\n"
-		"//--------------------------------------------------------------------------\n"
-		"/// If the stream is redirected to a file, forget about the file and if\n"
-		"/// ownership of the file was transferred to this object, close the file.\n"
-		"/// If the stream is backed by a local cache, clear this cache.\n"
-		"//--------------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBStream_Print", _wrap_SBStream_Print, METH_VARARGS, (char *)"SBStream_Print(SBStream self, char const * str)"},
 	 { (char *)"SBStream_RedirectToFile", _wrap_SBStream_RedirectToFile, METH_VARARGS, (char *)"SBStream_RedirectToFile(SBStream self, char const * path, bool append)"},
 	 { (char *)"SBStream_RedirectToFileHandle", _wrap_SBStream_RedirectToFileHandle, METH_VARARGS, (char *)"SBStream_RedirectToFileHandle(SBStream self, FILE * fh, bool transfer_fh_ownership)"},
@@ -83307,34 +81334,11 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBStream_Clear", _wrap_SBStream_Clear, METH_VARARGS, (char *)"\n"
 		"SBStream_Clear(SBStream self)\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"If the stream is redirected to a file, forget about the file and if\n"
 		"ownership of the file was transferred to this object, close the file.\n"
 		"If the stream is backed by a local cache, clear this cache.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBStream_write", _wrap_SBStream_write, METH_VARARGS, (char *)"SBStream_write(SBStream self, char const * str)"},
-	 { "SBStream_flush", _wrap_SBStream_flush, METH_VARARGS, (char *)"SBStream_flush(SBStream self)"},
-	 { "SBStream_swigregister", SBStream_swigregister, METH_VARARGS, NULL},
-	 { "new_SBStringList", _wrap_new_SBStringList, METH_VARARGS, (char *)"\n"
-		"SBStringList()\n"
-		"new_SBStringList(SBStringList rhs) -> SBStringList\n"
-		""},
-	 { "delete_SBStringList", _wrap_delete_SBStringList, METH_VARARGS, (char *)"delete_SBStringList(SBStringList self)"},
-	 { "SBStringList_IsValid", _wrap_SBStringList_IsValid, METH_VARARGS, (char *)"SBStringList_IsValid(SBStringList self) -> bool"},
-	 { "SBStringList___nonzero__", _wrap_SBStringList___nonzero__, METH_VARARGS, (char *)"SBStringList___nonzero__(SBStringList self) -> bool"},
-	 { "SBStringList_AppendString", _wrap_SBStringList_AppendString, METH_VARARGS, (char *)"SBStringList_AppendString(SBStringList self, char const * str)"},
-	 { "SBStringList_AppendList", _wrap_SBStringList_AppendList, METH_VARARGS, (char *)"\n"
-		"AppendList(char const ** strv, int strc)\n"
-		"SBStringList_AppendList(SBStringList self, SBStringList strings)\n"
-		""},
-	 { "SBStringList_GetSize", _wrap_SBStringList_GetSize, METH_VARARGS, (char *)"SBStringList_GetSize(SBStringList self) -> uint32_t"},
-	 { "SBStringList_GetStringAtIndex", _wrap_SBStringList_GetStringAtIndex, METH_VARARGS, (char *)"SBStringList_GetStringAtIndex(SBStringList self, size_t idx) -> char const *"},
-	 { "SBStringList_Clear", _wrap_SBStringList_Clear, METH_VARARGS, (char *)"SBStringList_Clear(SBStringList self)"},
-	 { "SBStringList_swigregister", SBStringList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBStructuredData", _wrap_new_SBStructuredData, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBStream_write", _wrap_SBStream_write, METH_VARARGS, (char *)"SBStream_write(SBStream self, char const * str)"},
 	 { (char *)"SBStream_flush", _wrap_SBStream_flush, METH_VARARGS, (char *)"SBStream_flush(SBStream self)"},
 	 { (char *)"SBStream_swigregister", SBStream_swigregister, METH_VARARGS, NULL},
@@ -83355,130 +81359,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBStringList_Clear", _wrap_SBStringList_Clear, METH_VARARGS, (char *)"SBStringList_Clear(SBStringList self)"},
 	 { (char *)"SBStringList_swigregister", SBStringList_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBStructuredData", _wrap_new_SBStructuredData, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBStructuredData()\n"
 		"SBStructuredData(SBStructuredData rhs)\n"
 		"new_SBStructuredData(lldb::EventSP const & event_sp) -> SBStructuredData\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBStructuredData", _wrap_delete_SBStructuredData, METH_VARARGS, (char *)"delete_SBStructuredData(SBStructuredData self)"},
-	 { "SBStructuredData_IsValid", _wrap_SBStructuredData_IsValid, METH_VARARGS, (char *)"SBStructuredData_IsValid(SBStructuredData self) -> bool"},
-	 { "SBStructuredData___nonzero__", _wrap_SBStructuredData___nonzero__, METH_VARARGS, (char *)"SBStructuredData___nonzero__(SBStructuredData self) -> bool"},
-	 { "SBStructuredData_Clear", _wrap_SBStructuredData_Clear, METH_VARARGS, (char *)"SBStructuredData_Clear(SBStructuredData self)"},
-	 { "SBStructuredData_GetType", _wrap_SBStructuredData_GetType, METH_VARARGS, (char *)"SBStructuredData_GetType(SBStructuredData self) -> lldb::StructuredDataType"},
-	 { "SBStructuredData_GetSize", _wrap_SBStructuredData_GetSize, METH_VARARGS, (char *)"SBStructuredData_GetSize(SBStructuredData self) -> size_t"},
-	 { "SBStructuredData_GetKeys", _wrap_SBStructuredData_GetKeys, METH_VARARGS, (char *)"SBStructuredData_GetKeys(SBStructuredData self, SBStringList keys) -> bool"},
-	 { "SBStructuredData_GetValueForKey", _wrap_SBStructuredData_GetValueForKey, METH_VARARGS, (char *)"SBStructuredData_GetValueForKey(SBStructuredData self, char const * key) -> SBStructuredData"},
-	 { "SBStructuredData_GetItemAtIndex", _wrap_SBStructuredData_GetItemAtIndex, METH_VARARGS, (char *)"SBStructuredData_GetItemAtIndex(SBStructuredData self, size_t idx) -> SBStructuredData"},
-	 { "SBStructuredData_GetIntegerValue", _wrap_SBStructuredData_GetIntegerValue, METH_VARARGS, (char *)"\n"
-		"GetIntegerValue(uint64_t fail_value=0) -> uint64_t\n"
-		"SBStructuredData_GetIntegerValue(SBStructuredData self) -> uint64_t\n"
-		""},
-	 { "SBStructuredData_GetFloatValue", _wrap_SBStructuredData_GetFloatValue, METH_VARARGS, (char *)"\n"
-		"GetFloatValue(double fail_value=0.0) -> double\n"
-		"SBStructuredData_GetFloatValue(SBStructuredData self) -> double\n"
-		""},
-	 { "SBStructuredData_GetBooleanValue", _wrap_SBStructuredData_GetBooleanValue, METH_VARARGS, (char *)"\n"
-		"GetBooleanValue(bool fail_value=False) -> bool\n"
-		"SBStructuredData_GetBooleanValue(SBStructuredData self) -> bool\n"
-		""},
-	 { "SBStructuredData_GetStringValue", _wrap_SBStructuredData_GetStringValue, METH_VARARGS, (char *)"SBStructuredData_GetStringValue(SBStructuredData self, char * dst) -> size_t"},
-	 { "SBStructuredData_GetAsJSON", _wrap_SBStructuredData_GetAsJSON, METH_VARARGS, (char *)"SBStructuredData_GetAsJSON(SBStructuredData self, SBStream stream) -> SBError"},
-	 { "SBStructuredData_GetDescription", _wrap_SBStructuredData_GetDescription, METH_VARARGS, (char *)"SBStructuredData_GetDescription(SBStructuredData self, SBStream stream) -> SBError"},
-	 { "SBStructuredData_SetFromJSON", _wrap_SBStructuredData_SetFromJSON, METH_VARARGS, (char *)"SBStructuredData_SetFromJSON(SBStructuredData self, SBStream stream) -> SBError"},
-	 { "SBStructuredData_swigregister", SBStructuredData_swigregister, METH_VARARGS, NULL},
-	 { "delete_SBSymbol", _wrap_delete_SBSymbol, METH_VARARGS, (char *)"delete_SBSymbol(SBSymbol self)"},
-	 { "new_SBSymbol", _wrap_new_SBSymbol, METH_VARARGS, (char *)"\n"
-		"SBSymbol()\n"
-		"new_SBSymbol(SBSymbol rhs) -> SBSymbol\n"
-		""},
-	 { "SBSymbol_IsValid", _wrap_SBSymbol_IsValid, METH_VARARGS, (char *)"SBSymbol_IsValid(SBSymbol self) -> bool"},
-	 { "SBSymbol___nonzero__", _wrap_SBSymbol___nonzero__, METH_VARARGS, (char *)"SBSymbol___nonzero__(SBSymbol self) -> bool"},
-	 { "SBSymbol_GetName", _wrap_SBSymbol_GetName, METH_VARARGS, (char *)"SBSymbol_GetName(SBSymbol self) -> char const *"},
-	 { "SBSymbol_GetDisplayName", _wrap_SBSymbol_GetDisplayName, METH_VARARGS, (char *)"SBSymbol_GetDisplayName(SBSymbol self) -> char const *"},
-	 { "SBSymbol_GetMangledName", _wrap_SBSymbol_GetMangledName, METH_VARARGS, (char *)"SBSymbol_GetMangledName(SBSymbol self) -> char const *"},
-	 { "SBSymbol_GetInstructions", _wrap_SBSymbol_GetInstructions, METH_VARARGS, (char *)"\n"
-		"GetInstructions(SBTarget target) -> SBInstructionList\n"
-		"SBSymbol_GetInstructions(SBSymbol self, SBTarget target, char const * flavor_string) -> SBInstructionList\n"
-		""},
-	 { "SBSymbol_GetStartAddress", _wrap_SBSymbol_GetStartAddress, METH_VARARGS, (char *)"SBSymbol_GetStartAddress(SBSymbol self) -> SBAddress"},
-	 { "SBSymbol_GetEndAddress", _wrap_SBSymbol_GetEndAddress, METH_VARARGS, (char *)"SBSymbol_GetEndAddress(SBSymbol self) -> SBAddress"},
-	 { "SBSymbol_GetPrologueByteSize", _wrap_SBSymbol_GetPrologueByteSize, METH_VARARGS, (char *)"SBSymbol_GetPrologueByteSize(SBSymbol self) -> uint32_t"},
-	 { "SBSymbol_GetType", _wrap_SBSymbol_GetType, METH_VARARGS, (char *)"SBSymbol_GetType(SBSymbol self) -> lldb::SymbolType"},
-	 { "SBSymbol_GetDescription", _wrap_SBSymbol_GetDescription, METH_VARARGS, (char *)"SBSymbol_GetDescription(SBSymbol self, SBStream description) -> bool"},
-	 { "SBSymbol_IsExternal", _wrap_SBSymbol_IsExternal, METH_VARARGS, (char *)"SBSymbol_IsExternal(SBSymbol self) -> bool"},
-	 { "SBSymbol_IsSynthetic", _wrap_SBSymbol_IsSynthetic, METH_VARARGS, (char *)"SBSymbol_IsSynthetic(SBSymbol self) -> bool"},
-	 { "SBSymbol___eq__", _wrap_SBSymbol___eq__, METH_VARARGS, (char *)"SBSymbol___eq__(SBSymbol self, SBSymbol rhs) -> bool"},
-	 { "SBSymbol___ne__", _wrap_SBSymbol___ne__, METH_VARARGS, (char *)"SBSymbol___ne__(SBSymbol self, SBSymbol rhs) -> bool"},
-	 { "SBSymbol___str__", _wrap_SBSymbol___str__, METH_VARARGS, (char *)"SBSymbol___str__(SBSymbol self) -> PyObject *"},
-	 { "SBSymbol_swigregister", SBSymbol_swigregister, METH_VARARGS, NULL},
-	 { "new_SBSymbolContext", _wrap_new_SBSymbolContext, METH_VARARGS, (char *)"\n"
-		"SBSymbolContext()\n"
-		"new_SBSymbolContext(SBSymbolContext rhs) -> SBSymbolContext\n"
-		""},
-	 { "delete_SBSymbolContext", _wrap_delete_SBSymbolContext, METH_VARARGS, (char *)"delete_SBSymbolContext(SBSymbolContext self)"},
-	 { "SBSymbolContext_IsValid", _wrap_SBSymbolContext_IsValid, METH_VARARGS, (char *)"SBSymbolContext_IsValid(SBSymbolContext self) -> bool"},
-	 { "SBSymbolContext___nonzero__", _wrap_SBSymbolContext___nonzero__, METH_VARARGS, (char *)"SBSymbolContext___nonzero__(SBSymbolContext self) -> bool"},
-	 { "SBSymbolContext_GetModule", _wrap_SBSymbolContext_GetModule, METH_VARARGS, (char *)"SBSymbolContext_GetModule(SBSymbolContext self) -> SBModule"},
-	 { "SBSymbolContext_GetCompileUnit", _wrap_SBSymbolContext_GetCompileUnit, METH_VARARGS, (char *)"SBSymbolContext_GetCompileUnit(SBSymbolContext self) -> SBCompileUnit"},
-	 { "SBSymbolContext_GetFunction", _wrap_SBSymbolContext_GetFunction, METH_VARARGS, (char *)"SBSymbolContext_GetFunction(SBSymbolContext self) -> SBFunction"},
-	 { "SBSymbolContext_GetBlock", _wrap_SBSymbolContext_GetBlock, METH_VARARGS, (char *)"SBSymbolContext_GetBlock(SBSymbolContext self) -> SBBlock"},
-	 { "SBSymbolContext_GetLineEntry", _wrap_SBSymbolContext_GetLineEntry, METH_VARARGS, (char *)"SBSymbolContext_GetLineEntry(SBSymbolContext self) -> SBLineEntry"},
-	 { "SBSymbolContext_GetSymbol", _wrap_SBSymbolContext_GetSymbol, METH_VARARGS, (char *)"SBSymbolContext_GetSymbol(SBSymbolContext self) -> SBSymbol"},
-	 { "SBSymbolContext_SetModule", _wrap_SBSymbolContext_SetModule, METH_VARARGS, (char *)"SBSymbolContext_SetModule(SBSymbolContext self, SBModule module)"},
-	 { "SBSymbolContext_SetCompileUnit", _wrap_SBSymbolContext_SetCompileUnit, METH_VARARGS, (char *)"SBSymbolContext_SetCompileUnit(SBSymbolContext self, SBCompileUnit compile_unit)"},
-	 { "SBSymbolContext_SetFunction", _wrap_SBSymbolContext_SetFunction, METH_VARARGS, (char *)"SBSymbolContext_SetFunction(SBSymbolContext self, SBFunction function)"},
-	 { "SBSymbolContext_SetBlock", _wrap_SBSymbolContext_SetBlock, METH_VARARGS, (char *)"SBSymbolContext_SetBlock(SBSymbolContext self, SBBlock block)"},
-	 { "SBSymbolContext_SetLineEntry", _wrap_SBSymbolContext_SetLineEntry, METH_VARARGS, (char *)"SBSymbolContext_SetLineEntry(SBSymbolContext self, SBLineEntry line_entry)"},
-	 { "SBSymbolContext_SetSymbol", _wrap_SBSymbolContext_SetSymbol, METH_VARARGS, (char *)"SBSymbolContext_SetSymbol(SBSymbolContext self, SBSymbol symbol)"},
-	 { "SBSymbolContext_GetParentOfInlinedScope", _wrap_SBSymbolContext_GetParentOfInlinedScope, METH_VARARGS, (char *)"SBSymbolContext_GetParentOfInlinedScope(SBSymbolContext self, SBAddress curr_frame_pc, SBAddress parent_frame_addr) -> SBSymbolContext"},
-	 { "SBSymbolContext_GetDescription", _wrap_SBSymbolContext_GetDescription, METH_VARARGS, (char *)"SBSymbolContext_GetDescription(SBSymbolContext self, SBStream description) -> bool"},
-	 { "SBSymbolContext___str__", _wrap_SBSymbolContext___str__, METH_VARARGS, (char *)"SBSymbolContext___str__(SBSymbolContext self) -> PyObject *"},
-	 { "SBSymbolContext_swigregister", SBSymbolContext_swigregister, METH_VARARGS, NULL},
-	 { "new_SBSymbolContextList", _wrap_new_SBSymbolContextList, METH_VARARGS, (char *)"\n"
-		"SBSymbolContextList()\n"
-		"new_SBSymbolContextList(SBSymbolContextList rhs) -> SBSymbolContextList\n"
-		""},
-	 { "delete_SBSymbolContextList", _wrap_delete_SBSymbolContextList, METH_VARARGS, (char *)"delete_SBSymbolContextList(SBSymbolContextList self)"},
-	 { "SBSymbolContextList_IsValid", _wrap_SBSymbolContextList_IsValid, METH_VARARGS, (char *)"SBSymbolContextList_IsValid(SBSymbolContextList self) -> bool"},
-	 { "SBSymbolContextList___nonzero__", _wrap_SBSymbolContextList___nonzero__, METH_VARARGS, (char *)"SBSymbolContextList___nonzero__(SBSymbolContextList self) -> bool"},
-	 { "SBSymbolContextList_GetSize", _wrap_SBSymbolContextList_GetSize, METH_VARARGS, (char *)"SBSymbolContextList_GetSize(SBSymbolContextList self) -> uint32_t"},
-	 { "SBSymbolContextList_GetContextAtIndex", _wrap_SBSymbolContextList_GetContextAtIndex, METH_VARARGS, (char *)"SBSymbolContextList_GetContextAtIndex(SBSymbolContextList self, uint32_t idx) -> SBSymbolContext"},
-	 { "SBSymbolContextList_Append", _wrap_SBSymbolContextList_Append, METH_VARARGS, (char *)"\n"
-		"Append(SBSymbolContext sc)\n"
-		"SBSymbolContextList_Append(SBSymbolContextList self, SBSymbolContextList sc_list)\n"
-		""},
-	 { "SBSymbolContextList_GetDescription", _wrap_SBSymbolContextList_GetDescription, METH_VARARGS, (char *)"SBSymbolContextList_GetDescription(SBSymbolContextList self, SBStream description) -> bool"},
-	 { "SBSymbolContextList_Clear", _wrap_SBSymbolContextList_Clear, METH_VARARGS, (char *)"SBSymbolContextList_Clear(SBSymbolContextList self)"},
-	 { "SBSymbolContextList___str__", _wrap_SBSymbolContextList___str__, METH_VARARGS, (char *)"SBSymbolContextList___str__(SBSymbolContextList self) -> PyObject *"},
-	 { "SBSymbolContextList_swigregister", SBSymbolContextList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTarget", _wrap_new_SBTarget, METH_VARARGS, (char *)"\n"
-		"SBTarget()\n"
-		"new_SBTarget(SBTarget rhs) -> SBTarget\n"
-		""},
-	 { "delete_SBTarget", _wrap_delete_SBTarget, METH_VARARGS, (char *)"delete_SBTarget(SBTarget self)"},
-	 { "SBTarget_GetBroadcasterClassName", _wrap_SBTarget_GetBroadcasterClassName, METH_VARARGS, (char *)"SBTarget_GetBroadcasterClassName() -> char const *"},
-	 { "SBTarget_IsValid", _wrap_SBTarget_IsValid, METH_VARARGS, (char *)"SBTarget_IsValid(SBTarget self) -> bool"},
-	 { "SBTarget___nonzero__", _wrap_SBTarget___nonzero__, METH_VARARGS, (char *)"SBTarget___nonzero__(SBTarget self) -> bool"},
-	 { "SBTarget_EventIsTargetEvent", _wrap_SBTarget_EventIsTargetEvent, METH_VARARGS, (char *)"SBTarget_EventIsTargetEvent(SBEvent event) -> bool"},
-	 { "SBTarget_GetTargetFromEvent", _wrap_SBTarget_GetTargetFromEvent, METH_VARARGS, (char *)"SBTarget_GetTargetFromEvent(SBEvent event) -> SBTarget"},
-	 { "SBTarget_GetNumModulesFromEvent", _wrap_SBTarget_GetNumModulesFromEvent, METH_VARARGS, (char *)"SBTarget_GetNumModulesFromEvent(SBEvent event) -> uint32_t"},
-	 { "SBTarget_GetModuleAtIndexFromEvent", _wrap_SBTarget_GetModuleAtIndexFromEvent, METH_VARARGS, (char *)"SBTarget_GetModuleAtIndexFromEvent(uint32_t const idx, SBEvent event) -> SBModule"},
-	 { "SBTarget_GetProcess", _wrap_SBTarget_GetProcess, METH_VARARGS, (char *)"SBTarget_GetProcess(SBTarget self) -> SBProcess"},
-	 { "SBTarget_GetPlatform", _wrap_SBTarget_GetPlatform, METH_VARARGS, (char *)"\n"
-		"SBTarget_GetPlatform(SBTarget self) -> SBPlatform\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Return the platform object associated with the target.\n"
-		"///\n"
-		"/// After return, the platform object should be checked for\n"
-		"/// validity.\n"
-		"///\n"
-		"/// @return\n"
-		"///     A platform object.\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"delete_SBStructuredData", _wrap_delete_SBStructuredData, METH_VARARGS, (char *)"delete_SBStructuredData(SBStructuredData self)"},
 	 { (char *)"SBStructuredData_IsValid", _wrap_SBStructuredData_IsValid, METH_VARARGS, (char *)"SBStructuredData_IsValid(SBStructuredData self) -> bool"},
 	 { (char *)"SBStructuredData___nonzero__", _wrap_SBStructuredData___nonzero__, METH_VARARGS, (char *)"SBStructuredData___nonzero__(SBStructuredData self) -> bool"},
@@ -83586,7 +81470,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTarget_GetPlatform", _wrap_SBTarget_GetPlatform, METH_VARARGS, (char *)"\n"
 		"SBTarget_GetPlatform(SBTarget self) -> SBPlatform\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the platform object associated with the target.\n"
 		"\n"
@@ -83596,27 +81479,9 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    A platform object.\n"
 		""},
-	 { "SBTarget_Install", _wrap_SBTarget_Install, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBTarget_Install", _wrap_SBTarget_Install, METH_VARARGS, (char *)"\n"
 		"SBTarget_Install(SBTarget self) -> SBError\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Install any binaries that need to be installed.\n"
-		"///\n"
-		"/// This function does nothing when debugging on the host system.\n"
-		"/// When connected to remote platforms, the target's main executable\n"
-		"/// and any modules that have their install path set will be\n"
-		"/// installed on the remote platform. If the main executable doesn't\n"
-		"/// have an install location set, it will be installed in the remote\n"
-		"/// platform's working directory.\n"
-		"///\n"
-		"/// @return\n"
-		"///     An error describing anything that went wrong during\n"
-		"///     installation.\n"
-		"//------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Install any binaries that need to be installed.\n"
 		"\n"
@@ -83631,11 +81496,6 @@ static PyMethodDef SwigMethods[] = {
 		"    An error describing anything that went wrong during\n"
 		"    installation.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_LaunchSimple", _wrap_SBTarget_LaunchSimple, METH_VARARGS, (char *)"\n"
-		"SBTarget_LaunchSimple(SBTarget self, char const ** argv, char const ** envp, char const * working_directory) -> SBProcess\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_LaunchSimple", _wrap_SBTarget_LaunchSimple, METH_VARARGS, (char *)"\n"
 		"SBTarget_LaunchSimple(SBTarget self, char const ** argv, char const ** envp, char const * working_directory) -> SBProcess\n"
 		"\n"
@@ -83644,7 +81504,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"@param[in] argv\n"
 		"    The argument array.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[in] envp\n"
 		"    The environment array.\n"
@@ -83673,73 +81532,11 @@ static PyMethodDef SwigMethods[] = {
 		"launches a new process by passing 'X', 'Y', 'Z' as the args to the\n"
 		"executable.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_Launch", _wrap_SBTarget_Launch, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_Launch", _wrap_SBTarget_Launch, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"Launch(SBListener listener, char const ** argv, char const ** envp, char const * stdin_path, char const * stdout_path, char const * stderr_path, char const * working_directory, uint32_t launch_flags, bool stop_at_entry, SBError error) -> SBProcess\n"
 		"SBTarget_Launch(SBTarget self, SBLaunchInfo launch_info, SBError error) -> SBProcess\n"
 		"\n"
 		"\n"
-<<<<<<< HEAD
-		"//------------------------------------------------------------------\n"
-		"/// Launch a new process.\n"
-		"///\n"
-		"/// Launch a new process by spawning a new process using the\n"
-		"/// target object's executable module's file as the file to launch.\n"
-		"/// Arguments are given in  argv, and the environment variables\n"
-		"/// are in  envp. Standard input and output files can be\n"
-		"/// optionally re-directed to  stdin_path,  stdout_path, and\n"
-		"///  stderr_path.\n"
-		"///\n"
-		"/// @param[in] listener\n"
-		"///     An optional listener that will receive all process events.\n"
-		"///     If  listener is valid then  listener will listen to all\n"
-		"///     process events. If not valid, then this target's debugger\n"
-		"///     (SBTarget::GetDebugger()) will listen to all process events.\n"
-		"///\n"
-		"/// @param[in] argv\n"
-		"///     The argument array.\n"
-		"///\n"
-		"/// @param[in] envp\n"
-		"///     The environment array.\n"
-		"///\n"
-		"/// @param[in] launch_flags\n"
-		"///     Flags to modify the launch (@see lldb::LaunchFlags)\n"
-		"///\n"
-		"/// @param[in] stdin_path\n"
-		"///     The path to use when re-directing the STDIN of the new\n"
-		"///     process. If all stdXX_path arguments are NULL, a pseudo\n"
-		"///     terminal will be used.\n"
-		"///\n"
-		"/// @param[in] stdout_path\n"
-		"///     The path to use when re-directing the STDOUT of the new\n"
-		"///     process. If all stdXX_path arguments are NULL, a pseudo\n"
-		"///     terminal will be used.\n"
-		"///\n"
-		"/// @param[in] stderr_path\n"
-		"///     The path to use when re-directing the STDERR of the new\n"
-		"///     process. If all stdXX_path arguments are NULL, a pseudo\n"
-		"///     terminal will be used.\n"
-		"///\n"
-		"/// @param[in] working_directory\n"
-		"///     The working directory to have the child process run in\n"
-		"///\n"
-		"/// @param[in] launch_flags\n"
-		"///     Some launch options specified by logical OR'ing\n"
-		"///     lldb::LaunchFlags enumeration values together.\n"
-		"///\n"
-		"/// @param[in] stop_at_entry\n"
-		"///     If false do not stop the inferior at the entry point.\n"
-		"///\n"
-		"/// @param[out]\n"
-		"///     An error object. Contains the reason if there is some failure.\n"
-		"///\n"
-		"/// @return\n"
-		"///      A process object for the newly created process.\n"
-		"//------------------------------------------------------------------\n"
-=======
 		"Launch a new process.\n"
 		"\n"
 		"Launch a new process by spawning a new process using the\n"
@@ -83794,7 +81591,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"@return\n"
 		"     A process object for the newly created process.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"For example,\n"
 		"\n"
@@ -83810,12 +81606,6 @@ static PyMethodDef SwigMethods[] = {
 		"entry point. If no breakpoint is specified for the inferior, it should\n"
 		"run to completion if no user interaction is required.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_LoadCore", _wrap_SBTarget_LoadCore, METH_VARARGS, (char *)"\n"
-		"LoadCore(char const * core_file) -> SBProcess\n"
-		"SBTarget_LoadCore(SBTarget self, char const * core_file, SBError error) -> SBProcess\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_LoadCore", _wrap_SBTarget_LoadCore, METH_VARARGS, (char *)"\n"
 		"LoadCore(char const * core_file) -> SBProcess\n"
 		"SBTarget_LoadCore(SBTarget self, char const * core_file, SBError error) -> SBProcess\n"
@@ -83825,7 +81615,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"@param[in] core_file\n"
 		"    File path of the core dump.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[out] error\n"
 		"    An error explaining what went wrong if the operation fails.\n"
@@ -83840,19 +81629,12 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"loads a new core file and returns the process object.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_Attach", _wrap_SBTarget_Attach, METH_VARARGS, (char *)"SBTarget_Attach(SBTarget self, SBAttachInfo attach_info, SBError error) -> SBProcess"},
-	 { "SBTarget_AttachToProcessWithID", _wrap_SBTarget_AttachToProcessWithID, METH_VARARGS, (char *)"\n"
-		"SBTarget_AttachToProcessWithID(SBTarget self, SBListener listener, lldb::pid_t pid, SBError error) -> SBProcess\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_Attach", _wrap_SBTarget_Attach, METH_VARARGS, (char *)"SBTarget_Attach(SBTarget self, SBAttachInfo attach_info, SBError error) -> SBProcess"},
 	 { (char *)"SBTarget_AttachToProcessWithID", _wrap_SBTarget_AttachToProcessWithID, METH_VARARGS, (char *)"\n"
 		"SBTarget_AttachToProcessWithID(SBTarget self, SBListener listener, lldb::pid_t pid, SBError error) -> SBProcess\n"
 		"\n"
 		"\n"
 		"Attach to process with pid.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[in] listener\n"
 		"    An optional listener that will receive all process events.\n"
@@ -83869,17 +81651,11 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"     A process object for the attached process.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_AttachToProcessWithName", _wrap_SBTarget_AttachToProcessWithName, METH_VARARGS, (char *)"\n"
-		"SBTarget_AttachToProcessWithName(SBTarget self, SBListener listener, char const * name, bool wait_for, SBError error) -> SBProcess\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_AttachToProcessWithName", _wrap_SBTarget_AttachToProcessWithName, METH_VARARGS, (char *)"\n"
 		"SBTarget_AttachToProcessWithName(SBTarget self, SBListener listener, char const * name, bool wait_for, SBError error) -> SBProcess\n"
 		"\n"
 		"\n"
 		"Attach to process with name.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[in] listener\n"
 		"    An optional listener that will receive all process events.\n"
@@ -83899,11 +81675,6 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"     A process object for the attached process.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_ConnectRemote", _wrap_SBTarget_ConnectRemote, METH_VARARGS, (char *)"\n"
-		"SBTarget_ConnectRemote(SBTarget self, SBListener listener, char const * url, char const * plugin_name, SBError error) -> SBProcess\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_ConnectRemote", _wrap_SBTarget_ConnectRemote, METH_VARARGS, (char *)"\n"
 		"SBTarget_ConnectRemote(SBTarget self, SBListener listener, char const * url, char const * plugin_name, SBError error) -> SBProcess\n"
 		"\n"
@@ -83921,7 +81692,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"@param[in] plugin_name\n"
 		"    The plugin name to be used; can be NULL.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[out]\n"
 		"    An error explaining what went wrong if the connect fails.\n"
@@ -83929,50 +81699,27 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"     A process object for the connected process.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_GetExecutable", _wrap_SBTarget_GetExecutable, METH_VARARGS, (char *)"SBTarget_GetExecutable(SBTarget self) -> SBFileSpec"},
-	 { "SBTarget_AppendImageSearchPath", _wrap_SBTarget_AppendImageSearchPath, METH_VARARGS, (char *)"\n"
-		"SBTarget_AppendImageSearchPath(SBTarget self, char const * arg3, char const * to, SBError error)\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_GetExecutable", _wrap_SBTarget_GetExecutable, METH_VARARGS, (char *)"SBTarget_GetExecutable(SBTarget self) -> SBFileSpec"},
 	 { (char *)"SBTarget_AppendImageSearchPath", _wrap_SBTarget_AppendImageSearchPath, METH_VARARGS, (char *)"\n"
 		"SBTarget_AppendImageSearchPath(SBTarget self, char const * arg3, char const * to, SBError error)\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Append the path mapping (from -> to) to the target's paths mapping list.\n"
 		""},
-	 { "SBTarget_AddModule", _wrap_SBTarget_AddModule, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBTarget_AddModule", _wrap_SBTarget_AddModule, METH_VARARGS, (char *)"\n"
 		"AddModule(SBModule module) -> bool\n"
 		"AddModule(char const * path, char const * triple, char const * uuid) -> SBModule\n"
 		"AddModule(char const * path, char const * triple, char const * uuid_cstr, char const * symfile) -> SBModule\n"
 		"SBTarget_AddModule(SBTarget self, SBModuleSpec module_spec) -> SBModule\n"
 		""},
-	 { "SBTarget_GetNumModules", _wrap_SBTarget_GetNumModules, METH_VARARGS, (char *)"SBTarget_GetNumModules(SBTarget self) -> uint32_t"},
-	 { "SBTarget_GetModuleAtIndex", _wrap_SBTarget_GetModuleAtIndex, METH_VARARGS, (char *)"SBTarget_GetModuleAtIndex(SBTarget self, uint32_t idx) -> SBModule"},
-	 { "SBTarget_RemoveModule", _wrap_SBTarget_RemoveModule, METH_VARARGS, (char *)"SBTarget_RemoveModule(SBTarget self, SBModule module) -> bool"},
-	 { "SBTarget_GetDebugger", _wrap_SBTarget_GetDebugger, METH_VARARGS, (char *)"SBTarget_GetDebugger(SBTarget self) -> SBDebugger"},
-	 { "SBTarget_FindModule", _wrap_SBTarget_FindModule, METH_VARARGS, (char *)"SBTarget_FindModule(SBTarget self, SBFileSpec file_spec) -> SBModule"},
-	 { "SBTarget_FindCompileUnits", _wrap_SBTarget_FindCompileUnits, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBTarget_GetNumModules", _wrap_SBTarget_GetNumModules, METH_VARARGS, (char *)"SBTarget_GetNumModules(SBTarget self) -> uint32_t"},
+	 { (char *)"SBTarget_GetModuleAtIndex", _wrap_SBTarget_GetModuleAtIndex, METH_VARARGS, (char *)"SBTarget_GetModuleAtIndex(SBTarget self, uint32_t idx) -> SBModule"},
+	 { (char *)"SBTarget_RemoveModule", _wrap_SBTarget_RemoveModule, METH_VARARGS, (char *)"SBTarget_RemoveModule(SBTarget self, SBModule module) -> bool"},
+	 { (char *)"SBTarget_GetDebugger", _wrap_SBTarget_GetDebugger, METH_VARARGS, (char *)"SBTarget_GetDebugger(SBTarget self) -> SBDebugger"},
+	 { (char *)"SBTarget_FindModule", _wrap_SBTarget_FindModule, METH_VARARGS, (char *)"SBTarget_FindModule(SBTarget self, SBFileSpec file_spec) -> SBModule"},
+	 { (char *)"SBTarget_FindCompileUnits", _wrap_SBTarget_FindCompileUnits, METH_VARARGS, (char *)"\n"
 		"SBTarget_FindCompileUnits(SBTarget self, SBFileSpec sb_file_spec) -> SBSymbolContextList\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Find compile units related to *this target and passed source\n"
-		"/// file.\n"
-		"///\n"
-		"/// @param[in] sb_file_spec\n"
-		"///     A lldb::SBFileSpec object that contains source file\n"
-		"///     specification.\n"
-		"///\n"
-		"/// @return\n"
-		"///     A lldb::SBSymbolContextList that gets filled in with all of\n"
-		"///     the symbol contexts for all the matches.\n"
-		"//------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Find compile units related to *this target and passed source\n"
 		"file.\n"
@@ -83985,29 +81732,12 @@ static PyMethodDef SwigMethods[] = {
 		"    A lldb::SBSymbolContextList that gets filled in with all of\n"
 		"    the symbol contexts for all the matches.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_GetByteOrder", _wrap_SBTarget_GetByteOrder, METH_VARARGS, (char *)"SBTarget_GetByteOrder(SBTarget self) -> lldb::ByteOrder"},
-	 { "SBTarget_GetAddressByteSize", _wrap_SBTarget_GetAddressByteSize, METH_VARARGS, (char *)"SBTarget_GetAddressByteSize(SBTarget self) -> uint32_t"},
-	 { "SBTarget_GetTriple", _wrap_SBTarget_GetTriple, METH_VARARGS, (char *)"SBTarget_GetTriple(SBTarget self) -> char const *"},
-	 { "SBTarget_GetDataByteSize", _wrap_SBTarget_GetDataByteSize, METH_VARARGS, (char *)"\n"
-		"SBTarget_GetDataByteSize(SBTarget self) -> uint32_t\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Architecture data byte width accessor\n"
-		"///\n"
-		"/// @return\n"
-		"/// The size in 8-bit (host) bytes of a minimum addressable\n"
-		"/// unit from the Architecture's data bus\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBTarget_GetByteOrder", _wrap_SBTarget_GetByteOrder, METH_VARARGS, (char *)"SBTarget_GetByteOrder(SBTarget self) -> lldb::ByteOrder"},
 	 { (char *)"SBTarget_GetAddressByteSize", _wrap_SBTarget_GetAddressByteSize, METH_VARARGS, (char *)"SBTarget_GetAddressByteSize(SBTarget self) -> uint32_t"},
 	 { (char *)"SBTarget_GetTriple", _wrap_SBTarget_GetTriple, METH_VARARGS, (char *)"SBTarget_GetTriple(SBTarget self) -> char const *"},
 	 { (char *)"SBTarget_GetDataByteSize", _wrap_SBTarget_GetDataByteSize, METH_VARARGS, (char *)"\n"
 		"SBTarget_GetDataByteSize(SBTarget self) -> uint32_t\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Architecture data byte width accessor\n"
 		"\n"
@@ -84015,20 +81745,9 @@ static PyMethodDef SwigMethods[] = {
 		"The size in 8-bit (host) bytes of a minimum addressable\n"
 		"unit from the Architecture's data bus\n"
 		""},
-	 { "SBTarget_GetCodeByteSize", _wrap_SBTarget_GetCodeByteSize, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBTarget_GetCodeByteSize", _wrap_SBTarget_GetCodeByteSize, METH_VARARGS, (char *)"\n"
 		"SBTarget_GetCodeByteSize(SBTarget self) -> uint32_t\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Architecture code byte width accessor\n"
-		"///\n"
-		"/// @return\n"
-		"/// The size in 8-bit (host) bytes of a minimum addressable\n"
-		"/// unit from the Architecture's code bus\n"
-		"//------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Architecture code byte width accessor\n"
 		"\n"
@@ -84036,19 +81755,11 @@ static PyMethodDef SwigMethods[] = {
 		"The size in 8-bit (host) bytes of a minimum addressable\n"
 		"unit from the Architecture's code bus\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_SetSectionLoadAddress", _wrap_SBTarget_SetSectionLoadAddress, METH_VARARGS, (char *)"SBTarget_SetSectionLoadAddress(SBTarget self, SBSection section, lldb::addr_t section_base_addr) -> SBError"},
-	 { "SBTarget_ClearSectionLoadAddress", _wrap_SBTarget_ClearSectionLoadAddress, METH_VARARGS, (char *)"SBTarget_ClearSectionLoadAddress(SBTarget self, SBSection section) -> SBError"},
-	 { "SBTarget_SetModuleLoadAddress", _wrap_SBTarget_SetModuleLoadAddress, METH_VARARGS, (char *)"SBTarget_SetModuleLoadAddress(SBTarget self, SBModule module, int64_t sections_offset) -> SBError"},
-	 { "SBTarget_ClearModuleLoadAddress", _wrap_SBTarget_ClearModuleLoadAddress, METH_VARARGS, (char *)"SBTarget_ClearModuleLoadAddress(SBTarget self, SBModule module) -> SBError"},
-	 { "SBTarget_FindFunctions", _wrap_SBTarget_FindFunctions, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_SetSectionLoadAddress", _wrap_SBTarget_SetSectionLoadAddress, METH_VARARGS, (char *)"SBTarget_SetSectionLoadAddress(SBTarget self, SBSection section, lldb::addr_t section_base_addr) -> SBError"},
 	 { (char *)"SBTarget_ClearSectionLoadAddress", _wrap_SBTarget_ClearSectionLoadAddress, METH_VARARGS, (char *)"SBTarget_ClearSectionLoadAddress(SBTarget self, SBSection section) -> SBError"},
 	 { (char *)"SBTarget_SetModuleLoadAddress", _wrap_SBTarget_SetModuleLoadAddress, METH_VARARGS, (char *)"SBTarget_SetModuleLoadAddress(SBTarget self, SBModule module, int64_t sections_offset) -> SBError"},
 	 { (char *)"SBTarget_ClearModuleLoadAddress", _wrap_SBTarget_ClearModuleLoadAddress, METH_VARARGS, (char *)"SBTarget_ClearModuleLoadAddress(SBTarget self, SBModule module) -> SBError"},
 	 { (char *)"SBTarget_FindFunctions", _wrap_SBTarget_FindFunctions, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"FindFunctions(char const * name, uint32_t name_type_mask) -> SBSymbolContextList\n"
 		"SBTarget_FindFunctions(SBTarget self, char const * name) -> SBSymbolContextList\n"
 		"\n"
@@ -84069,15 +81780,6 @@ static PyMethodDef SwigMethods[] = {
 		"    A lldb::SBSymbolContextList that gets filled in with all of\n"
 		"    the symbol contexts for all the matches.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_FindFirstType", _wrap_SBTarget_FindFirstType, METH_VARARGS, (char *)"SBTarget_FindFirstType(SBTarget self, char const * type) -> SBType"},
-	 { "SBTarget_FindTypes", _wrap_SBTarget_FindTypes, METH_VARARGS, (char *)"SBTarget_FindTypes(SBTarget self, char const * type) -> SBTypeList"},
-	 { "SBTarget_GetBasicType", _wrap_SBTarget_GetBasicType, METH_VARARGS, (char *)"SBTarget_GetBasicType(SBTarget self, lldb::BasicType type) -> SBType"},
-	 { "SBTarget_GetSourceManager", _wrap_SBTarget_GetSourceManager, METH_VARARGS, (char *)"SBTarget_GetSourceManager(SBTarget self) -> SBSourceManager"},
-	 { "SBTarget_FindFirstGlobalVariable", _wrap_SBTarget_FindFirstGlobalVariable, METH_VARARGS, (char *)"\n"
-		"SBTarget_FindFirstGlobalVariable(SBTarget self, char const * name) -> SBValue\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_FindFirstType", _wrap_SBTarget_FindFirstType, METH_VARARGS, (char *)"SBTarget_FindFirstType(SBTarget self, char const * type) -> SBType"},
 	 { (char *)"SBTarget_FindTypes", _wrap_SBTarget_FindTypes, METH_VARARGS, (char *)"SBTarget_FindTypes(SBTarget self, char const * type) -> SBTypeList"},
 	 { (char *)"SBTarget_GetBasicType", _wrap_SBTarget_GetBasicType, METH_VARARGS, (char *)"SBTarget_GetBasicType(SBTarget self, lldb::BasicType type) -> SBType"},
@@ -84087,7 +81789,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"\n"
 		"Find the first global (or static) variable by name.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[in] name\n"
 		"    The name of the global or static variable we are looking\n"
@@ -84096,16 +81797,9 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    An SBValue that gets filled in with the found variable (if any).\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_FindGlobalVariables", _wrap_SBTarget_FindGlobalVariables, METH_VARARGS, (char *)"\n"
-		"FindGlobalVariables(char const * name, uint32_t max_matches) -> SBValueList\n"
-		"SBTarget_FindGlobalVariables(SBTarget self, char const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBValueList\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_FindGlobalVariables", _wrap_SBTarget_FindGlobalVariables, METH_VARARGS, (char *)"\n"
 		"FindGlobalVariables(char const * name, uint32_t max_matches) -> SBValueList\n"
 		"SBTarget_FindGlobalVariables(SBTarget self, char const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBValueList\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Find global and static variables by name.\n"
@@ -84120,15 +81814,9 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    A list of matched variables in an SBValueList.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_FindGlobalFunctions", _wrap_SBTarget_FindGlobalFunctions, METH_VARARGS, (char *)"SBTarget_FindGlobalFunctions(SBTarget self, char const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBSymbolContextList"},
-	 { "SBTarget_Clear", _wrap_SBTarget_Clear, METH_VARARGS, (char *)"SBTarget_Clear(SBTarget self)"},
-	 { "SBTarget_ResolveFileAddress", _wrap_SBTarget_ResolveFileAddress, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_FindGlobalFunctions", _wrap_SBTarget_FindGlobalFunctions, METH_VARARGS, (char *)"SBTarget_FindGlobalFunctions(SBTarget self, char const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBSymbolContextList"},
 	 { (char *)"SBTarget_Clear", _wrap_SBTarget_Clear, METH_VARARGS, (char *)"SBTarget_Clear(SBTarget self)"},
 	 { (char *)"SBTarget_ResolveFileAddress", _wrap_SBTarget_ResolveFileAddress, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTarget_ResolveFileAddress(SBTarget self, lldb::addr_t file_addr) -> SBAddress\n"
 		"\n"
 		"\n"
@@ -84139,14 +81827,6 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    An SBAddress which will be valid if...\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_ResolveLoadAddress", _wrap_SBTarget_ResolveLoadAddress, METH_VARARGS, (char *)"SBTarget_ResolveLoadAddress(SBTarget self, lldb::addr_t vm_addr) -> SBAddress"},
-	 { "SBTarget_ResolvePastLoadAddress", _wrap_SBTarget_ResolvePastLoadAddress, METH_VARARGS, (char *)"SBTarget_ResolvePastLoadAddress(SBTarget self, uint32_t stop_id, lldb::addr_t vm_addr) -> SBAddress"},
-	 { "SBTarget_ResolveSymbolContextForAddress", _wrap_SBTarget_ResolveSymbolContextForAddress, METH_VARARGS, (char *)"SBTarget_ResolveSymbolContextForAddress(SBTarget self, SBAddress addr, uint32_t resolve_scope) -> SBSymbolContext"},
-	 { "SBTarget_ReadMemory", _wrap_SBTarget_ReadMemory, METH_VARARGS, (char *)"\n"
-		"SBTarget_ReadMemory(SBTarget self, SBAddress addr, void * buf, SBError error) -> size_t\n"
-		"\n"
-=======
 	 { (char *)"SBTarget_ResolveLoadAddress", _wrap_SBTarget_ResolveLoadAddress, METH_VARARGS, (char *)"SBTarget_ResolveLoadAddress(SBTarget self, lldb::addr_t vm_addr) -> SBAddress"},
 	 { (char *)"SBTarget_ResolvePastLoadAddress", _wrap_SBTarget_ResolvePastLoadAddress, METH_VARARGS, (char *)"SBTarget_ResolvePastLoadAddress(SBTarget self, uint32_t stop_id, lldb::addr_t vm_addr) -> SBAddress"},
 	 { (char *)"SBTarget_ResolveSymbolContextForAddress", _wrap_SBTarget_ResolveSymbolContextForAddress, METH_VARARGS, (char *)"SBTarget_ResolveSymbolContextForAddress(SBTarget self, SBAddress addr, uint32_t resolve_scope) -> SBSymbolContext"},
@@ -84161,7 +81841,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"@param[in] addr\n"
 		"    A target address to read from.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[out] buf\n"
 		"    The buffer to read memory into.\n"
@@ -84176,140 +81855,35 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    The amount of data read in host bytes.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_BreakpointCreateByLocation", _wrap_SBTarget_BreakpointCreateByLocation, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_BreakpointCreateByLocation", _wrap_SBTarget_BreakpointCreateByLocation, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"BreakpointCreateByLocation(char const * file, uint32_t line) -> SBBreakpoint\n"
 		"BreakpointCreateByLocation(SBFileSpec file_spec, uint32_t line) -> SBBreakpoint\n"
 		"BreakpointCreateByLocation(SBFileSpec file_spec, uint32_t line, lldb::addr_t offset) -> SBBreakpoint\n"
 		"BreakpointCreateByLocation(SBFileSpec file_spec, uint32_t line, lldb::addr_t offset, SBFileSpecList module_list) -> SBBreakpoint\n"
 		"SBTarget_BreakpointCreateByLocation(SBTarget self, SBFileSpec file_spec, uint32_t line, uint32_t column, lldb::addr_t offset, SBFileSpecList module_list) -> SBBreakpoint\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_BreakpointCreateByName", _wrap_SBTarget_BreakpointCreateByName, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_BreakpointCreateByName", _wrap_SBTarget_BreakpointCreateByName, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"BreakpointCreateByName(char const * symbol_name, char const * module_name=None) -> SBBreakpoint\n"
 		"BreakpointCreateByName(char const * symbol_name) -> SBBreakpoint\n"
 		"BreakpointCreateByName(char const * symbol_name, uint32_t func_name_type, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint\n"
 		"SBTarget_BreakpointCreateByName(SBTarget self, char const * symbol_name, uint32_t func_name_type, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_BreakpointCreateByNames", _wrap_SBTarget_BreakpointCreateByNames, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_BreakpointCreateByNames", _wrap_SBTarget_BreakpointCreateByNames, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"BreakpointCreateByNames(char const ** symbol_name, uint32_t name_type_mask, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint\n"
 		"BreakpointCreateByNames(char const ** symbol_name, uint32_t name_type_mask, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint\n"
 		"SBTarget_BreakpointCreateByNames(SBTarget self, char const ** symbol_name, uint32_t name_type_mask, lldb::LanguageType symbol_language, lldb::addr_t offset, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_BreakpointCreateByRegex", _wrap_SBTarget_BreakpointCreateByRegex, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_BreakpointCreateByRegex", _wrap_SBTarget_BreakpointCreateByRegex, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"BreakpointCreateByRegex(char const * symbol_name_regex, char const * module_name=None) -> SBBreakpoint\n"
 		"BreakpointCreateByRegex(char const * symbol_name_regex) -> SBBreakpoint\n"
 		"SBTarget_BreakpointCreateByRegex(SBTarget self, char const * symbol_name_regex, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_BreakpointCreateBySourceRegex", _wrap_SBTarget_BreakpointCreateBySourceRegex, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_BreakpointCreateBySourceRegex", _wrap_SBTarget_BreakpointCreateBySourceRegex, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"BreakpointCreateBySourceRegex(char const * source_regex, SBFileSpec source_file, char const * module_name=None) -> SBBreakpoint\n"
 		"BreakpointCreateBySourceRegex(char const * source_regex, SBFileSpec source_file) -> SBBreakpoint\n"
 		"BreakpointCreateBySourceRegex(char const * source_regex, SBFileSpecList module_list, SBFileSpecList file_list) -> SBBreakpoint\n"
 		"SBTarget_BreakpointCreateBySourceRegex(SBTarget self, char const * source_regex, SBFileSpecList module_list, SBFileSpecList source_file, SBStringList func_names) -> SBBreakpoint\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_BreakpointCreateForException", _wrap_SBTarget_BreakpointCreateForException, METH_VARARGS, (char *)"\n"
-		"BreakpointCreateForException(lldb::LanguageType language, bool catch_bp, bool throw_bp) -> SBBreakpoint\n"
-		"SBTarget_BreakpointCreateForException(SBTarget self, lldb::LanguageType language, bool catch_bp, bool throw_bp, SBStringList extra_args) -> SBBreakpoint\n"
-		""},
-	 { "SBTarget_BreakpointCreateByAddress", _wrap_SBTarget_BreakpointCreateByAddress, METH_VARARGS, (char *)"SBTarget_BreakpointCreateByAddress(SBTarget self, lldb::addr_t address) -> SBBreakpoint"},
-	 { "SBTarget_BreakpointCreateBySBAddress", _wrap_SBTarget_BreakpointCreateBySBAddress, METH_VARARGS, (char *)"SBTarget_BreakpointCreateBySBAddress(SBTarget self, SBAddress sb_address) -> SBBreakpoint"},
-	 { "SBTarget_BreakpointCreateFromScript", _wrap_SBTarget_BreakpointCreateFromScript, METH_VARARGS, (char *)"\n"
-		"BreakpointCreateFromScript(char const * class_name, SBStructuredData extra_args, SBFileSpecList module_list, SBFileSpecList file_list, bool request_hardware=False) -> SBBreakpoint\n"
-		"SBTarget_BreakpointCreateFromScript(SBTarget self, char const * class_name, SBStructuredData extra_args, SBFileSpecList module_list, SBFileSpecList file_list) -> SBBreakpoint\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// Create a breakpoint using a scripted resolver.\n"
-		"///\n"
-		"/// @param[in] class_name\n"
-		"///    This is the name of the class that implements a scripted resolver.\n"
-		"///    The class should have the following signature:\n"
-		"///    class Resolver:\n"
-		"///        def __init__(self, bkpt, extra_args):\n"
-		"///            # bkpt - the breakpoint for which this is the resolver.  When\n"
-		"///            # the resolver finds an interesting address, call AddLocation\n"
-		"///            # on this breakpoint to add it.\n"
-		"///            #\n"
-		"///            # extra_args - an SBStructuredData that can be used to \n"
-		"///            # parametrize this instance.  Same as the extra_args passed\n"
-		"///            # to BreakpointCreateFromScript.\n"
-		"///\n"
-		"///        def __get_depth__ (self):\n"
-		"///            # This is optional, but if defined, you should return the\n"
-		"///            # depth at which you want the callback to be called.  The\n"
-		"///            # available options are:\n"
-		"///            #    lldb.eSearchDepthModule\n"
-		"///            #    lldb.eSearchDepthCompUnit\n"
-		"///            # The default if you don't implement this method is\n"
-		"///            # eSearchDepthModule.\n"
-		"///            \n"
-		"///        def __callback__(self, sym_ctx):\n"
-		"///            # sym_ctx - an SBSymbolContext that is the cursor in the \n"
-		"///            # search through the program to resolve breakpoints.  \n"
-		"///            # The sym_ctx will be filled out to the depth requested in\n"
-		"///            # __get_depth__.\n"
-		"///            # Look in this sym_ctx for new breakpoint locations,\n"
-		"///            # and if found use bkpt.AddLocation to add them.\n"
-		"///            # Note, you will only get called for modules/compile_units that\n"
-		"///            # pass the SearchFilter provided by the module_list & file_list\n"
-		"///            # passed into BreakpointCreateFromScript.\n"
-		"///\n"
-		"///        def get_short_help(self):\n"
-		"///            # Optional, but if implemented return a short string that will\n"
-		"///            # be printed at the beginning of the break list output for the\n"
-		"///            # breakpoint.\n"
-		"///\n"
-		"/// @param[in] extra_args\n"
-		"///    This is an SBStructuredData object that will get passed to the\n"
-		"///    constructor of the class in class_name.  You can use this to \n"
-		"///    reuse the same class, parametrizing it with entries from this \n"
-		"///    dictionary.\n"
-		"///\n"
-		"/// @param module_list\n"
-		"///    If this is non-empty, this will be used as the module filter in the \n"
-		"///    SearchFilter created for this breakpoint.\n"
-		"///\n"
-		"/// @param file_list\n"
-		"///    If this is non-empty, this will be used as the comp unit filter in the \n"
-		"///    SearchFilter created for this breakpoint.\n"
-		"///\n"
-		"/// @return\n"
-		"///     An SBBreakpoint that will set locations based on the logic in the\n"
-		"///     resolver's search callback.\n"
-		"//------------------------------------------------------------------\n"
-		"\n"
-		""},
-	 { "SBTarget_GetNumBreakpoints", _wrap_SBTarget_GetNumBreakpoints, METH_VARARGS, (char *)"SBTarget_GetNumBreakpoints(SBTarget self) -> uint32_t"},
-	 { "SBTarget_GetBreakpointAtIndex", _wrap_SBTarget_GetBreakpointAtIndex, METH_VARARGS, (char *)"SBTarget_GetBreakpointAtIndex(SBTarget self, uint32_t idx) -> SBBreakpoint"},
-	 { "SBTarget_BreakpointDelete", _wrap_SBTarget_BreakpointDelete, METH_VARARGS, (char *)"SBTarget_BreakpointDelete(SBTarget self, lldb::break_id_t break_id) -> bool"},
-	 { "SBTarget_FindBreakpointByID", _wrap_SBTarget_FindBreakpointByID, METH_VARARGS, (char *)"SBTarget_FindBreakpointByID(SBTarget self, lldb::break_id_t break_id) -> SBBreakpoint"},
-	 { "SBTarget_FindBreakpointsByName", _wrap_SBTarget_FindBreakpointsByName, METH_VARARGS, (char *)"SBTarget_FindBreakpointsByName(SBTarget self, char const * name, SBBreakpointList bkpt_list) -> bool"},
-	 { "SBTarget_DeleteBreakpointName", _wrap_SBTarget_DeleteBreakpointName, METH_VARARGS, (char *)"SBTarget_DeleteBreakpointName(SBTarget self, char const * name)"},
-	 { "SBTarget_GetBreakpointNames", _wrap_SBTarget_GetBreakpointNames, METH_VARARGS, (char *)"SBTarget_GetBreakpointNames(SBTarget self, SBStringList names)"},
-	 { "SBTarget_EnableAllBreakpoints", _wrap_SBTarget_EnableAllBreakpoints, METH_VARARGS, (char *)"SBTarget_EnableAllBreakpoints(SBTarget self) -> bool"},
-	 { "SBTarget_DisableAllBreakpoints", _wrap_SBTarget_DisableAllBreakpoints, METH_VARARGS, (char *)"SBTarget_DisableAllBreakpoints(SBTarget self) -> bool"},
-	 { "SBTarget_DeleteAllBreakpoints", _wrap_SBTarget_DeleteAllBreakpoints, METH_VARARGS, (char *)"SBTarget_DeleteAllBreakpoints(SBTarget self) -> bool"},
-	 { "SBTarget_BreakpointsCreateFromFile", _wrap_SBTarget_BreakpointsCreateFromFile, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_BreakpointCreateForException", _wrap_SBTarget_BreakpointCreateForException, METH_VARARGS, (char *)"\n"
 		"BreakpointCreateForException(lldb::LanguageType language, bool catch_bp, bool throw_bp) -> SBBreakpoint\n"
 		"SBTarget_BreakpointCreateForException(SBTarget self, lldb::LanguageType language, bool catch_bp, bool throw_bp, SBStringList extra_args) -> SBBreakpoint\n"
@@ -84390,7 +81964,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTarget_DisableAllBreakpoints", _wrap_SBTarget_DisableAllBreakpoints, METH_VARARGS, (char *)"SBTarget_DisableAllBreakpoints(SBTarget self) -> bool"},
 	 { (char *)"SBTarget_DeleteAllBreakpoints", _wrap_SBTarget_DeleteAllBreakpoints, METH_VARARGS, (char *)"SBTarget_DeleteAllBreakpoints(SBTarget self) -> bool"},
 	 { (char *)"SBTarget_BreakpointsCreateFromFile", _wrap_SBTarget_BreakpointsCreateFromFile, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"BreakpointsCreateFromFile(SBFileSpec source_file, SBBreakpointList bkpt_list) -> SBError\n"
 		"SBTarget_BreakpointsCreateFromFile(SBTarget self, SBFileSpec source_file, SBStringList matching_names, SBBreakpointList new_bps) -> SBError\n"
 		"\n"
@@ -84407,23 +81980,11 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    An SBError detailing any errors in reading in the breakpoints.\n"
 		""},
-	 { "SBTarget_BreakpointsWriteToFile", _wrap_SBTarget_BreakpointsWriteToFile, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBTarget_BreakpointsWriteToFile", _wrap_SBTarget_BreakpointsWriteToFile, METH_VARARGS, (char *)"\n"
 		"BreakpointsWriteToFile(SBFileSpec dest_file) -> SBError\n"
 		"BreakpointsWriteToFile(SBFileSpec dest_file, SBBreakpointList bkpt_list, bool append=False) -> SBError\n"
 		"SBTarget_BreakpointsWriteToFile(SBTarget self, SBFileSpec dest_file, SBBreakpointList bkpt_list) -> SBError\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_GetNumWatchpoints", _wrap_SBTarget_GetNumWatchpoints, METH_VARARGS, (char *)"SBTarget_GetNumWatchpoints(SBTarget self) -> uint32_t"},
-	 { "SBTarget_GetWatchpointAtIndex", _wrap_SBTarget_GetWatchpointAtIndex, METH_VARARGS, (char *)"SBTarget_GetWatchpointAtIndex(SBTarget self, uint32_t idx) -> SBWatchpoint"},
-	 { "SBTarget_DeleteWatchpoint", _wrap_SBTarget_DeleteWatchpoint, METH_VARARGS, (char *)"SBTarget_DeleteWatchpoint(SBTarget self, lldb::watch_id_t watch_id) -> bool"},
-	 { "SBTarget_FindWatchpointByID", _wrap_SBTarget_FindWatchpointByID, METH_VARARGS, (char *)"SBTarget_FindWatchpointByID(SBTarget self, lldb::watch_id_t watch_id) -> SBWatchpoint"},
-	 { "SBTarget_EnableAllWatchpoints", _wrap_SBTarget_EnableAllWatchpoints, METH_VARARGS, (char *)"SBTarget_EnableAllWatchpoints(SBTarget self) -> bool"},
-	 { "SBTarget_DisableAllWatchpoints", _wrap_SBTarget_DisableAllWatchpoints, METH_VARARGS, (char *)"SBTarget_DisableAllWatchpoints(SBTarget self) -> bool"},
-	 { "SBTarget_DeleteAllWatchpoints", _wrap_SBTarget_DeleteAllWatchpoints, METH_VARARGS, (char *)"SBTarget_DeleteAllWatchpoints(SBTarget self) -> bool"},
-	 { "SBTarget_WatchAddress", _wrap_SBTarget_WatchAddress, METH_VARARGS, (char *)"SBTarget_WatchAddress(SBTarget self, lldb::addr_t addr, size_t size, bool read, bool write, SBError error) -> SBWatchpoint"},
-	 { "SBTarget_GetBroadcaster", _wrap_SBTarget_GetBroadcaster, METH_VARARGS, (char *)"SBTarget_GetBroadcaster(SBTarget self) -> SBBroadcaster"},
-	 { "SBTarget_CreateValueFromAddress", _wrap_SBTarget_CreateValueFromAddress, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_GetNumWatchpoints", _wrap_SBTarget_GetNumWatchpoints, METH_VARARGS, (char *)"SBTarget_GetNumWatchpoints(SBTarget self) -> uint32_t"},
 	 { (char *)"SBTarget_GetWatchpointAtIndex", _wrap_SBTarget_GetWatchpointAtIndex, METH_VARARGS, (char *)"SBTarget_GetWatchpointAtIndex(SBTarget self, uint32_t idx) -> SBWatchpoint"},
 	 { (char *)"SBTarget_DeleteWatchpoint", _wrap_SBTarget_DeleteWatchpoint, METH_VARARGS, (char *)"SBTarget_DeleteWatchpoint(SBTarget self, lldb::watch_id_t watch_id) -> bool"},
@@ -84434,7 +81995,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTarget_WatchAddress", _wrap_SBTarget_WatchAddress, METH_VARARGS, (char *)"SBTarget_WatchAddress(SBTarget self, lldb::addr_t addr, size_t size, bool read, bool write, SBError error) -> SBWatchpoint"},
 	 { (char *)"SBTarget_GetBroadcaster", _wrap_SBTarget_GetBroadcaster, METH_VARARGS, (char *)"SBTarget_GetBroadcaster(SBTarget self) -> SBBroadcaster"},
 	 { (char *)"SBTarget_CreateValueFromAddress", _wrap_SBTarget_CreateValueFromAddress, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTarget_CreateValueFromAddress(SBTarget self, char const * name, SBAddress addr, SBType type) -> SBValue\n"
 		"\n"
 		"\n"
@@ -84453,15 +82013,9 @@ static PyMethodDef SwigMethods[] = {
 		"    An SBValue of the given type, may be invalid if there was an error reading\n"
 		"    the underlying memory.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_CreateValueFromData", _wrap_SBTarget_CreateValueFromData, METH_VARARGS, (char *)"SBTarget_CreateValueFromData(SBTarget self, char const * name, SBData data, SBType type) -> SBValue"},
-	 { "SBTarget_CreateValueFromExpression", _wrap_SBTarget_CreateValueFromExpression, METH_VARARGS, (char *)"SBTarget_CreateValueFromExpression(SBTarget self, char const * name, char const * expr) -> SBValue"},
-	 { "SBTarget_ReadInstructions", _wrap_SBTarget_ReadInstructions, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_CreateValueFromData", _wrap_SBTarget_CreateValueFromData, METH_VARARGS, (char *)"SBTarget_CreateValueFromData(SBTarget self, char const * name, SBData data, SBType type) -> SBValue"},
 	 { (char *)"SBTarget_CreateValueFromExpression", _wrap_SBTarget_CreateValueFromExpression, METH_VARARGS, (char *)"SBTarget_CreateValueFromExpression(SBTarget self, char const * name, char const * expr) -> SBValue"},
 	 { (char *)"SBTarget_ReadInstructions", _wrap_SBTarget_ReadInstructions, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"ReadInstructions(SBAddress base_addr, uint32_t count) -> SBInstructionList\n"
 		"SBTarget_ReadInstructions(SBTarget self, SBAddress base_addr, uint32_t count, char const * flavor_string) -> SBInstructionList\n"
 		"\n"
@@ -84473,11 +82027,7 @@ static PyMethodDef SwigMethods[] = {
 		"   flavor_string   -- may be 'intel' or 'att' on x86 targets to specify that style of disassembly\n"
 		"Returns an SBInstructionList.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_GetInstructions", _wrap_SBTarget_GetInstructions, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_GetInstructions", _wrap_SBTarget_GetInstructions, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTarget_GetInstructions(SBTarget self, SBAddress base_addr, void const * buf) -> SBInstructionList\n"
 		"\n"
 		"\n"
@@ -84488,11 +82038,7 @@ static PyMethodDef SwigMethods[] = {
 		"   size      -- (C++) size of the buffer\n"
 		"Returns an SBInstructionList.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_GetInstructionsWithFlavor", _wrap_SBTarget_GetInstructionsWithFlavor, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBTarget_GetInstructionsWithFlavor", _wrap_SBTarget_GetInstructionsWithFlavor, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTarget_GetInstructionsWithFlavor(SBTarget self, SBAddress base_addr, char const * flavor_string, void const * buf) -> SBInstructionList\n"
 		"\n"
 		"\n"
@@ -84504,59 +82050,6 @@ static PyMethodDef SwigMethods[] = {
 		"   size      -- (C++) size of the buffer\n"
 		"Returns an SBInstructionList.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBTarget_FindSymbols", _wrap_SBTarget_FindSymbols, METH_VARARGS, (char *)"\n"
-		"FindSymbols(char const * name, lldb::SymbolType type) -> SBSymbolContextList\n"
-		"SBTarget_FindSymbols(SBTarget self, char const * name) -> SBSymbolContextList\n"
-		""},
-	 { "SBTarget_GetDescription", _wrap_SBTarget_GetDescription, METH_VARARGS, (char *)"SBTarget_GetDescription(SBTarget self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTarget_GetStackRedZoneSize", _wrap_SBTarget_GetStackRedZoneSize, METH_VARARGS, (char *)"SBTarget_GetStackRedZoneSize(SBTarget self) -> lldb::addr_t"},
-	 { "SBTarget_GetLaunchInfo", _wrap_SBTarget_GetLaunchInfo, METH_VARARGS, (char *)"SBTarget_GetLaunchInfo(SBTarget self) -> SBLaunchInfo"},
-	 { "SBTarget_SetLaunchInfo", _wrap_SBTarget_SetLaunchInfo, METH_VARARGS, (char *)"SBTarget_SetLaunchInfo(SBTarget self, SBLaunchInfo launch_info)"},
-	 { "SBTarget_SetCollectingStats", _wrap_SBTarget_SetCollectingStats, METH_VARARGS, (char *)"SBTarget_SetCollectingStats(SBTarget self, bool v)"},
-	 { "SBTarget_GetCollectingStats", _wrap_SBTarget_GetCollectingStats, METH_VARARGS, (char *)"SBTarget_GetCollectingStats(SBTarget self) -> bool"},
-	 { "SBTarget_GetStatistics", _wrap_SBTarget_GetStatistics, METH_VARARGS, (char *)"SBTarget_GetStatistics(SBTarget self) -> SBStructuredData"},
-	 { "SBTarget___eq__", _wrap_SBTarget___eq__, METH_VARARGS, (char *)"SBTarget___eq__(SBTarget self, SBTarget rhs) -> bool"},
-	 { "SBTarget___ne__", _wrap_SBTarget___ne__, METH_VARARGS, (char *)"SBTarget___ne__(SBTarget self, SBTarget rhs) -> bool"},
-	 { "SBTarget_EvaluateExpression", _wrap_SBTarget_EvaluateExpression, METH_VARARGS, (char *)"\n"
-		"EvaluateExpression(char const * expr) -> SBValue\n"
-		"SBTarget_EvaluateExpression(SBTarget self, char const * expr, SBExpressionOptions options) -> SBValue\n"
-		""},
-	 { "SBTarget_CompleteCode", _wrap_SBTarget_CompleteCode, METH_VARARGS, (char *)"\n"
-		"SBTarget_CompleteCode(SBTarget self, lldb::LanguageType language, SBSymbolContext symbol_context, char const * current_code) -> SBCompletionResponse\n"
-		"\n"
-		"\n"
-		"Complete code.\n"
-		"Parameters:\n"
-		"  language          -- the language to use\n"
-		"  symbol_context    -- the context in which to do the completion\n"
-		"  current_code      -- the code to complete\n"
-		"Returns an SBCompletionResponse with completions that fit immediately after\n"
-		"the last character of `current_code`.\n"
-		"\n"
-		""},
-	 { "SBTarget___str__", _wrap_SBTarget___str__, METH_VARARGS, (char *)"SBTarget___str__(SBTarget self) -> PyObject *"},
-	 { "SBTarget_swigregister", SBTarget_swigregister, METH_VARARGS, NULL},
-	 { "new_SBThread", _wrap_new_SBThread, METH_VARARGS, (char *)"\n"
-		"SBThread()\n"
-		"new_SBThread(SBThread thread) -> SBThread\n"
-		""},
-	 { "delete_SBThread", _wrap_delete_SBThread, METH_VARARGS, (char *)"delete_SBThread(SBThread self)"},
-	 { "SBThread_GetBroadcasterClassName", _wrap_SBThread_GetBroadcasterClassName, METH_VARARGS, (char *)"SBThread_GetBroadcasterClassName() -> char const *"},
-	 { "SBThread_EventIsThreadEvent", _wrap_SBThread_EventIsThreadEvent, METH_VARARGS, (char *)"SBThread_EventIsThreadEvent(SBEvent event) -> bool"},
-	 { "SBThread_GetStackFrameFromEvent", _wrap_SBThread_GetStackFrameFromEvent, METH_VARARGS, (char *)"SBThread_GetStackFrameFromEvent(SBEvent event) -> SBFrame"},
-	 { "SBThread_GetThreadFromEvent", _wrap_SBThread_GetThreadFromEvent, METH_VARARGS, (char *)"SBThread_GetThreadFromEvent(SBEvent event) -> SBThread"},
-	 { "SBThread_IsValid", _wrap_SBThread_IsValid, METH_VARARGS, (char *)"SBThread_IsValid(SBThread self) -> bool"},
-	 { "SBThread___nonzero__", _wrap_SBThread___nonzero__, METH_VARARGS, (char *)"SBThread___nonzero__(SBThread self) -> bool"},
-	 { "SBThread_Clear", _wrap_SBThread_Clear, METH_VARARGS, (char *)"SBThread_Clear(SBThread self)"},
-	 { "SBThread_GetStopReason", _wrap_SBThread_GetStopReason, METH_VARARGS, (char *)"SBThread_GetStopReason(SBThread self) -> lldb::StopReason"},
-	 { "SBThread_GetStopReasonDataCount", _wrap_SBThread_GetStopReasonDataCount, METH_VARARGS, (char *)"\n"
-		"SBThread_GetStopReasonDataCount(SBThread self) -> size_t\n"
-		"\n"
-		"\n"
-		"/// Get the number of words associated with the stop reason.\n"
-		"/// See also GetStopReasonDataAtIndex().\n"
-=======
 	 { (char *)"SBTarget_FindSymbols", _wrap_SBTarget_FindSymbols, METH_VARARGS, (char *)"\n"
 		"FindSymbols(char const * name, lldb::SymbolType type) -> SBSymbolContextList\n"
 		"SBTarget_FindSymbols(SBTarget self, char const * name) -> SBSymbolContextList\n"
@@ -84573,6 +82066,19 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTarget_EvaluateExpression", _wrap_SBTarget_EvaluateExpression, METH_VARARGS, (char *)"\n"
 		"EvaluateExpression(char const * expr) -> SBValue\n"
 		"SBTarget_EvaluateExpression(SBTarget self, char const * expr, SBExpressionOptions options) -> SBValue\n"
+		""},
+	 { (char *)"SBTarget_CompleteCode", _wrap_SBTarget_CompleteCode, METH_VARARGS, (char *)"\n"
+		"SBTarget_CompleteCode(SBTarget self, lldb::LanguageType language, SBSymbolContext symbol_context, char const * current_code) -> SBCompletionResponse\n"
+		"\n"
+		"\n"
+		"Complete code.\n"
+		"Parameters:\n"
+		"  language          -- the language to use\n"
+		"  symbol_context    -- the context in which to do the completion\n"
+		"  current_code      -- the code to complete\n"
+		"Returns an SBCompletionResponse with completions that fit immediately after\n"
+		"the last character of `current_code`.\n"
+		"\n"
 		""},
 	 { (char *)"SBTarget___str__", _wrap_SBTarget___str__, METH_VARARGS, (char *)"SBTarget___str__(SBTarget self) -> PyObject *"},
 	 { (char *)"SBTarget_swigregister", SBTarget_swigregister, METH_VARARGS, NULL},
@@ -84592,36 +82098,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBThread_GetStopReasonDataCount", _wrap_SBThread_GetStopReasonDataCount, METH_VARARGS, (char *)"\n"
 		"SBThread_GetStopReasonDataCount(SBThread self) -> size_t\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get the number of words associated with the stop reason.\n"
 		"See also GetStopReasonDataAtIndex().\n"
 		""},
-	 { "SBThread_GetStopReasonDataAtIndex", _wrap_SBThread_GetStopReasonDataAtIndex, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_GetStopReasonDataAtIndex", _wrap_SBThread_GetStopReasonDataAtIndex, METH_VARARGS, (char *)"\n"
 		"SBThread_GetStopReasonDataAtIndex(SBThread self, uint32_t idx) -> uint64_t\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//--------------------------------------------------------------------------\n"
-		"/// Get information associated with a stop reason.\n"
-		"///\n"
-		"/// Breakpoint stop reasons will have data that consists of pairs of \n"
-		"/// breakpoint IDs followed by the breakpoint location IDs (they always come\n"
-		"/// in pairs).\n"
-		"///\n"
-		"/// Stop Reason              Count Data Type\n"
-		"/// ======================== ===== =========================================\n"
-		"/// eStopReasonNone          0\n"
-		"/// eStopReasonTrace         0\n"
-		"/// eStopReasonBreakpoint    N     duple: {breakpoint id, location id}\n"
-		"/// eStopReasonWatchpoint    1     watchpoint id\n"
-		"/// eStopReasonSignal        1     unix signal number\n"
-		"/// eStopReasonException     N     exception data\n"
-		"/// eStopReasonExec          0\n"
-		"/// eStopReasonPlanComplete  0\n"
-		"//--------------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get information associated with a stop reason.\n"
 		"\n"
@@ -84640,62 +82123,38 @@ static PyMethodDef SwigMethods[] = {
 		"eStopReasonExec          0\n"
 		"eStopReasonPlanComplete  0\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetStopReasonExtendedInfoAsJSON", _wrap_SBThread_GetStopReasonExtendedInfoAsJSON, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetStopReasonExtendedInfoAsJSON", _wrap_SBThread_GetStopReasonExtendedInfoAsJSON, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Collects a thread's stop reason extended information dictionary and prints it\n"
 		"into the SBStream in a JSON format. The format of this JSON dictionary depends\n"
 		"on the stop reason and is currently used only for instrumentation plugins.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetStopReasonExtendedBacktraces", _wrap_SBThread_GetStopReasonExtendedBacktraces, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetStopReasonExtendedBacktraces", _wrap_SBThread_GetStopReasonExtendedBacktraces, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns a collection of historical stack traces that are significant to the\n"
 		"current stop reason. Used by ThreadSanitizer, where we provide various stack\n"
 		"traces that were involved in a data race or other type of detected issue.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetStopDescription", _wrap_SBThread_GetStopDescription, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetStopDescription", _wrap_SBThread_GetStopDescription, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Pass only an (int)length and expect to get a Python string describing the\n"
 		"stop reason.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetStopReturnValue", _wrap_SBThread_GetStopReturnValue, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetStopReturnValue", _wrap_SBThread_GetStopReturnValue, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"If the last stop on this thread was a thread plan that gathered a return value from the stop,\n"
 		"this function will fetch that stop result.  At present only the \"step-out\" thread plan gathers\n"
 		"stop return values.\n"
 		"\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetStopErrorValue", _wrap_SBThread_GetStopErrorValue, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetStopErrorValue", _wrap_SBThread_GetStopErrorValue, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"If the last stop on this thread was a thread plan that gathered an error value from the stop,\n"
 		"this function will fetch that stop result.  At present only the \"step-out\" thread plan gathers\n"
 		"stop error values, and that only for stepping out of Swift functions.\n"
 		"\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetThreadID", _wrap_SBThread_GetThreadID, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetThreadID", _wrap_SBThread_GetThreadID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns a unique thread identifier (type lldb::tid_t, typically a 64-bit type)\n"
 		"for the current SBThread that will remain constant throughout the thread's\n"
@@ -84704,11 +82163,7 @@ static PyMethodDef SwigMethods[] = {
 		"identifier; this identifier is also used by other tools like sample which helps\n"
 		"to associate data from those tools with lldb.  See related GetIndexID.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetIndexID", _wrap_SBThread_GetIndexID, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetIndexID", _wrap_SBThread_GetIndexID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the index number for this SBThread.  The index number is the same thing\n"
 		"that a user gives as an argument to 'thread select' in the command line lldb.\n"
@@ -84718,34 +82173,19 @@ static PyMethodDef SwigMethods[] = {
 		"associated with the same thread.  See related GetThreadID.\n"
 		"This method returns a uint32_t index number, takes no arguments.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetName", _wrap_SBThread_GetName, METH_VARARGS, (char *)"SBThread_GetName(SBThread self) -> char const *"},
-	 { "SBThread_GetQueueName", _wrap_SBThread_GetQueueName, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetName", _wrap_SBThread_GetName, METH_VARARGS, (char *)"SBThread_GetName(SBThread self) -> char const *"},
 	 { (char *)"SBThread_GetQueueName", _wrap_SBThread_GetQueueName, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the queue name associated with this thread, if any, as a str.\n"
 		"For example, with a libdispatch (aka Grand Central Dispatch) queue.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetQueueID", _wrap_SBThread_GetQueueID, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetQueueID", _wrap_SBThread_GetQueueID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the dispatch_queue_id for this thread, if any, as a lldb::queue_id_t.\n"
 		"For example, with a libdispatch (aka Grand Central Dispatch) queue.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetInfoItemByPathAsString", _wrap_SBThread_GetInfoItemByPathAsString, METH_VARARGS, (char *)"\n"
-		"SBThread_GetInfoItemByPathAsString(SBThread self, char const * path, SBStream strm) -> bool\n"
-		"\n"
-=======
 	 { (char *)"SBThread_GetInfoItemByPathAsString", _wrap_SBThread_GetInfoItemByPathAsString, METH_VARARGS, (char *)"\n"
 		"SBThread_GetInfoItemByPathAsString(SBThread self, char const * path, SBStream strm) -> bool\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Takes a path string and a SBStream reference as parameters, returns a bool.\n"
@@ -84754,11 +82194,7 @@ static PyMethodDef SwigMethods[] = {
 		"it into the SBStream in a natural format.  Return bool is to indicate if\n"
 		"anything was printed into the stream (true) or not (false).\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetQueue", _wrap_SBThread_GetQueue, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetQueue", _wrap_SBThread_GetQueue, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Return the SBQueue for this thread.  If this thread is not currently associated\n"
 		"with a libdispatch queue, the SBQueue object's IsValid() method will return false.\n"
@@ -84768,20 +82204,12 @@ static PyMethodDef SwigMethods[] = {
 		"entire SBQueue at that time.\n"
 		"This method takes no arguments, returns an SBQueue.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_StepOver", _wrap_SBThread_StepOver, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_StepOver", _wrap_SBThread_StepOver, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"StepOver(lldb::RunMode stop_other_threads)\n"
 		"StepOver()\n"
 		"Do a source level single step over in the currently selected thread.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_StepInto", _wrap_SBThread_StepInto, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_StepInto", _wrap_SBThread_StepInto, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"StepInto(lldb::RunMode stop_other_threads)\n"
 		"StepInto()\n"
 		"StepInto(char const * target_name, lldb::RunMode stop_other_threads)\n"
@@ -84790,45 +82218,22 @@ static PyMethodDef SwigMethods[] = {
 		"    Step the current thread from the current source line to the line given by end_line, stopping if\n"
 		"    the thread steps into the function given by target_name.  If target_name is None, then stepping will stop\n"
 		"    in any of the places we would normally stop.\n"
-<<<<<<< HEAD
-		"\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"    Step the current thread from the current source line to the line given by end_line, stopping if\n"
 		"    the thread steps into the function given by target_name.  If target_name is None, then stepping will stop\n"
 		"    in any of the places we would normally stop.\n"
-<<<<<<< HEAD
-		"\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		""},
-	 { "SBThread_StepOut", _wrap_SBThread_StepOut, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_StepOut", _wrap_SBThread_StepOut, METH_VARARGS, (char *)"\n"
 		"StepOut()\n"
 		"Step out of the currently selected thread.\n"
 		""},
-	 { "SBThread_StepOutOfFrame", _wrap_SBThread_StepOutOfFrame, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_StepOutOfFrame", _wrap_SBThread_StepOutOfFrame, METH_VARARGS, (char *)"\n"
 		"StepOutOfFrame(SBFrame frame)\n"
 		"Step out of the specified frame.\n"
 		""},
-	 { "SBThread_StepInstruction", _wrap_SBThread_StepInstruction, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_StepInstruction", _wrap_SBThread_StepInstruction, METH_VARARGS, (char *)"\n"
 		"StepInstruction(bool step_over)\n"
 		"Do an instruction level single step in the currently selected thread.\n"
-<<<<<<< HEAD
-		"\n"
-		""},
-	 { "SBThread_StepOverUntil", _wrap_SBThread_StepOverUntil, METH_VARARGS, (char *)"SBThread_StepOverUntil(SBThread self, SBFrame frame, SBFileSpec file_spec, uint32_t line) -> SBError"},
-	 { "SBThread_StepUsingScriptedThreadPlan", _wrap_SBThread_StepUsingScriptedThreadPlan, METH_VARARGS, (char *)"\n"
-		"StepUsingScriptedThreadPlan(char const * script_class_name) -> SBError\n"
-		"SBThread_StepUsingScriptedThreadPlan(SBThread self, char const * script_class_name, bool resume_immediately) -> SBError\n"
-		""},
-	 { "SBThread_JumpToLine", _wrap_SBThread_JumpToLine, METH_VARARGS, (char *)"SBThread_JumpToLine(SBThread self, SBFileSpec file_spec, uint32_t line) -> SBError"},
-	 { "SBThread_RunToAddress", _wrap_SBThread_RunToAddress, METH_VARARGS, (char *)"\n"
-		"RunToAddress(lldb::addr_t addr)\n"
-		"SBThread_RunToAddress(SBThread self, lldb::addr_t addr, SBError error)\n"
-		""},
-	 { "SBThread_ReturnFromFrame", _wrap_SBThread_ReturnFromFrame, METH_VARARGS, (char *)"\n"
-=======
 		""},
 	 { (char *)"SBThread_StepOverUntil", _wrap_SBThread_StepOverUntil, METH_VARARGS, (char *)"SBThread_StepOverUntil(SBThread self, SBFrame frame, SBFileSpec file_spec, uint32_t line) -> SBError"},
 	 { (char *)"SBThread_StepUsingScriptedThreadPlan", _wrap_SBThread_StepUsingScriptedThreadPlan, METH_VARARGS, (char *)"\n"
@@ -84841,51 +82246,21 @@ static PyMethodDef SwigMethods[] = {
 		"SBThread_RunToAddress(SBThread self, lldb::addr_t addr, SBError error)\n"
 		""},
 	 { (char *)"SBThread_ReturnFromFrame", _wrap_SBThread_ReturnFromFrame, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Force a return from the frame passed in (and any frames younger than it)\n"
 		"without executing any more code in those frames.  If return_value contains\n"
 		"a valid SBValue, that will be set as the return value from frame.  Note, at\n"
 		"present only scalar return values are supported.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_UnwindInnermostExpression", _wrap_SBThread_UnwindInnermostExpression, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_UnwindInnermostExpression", _wrap_SBThread_UnwindInnermostExpression, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Unwind the stack frames from the innermost expression evaluation.\n"
 		"This API is equivalent to 'thread return -x'.\n"
 		""},
-	 { "SBThread_Suspend", _wrap_SBThread_Suspend, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_Suspend", _wrap_SBThread_Suspend, METH_VARARGS, (char *)"\n"
 		"Suspend() -> bool\n"
 		"SBThread_Suspend(SBThread self, SBError error) -> bool\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//--------------------------------------------------------------------------\n"
-		"/// LLDB currently supports process centric debugging which means when any\n"
-		"/// thread in a process stops, all other threads are stopped. The Suspend()\n"
-		"/// call here tells our process to suspend a thread and not let it run when\n"
-		"/// the other threads in a process are allowed to run. So when \n"
-		"/// SBProcess::Continue() is called, any threads that aren't suspended will\n"
-		"/// be allowed to run. If any of the SBThread functions for stepping are \n"
-		"/// called (StepOver, StepInto, StepOut, StepInstruction, RunToAddres), the\n"
-		"/// thread will now be allowed to run and these functions will simply return.\n"
-		"///\n"
-		"/// Eventually we plan to add support for thread centric debugging where\n"
-		"/// each thread is controlled individually and each thread would broadcast\n"
-		"/// its state, but we haven't implemented this yet.\n"
-		"/// \n"
-		"/// Likewise the SBThread::Resume() call will again allow the thread to run\n"
-		"/// when the process is continued.\n"
-		"///\n"
-		"/// Suspend() and Resume() functions are not currently reference counted, if\n"
-		"/// anyone has the need for them to be reference counted, please let us\n"
-		"/// know.\n"
-		"//--------------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"LLDB currently supports process centric debugging which means when any\n"
 		"thread in a process stops, all other threads are stopped. The Suspend()\n"
@@ -84907,32 +82282,25 @@ static PyMethodDef SwigMethods[] = {
 		"anyone has the need for them to be reference counted, please let us\n"
 		"know.\n"
 		""},
-	 { "SBThread_Resume", _wrap_SBThread_Resume, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_Resume", _wrap_SBThread_Resume, METH_VARARGS, (char *)"\n"
 		"Resume() -> bool\n"
 		"SBThread_Resume(SBThread self, SBError error) -> bool\n"
 		""},
-	 { "SBThread_IsSuspended", _wrap_SBThread_IsSuspended, METH_VARARGS, (char *)"SBThread_IsSuspended(SBThread self) -> bool"},
-	 { "SBThread_IsStopped", _wrap_SBThread_IsStopped, METH_VARARGS, (char *)"SBThread_IsStopped(SBThread self) -> bool"},
-	 { "SBThread_GetNumFrames", _wrap_SBThread_GetNumFrames, METH_VARARGS, (char *)"SBThread_GetNumFrames(SBThread self) -> uint32_t"},
-	 { "SBThread_GetFrameAtIndex", _wrap_SBThread_GetFrameAtIndex, METH_VARARGS, (char *)"SBThread_GetFrameAtIndex(SBThread self, uint32_t idx) -> SBFrame"},
-	 { "SBThread_GetSelectedFrame", _wrap_SBThread_GetSelectedFrame, METH_VARARGS, (char *)"SBThread_GetSelectedFrame(SBThread self) -> SBFrame"},
-	 { "SBThread_SetSelectedFrame", _wrap_SBThread_SetSelectedFrame, METH_VARARGS, (char *)"SBThread_SetSelectedFrame(SBThread self, uint32_t frame_idx) -> SBFrame"},
-	 { "SBThread_GetProcess", _wrap_SBThread_GetProcess, METH_VARARGS, (char *)"SBThread_GetProcess(SBThread self) -> SBProcess"},
-	 { "SBThread_GetDescription", _wrap_SBThread_GetDescription, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBThread_IsSuspended", _wrap_SBThread_IsSuspended, METH_VARARGS, (char *)"SBThread_IsSuspended(SBThread self) -> bool"},
+	 { (char *)"SBThread_IsStopped", _wrap_SBThread_IsStopped, METH_VARARGS, (char *)"SBThread_IsStopped(SBThread self) -> bool"},
+	 { (char *)"SBThread_GetNumFrames", _wrap_SBThread_GetNumFrames, METH_VARARGS, (char *)"SBThread_GetNumFrames(SBThread self) -> uint32_t"},
+	 { (char *)"SBThread_GetFrameAtIndex", _wrap_SBThread_GetFrameAtIndex, METH_VARARGS, (char *)"SBThread_GetFrameAtIndex(SBThread self, uint32_t idx) -> SBFrame"},
+	 { (char *)"SBThread_GetSelectedFrame", _wrap_SBThread_GetSelectedFrame, METH_VARARGS, (char *)"SBThread_GetSelectedFrame(SBThread self) -> SBFrame"},
+	 { (char *)"SBThread_SetSelectedFrame", _wrap_SBThread_SetSelectedFrame, METH_VARARGS, (char *)"SBThread_SetSelectedFrame(SBThread self, uint32_t frame_idx) -> SBFrame"},
+	 { (char *)"SBThread_GetProcess", _wrap_SBThread_GetProcess, METH_VARARGS, (char *)"SBThread_GetProcess(SBThread self) -> SBProcess"},
+	 { (char *)"SBThread_GetDescription", _wrap_SBThread_GetDescription, METH_VARARGS, (char *)"\n"
 		"GetDescription(SBStream description) -> bool\n"
 		"SBThread_GetDescription(SBThread self, SBStream description, bool stop_format) -> bool\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetStatus", _wrap_SBThread_GetStatus, METH_VARARGS, (char *)"SBThread_GetStatus(SBThread self, SBStream status) -> bool"},
-	 { "SBThread___eq__", _wrap_SBThread___eq__, METH_VARARGS, (char *)"SBThread___eq__(SBThread self, SBThread rhs) -> bool"},
-	 { "SBThread___ne__", _wrap_SBThread___ne__, METH_VARARGS, (char *)"SBThread___ne__(SBThread self, SBThread rhs) -> bool"},
-	 { "SBThread_GetExtendedBacktraceThread", _wrap_SBThread_GetExtendedBacktraceThread, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetStatus", _wrap_SBThread_GetStatus, METH_VARARGS, (char *)"SBThread_GetStatus(SBThread self, SBStream status) -> bool"},
 	 { (char *)"SBThread___eq__", _wrap_SBThread___eq__, METH_VARARGS, (char *)"SBThread___eq__(SBThread self, SBThread rhs) -> bool"},
 	 { (char *)"SBThread___ne__", _wrap_SBThread___ne__, METH_VARARGS, (char *)"SBThread___ne__(SBThread self, SBThread rhs) -> bool"},
 	 { (char *)"SBThread_GetExtendedBacktraceThread", _wrap_SBThread_GetExtendedBacktraceThread, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Given an argument of str to specify the type of thread-origin extended\n"
 		"backtrace to retrieve, query whether the origin of this thread is\n"
@@ -84943,11 +82311,7 @@ static PyMethodDef SwigMethods[] = {
 		"intended to used primarily for generating a backtrace.  You may request\n"
 		"the returned thread's own thread origin in turn.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetExtendedBacktraceOriginatingIndexID", _wrap_SBThread_GetExtendedBacktraceOriginatingIndexID, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetExtendedBacktraceOriginatingIndexID", _wrap_SBThread_GetExtendedBacktraceOriginatingIndexID, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Takes no arguments, returns a uint32_t.\n"
 		"If this SBThread is an ExtendedBacktrace thread, get the IndexID of the\n"
@@ -84957,33 +82321,21 @@ static PyMethodDef SwigMethods[] = {
 		"did its work, and was destroyed without lldb ever stopping execution).\n"
 		"In that case, this ExtendedBacktrace thread's IndexID will be returned.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetCurrentException", _wrap_SBThread_GetCurrentException, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetCurrentException", _wrap_SBThread_GetCurrentException, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns an SBValue object represeting the current exception for the thread,\n"
 		"if there is any. Currently, this works for Obj-C code and returns an SBValue\n"
 		"representing the NSException object at the throw site or that's currently\n"
 		"being processes.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_GetCurrentExceptionBacktrace", _wrap_SBThread_GetCurrentExceptionBacktrace, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_GetCurrentExceptionBacktrace", _wrap_SBThread_GetCurrentExceptionBacktrace, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Returns a historical (fake) SBThread representing the stack trace of an\n"
 		"exception, if there is one for the thread. Currently, this works for Obj-C\n"
 		"code, and can retrieve the throw-site backtrace of an NSException object\n"
 		"even when the program is no longer at the throw site.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread_SafeToCallFunctions", _wrap_SBThread_SafeToCallFunctions, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread_SafeToCallFunctions", _wrap_SBThread_SafeToCallFunctions, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Takes no arguments, returns a bool.\n"
 		"lldb may be able to detect that function calls should not be executed\n"
@@ -84991,21 +82343,6 @@ static PyMethodDef SwigMethods[] = {
 		"this is checked before performing an inferior function call on a given\n"
 		"thread.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBThread___str__", _wrap_SBThread___str__, METH_VARARGS, (char *)"SBThread___str__(SBThread self) -> PyObject *"},
-	 { "SBThread_swigregister", SBThread_swigregister, METH_VARARGS, NULL},
-	 { "new_SBThreadCollection", _wrap_new_SBThreadCollection, METH_VARARGS, (char *)"\n"
-		"SBThreadCollection()\n"
-		"new_SBThreadCollection(SBThreadCollection rhs) -> SBThreadCollection\n"
-		""},
-	 { "delete_SBThreadCollection", _wrap_delete_SBThreadCollection, METH_VARARGS, (char *)"delete_SBThreadCollection(SBThreadCollection self)"},
-	 { "SBThreadCollection_IsValid", _wrap_SBThreadCollection_IsValid, METH_VARARGS, (char *)"SBThreadCollection_IsValid(SBThreadCollection self) -> bool"},
-	 { "SBThreadCollection___nonzero__", _wrap_SBThreadCollection___nonzero__, METH_VARARGS, (char *)"SBThreadCollection___nonzero__(SBThreadCollection self) -> bool"},
-	 { "SBThreadCollection_GetSize", _wrap_SBThreadCollection_GetSize, METH_VARARGS, (char *)"SBThreadCollection_GetSize(SBThreadCollection self) -> size_t"},
-	 { "SBThreadCollection_GetThreadAtIndex", _wrap_SBThreadCollection_GetThreadAtIndex, METH_VARARGS, (char *)"SBThreadCollection_GetThreadAtIndex(SBThreadCollection self, size_t idx) -> SBThread"},
-	 { "SBThreadCollection_swigregister", SBThreadCollection_swigregister, METH_VARARGS, NULL},
-	 { "new_SBThreadPlan", _wrap_new_SBThreadPlan, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBThread___str__", _wrap_SBThread___str__, METH_VARARGS, (char *)"SBThread___str__(SBThread self) -> PyObject *"},
 	 { (char *)"SBThread_swigregister", SBThread_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBThreadCollection", _wrap_new_SBThreadCollection, METH_VARARGS, (char *)"\n"
@@ -85019,221 +82356,11 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBThreadCollection_GetThreadAtIndex", _wrap_SBThreadCollection_GetThreadAtIndex, METH_VARARGS, (char *)"SBThreadCollection_GetThreadAtIndex(SBThreadCollection self, size_t idx) -> SBThread"},
 	 { (char *)"SBThreadCollection_swigregister", SBThreadCollection_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBThreadPlan", _wrap_new_SBThreadPlan, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBThreadPlan()\n"
 		"SBThreadPlan(SBThreadPlan threadPlan)\n"
 		"SBThreadPlan(lldb::ThreadPlanSP const & lldb_object_sp)\n"
 		"new_SBThreadPlan(SBThread thread, char const * class_name) -> SBThreadPlan\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBThreadPlan", _wrap_delete_SBThreadPlan, METH_VARARGS, (char *)"delete_SBThreadPlan(SBThreadPlan self)"},
-	 { "SBThreadPlan___nonzero__", _wrap_SBThreadPlan___nonzero__, METH_VARARGS, (char *)"SBThreadPlan___nonzero__(SBThreadPlan self) -> bool"},
-	 { "SBThreadPlan_Clear", _wrap_SBThreadPlan_Clear, METH_VARARGS, (char *)"SBThreadPlan_Clear(SBThreadPlan self)"},
-	 { "SBThreadPlan_GetStopReason", _wrap_SBThreadPlan_GetStopReason, METH_VARARGS, (char *)"SBThreadPlan_GetStopReason(SBThreadPlan self) -> lldb::StopReason"},
-	 { "SBThreadPlan_GetStopReasonDataCount", _wrap_SBThreadPlan_GetStopReasonDataCount, METH_VARARGS, (char *)"SBThreadPlan_GetStopReasonDataCount(SBThreadPlan self) -> size_t"},
-	 { "SBThreadPlan_GetStopReasonDataAtIndex", _wrap_SBThreadPlan_GetStopReasonDataAtIndex, METH_VARARGS, (char *)"SBThreadPlan_GetStopReasonDataAtIndex(SBThreadPlan self, uint32_t idx) -> uint64_t"},
-	 { "SBThreadPlan_GetThread", _wrap_SBThreadPlan_GetThread, METH_VARARGS, (char *)"SBThreadPlan_GetThread(SBThreadPlan self) -> SBThread"},
-	 { "SBThreadPlan_GetDescription", _wrap_SBThreadPlan_GetDescription, METH_VARARGS, (char *)"SBThreadPlan_GetDescription(SBThreadPlan self, SBStream description) -> bool"},
-	 { "SBThreadPlan_SetPlanComplete", _wrap_SBThreadPlan_SetPlanComplete, METH_VARARGS, (char *)"SBThreadPlan_SetPlanComplete(SBThreadPlan self, bool success)"},
-	 { "SBThreadPlan_IsPlanComplete", _wrap_SBThreadPlan_IsPlanComplete, METH_VARARGS, (char *)"SBThreadPlan_IsPlanComplete(SBThreadPlan self) -> bool"},
-	 { "SBThreadPlan_IsPlanStale", _wrap_SBThreadPlan_IsPlanStale, METH_VARARGS, (char *)"SBThreadPlan_IsPlanStale(SBThreadPlan self) -> bool"},
-	 { "SBThreadPlan_IsValid", _wrap_SBThreadPlan_IsValid, METH_VARARGS, (char *)"\n"
-		"IsValid() -> bool\n"
-		"SBThreadPlan_IsValid(SBThreadPlan self) -> bool\n"
-		""},
-	 { "SBThreadPlan_QueueThreadPlanForStepOverRange", _wrap_SBThreadPlan_QueueThreadPlanForStepOverRange, METH_VARARGS, (char *)"SBThreadPlan_QueueThreadPlanForStepOverRange(SBThreadPlan self, SBAddress start_address, lldb::addr_t range_size) -> SBThreadPlan"},
-	 { "SBThreadPlan_QueueThreadPlanForStepInRange", _wrap_SBThreadPlan_QueueThreadPlanForStepInRange, METH_VARARGS, (char *)"SBThreadPlan_QueueThreadPlanForStepInRange(SBThreadPlan self, SBAddress start_address, lldb::addr_t range_size) -> SBThreadPlan"},
-	 { "SBThreadPlan_QueueThreadPlanForStepOut", _wrap_SBThreadPlan_QueueThreadPlanForStepOut, METH_VARARGS, (char *)"\n"
-		"QueueThreadPlanForStepOut(uint32_t frame_idx_to_step_to, bool first_insn=False) -> SBThreadPlan\n"
-		"SBThreadPlan_QueueThreadPlanForStepOut(SBThreadPlan self, uint32_t frame_idx_to_step_to) -> SBThreadPlan\n"
-		""},
-	 { "SBThreadPlan_QueueThreadPlanForRunToAddress", _wrap_SBThreadPlan_QueueThreadPlanForRunToAddress, METH_VARARGS, (char *)"SBThreadPlan_QueueThreadPlanForRunToAddress(SBThreadPlan self, SBAddress address) -> SBThreadPlan"},
-	 { "SBThreadPlan_QueueThreadPlanForStepScripted", _wrap_SBThreadPlan_QueueThreadPlanForStepScripted, METH_VARARGS, (char *)"SBThreadPlan_QueueThreadPlanForStepScripted(SBThreadPlan self, char const * script_class_name) -> SBThreadPlan"},
-	 { "SBThreadPlan_swigregister", SBThreadPlan_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTrace", _wrap_new_SBTrace, METH_VARARGS, (char *)"new_SBTrace() -> SBTrace"},
-	 { "SBTrace_GetTraceData", _wrap_SBTrace_GetTraceData, METH_VARARGS, (char *)"SBTrace_GetTraceData(SBTrace self, SBError error, void * buf, size_t offset, lldb::tid_t thread_id) -> size_t"},
-	 { "SBTrace_GetMetaData", _wrap_SBTrace_GetMetaData, METH_VARARGS, (char *)"SBTrace_GetMetaData(SBTrace self, SBError error, void * buf, size_t offset, lldb::tid_t thread_id) -> size_t"},
-	 { "SBTrace_StopTrace", _wrap_SBTrace_StopTrace, METH_VARARGS, (char *)"SBTrace_StopTrace(SBTrace self, SBError error, lldb::tid_t thread_id)"},
-	 { "SBTrace_GetTraceConfig", _wrap_SBTrace_GetTraceConfig, METH_VARARGS, (char *)"SBTrace_GetTraceConfig(SBTrace self, SBTraceOptions options, SBError error)"},
-	 { "SBTrace_GetTraceUID", _wrap_SBTrace_GetTraceUID, METH_VARARGS, (char *)"SBTrace_GetTraceUID(SBTrace self) -> lldb::user_id_t"},
-	 { "SBTrace___nonzero__", _wrap_SBTrace___nonzero__, METH_VARARGS, (char *)"SBTrace___nonzero__(SBTrace self) -> bool"},
-	 { "SBTrace_IsValid", _wrap_SBTrace_IsValid, METH_VARARGS, (char *)"SBTrace_IsValid(SBTrace self) -> bool"},
-	 { "delete_SBTrace", _wrap_delete_SBTrace, METH_VARARGS, (char *)"delete_SBTrace(SBTrace self)"},
-	 { "SBTrace_swigregister", SBTrace_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTraceOptions", _wrap_new_SBTraceOptions, METH_VARARGS, (char *)"new_SBTraceOptions() -> SBTraceOptions"},
-	 { "SBTraceOptions_getType", _wrap_SBTraceOptions_getType, METH_VARARGS, (char *)"SBTraceOptions_getType(SBTraceOptions self) -> lldb::TraceType"},
-	 { "SBTraceOptions_getTraceBufferSize", _wrap_SBTraceOptions_getTraceBufferSize, METH_VARARGS, (char *)"SBTraceOptions_getTraceBufferSize(SBTraceOptions self) -> uint64_t"},
-	 { "SBTraceOptions_getTraceParams", _wrap_SBTraceOptions_getTraceParams, METH_VARARGS, (char *)"SBTraceOptions_getTraceParams(SBTraceOptions self, SBError error) -> SBStructuredData"},
-	 { "SBTraceOptions_getMetaDataBufferSize", _wrap_SBTraceOptions_getMetaDataBufferSize, METH_VARARGS, (char *)"SBTraceOptions_getMetaDataBufferSize(SBTraceOptions self) -> uint64_t"},
-	 { "SBTraceOptions_setTraceParams", _wrap_SBTraceOptions_setTraceParams, METH_VARARGS, (char *)"SBTraceOptions_setTraceParams(SBTraceOptions self, SBStructuredData params)"},
-	 { "SBTraceOptions_setType", _wrap_SBTraceOptions_setType, METH_VARARGS, (char *)"SBTraceOptions_setType(SBTraceOptions self, lldb::TraceType type)"},
-	 { "SBTraceOptions_setTraceBufferSize", _wrap_SBTraceOptions_setTraceBufferSize, METH_VARARGS, (char *)"SBTraceOptions_setTraceBufferSize(SBTraceOptions self, uint64_t size)"},
-	 { "SBTraceOptions_setMetaDataBufferSize", _wrap_SBTraceOptions_setMetaDataBufferSize, METH_VARARGS, (char *)"SBTraceOptions_setMetaDataBufferSize(SBTraceOptions self, uint64_t size)"},
-	 { "SBTraceOptions_setThreadID", _wrap_SBTraceOptions_setThreadID, METH_VARARGS, (char *)"SBTraceOptions_setThreadID(SBTraceOptions self, lldb::tid_t thread_id)"},
-	 { "SBTraceOptions_getThreadID", _wrap_SBTraceOptions_getThreadID, METH_VARARGS, (char *)"SBTraceOptions_getThreadID(SBTraceOptions self) -> lldb::tid_t"},
-	 { "SBTraceOptions___nonzero__", _wrap_SBTraceOptions___nonzero__, METH_VARARGS, (char *)"SBTraceOptions___nonzero__(SBTraceOptions self) -> bool"},
-	 { "SBTraceOptions_IsValid", _wrap_SBTraceOptions_IsValid, METH_VARARGS, (char *)"SBTraceOptions_IsValid(SBTraceOptions self) -> bool"},
-	 { "delete_SBTraceOptions", _wrap_delete_SBTraceOptions, METH_VARARGS, (char *)"delete_SBTraceOptions(SBTraceOptions self)"},
-	 { "SBTraceOptions_swigregister", SBTraceOptions_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeMember", _wrap_new_SBTypeMember, METH_VARARGS, (char *)"\n"
-		"SBTypeMember()\n"
-		"new_SBTypeMember(SBTypeMember rhs) -> SBTypeMember\n"
-		""},
-	 { "delete_SBTypeMember", _wrap_delete_SBTypeMember, METH_VARARGS, (char *)"delete_SBTypeMember(SBTypeMember self)"},
-	 { "SBTypeMember_IsValid", _wrap_SBTypeMember_IsValid, METH_VARARGS, (char *)"SBTypeMember_IsValid(SBTypeMember self) -> bool"},
-	 { "SBTypeMember___nonzero__", _wrap_SBTypeMember___nonzero__, METH_VARARGS, (char *)"SBTypeMember___nonzero__(SBTypeMember self) -> bool"},
-	 { "SBTypeMember_GetName", _wrap_SBTypeMember_GetName, METH_VARARGS, (char *)"SBTypeMember_GetName(SBTypeMember self) -> char const *"},
-	 { "SBTypeMember_GetType", _wrap_SBTypeMember_GetType, METH_VARARGS, (char *)"SBTypeMember_GetType(SBTypeMember self) -> SBType"},
-	 { "SBTypeMember_GetOffsetInBytes", _wrap_SBTypeMember_GetOffsetInBytes, METH_VARARGS, (char *)"SBTypeMember_GetOffsetInBytes(SBTypeMember self) -> uint64_t"},
-	 { "SBTypeMember_GetOffsetInBits", _wrap_SBTypeMember_GetOffsetInBits, METH_VARARGS, (char *)"SBTypeMember_GetOffsetInBits(SBTypeMember self) -> uint64_t"},
-	 { "SBTypeMember_IsBitfield", _wrap_SBTypeMember_IsBitfield, METH_VARARGS, (char *)"SBTypeMember_IsBitfield(SBTypeMember self) -> bool"},
-	 { "SBTypeMember_GetBitfieldSizeInBits", _wrap_SBTypeMember_GetBitfieldSizeInBits, METH_VARARGS, (char *)"SBTypeMember_GetBitfieldSizeInBits(SBTypeMember self) -> uint32_t"},
-	 { "SBTypeMember___str__", _wrap_SBTypeMember___str__, METH_VARARGS, (char *)"SBTypeMember___str__(SBTypeMember self) -> PyObject *"},
-	 { "SBTypeMember_swigregister", SBTypeMember_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeMemberFunction", _wrap_new_SBTypeMemberFunction, METH_VARARGS, (char *)"\n"
-		"SBTypeMemberFunction()\n"
-		"new_SBTypeMemberFunction(SBTypeMemberFunction rhs) -> SBTypeMemberFunction\n"
-		""},
-	 { "delete_SBTypeMemberFunction", _wrap_delete_SBTypeMemberFunction, METH_VARARGS, (char *)"delete_SBTypeMemberFunction(SBTypeMemberFunction self)"},
-	 { "SBTypeMemberFunction_IsValid", _wrap_SBTypeMemberFunction_IsValid, METH_VARARGS, (char *)"SBTypeMemberFunction_IsValid(SBTypeMemberFunction self) -> bool"},
-	 { "SBTypeMemberFunction___nonzero__", _wrap_SBTypeMemberFunction___nonzero__, METH_VARARGS, (char *)"SBTypeMemberFunction___nonzero__(SBTypeMemberFunction self) -> bool"},
-	 { "SBTypeMemberFunction_GetName", _wrap_SBTypeMemberFunction_GetName, METH_VARARGS, (char *)"SBTypeMemberFunction_GetName(SBTypeMemberFunction self) -> char const *"},
-	 { "SBTypeMemberFunction_GetDemangledName", _wrap_SBTypeMemberFunction_GetDemangledName, METH_VARARGS, (char *)"SBTypeMemberFunction_GetDemangledName(SBTypeMemberFunction self) -> char const *"},
-	 { "SBTypeMemberFunction_GetMangledName", _wrap_SBTypeMemberFunction_GetMangledName, METH_VARARGS, (char *)"SBTypeMemberFunction_GetMangledName(SBTypeMemberFunction self) -> char const *"},
-	 { "SBTypeMemberFunction_GetType", _wrap_SBTypeMemberFunction_GetType, METH_VARARGS, (char *)"SBTypeMemberFunction_GetType(SBTypeMemberFunction self) -> SBType"},
-	 { "SBTypeMemberFunction_GetReturnType", _wrap_SBTypeMemberFunction_GetReturnType, METH_VARARGS, (char *)"SBTypeMemberFunction_GetReturnType(SBTypeMemberFunction self) -> SBType"},
-	 { "SBTypeMemberFunction_GetNumberOfArguments", _wrap_SBTypeMemberFunction_GetNumberOfArguments, METH_VARARGS, (char *)"SBTypeMemberFunction_GetNumberOfArguments(SBTypeMemberFunction self) -> uint32_t"},
-	 { "SBTypeMemberFunction_GetArgumentTypeAtIndex", _wrap_SBTypeMemberFunction_GetArgumentTypeAtIndex, METH_VARARGS, (char *)"SBTypeMemberFunction_GetArgumentTypeAtIndex(SBTypeMemberFunction self, uint32_t arg3) -> SBType"},
-	 { "SBTypeMemberFunction_GetKind", _wrap_SBTypeMemberFunction_GetKind, METH_VARARGS, (char *)"SBTypeMemberFunction_GetKind(SBTypeMemberFunction self) -> lldb::MemberFunctionKind"},
-	 { "SBTypeMemberFunction_GetDescription", _wrap_SBTypeMemberFunction_GetDescription, METH_VARARGS, (char *)"SBTypeMemberFunction_GetDescription(SBTypeMemberFunction self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeMemberFunction___str__", _wrap_SBTypeMemberFunction___str__, METH_VARARGS, (char *)"SBTypeMemberFunction___str__(SBTypeMemberFunction self) -> PyObject *"},
-	 { "SBTypeMemberFunction_swigregister", SBTypeMemberFunction_swigregister, METH_VARARGS, NULL},
-	 { "new_SBType", _wrap_new_SBType, METH_VARARGS, (char *)"\n"
-		"SBType()\n"
-		"new_SBType(SBType rhs) -> SBType\n"
-		""},
-	 { "delete_SBType", _wrap_delete_SBType, METH_VARARGS, (char *)"delete_SBType(SBType self)"},
-	 { "SBType_IsValid", _wrap_SBType_IsValid, METH_VARARGS, (char *)"SBType_IsValid(SBType self) -> bool"},
-	 { "SBType___nonzero__", _wrap_SBType___nonzero__, METH_VARARGS, (char *)"SBType___nonzero__(SBType self) -> bool"},
-	 { "SBType_GetByteSize", _wrap_SBType_GetByteSize, METH_VARARGS, (char *)"SBType_GetByteSize(SBType self) -> uint64_t"},
-	 { "SBType_IsPointerType", _wrap_SBType_IsPointerType, METH_VARARGS, (char *)"SBType_IsPointerType(SBType self) -> bool"},
-	 { "SBType_IsReferenceType", _wrap_SBType_IsReferenceType, METH_VARARGS, (char *)"SBType_IsReferenceType(SBType self) -> bool"},
-	 { "SBType_IsFunctionType", _wrap_SBType_IsFunctionType, METH_VARARGS, (char *)"SBType_IsFunctionType(SBType self) -> bool"},
-	 { "SBType_IsPolymorphicClass", _wrap_SBType_IsPolymorphicClass, METH_VARARGS, (char *)"SBType_IsPolymorphicClass(SBType self) -> bool"},
-	 { "SBType_IsArrayType", _wrap_SBType_IsArrayType, METH_VARARGS, (char *)"SBType_IsArrayType(SBType self) -> bool"},
-	 { "SBType_IsVectorType", _wrap_SBType_IsVectorType, METH_VARARGS, (char *)"SBType_IsVectorType(SBType self) -> bool"},
-	 { "SBType_IsTypedefType", _wrap_SBType_IsTypedefType, METH_VARARGS, (char *)"SBType_IsTypedefType(SBType self) -> bool"},
-	 { "SBType_IsAnonymousType", _wrap_SBType_IsAnonymousType, METH_VARARGS, (char *)"SBType_IsAnonymousType(SBType self) -> bool"},
-	 { "SBType_GetPointerType", _wrap_SBType_GetPointerType, METH_VARARGS, (char *)"SBType_GetPointerType(SBType self) -> SBType"},
-	 { "SBType_GetPointeeType", _wrap_SBType_GetPointeeType, METH_VARARGS, (char *)"SBType_GetPointeeType(SBType self) -> SBType"},
-	 { "SBType_GetReferenceType", _wrap_SBType_GetReferenceType, METH_VARARGS, (char *)"SBType_GetReferenceType(SBType self) -> SBType"},
-	 { "SBType_GetTypedefedType", _wrap_SBType_GetTypedefedType, METH_VARARGS, (char *)"SBType_GetTypedefedType(SBType self) -> SBType"},
-	 { "SBType_GetDereferencedType", _wrap_SBType_GetDereferencedType, METH_VARARGS, (char *)"SBType_GetDereferencedType(SBType self) -> SBType"},
-	 { "SBType_GetUnqualifiedType", _wrap_SBType_GetUnqualifiedType, METH_VARARGS, (char *)"SBType_GetUnqualifiedType(SBType self) -> SBType"},
-	 { "SBType_GetCanonicalType", _wrap_SBType_GetCanonicalType, METH_VARARGS, (char *)"SBType_GetCanonicalType(SBType self) -> SBType"},
-	 { "SBType_GetArrayElementType", _wrap_SBType_GetArrayElementType, METH_VARARGS, (char *)"SBType_GetArrayElementType(SBType self) -> SBType"},
-	 { "SBType_GetArrayType", _wrap_SBType_GetArrayType, METH_VARARGS, (char *)"SBType_GetArrayType(SBType self, uint64_t size) -> SBType"},
-	 { "SBType_GetVectorElementType", _wrap_SBType_GetVectorElementType, METH_VARARGS, (char *)"SBType_GetVectorElementType(SBType self) -> SBType"},
-	 { "SBType_GetBasicType", _wrap_SBType_GetBasicType, METH_VARARGS, (char *)"\n"
-		"GetBasicType() -> lldb::BasicType\n"
-		"SBType_GetBasicType(SBType self, lldb::BasicType type) -> SBType\n"
-		""},
-	 { "SBType_GetNumberOfFields", _wrap_SBType_GetNumberOfFields, METH_VARARGS, (char *)"SBType_GetNumberOfFields(SBType self) -> uint32_t"},
-	 { "SBType_GetNumberOfDirectBaseClasses", _wrap_SBType_GetNumberOfDirectBaseClasses, METH_VARARGS, (char *)"SBType_GetNumberOfDirectBaseClasses(SBType self) -> uint32_t"},
-	 { "SBType_GetNumberOfVirtualBaseClasses", _wrap_SBType_GetNumberOfVirtualBaseClasses, METH_VARARGS, (char *)"SBType_GetNumberOfVirtualBaseClasses(SBType self) -> uint32_t"},
-	 { "SBType_GetFieldAtIndex", _wrap_SBType_GetFieldAtIndex, METH_VARARGS, (char *)"SBType_GetFieldAtIndex(SBType self, uint32_t idx) -> SBTypeMember"},
-	 { "SBType_GetDirectBaseClassAtIndex", _wrap_SBType_GetDirectBaseClassAtIndex, METH_VARARGS, (char *)"SBType_GetDirectBaseClassAtIndex(SBType self, uint32_t idx) -> SBTypeMember"},
-	 { "SBType_GetVirtualBaseClassAtIndex", _wrap_SBType_GetVirtualBaseClassAtIndex, METH_VARARGS, (char *)"SBType_GetVirtualBaseClassAtIndex(SBType self, uint32_t idx) -> SBTypeMember"},
-	 { "SBType_GetEnumMembers", _wrap_SBType_GetEnumMembers, METH_VARARGS, (char *)"SBType_GetEnumMembers(SBType self) -> SBTypeEnumMemberList"},
-	 { "SBType_GetName", _wrap_SBType_GetName, METH_VARARGS, (char *)"SBType_GetName(SBType self) -> char const *"},
-	 { "SBType_GetDisplayTypeName", _wrap_SBType_GetDisplayTypeName, METH_VARARGS, (char *)"SBType_GetDisplayTypeName(SBType self) -> char const *"},
-	 { "SBType_GetTypeClass", _wrap_SBType_GetTypeClass, METH_VARARGS, (char *)"SBType_GetTypeClass(SBType self) -> lldb::TypeClass"},
-	 { "SBType_GetNumberOfTemplateArguments", _wrap_SBType_GetNumberOfTemplateArguments, METH_VARARGS, (char *)"SBType_GetNumberOfTemplateArguments(SBType self) -> uint32_t"},
-	 { "SBType_GetTemplateArgumentType", _wrap_SBType_GetTemplateArgumentType, METH_VARARGS, (char *)"SBType_GetTemplateArgumentType(SBType self, uint32_t idx) -> SBType"},
-	 { "SBType_GetTemplateArgumentKind", _wrap_SBType_GetTemplateArgumentKind, METH_VARARGS, (char *)"SBType_GetTemplateArgumentKind(SBType self, uint32_t idx) -> lldb::TemplateArgumentKind"},
-	 { "SBType_GetFunctionReturnType", _wrap_SBType_GetFunctionReturnType, METH_VARARGS, (char *)"SBType_GetFunctionReturnType(SBType self) -> SBType"},
-	 { "SBType_GetFunctionArgumentTypes", _wrap_SBType_GetFunctionArgumentTypes, METH_VARARGS, (char *)"SBType_GetFunctionArgumentTypes(SBType self) -> SBTypeList"},
-	 { "SBType_GetNumberOfMemberFunctions", _wrap_SBType_GetNumberOfMemberFunctions, METH_VARARGS, (char *)"SBType_GetNumberOfMemberFunctions(SBType self) -> uint32_t"},
-	 { "SBType_GetMemberFunctionAtIndex", _wrap_SBType_GetMemberFunctionAtIndex, METH_VARARGS, (char *)"SBType_GetMemberFunctionAtIndex(SBType self, uint32_t idx) -> SBTypeMemberFunction"},
-	 { "SBType_IsTypeComplete", _wrap_SBType_IsTypeComplete, METH_VARARGS, (char *)"SBType_IsTypeComplete(SBType self) -> bool"},
-	 { "SBType_GetTypeFlags", _wrap_SBType_GetTypeFlags, METH_VARARGS, (char *)"SBType_GetTypeFlags(SBType self) -> uint32_t"},
-	 { "SBType___str__", _wrap_SBType___str__, METH_VARARGS, (char *)"SBType___str__(SBType self) -> PyObject *"},
-	 { "SBType_swigregister", SBType_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeList", _wrap_new_SBTypeList, METH_VARARGS, (char *)"new_SBTypeList() -> SBTypeList"},
-	 { "SBTypeList_IsValid", _wrap_SBTypeList_IsValid, METH_VARARGS, (char *)"SBTypeList_IsValid(SBTypeList self) -> bool"},
-	 { "SBTypeList___nonzero__", _wrap_SBTypeList___nonzero__, METH_VARARGS, (char *)"SBTypeList___nonzero__(SBTypeList self) -> bool"},
-	 { "SBTypeList_Append", _wrap_SBTypeList_Append, METH_VARARGS, (char *)"SBTypeList_Append(SBTypeList self, SBType type)"},
-	 { "SBTypeList_GetTypeAtIndex", _wrap_SBTypeList_GetTypeAtIndex, METH_VARARGS, (char *)"SBTypeList_GetTypeAtIndex(SBTypeList self, uint32_t index) -> SBType"},
-	 { "SBTypeList_GetSize", _wrap_SBTypeList_GetSize, METH_VARARGS, (char *)"SBTypeList_GetSize(SBTypeList self) -> uint32_t"},
-	 { "delete_SBTypeList", _wrap_delete_SBTypeList, METH_VARARGS, (char *)"delete_SBTypeList(SBTypeList self)"},
-	 { "SBTypeList_swigregister", SBTypeList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeCategory", _wrap_new_SBTypeCategory, METH_VARARGS, (char *)"\n"
-		"SBTypeCategory()\n"
-		"new_SBTypeCategory(SBTypeCategory rhs) -> SBTypeCategory\n"
-		""},
-	 { "delete_SBTypeCategory", _wrap_delete_SBTypeCategory, METH_VARARGS, (char *)"delete_SBTypeCategory(SBTypeCategory self)"},
-	 { "SBTypeCategory_IsValid", _wrap_SBTypeCategory_IsValid, METH_VARARGS, (char *)"SBTypeCategory_IsValid(SBTypeCategory self) -> bool"},
-	 { "SBTypeCategory___nonzero__", _wrap_SBTypeCategory___nonzero__, METH_VARARGS, (char *)"SBTypeCategory___nonzero__(SBTypeCategory self) -> bool"},
-	 { "SBTypeCategory_GetEnabled", _wrap_SBTypeCategory_GetEnabled, METH_VARARGS, (char *)"SBTypeCategory_GetEnabled(SBTypeCategory self) -> bool"},
-	 { "SBTypeCategory_SetEnabled", _wrap_SBTypeCategory_SetEnabled, METH_VARARGS, (char *)"SBTypeCategory_SetEnabled(SBTypeCategory self, bool arg3)"},
-	 { "SBTypeCategory_GetName", _wrap_SBTypeCategory_GetName, METH_VARARGS, (char *)"SBTypeCategory_GetName(SBTypeCategory self) -> char const *"},
-	 { "SBTypeCategory_GetLanguageAtIndex", _wrap_SBTypeCategory_GetLanguageAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetLanguageAtIndex(SBTypeCategory self, uint32_t idx) -> lldb::LanguageType"},
-	 { "SBTypeCategory_GetNumLanguages", _wrap_SBTypeCategory_GetNumLanguages, METH_VARARGS, (char *)"SBTypeCategory_GetNumLanguages(SBTypeCategory self) -> uint32_t"},
-	 { "SBTypeCategory_AddLanguage", _wrap_SBTypeCategory_AddLanguage, METH_VARARGS, (char *)"SBTypeCategory_AddLanguage(SBTypeCategory self, lldb::LanguageType language)"},
-	 { "SBTypeCategory_GetDescription", _wrap_SBTypeCategory_GetDescription, METH_VARARGS, (char *)"SBTypeCategory_GetDescription(SBTypeCategory self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeCategory_GetNumFormats", _wrap_SBTypeCategory_GetNumFormats, METH_VARARGS, (char *)"SBTypeCategory_GetNumFormats(SBTypeCategory self) -> uint32_t"},
-	 { "SBTypeCategory_GetNumSummaries", _wrap_SBTypeCategory_GetNumSummaries, METH_VARARGS, (char *)"SBTypeCategory_GetNumSummaries(SBTypeCategory self) -> uint32_t"},
-	 { "SBTypeCategory_GetNumFilters", _wrap_SBTypeCategory_GetNumFilters, METH_VARARGS, (char *)"SBTypeCategory_GetNumFilters(SBTypeCategory self) -> uint32_t"},
-	 { "SBTypeCategory_GetNumSynthetics", _wrap_SBTypeCategory_GetNumSynthetics, METH_VARARGS, (char *)"SBTypeCategory_GetNumSynthetics(SBTypeCategory self) -> uint32_t"},
-	 { "SBTypeCategory_GetTypeNameSpecifierForFilterAtIndex", _wrap_SBTypeCategory_GetTypeNameSpecifierForFilterAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetTypeNameSpecifierForFilterAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeNameSpecifier"},
-	 { "SBTypeCategory_GetTypeNameSpecifierForFormatAtIndex", _wrap_SBTypeCategory_GetTypeNameSpecifierForFormatAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetTypeNameSpecifierForFormatAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeNameSpecifier"},
-	 { "SBTypeCategory_GetTypeNameSpecifierForSummaryAtIndex", _wrap_SBTypeCategory_GetTypeNameSpecifierForSummaryAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetTypeNameSpecifierForSummaryAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeNameSpecifier"},
-	 { "SBTypeCategory_GetTypeNameSpecifierForSyntheticAtIndex", _wrap_SBTypeCategory_GetTypeNameSpecifierForSyntheticAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetTypeNameSpecifierForSyntheticAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeNameSpecifier"},
-	 { "SBTypeCategory_GetFilterForType", _wrap_SBTypeCategory_GetFilterForType, METH_VARARGS, (char *)"SBTypeCategory_GetFilterForType(SBTypeCategory self, SBTypeNameSpecifier arg3) -> SBTypeFilter"},
-	 { "SBTypeCategory_GetFormatForType", _wrap_SBTypeCategory_GetFormatForType, METH_VARARGS, (char *)"SBTypeCategory_GetFormatForType(SBTypeCategory self, SBTypeNameSpecifier arg3) -> SBTypeFormat"},
-	 { "SBTypeCategory_GetSummaryForType", _wrap_SBTypeCategory_GetSummaryForType, METH_VARARGS, (char *)"SBTypeCategory_GetSummaryForType(SBTypeCategory self, SBTypeNameSpecifier arg3) -> SBTypeSummary"},
-	 { "SBTypeCategory_GetSyntheticForType", _wrap_SBTypeCategory_GetSyntheticForType, METH_VARARGS, (char *)"SBTypeCategory_GetSyntheticForType(SBTypeCategory self, SBTypeNameSpecifier arg3) -> SBTypeSynthetic"},
-	 { "SBTypeCategory_GetFilterAtIndex", _wrap_SBTypeCategory_GetFilterAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetFilterAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeFilter"},
-	 { "SBTypeCategory_GetFormatAtIndex", _wrap_SBTypeCategory_GetFormatAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetFormatAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeFormat"},
-	 { "SBTypeCategory_GetSummaryAtIndex", _wrap_SBTypeCategory_GetSummaryAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetSummaryAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeSummary"},
-	 { "SBTypeCategory_GetSyntheticAtIndex", _wrap_SBTypeCategory_GetSyntheticAtIndex, METH_VARARGS, (char *)"SBTypeCategory_GetSyntheticAtIndex(SBTypeCategory self, uint32_t arg3) -> SBTypeSynthetic"},
-	 { "SBTypeCategory_AddTypeFormat", _wrap_SBTypeCategory_AddTypeFormat, METH_VARARGS, (char *)"SBTypeCategory_AddTypeFormat(SBTypeCategory self, SBTypeNameSpecifier arg3, SBTypeFormat arg4) -> bool"},
-	 { "SBTypeCategory_DeleteTypeFormat", _wrap_SBTypeCategory_DeleteTypeFormat, METH_VARARGS, (char *)"SBTypeCategory_DeleteTypeFormat(SBTypeCategory self, SBTypeNameSpecifier arg3) -> bool"},
-	 { "SBTypeCategory_AddTypeSummary", _wrap_SBTypeCategory_AddTypeSummary, METH_VARARGS, (char *)"SBTypeCategory_AddTypeSummary(SBTypeCategory self, SBTypeNameSpecifier arg3, SBTypeSummary arg4) -> bool"},
-	 { "SBTypeCategory_DeleteTypeSummary", _wrap_SBTypeCategory_DeleteTypeSummary, METH_VARARGS, (char *)"SBTypeCategory_DeleteTypeSummary(SBTypeCategory self, SBTypeNameSpecifier arg3) -> bool"},
-	 { "SBTypeCategory_AddTypeFilter", _wrap_SBTypeCategory_AddTypeFilter, METH_VARARGS, (char *)"SBTypeCategory_AddTypeFilter(SBTypeCategory self, SBTypeNameSpecifier arg3, SBTypeFilter arg4) -> bool"},
-	 { "SBTypeCategory_DeleteTypeFilter", _wrap_SBTypeCategory_DeleteTypeFilter, METH_VARARGS, (char *)"SBTypeCategory_DeleteTypeFilter(SBTypeCategory self, SBTypeNameSpecifier arg3) -> bool"},
-	 { "SBTypeCategory_AddTypeSynthetic", _wrap_SBTypeCategory_AddTypeSynthetic, METH_VARARGS, (char *)"SBTypeCategory_AddTypeSynthetic(SBTypeCategory self, SBTypeNameSpecifier arg3, SBTypeSynthetic arg4) -> bool"},
-	 { "SBTypeCategory_DeleteTypeSynthetic", _wrap_SBTypeCategory_DeleteTypeSynthetic, METH_VARARGS, (char *)"SBTypeCategory_DeleteTypeSynthetic(SBTypeCategory self, SBTypeNameSpecifier arg3) -> bool"},
-	 { "SBTypeCategory___str__", _wrap_SBTypeCategory___str__, METH_VARARGS, (char *)"SBTypeCategory___str__(SBTypeCategory self) -> PyObject *"},
-	 { "SBTypeCategory_swigregister", SBTypeCategory_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeEnumMember", _wrap_new_SBTypeEnumMember, METH_VARARGS, (char *)"\n"
-		"SBTypeEnumMember()\n"
-		"new_SBTypeEnumMember(SBTypeEnumMember rhs) -> SBTypeEnumMember\n"
-		""},
-	 { "delete_SBTypeEnumMember", _wrap_delete_SBTypeEnumMember, METH_VARARGS, (char *)"delete_SBTypeEnumMember(SBTypeEnumMember self)"},
-	 { "SBTypeEnumMember_IsValid", _wrap_SBTypeEnumMember_IsValid, METH_VARARGS, (char *)"SBTypeEnumMember_IsValid(SBTypeEnumMember self) -> bool"},
-	 { "SBTypeEnumMember___nonzero__", _wrap_SBTypeEnumMember___nonzero__, METH_VARARGS, (char *)"SBTypeEnumMember___nonzero__(SBTypeEnumMember self) -> bool"},
-	 { "SBTypeEnumMember_GetValueAsSigned", _wrap_SBTypeEnumMember_GetValueAsSigned, METH_VARARGS, (char *)"SBTypeEnumMember_GetValueAsSigned(SBTypeEnumMember self) -> int64_t"},
-	 { "SBTypeEnumMember_GetValueAsUnsigned", _wrap_SBTypeEnumMember_GetValueAsUnsigned, METH_VARARGS, (char *)"SBTypeEnumMember_GetValueAsUnsigned(SBTypeEnumMember self) -> uint64_t"},
-	 { "SBTypeEnumMember_GetName", _wrap_SBTypeEnumMember_GetName, METH_VARARGS, (char *)"SBTypeEnumMember_GetName(SBTypeEnumMember self) -> char const *"},
-	 { "SBTypeEnumMember_GetType", _wrap_SBTypeEnumMember_GetType, METH_VARARGS, (char *)"SBTypeEnumMember_GetType(SBTypeEnumMember self) -> SBType"},
-	 { "SBTypeEnumMember_GetDescription", _wrap_SBTypeEnumMember_GetDescription, METH_VARARGS, (char *)"SBTypeEnumMember_GetDescription(SBTypeEnumMember self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeEnumMember___str__", _wrap_SBTypeEnumMember___str__, METH_VARARGS, (char *)"SBTypeEnumMember___str__(SBTypeEnumMember self) -> PyObject *"},
-	 { "SBTypeEnumMember_swigregister", SBTypeEnumMember_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeEnumMemberList", _wrap_new_SBTypeEnumMemberList, METH_VARARGS, (char *)"\n"
-		"SBTypeEnumMemberList()\n"
-		"new_SBTypeEnumMemberList(SBTypeEnumMemberList rhs) -> SBTypeEnumMemberList\n"
-		""},
-	 { "delete_SBTypeEnumMemberList", _wrap_delete_SBTypeEnumMemberList, METH_VARARGS, (char *)"delete_SBTypeEnumMemberList(SBTypeEnumMemberList self)"},
-	 { "SBTypeEnumMemberList_IsValid", _wrap_SBTypeEnumMemberList_IsValid, METH_VARARGS, (char *)"SBTypeEnumMemberList_IsValid(SBTypeEnumMemberList self) -> bool"},
-	 { "SBTypeEnumMemberList___nonzero__", _wrap_SBTypeEnumMemberList___nonzero__, METH_VARARGS, (char *)"SBTypeEnumMemberList___nonzero__(SBTypeEnumMemberList self) -> bool"},
-	 { "SBTypeEnumMemberList_Append", _wrap_SBTypeEnumMemberList_Append, METH_VARARGS, (char *)"SBTypeEnumMemberList_Append(SBTypeEnumMemberList self, SBTypeEnumMember entry)"},
-	 { "SBTypeEnumMemberList_GetTypeEnumMemberAtIndex", _wrap_SBTypeEnumMemberList_GetTypeEnumMemberAtIndex, METH_VARARGS, (char *)"SBTypeEnumMemberList_GetTypeEnumMemberAtIndex(SBTypeEnumMemberList self, uint32_t index) -> SBTypeEnumMember"},
-	 { "SBTypeEnumMemberList_GetSize", _wrap_SBTypeEnumMemberList_GetSize, METH_VARARGS, (char *)"SBTypeEnumMemberList_GetSize(SBTypeEnumMemberList self) -> uint32_t"},
-	 { "SBTypeEnumMemberList_swigregister", SBTypeEnumMemberList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeFilter", _wrap_new_SBTypeFilter, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBThreadPlan", _wrap_delete_SBThreadPlan, METH_VARARGS, (char *)"delete_SBThreadPlan(SBThreadPlan self)"},
 	 { (char *)"SBThreadPlan___nonzero__", _wrap_SBThreadPlan___nonzero__, METH_VARARGS, (char *)"SBThreadPlan___nonzero__(SBThreadPlan self) -> bool"},
 	 { (char *)"SBThreadPlan_Clear", _wrap_SBThreadPlan_Clear, METH_VARARGS, (char *)"SBThreadPlan_Clear(SBThreadPlan self)"},
@@ -85469,30 +82596,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTypeEnumMemberList_GetSize", _wrap_SBTypeEnumMemberList_GetSize, METH_VARARGS, (char *)"SBTypeEnumMemberList_GetSize(SBTypeEnumMemberList self) -> uint32_t"},
 	 { (char *)"SBTypeEnumMemberList_swigregister", SBTypeEnumMemberList_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBTypeFilter", _wrap_new_SBTypeFilter, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTypeFilter()\n"
 		"SBTypeFilter(uint32_t options)\n"
 		"new_SBTypeFilter(SBTypeFilter rhs) -> SBTypeFilter\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBTypeFilter", _wrap_delete_SBTypeFilter, METH_VARARGS, (char *)"delete_SBTypeFilter(SBTypeFilter self)"},
-	 { "SBTypeFilter_IsValid", _wrap_SBTypeFilter_IsValid, METH_VARARGS, (char *)"SBTypeFilter_IsValid(SBTypeFilter self) -> bool"},
-	 { "SBTypeFilter___nonzero__", _wrap_SBTypeFilter___nonzero__, METH_VARARGS, (char *)"SBTypeFilter___nonzero__(SBTypeFilter self) -> bool"},
-	 { "SBTypeFilter_IsEqualTo", _wrap_SBTypeFilter_IsEqualTo, METH_VARARGS, (char *)"SBTypeFilter_IsEqualTo(SBTypeFilter self, SBTypeFilter rhs) -> bool"},
-	 { "SBTypeFilter_GetNumberOfExpressionPaths", _wrap_SBTypeFilter_GetNumberOfExpressionPaths, METH_VARARGS, (char *)"SBTypeFilter_GetNumberOfExpressionPaths(SBTypeFilter self) -> uint32_t"},
-	 { "SBTypeFilter_GetExpressionPathAtIndex", _wrap_SBTypeFilter_GetExpressionPathAtIndex, METH_VARARGS, (char *)"SBTypeFilter_GetExpressionPathAtIndex(SBTypeFilter self, uint32_t i) -> char const *"},
-	 { "SBTypeFilter_ReplaceExpressionPathAtIndex", _wrap_SBTypeFilter_ReplaceExpressionPathAtIndex, METH_VARARGS, (char *)"SBTypeFilter_ReplaceExpressionPathAtIndex(SBTypeFilter self, uint32_t i, char const * item) -> bool"},
-	 { "SBTypeFilter_AppendExpressionPath", _wrap_SBTypeFilter_AppendExpressionPath, METH_VARARGS, (char *)"SBTypeFilter_AppendExpressionPath(SBTypeFilter self, char const * item)"},
-	 { "SBTypeFilter_Clear", _wrap_SBTypeFilter_Clear, METH_VARARGS, (char *)"SBTypeFilter_Clear(SBTypeFilter self)"},
-	 { "SBTypeFilter_GetOptions", _wrap_SBTypeFilter_GetOptions, METH_VARARGS, (char *)"SBTypeFilter_GetOptions(SBTypeFilter self) -> uint32_t"},
-	 { "SBTypeFilter_SetOptions", _wrap_SBTypeFilter_SetOptions, METH_VARARGS, (char *)"SBTypeFilter_SetOptions(SBTypeFilter self, uint32_t arg3)"},
-	 { "SBTypeFilter_GetDescription", _wrap_SBTypeFilter_GetDescription, METH_VARARGS, (char *)"SBTypeFilter_GetDescription(SBTypeFilter self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeFilter___eq__", _wrap_SBTypeFilter___eq__, METH_VARARGS, (char *)"SBTypeFilter___eq__(SBTypeFilter self, SBTypeFilter rhs) -> bool"},
-	 { "SBTypeFilter___ne__", _wrap_SBTypeFilter___ne__, METH_VARARGS, (char *)"SBTypeFilter___ne__(SBTypeFilter self, SBTypeFilter rhs) -> bool"},
-	 { "SBTypeFilter___str__", _wrap_SBTypeFilter___str__, METH_VARARGS, (char *)"SBTypeFilter___str__(SBTypeFilter self) -> PyObject *"},
-	 { "SBTypeFilter_swigregister", SBTypeFilter_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeFormat", _wrap_new_SBTypeFormat, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBTypeFilter", _wrap_delete_SBTypeFilter, METH_VARARGS, (char *)"delete_SBTypeFilter(SBTypeFilter self)"},
 	 { (char *)"SBTypeFilter_IsValid", _wrap_SBTypeFilter_IsValid, METH_VARARGS, (char *)"SBTypeFilter_IsValid(SBTypeFilter self) -> bool"},
 	 { (char *)"SBTypeFilter___nonzero__", _wrap_SBTypeFilter___nonzero__, METH_VARARGS, (char *)"SBTypeFilter___nonzero__(SBTypeFilter self) -> bool"},
@@ -85510,7 +82617,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTypeFilter___str__", _wrap_SBTypeFilter___str__, METH_VARARGS, (char *)"SBTypeFilter___str__(SBTypeFilter self) -> PyObject *"},
 	 { (char *)"SBTypeFilter_swigregister", SBTypeFilter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBTypeFormat", _wrap_new_SBTypeFormat, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTypeFormat()\n"
 		"SBTypeFormat(lldb::Format format, uint32_t options=0)\n"
 		"SBTypeFormat(lldb::Format format)\n"
@@ -85518,24 +82624,6 @@ static PyMethodDef SwigMethods[] = {
 		"SBTypeFormat(char const * type)\n"
 		"new_SBTypeFormat(SBTypeFormat rhs) -> SBTypeFormat\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBTypeFormat", _wrap_delete_SBTypeFormat, METH_VARARGS, (char *)"delete_SBTypeFormat(SBTypeFormat self)"},
-	 { "SBTypeFormat_IsValid", _wrap_SBTypeFormat_IsValid, METH_VARARGS, (char *)"SBTypeFormat_IsValid(SBTypeFormat self) -> bool"},
-	 { "SBTypeFormat___nonzero__", _wrap_SBTypeFormat___nonzero__, METH_VARARGS, (char *)"SBTypeFormat___nonzero__(SBTypeFormat self) -> bool"},
-	 { "SBTypeFormat_IsEqualTo", _wrap_SBTypeFormat_IsEqualTo, METH_VARARGS, (char *)"SBTypeFormat_IsEqualTo(SBTypeFormat self, SBTypeFormat rhs) -> bool"},
-	 { "SBTypeFormat_GetFormat", _wrap_SBTypeFormat_GetFormat, METH_VARARGS, (char *)"SBTypeFormat_GetFormat(SBTypeFormat self) -> lldb::Format"},
-	 { "SBTypeFormat_GetTypeName", _wrap_SBTypeFormat_GetTypeName, METH_VARARGS, (char *)"SBTypeFormat_GetTypeName(SBTypeFormat self) -> char const *"},
-	 { "SBTypeFormat_GetOptions", _wrap_SBTypeFormat_GetOptions, METH_VARARGS, (char *)"SBTypeFormat_GetOptions(SBTypeFormat self) -> uint32_t"},
-	 { "SBTypeFormat_SetFormat", _wrap_SBTypeFormat_SetFormat, METH_VARARGS, (char *)"SBTypeFormat_SetFormat(SBTypeFormat self, lldb::Format arg3)"},
-	 { "SBTypeFormat_SetTypeName", _wrap_SBTypeFormat_SetTypeName, METH_VARARGS, (char *)"SBTypeFormat_SetTypeName(SBTypeFormat self, char const * arg3)"},
-	 { "SBTypeFormat_SetOptions", _wrap_SBTypeFormat_SetOptions, METH_VARARGS, (char *)"SBTypeFormat_SetOptions(SBTypeFormat self, uint32_t arg3)"},
-	 { "SBTypeFormat_GetDescription", _wrap_SBTypeFormat_GetDescription, METH_VARARGS, (char *)"SBTypeFormat_GetDescription(SBTypeFormat self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeFormat___eq__", _wrap_SBTypeFormat___eq__, METH_VARARGS, (char *)"SBTypeFormat___eq__(SBTypeFormat self, SBTypeFormat rhs) -> bool"},
-	 { "SBTypeFormat___ne__", _wrap_SBTypeFormat___ne__, METH_VARARGS, (char *)"SBTypeFormat___ne__(SBTypeFormat self, SBTypeFormat rhs) -> bool"},
-	 { "SBTypeFormat___str__", _wrap_SBTypeFormat___str__, METH_VARARGS, (char *)"SBTypeFormat___str__(SBTypeFormat self) -> PyObject *"},
-	 { "SBTypeFormat_swigregister", SBTypeFormat_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeNameSpecifier", _wrap_new_SBTypeNameSpecifier, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBTypeFormat", _wrap_delete_SBTypeFormat, METH_VARARGS, (char *)"delete_SBTypeFormat(SBTypeFormat self)"},
 	 { (char *)"SBTypeFormat_IsValid", _wrap_SBTypeFormat_IsValid, METH_VARARGS, (char *)"SBTypeFormat_IsValid(SBTypeFormat self) -> bool"},
 	 { (char *)"SBTypeFormat___nonzero__", _wrap_SBTypeFormat___nonzero__, METH_VARARGS, (char *)"SBTypeFormat___nonzero__(SBTypeFormat self) -> bool"},
@@ -85552,48 +82640,12 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBTypeFormat___str__", _wrap_SBTypeFormat___str__, METH_VARARGS, (char *)"SBTypeFormat___str__(SBTypeFormat self) -> PyObject *"},
 	 { (char *)"SBTypeFormat_swigregister", SBTypeFormat_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_SBTypeNameSpecifier", _wrap_new_SBTypeNameSpecifier, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBTypeNameSpecifier()\n"
 		"SBTypeNameSpecifier(char const * name, bool is_regex=False)\n"
 		"SBTypeNameSpecifier(char const * name)\n"
 		"SBTypeNameSpecifier(SBType type)\n"
 		"new_SBTypeNameSpecifier(SBTypeNameSpecifier rhs) -> SBTypeNameSpecifier\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBTypeNameSpecifier", _wrap_delete_SBTypeNameSpecifier, METH_VARARGS, (char *)"delete_SBTypeNameSpecifier(SBTypeNameSpecifier self)"},
-	 { "SBTypeNameSpecifier_IsValid", _wrap_SBTypeNameSpecifier_IsValid, METH_VARARGS, (char *)"SBTypeNameSpecifier_IsValid(SBTypeNameSpecifier self) -> bool"},
-	 { "SBTypeNameSpecifier___nonzero__", _wrap_SBTypeNameSpecifier___nonzero__, METH_VARARGS, (char *)"SBTypeNameSpecifier___nonzero__(SBTypeNameSpecifier self) -> bool"},
-	 { "SBTypeNameSpecifier_IsEqualTo", _wrap_SBTypeNameSpecifier_IsEqualTo, METH_VARARGS, (char *)"SBTypeNameSpecifier_IsEqualTo(SBTypeNameSpecifier self, SBTypeNameSpecifier rhs) -> bool"},
-	 { "SBTypeNameSpecifier_GetName", _wrap_SBTypeNameSpecifier_GetName, METH_VARARGS, (char *)"SBTypeNameSpecifier_GetName(SBTypeNameSpecifier self) -> char const *"},
-	 { "SBTypeNameSpecifier_GetType", _wrap_SBTypeNameSpecifier_GetType, METH_VARARGS, (char *)"SBTypeNameSpecifier_GetType(SBTypeNameSpecifier self) -> SBType"},
-	 { "SBTypeNameSpecifier_IsRegex", _wrap_SBTypeNameSpecifier_IsRegex, METH_VARARGS, (char *)"SBTypeNameSpecifier_IsRegex(SBTypeNameSpecifier self) -> bool"},
-	 { "SBTypeNameSpecifier_GetDescription", _wrap_SBTypeNameSpecifier_GetDescription, METH_VARARGS, (char *)"SBTypeNameSpecifier_GetDescription(SBTypeNameSpecifier self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeNameSpecifier___eq__", _wrap_SBTypeNameSpecifier___eq__, METH_VARARGS, (char *)"SBTypeNameSpecifier___eq__(SBTypeNameSpecifier self, SBTypeNameSpecifier rhs) -> bool"},
-	 { "SBTypeNameSpecifier___ne__", _wrap_SBTypeNameSpecifier___ne__, METH_VARARGS, (char *)"SBTypeNameSpecifier___ne__(SBTypeNameSpecifier self, SBTypeNameSpecifier rhs) -> bool"},
-	 { "SBTypeNameSpecifier___str__", _wrap_SBTypeNameSpecifier___str__, METH_VARARGS, (char *)"SBTypeNameSpecifier___str__(SBTypeNameSpecifier self) -> PyObject *"},
-	 { "SBTypeNameSpecifier_swigregister", SBTypeNameSpecifier_swigregister, METH_VARARGS, NULL},
-	 { "new_SBTypeSummaryOptions", _wrap_new_SBTypeSummaryOptions, METH_VARARGS, (char *)"\n"
-		"SBTypeSummaryOptions()\n"
-		"new_SBTypeSummaryOptions(SBTypeSummaryOptions rhs) -> SBTypeSummaryOptions\n"
-		""},
-	 { "delete_SBTypeSummaryOptions", _wrap_delete_SBTypeSummaryOptions, METH_VARARGS, (char *)"delete_SBTypeSummaryOptions(SBTypeSummaryOptions self)"},
-	 { "SBTypeSummaryOptions_IsValid", _wrap_SBTypeSummaryOptions_IsValid, METH_VARARGS, (char *)"SBTypeSummaryOptions_IsValid(SBTypeSummaryOptions self) -> bool"},
-	 { "SBTypeSummaryOptions___nonzero__", _wrap_SBTypeSummaryOptions___nonzero__, METH_VARARGS, (char *)"SBTypeSummaryOptions___nonzero__(SBTypeSummaryOptions self) -> bool"},
-	 { "SBTypeSummaryOptions_GetLanguage", _wrap_SBTypeSummaryOptions_GetLanguage, METH_VARARGS, (char *)"SBTypeSummaryOptions_GetLanguage(SBTypeSummaryOptions self) -> lldb::LanguageType"},
-	 { "SBTypeSummaryOptions_GetCapping", _wrap_SBTypeSummaryOptions_GetCapping, METH_VARARGS, (char *)"SBTypeSummaryOptions_GetCapping(SBTypeSummaryOptions self) -> lldb::TypeSummaryCapping"},
-	 { "SBTypeSummaryOptions_SetLanguage", _wrap_SBTypeSummaryOptions_SetLanguage, METH_VARARGS, (char *)"SBTypeSummaryOptions_SetLanguage(SBTypeSummaryOptions self, lldb::LanguageType arg3)"},
-	 { "SBTypeSummaryOptions_SetCapping", _wrap_SBTypeSummaryOptions_SetCapping, METH_VARARGS, (char *)"SBTypeSummaryOptions_SetCapping(SBTypeSummaryOptions self, lldb::TypeSummaryCapping arg3)"},
-	 { "SBTypeSummaryOptions_swigregister", SBTypeSummaryOptions_swigregister, METH_VARARGS, NULL},
-	 { "SBTypeSummary_CreateWithSummaryString", _wrap_SBTypeSummary_CreateWithSummaryString, METH_VARARGS, (char *)"\n"
-		"CreateWithSummaryString(char const * data, uint32_t options=0) -> SBTypeSummary\n"
-		"SBTypeSummary_CreateWithSummaryString(char const * data) -> SBTypeSummary\n"
-		""},
-	 { "SBTypeSummary_CreateWithFunctionName", _wrap_SBTypeSummary_CreateWithFunctionName, METH_VARARGS, (char *)"\n"
-		"CreateWithFunctionName(char const * data, uint32_t options=0) -> SBTypeSummary\n"
-		"SBTypeSummary_CreateWithFunctionName(char const * data) -> SBTypeSummary\n"
-		""},
-	 { "SBTypeSummary_CreateWithScriptCode", _wrap_SBTypeSummary_CreateWithScriptCode, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBTypeNameSpecifier", _wrap_delete_SBTypeNameSpecifier, METH_VARARGS, (char *)"delete_SBTypeNameSpecifier(SBTypeNameSpecifier self)"},
 	 { (char *)"SBTypeNameSpecifier_IsValid", _wrap_SBTypeNameSpecifier_IsValid, METH_VARARGS, (char *)"SBTypeNameSpecifier_IsValid(SBTypeNameSpecifier self) -> bool"},
 	 { (char *)"SBTypeNameSpecifier___nonzero__", _wrap_SBTypeNameSpecifier___nonzero__, METH_VARARGS, (char *)"SBTypeNameSpecifier___nonzero__(SBTypeNameSpecifier self) -> bool"},
@@ -85627,39 +82679,13 @@ static PyMethodDef SwigMethods[] = {
 		"SBTypeSummary_CreateWithFunctionName(char const * data) -> SBTypeSummary\n"
 		""},
 	 { (char *)"SBTypeSummary_CreateWithScriptCode", _wrap_SBTypeSummary_CreateWithScriptCode, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"CreateWithScriptCode(char const * data, uint32_t options=0) -> SBTypeSummary\n"
 		"SBTypeSummary_CreateWithScriptCode(char const * data) -> SBTypeSummary\n"
 		""},
-	 { "new_SBTypeSummary", _wrap_new_SBTypeSummary, METH_VARARGS, (char *)"\n"
+	 { (char *)"new_SBTypeSummary", _wrap_new_SBTypeSummary, METH_VARARGS, (char *)"\n"
 		"SBTypeSummary()\n"
 		"new_SBTypeSummary(SBTypeSummary rhs) -> SBTypeSummary\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBTypeSummary", _wrap_delete_SBTypeSummary, METH_VARARGS, (char *)"delete_SBTypeSummary(SBTypeSummary self)"},
-	 { "SBTypeSummary_IsValid", _wrap_SBTypeSummary_IsValid, METH_VARARGS, (char *)"SBTypeSummary_IsValid(SBTypeSummary self) -> bool"},
-	 { "SBTypeSummary___nonzero__", _wrap_SBTypeSummary___nonzero__, METH_VARARGS, (char *)"SBTypeSummary___nonzero__(SBTypeSummary self) -> bool"},
-	 { "SBTypeSummary_IsEqualTo", _wrap_SBTypeSummary_IsEqualTo, METH_VARARGS, (char *)"SBTypeSummary_IsEqualTo(SBTypeSummary self, SBTypeSummary rhs) -> bool"},
-	 { "SBTypeSummary_IsFunctionCode", _wrap_SBTypeSummary_IsFunctionCode, METH_VARARGS, (char *)"SBTypeSummary_IsFunctionCode(SBTypeSummary self) -> bool"},
-	 { "SBTypeSummary_IsFunctionName", _wrap_SBTypeSummary_IsFunctionName, METH_VARARGS, (char *)"SBTypeSummary_IsFunctionName(SBTypeSummary self) -> bool"},
-	 { "SBTypeSummary_IsSummaryString", _wrap_SBTypeSummary_IsSummaryString, METH_VARARGS, (char *)"SBTypeSummary_IsSummaryString(SBTypeSummary self) -> bool"},
-	 { "SBTypeSummary_GetData", _wrap_SBTypeSummary_GetData, METH_VARARGS, (char *)"SBTypeSummary_GetData(SBTypeSummary self) -> char const *"},
-	 { "SBTypeSummary_SetSummaryString", _wrap_SBTypeSummary_SetSummaryString, METH_VARARGS, (char *)"SBTypeSummary_SetSummaryString(SBTypeSummary self, char const * data)"},
-	 { "SBTypeSummary_SetFunctionName", _wrap_SBTypeSummary_SetFunctionName, METH_VARARGS, (char *)"SBTypeSummary_SetFunctionName(SBTypeSummary self, char const * data)"},
-	 { "SBTypeSummary_SetFunctionCode", _wrap_SBTypeSummary_SetFunctionCode, METH_VARARGS, (char *)"SBTypeSummary_SetFunctionCode(SBTypeSummary self, char const * data)"},
-	 { "SBTypeSummary_GetOptions", _wrap_SBTypeSummary_GetOptions, METH_VARARGS, (char *)"SBTypeSummary_GetOptions(SBTypeSummary self) -> uint32_t"},
-	 { "SBTypeSummary_SetOptions", _wrap_SBTypeSummary_SetOptions, METH_VARARGS, (char *)"SBTypeSummary_SetOptions(SBTypeSummary self, uint32_t arg3)"},
-	 { "SBTypeSummary_GetDescription", _wrap_SBTypeSummary_GetDescription, METH_VARARGS, (char *)"SBTypeSummary_GetDescription(SBTypeSummary self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeSummary___eq__", _wrap_SBTypeSummary___eq__, METH_VARARGS, (char *)"SBTypeSummary___eq__(SBTypeSummary self, SBTypeSummary rhs) -> bool"},
-	 { "SBTypeSummary___ne__", _wrap_SBTypeSummary___ne__, METH_VARARGS, (char *)"SBTypeSummary___ne__(SBTypeSummary self, SBTypeSummary rhs) -> bool"},
-	 { "SBTypeSummary___str__", _wrap_SBTypeSummary___str__, METH_VARARGS, (char *)"SBTypeSummary___str__(SBTypeSummary self) -> PyObject *"},
-	 { "SBTypeSummary_swigregister", SBTypeSummary_swigregister, METH_VARARGS, NULL},
-	 { "SBTypeSynthetic_CreateWithClassName", _wrap_SBTypeSynthetic_CreateWithClassName, METH_VARARGS, (char *)"\n"
-		"CreateWithClassName(char const * data, uint32_t options=0) -> SBTypeSynthetic\n"
-		"SBTypeSynthetic_CreateWithClassName(char const * data) -> SBTypeSynthetic\n"
-		""},
-	 { "SBTypeSynthetic_CreateWithScriptCode", _wrap_SBTypeSynthetic_CreateWithScriptCode, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBTypeSummary", _wrap_delete_SBTypeSummary, METH_VARARGS, (char *)"delete_SBTypeSummary(SBTypeSummary self)"},
 	 { (char *)"SBTypeSummary_IsValid", _wrap_SBTypeSummary_IsValid, METH_VARARGS, (char *)"SBTypeSummary_IsValid(SBTypeSummary self) -> bool"},
 	 { (char *)"SBTypeSummary___nonzero__", _wrap_SBTypeSummary___nonzero__, METH_VARARGS, (char *)"SBTypeSummary___nonzero__(SBTypeSummary self) -> bool"},
@@ -85683,50 +82709,13 @@ static PyMethodDef SwigMethods[] = {
 		"SBTypeSynthetic_CreateWithClassName(char const * data) -> SBTypeSynthetic\n"
 		""},
 	 { (char *)"SBTypeSynthetic_CreateWithScriptCode", _wrap_SBTypeSynthetic_CreateWithScriptCode, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"CreateWithScriptCode(char const * data, uint32_t options=0) -> SBTypeSynthetic\n"
 		"SBTypeSynthetic_CreateWithScriptCode(char const * data) -> SBTypeSynthetic\n"
 		""},
-	 { "new_SBTypeSynthetic", _wrap_new_SBTypeSynthetic, METH_VARARGS, (char *)"\n"
+	 { (char *)"new_SBTypeSynthetic", _wrap_new_SBTypeSynthetic, METH_VARARGS, (char *)"\n"
 		"SBTypeSynthetic()\n"
 		"new_SBTypeSynthetic(SBTypeSynthetic rhs) -> SBTypeSynthetic\n"
 		""},
-<<<<<<< HEAD
-	 { "delete_SBTypeSynthetic", _wrap_delete_SBTypeSynthetic, METH_VARARGS, (char *)"delete_SBTypeSynthetic(SBTypeSynthetic self)"},
-	 { "SBTypeSynthetic_IsValid", _wrap_SBTypeSynthetic_IsValid, METH_VARARGS, (char *)"SBTypeSynthetic_IsValid(SBTypeSynthetic self) -> bool"},
-	 { "SBTypeSynthetic___nonzero__", _wrap_SBTypeSynthetic___nonzero__, METH_VARARGS, (char *)"SBTypeSynthetic___nonzero__(SBTypeSynthetic self) -> bool"},
-	 { "SBTypeSynthetic_IsEqualTo", _wrap_SBTypeSynthetic_IsEqualTo, METH_VARARGS, (char *)"SBTypeSynthetic_IsEqualTo(SBTypeSynthetic self, SBTypeSynthetic rhs) -> bool"},
-	 { "SBTypeSynthetic_IsClassCode", _wrap_SBTypeSynthetic_IsClassCode, METH_VARARGS, (char *)"SBTypeSynthetic_IsClassCode(SBTypeSynthetic self) -> bool"},
-	 { "SBTypeSynthetic_GetData", _wrap_SBTypeSynthetic_GetData, METH_VARARGS, (char *)"SBTypeSynthetic_GetData(SBTypeSynthetic self) -> char const *"},
-	 { "SBTypeSynthetic_SetClassName", _wrap_SBTypeSynthetic_SetClassName, METH_VARARGS, (char *)"SBTypeSynthetic_SetClassName(SBTypeSynthetic self, char const * data)"},
-	 { "SBTypeSynthetic_SetClassCode", _wrap_SBTypeSynthetic_SetClassCode, METH_VARARGS, (char *)"SBTypeSynthetic_SetClassCode(SBTypeSynthetic self, char const * data)"},
-	 { "SBTypeSynthetic_GetOptions", _wrap_SBTypeSynthetic_GetOptions, METH_VARARGS, (char *)"SBTypeSynthetic_GetOptions(SBTypeSynthetic self) -> uint32_t"},
-	 { "SBTypeSynthetic_SetOptions", _wrap_SBTypeSynthetic_SetOptions, METH_VARARGS, (char *)"SBTypeSynthetic_SetOptions(SBTypeSynthetic self, uint32_t arg3)"},
-	 { "SBTypeSynthetic_GetDescription", _wrap_SBTypeSynthetic_GetDescription, METH_VARARGS, (char *)"SBTypeSynthetic_GetDescription(SBTypeSynthetic self, SBStream description, lldb::DescriptionLevel description_level) -> bool"},
-	 { "SBTypeSynthetic___eq__", _wrap_SBTypeSynthetic___eq__, METH_VARARGS, (char *)"SBTypeSynthetic___eq__(SBTypeSynthetic self, SBTypeSynthetic rhs) -> bool"},
-	 { "SBTypeSynthetic___ne__", _wrap_SBTypeSynthetic___ne__, METH_VARARGS, (char *)"SBTypeSynthetic___ne__(SBTypeSynthetic self, SBTypeSynthetic rhs) -> bool"},
-	 { "SBTypeSynthetic___str__", _wrap_SBTypeSynthetic___str__, METH_VARARGS, (char *)"SBTypeSynthetic___str__(SBTypeSynthetic self) -> PyObject *"},
-	 { "SBTypeSynthetic_swigregister", SBTypeSynthetic_swigregister, METH_VARARGS, NULL},
-	 { "new_SBValue", _wrap_new_SBValue, METH_VARARGS, (char *)"\n"
-		"SBValue()\n"
-		"new_SBValue(SBValue rhs) -> SBValue\n"
-		""},
-	 { "delete_SBValue", _wrap_delete_SBValue, METH_VARARGS, (char *)"delete_SBValue(SBValue self)"},
-	 { "SBValue_IsValid", _wrap_SBValue_IsValid, METH_VARARGS, (char *)"SBValue_IsValid(SBValue self) -> bool"},
-	 { "SBValue___nonzero__", _wrap_SBValue___nonzero__, METH_VARARGS, (char *)"SBValue___nonzero__(SBValue self) -> bool"},
-	 { "SBValue_Clear", _wrap_SBValue_Clear, METH_VARARGS, (char *)"SBValue_Clear(SBValue self)"},
-	 { "SBValue_GetError", _wrap_SBValue_GetError, METH_VARARGS, (char *)"SBValue_GetError(SBValue self) -> SBError"},
-	 { "SBValue_GetID", _wrap_SBValue_GetID, METH_VARARGS, (char *)"SBValue_GetID(SBValue self) -> lldb::user_id_t"},
-	 { "SBValue_GetName", _wrap_SBValue_GetName, METH_VARARGS, (char *)"SBValue_GetName(SBValue self) -> char const *"},
-	 { "SBValue_GetTypeName", _wrap_SBValue_GetTypeName, METH_VARARGS, (char *)"SBValue_GetTypeName(SBValue self) -> char const *"},
-	 { "SBValue_GetDisplayTypeName", _wrap_SBValue_GetDisplayTypeName, METH_VARARGS, (char *)"SBValue_GetDisplayTypeName(SBValue self) -> char const *"},
-	 { "SBValue_GetByteSize", _wrap_SBValue_GetByteSize, METH_VARARGS, (char *)"SBValue_GetByteSize(SBValue self) -> size_t"},
-	 { "SBValue_IsInScope", _wrap_SBValue_IsInScope, METH_VARARGS, (char *)"SBValue_IsInScope(SBValue self) -> bool"},
-	 { "SBValue_GetFormat", _wrap_SBValue_GetFormat, METH_VARARGS, (char *)"SBValue_GetFormat(SBValue self) -> lldb::Format"},
-	 { "SBValue_SetFormat", _wrap_SBValue_SetFormat, METH_VARARGS, (char *)"SBValue_SetFormat(SBValue self, lldb::Format format)"},
-	 { "SBValue_GetValue", _wrap_SBValue_GetValue, METH_VARARGS, (char *)"SBValue_GetValue(SBValue self) -> char const *"},
-	 { "SBValue_GetValueAsSigned", _wrap_SBValue_GetValueAsSigned, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"delete_SBTypeSynthetic", _wrap_delete_SBTypeSynthetic, METH_VARARGS, (char *)"delete_SBTypeSynthetic(SBTypeSynthetic self)"},
 	 { (char *)"SBTypeSynthetic_IsValid", _wrap_SBTypeSynthetic_IsValid, METH_VARARGS, (char *)"SBTypeSynthetic_IsValid(SBTypeSynthetic self) -> bool"},
 	 { (char *)"SBTypeSynthetic___nonzero__", _wrap_SBTypeSynthetic___nonzero__, METH_VARARGS, (char *)"SBTypeSynthetic___nonzero__(SBTypeSynthetic self) -> bool"},
@@ -85761,45 +82750,17 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBValue_SetFormat", _wrap_SBValue_SetFormat, METH_VARARGS, (char *)"SBValue_SetFormat(SBValue self, lldb::Format format)"},
 	 { (char *)"SBValue_GetValue", _wrap_SBValue_GetValue, METH_VARARGS, (char *)"SBValue_GetValue(SBValue self) -> char const *"},
 	 { (char *)"SBValue_GetValueAsSigned", _wrap_SBValue_GetValueAsSigned, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"GetValueAsSigned(SBError error, int64_t fail_value=0) -> int64_t\n"
 		"GetValueAsSigned(SBError error) -> int64_t\n"
 		"GetValueAsSigned(int64_t fail_value=0) -> int64_t\n"
 		"SBValue_GetValueAsSigned(SBValue self) -> int64_t\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_GetValueAsUnsigned", _wrap_SBValue_GetValueAsUnsigned, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBValue_GetValueAsUnsigned", _wrap_SBValue_GetValueAsUnsigned, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"GetValueAsUnsigned(SBError error, uint64_t fail_value=0) -> uint64_t\n"
 		"GetValueAsUnsigned(SBError error) -> uint64_t\n"
 		"GetValueAsUnsigned(uint64_t fail_value=0) -> uint64_t\n"
 		"SBValue_GetValueAsUnsigned(SBValue self) -> uint64_t\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_GetValueType", _wrap_SBValue_GetValueType, METH_VARARGS, (char *)"SBValue_GetValueType(SBValue self) -> lldb::ValueType"},
-	 { "SBValue_GetValueDidChange", _wrap_SBValue_GetValueDidChange, METH_VARARGS, (char *)"SBValue_GetValueDidChange(SBValue self) -> bool"},
-	 { "SBValue_GetSummary", _wrap_SBValue_GetSummary, METH_VARARGS, (char *)"\n"
-		"GetSummary() -> char const\n"
-		"SBValue_GetSummary(SBValue self, SBStream stream, SBTypeSummaryOptions options) -> char const *\n"
-		""},
-	 { "SBValue_GetObjectDescription", _wrap_SBValue_GetObjectDescription, METH_VARARGS, (char *)"SBValue_GetObjectDescription(SBValue self) -> char const *"},
-	 { "SBValue_GetTypeValidatorResult", _wrap_SBValue_GetTypeValidatorResult, METH_VARARGS, (char *)"SBValue_GetTypeValidatorResult(SBValue self) -> char const *"},
-	 { "SBValue_GetDynamicValue", _wrap_SBValue_GetDynamicValue, METH_VARARGS, (char *)"SBValue_GetDynamicValue(SBValue self, lldb::DynamicValueType use_dynamic) -> SBValue"},
-	 { "SBValue_GetStaticValue", _wrap_SBValue_GetStaticValue, METH_VARARGS, (char *)"SBValue_GetStaticValue(SBValue self) -> SBValue"},
-	 { "SBValue_GetNonSyntheticValue", _wrap_SBValue_GetNonSyntheticValue, METH_VARARGS, (char *)"SBValue_GetNonSyntheticValue(SBValue self) -> SBValue"},
-	 { "SBValue_GetPreferDynamicValue", _wrap_SBValue_GetPreferDynamicValue, METH_VARARGS, (char *)"SBValue_GetPreferDynamicValue(SBValue self) -> lldb::DynamicValueType"},
-	 { "SBValue_SetPreferDynamicValue", _wrap_SBValue_SetPreferDynamicValue, METH_VARARGS, (char *)"SBValue_SetPreferDynamicValue(SBValue self, lldb::DynamicValueType use_dynamic)"},
-	 { "SBValue_GetPreferSyntheticValue", _wrap_SBValue_GetPreferSyntheticValue, METH_VARARGS, (char *)"SBValue_GetPreferSyntheticValue(SBValue self) -> bool"},
-	 { "SBValue_SetPreferSyntheticValue", _wrap_SBValue_SetPreferSyntheticValue, METH_VARARGS, (char *)"SBValue_SetPreferSyntheticValue(SBValue self, bool use_synthetic)"},
-	 { "SBValue_IsDynamic", _wrap_SBValue_IsDynamic, METH_VARARGS, (char *)"SBValue_IsDynamic(SBValue self) -> bool"},
-	 { "SBValue_IsSynthetic", _wrap_SBValue_IsSynthetic, METH_VARARGS, (char *)"SBValue_IsSynthetic(SBValue self) -> bool"},
-	 { "SBValue_IsSyntheticChildrenGenerated", _wrap_SBValue_IsSyntheticChildrenGenerated, METH_VARARGS, (char *)"SBValue_IsSyntheticChildrenGenerated(SBValue self) -> bool"},
-	 { "SBValue_SetSyntheticChildrenGenerated", _wrap_SBValue_SetSyntheticChildrenGenerated, METH_VARARGS, (char *)"SBValue_SetSyntheticChildrenGenerated(SBValue self, bool arg3)"},
-	 { "SBValue_GetLocation", _wrap_SBValue_GetLocation, METH_VARARGS, (char *)"SBValue_GetLocation(SBValue self) -> char const *"},
-	 { "SBValue_SetValueFromCString", _wrap_SBValue_SetValueFromCString, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBValue_GetValueType", _wrap_SBValue_GetValueType, METH_VARARGS, (char *)"SBValue_GetValueType(SBValue self) -> lldb::ValueType"},
 	 { (char *)"SBValue_GetValueDidChange", _wrap_SBValue_GetValueDidChange, METH_VARARGS, (char *)"SBValue_GetValueDidChange(SBValue self) -> bool"},
 	 { (char *)"SBValue_GetSummary", _wrap_SBValue_GetSummary, METH_VARARGS, (char *)"\n"
@@ -85821,32 +82782,17 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBValue_SetSyntheticChildrenGenerated", _wrap_SBValue_SetSyntheticChildrenGenerated, METH_VARARGS, (char *)"SBValue_SetSyntheticChildrenGenerated(SBValue self, bool arg3)"},
 	 { (char *)"SBValue_GetLocation", _wrap_SBValue_GetLocation, METH_VARARGS, (char *)"SBValue_GetLocation(SBValue self) -> char const *"},
 	 { (char *)"SBValue_SetValueFromCString", _wrap_SBValue_SetValueFromCString, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SetValueFromCString(char const * value_str) -> bool\n"
 		"SBValue_SetValueFromCString(SBValue self, char const * value_str, SBError error) -> bool\n"
 		""},
-	 { "SBValue_GetTypeFormat", _wrap_SBValue_GetTypeFormat, METH_VARARGS, (char *)"SBValue_GetTypeFormat(SBValue self) -> SBTypeFormat"},
-	 { "SBValue_GetTypeSummary", _wrap_SBValue_GetTypeSummary, METH_VARARGS, (char *)"SBValue_GetTypeSummary(SBValue self) -> SBTypeSummary"},
-	 { "SBValue_GetTypeFilter", _wrap_SBValue_GetTypeFilter, METH_VARARGS, (char *)"SBValue_GetTypeFilter(SBValue self) -> SBTypeFilter"},
-	 { "SBValue_GetTypeSynthetic", _wrap_SBValue_GetTypeSynthetic, METH_VARARGS, (char *)"SBValue_GetTypeSynthetic(SBValue self) -> SBTypeSynthetic"},
-	 { "SBValue_GetChildAtIndex", _wrap_SBValue_GetChildAtIndex, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBValue_GetTypeFormat", _wrap_SBValue_GetTypeFormat, METH_VARARGS, (char *)"SBValue_GetTypeFormat(SBValue self) -> SBTypeFormat"},
+	 { (char *)"SBValue_GetTypeSummary", _wrap_SBValue_GetTypeSummary, METH_VARARGS, (char *)"SBValue_GetTypeSummary(SBValue self) -> SBTypeSummary"},
+	 { (char *)"SBValue_GetTypeFilter", _wrap_SBValue_GetTypeFilter, METH_VARARGS, (char *)"SBValue_GetTypeFilter(SBValue self) -> SBTypeFilter"},
+	 { (char *)"SBValue_GetTypeSynthetic", _wrap_SBValue_GetTypeSynthetic, METH_VARARGS, (char *)"SBValue_GetTypeSynthetic(SBValue self) -> SBTypeSynthetic"},
+	 { (char *)"SBValue_GetChildAtIndex", _wrap_SBValue_GetChildAtIndex, METH_VARARGS, (char *)"\n"
 		"GetChildAtIndex(uint32_t idx) -> SBValue\n"
 		"SBValue_GetChildAtIndex(SBValue self, uint32_t idx, lldb::DynamicValueType use_dynamic, bool can_create_synthetic) -> SBValue\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_CreateChildAtOffset", _wrap_SBValue_CreateChildAtOffset, METH_VARARGS, (char *)"SBValue_CreateChildAtOffset(SBValue self, char const * name, uint32_t offset, SBType type) -> SBValue"},
-	 { "SBValue_Cast", _wrap_SBValue_Cast, METH_VARARGS, (char *)"SBValue_Cast(SBValue self, SBType type) -> SBValue"},
-	 { "SBValue_CreateValueFromExpression", _wrap_SBValue_CreateValueFromExpression, METH_VARARGS, (char *)"\n"
-		"CreateValueFromExpression(char const * name, char const * expression) -> SBValue\n"
-		"SBValue_CreateValueFromExpression(SBValue self, char const * name, char const * expression, SBExpressionOptions options) -> SBValue\n"
-		""},
-	 { "SBValue_CreateValueFromAddress", _wrap_SBValue_CreateValueFromAddress, METH_VARARGS, (char *)"SBValue_CreateValueFromAddress(SBValue self, char const * name, lldb::addr_t address, SBType type) -> SBValue"},
-	 { "SBValue_CreateValueFromData", _wrap_SBValue_CreateValueFromData, METH_VARARGS, (char *)"SBValue_CreateValueFromData(SBValue self, char const * name, SBData data, SBType type) -> SBValue"},
-	 { "SBValue_GetType", _wrap_SBValue_GetType, METH_VARARGS, (char *)"SBValue_GetType(SBValue self) -> SBType"},
-	 { "SBValue_GetIndexOfChildWithName", _wrap_SBValue_GetIndexOfChildWithName, METH_VARARGS, (char *)"\n"
-		"SBValue_GetIndexOfChildWithName(SBValue self, char const * name) -> uint32_t\n"
-		"\n"
-=======
 	 { (char *)"SBValue_CreateChildAtOffset", _wrap_SBValue_CreateChildAtOffset, METH_VARARGS, (char *)"SBValue_CreateChildAtOffset(SBValue self, char const * name, uint32_t offset, SBType type) -> SBValue"},
 	 { (char *)"SBValue_Cast", _wrap_SBValue_Cast, METH_VARARGS, (char *)"SBValue_Cast(SBValue self, SBType type) -> SBValue"},
 	 { (char *)"SBValue_CreateValueFromExpression", _wrap_SBValue_CreateValueFromExpression, METH_VARARGS, (char *)"\n"
@@ -85864,7 +82810,6 @@ static PyMethodDef SwigMethods[] = {
 		"\n"
 		"Matches children of this object only and will match base classes and\n"
 		"member names if this is a clang typed object.\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"@param[in] name\n"
 		"    The name of the child value to get\n"
@@ -85872,43 +82817,22 @@ static PyMethodDef SwigMethods[] = {
 		"@return\n"
 		"    An index to the child member value.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_GetChildMemberWithName", _wrap_SBValue_GetChildMemberWithName, METH_VARARGS, (char *)"\n"
-		"GetChildMemberWithName(char const * name) -> SBValue\n"
-		"SBValue_GetChildMemberWithName(SBValue self, char const * name, lldb::DynamicValueType use_dynamic) -> SBValue\n"
-		""},
-	 { "SBValue_GetValueForExpressionPath", _wrap_SBValue_GetValueForExpressionPath, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBValue_GetChildMemberWithName", _wrap_SBValue_GetChildMemberWithName, METH_VARARGS, (char *)"\n"
 		"GetChildMemberWithName(char const * name) -> SBValue\n"
 		"SBValue_GetChildMemberWithName(SBValue self, char const * name, lldb::DynamicValueType use_dynamic) -> SBValue\n"
 		""},
 	 { (char *)"SBValue_GetValueForExpressionPath", _wrap_SBValue_GetValueForExpressionPath, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"SBValue_GetValueForExpressionPath(SBValue self, char const * expr_path) -> SBValue\n"
 		"\n"
 		"Expands nested expressions like .a->b[0].c[1]->d.\n"
 		""},
-	 { "SBValue_GetDeclaration", _wrap_SBValue_GetDeclaration, METH_VARARGS, (char *)"SBValue_GetDeclaration(SBValue self) -> SBDeclaration"},
-	 { "SBValue_MightHaveChildren", _wrap_SBValue_MightHaveChildren, METH_VARARGS, (char *)"SBValue_MightHaveChildren(SBValue self) -> bool"},
-	 { "SBValue_IsRuntimeSupportValue", _wrap_SBValue_IsRuntimeSupportValue, METH_VARARGS, (char *)"SBValue_IsRuntimeSupportValue(SBValue self) -> bool"},
-	 { "SBValue_GetNumChildren", _wrap_SBValue_GetNumChildren, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBValue_GetDeclaration", _wrap_SBValue_GetDeclaration, METH_VARARGS, (char *)"SBValue_GetDeclaration(SBValue self) -> SBDeclaration"},
+	 { (char *)"SBValue_MightHaveChildren", _wrap_SBValue_MightHaveChildren, METH_VARARGS, (char *)"SBValue_MightHaveChildren(SBValue self) -> bool"},
+	 { (char *)"SBValue_IsRuntimeSupportValue", _wrap_SBValue_IsRuntimeSupportValue, METH_VARARGS, (char *)"SBValue_IsRuntimeSupportValue(SBValue self) -> bool"},
+	 { (char *)"SBValue_GetNumChildren", _wrap_SBValue_GetNumChildren, METH_VARARGS, (char *)"\n"
 		"GetNumChildren() -> uint32_t\n"
 		"SBValue_GetNumChildren(SBValue self, uint32_t max) -> uint32_t\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_GetOpaqueType", _wrap_SBValue_GetOpaqueType, METH_VARARGS, (char *)"SBValue_GetOpaqueType(SBValue self) -> void *"},
-	 { "SBValue_Dereference", _wrap_SBValue_Dereference, METH_VARARGS, (char *)"SBValue_Dereference(SBValue self) -> SBValue"},
-	 { "SBValue_AddressOf", _wrap_SBValue_AddressOf, METH_VARARGS, (char *)"SBValue_AddressOf(SBValue self) -> SBValue"},
-	 { "SBValue_TypeIsPointerType", _wrap_SBValue_TypeIsPointerType, METH_VARARGS, (char *)"SBValue_TypeIsPointerType(SBValue self) -> bool"},
-	 { "SBValue_GetTarget", _wrap_SBValue_GetTarget, METH_VARARGS, (char *)"SBValue_GetTarget(SBValue self) -> SBTarget"},
-	 { "SBValue_GetProcess", _wrap_SBValue_GetProcess, METH_VARARGS, (char *)"SBValue_GetProcess(SBValue self) -> SBProcess"},
-	 { "SBValue_GetThread", _wrap_SBValue_GetThread, METH_VARARGS, (char *)"SBValue_GetThread(SBValue self) -> SBThread"},
-	 { "SBValue_GetFrame", _wrap_SBValue_GetFrame, METH_VARARGS, (char *)"SBValue_GetFrame(SBValue self) -> SBFrame"},
-	 { "SBValue_Watch", _wrap_SBValue_Watch, METH_VARARGS, (char *)"\n"
-		"SBValue_Watch(SBValue self, bool resolve_location, bool read, bool write, SBError error) -> SBWatchpoint\n"
-		"\n"
-=======
 	 { (char *)"SBValue_GetOpaqueType", _wrap_SBValue_GetOpaqueType, METH_VARARGS, (char *)"SBValue_GetOpaqueType(SBValue self) -> void *"},
 	 { (char *)"SBValue_Dereference", _wrap_SBValue_Dereference, METH_VARARGS, (char *)"SBValue_Dereference(SBValue self) -> SBValue"},
 	 { (char *)"SBValue_AddressOf", _wrap_SBValue_AddressOf, METH_VARARGS, (char *)"SBValue_AddressOf(SBValue self) -> SBValue"},
@@ -85919,61 +82843,24 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBValue_GetFrame", _wrap_SBValue_GetFrame, METH_VARARGS, (char *)"SBValue_GetFrame(SBValue self) -> SBFrame"},
 	 { (char *)"SBValue_Watch", _wrap_SBValue_Watch, METH_VARARGS, (char *)"\n"
 		"SBValue_Watch(SBValue self, bool resolve_location, bool read, bool write, SBError error) -> SBWatchpoint\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Find and watch a variable.\n"
 		"It returns an SBWatchpoint, which may be invalid.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_WatchPointee", _wrap_SBValue_WatchPointee, METH_VARARGS, (char *)"\n"
-		"SBValue_WatchPointee(SBValue self, bool resolve_location, bool read, bool write, SBError error) -> SBWatchpoint\n"
-		"\n"
-=======
 	 { (char *)"SBValue_WatchPointee", _wrap_SBValue_WatchPointee, METH_VARARGS, (char *)"\n"
 		"SBValue_WatchPointee(SBValue self, bool resolve_location, bool read, bool write, SBError error) -> SBWatchpoint\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Find and watch the location pointed to by a variable.\n"
 		"It returns an SBWatchpoint, which may be invalid.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_GetDescription", _wrap_SBValue_GetDescription, METH_VARARGS, (char *)"SBValue_GetDescription(SBValue self, SBStream description) -> bool"},
-	 { "SBValue_GetPointeeData", _wrap_SBValue_GetPointeeData, METH_VARARGS, (char *)"\n"
-=======
 	 { (char *)"SBValue_GetDescription", _wrap_SBValue_GetDescription, METH_VARARGS, (char *)"SBValue_GetDescription(SBValue self, SBStream description) -> bool"},
 	 { (char *)"SBValue_GetPointeeData", _wrap_SBValue_GetPointeeData, METH_VARARGS, (char *)"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"GetPointeeData(uint32_t item_idx=0, uint32_t item_count=1) -> SBData\n"
 		"GetPointeeData(uint32_t item_idx=0) -> SBData\n"
 		"SBValue_GetPointeeData(SBValue self) -> SBData\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"  /// Get an SBData wrapping what this SBValue points to.\n"
-		"  ///\n"
-		"  /// This method will dereference the current SBValue, if its\n"
-		"  /// data type is a T* or T[], and extract item_count elements\n"
-		"  /// of type T from it, copying their contents in an SBData. \n"
-		"  ///\n"
-		"  /// @param[in] item_idx\n"
-		"  ///     The index of the first item to retrieve. For an array\n"
-		"  ///     this is equivalent to array[item_idx], for a pointer\n"
-		"  ///     to *(pointer + item_idx). In either case, the measurement\n"
-		"  ///     unit for item_idx is the sizeof(T) rather than the byte\n"
-		"  ///\n"
-		"  /// @param[in] item_count\n"
-		"  ///     How many items should be copied into the output. By default\n"
-		"  ///     only one item is copied, but more can be asked for.\n"
-		"  ///\n"
-		"  /// @return\n"
-		"  ///     An SBData with the contents of the copied items, on success.\n"
-		"  ///     An empty SBData otherwise.\n"
-		"  //------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get an SBData wrapping what this SBValue points to.\n"
 		"\n"
@@ -85995,23 +82882,9 @@ static PyMethodDef SwigMethods[] = {
 		"    An SBData with the contents of the copied items, on success.\n"
 		"    An empty SBData otherwise.\n"
 		""},
-	 { "SBValue_GetData", _wrap_SBValue_GetData, METH_VARARGS, (char *)"\n"
+	 { (char *)"SBValue_GetData", _wrap_SBValue_GetData, METH_VARARGS, (char *)"\n"
 		"SBValue_GetData(SBValue self) -> SBData\n"
 		"\n"
-<<<<<<< HEAD
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"  /// Get an SBData wrapping the contents of this SBValue.\n"
-		"  ///\n"
-		"  /// This method will read the contents of this object in memory\n"
-		"  /// and copy them into an SBData for future use. \n"
-		"  ///\n"
-		"  /// @return\n"
-		"  ///     An SBData with the contents of this SBValue, on success.\n"
-		"  ///     An empty SBData otherwise.\n"
-		"  //------------------------------------------------------------------\n"
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"Get an SBData wrapping the contents of this SBValue.\n"
 		"\n"
@@ -86022,74 +82895,6 @@ static PyMethodDef SwigMethods[] = {
 		"    An SBData with the contents of this SBValue, on success.\n"
 		"    An empty SBData otherwise.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBValue_SetData", _wrap_SBValue_SetData, METH_VARARGS, (char *)"SBValue_SetData(SBValue self, SBData data, SBError error) -> bool"},
-	 { "SBValue_GetLoadAddress", _wrap_SBValue_GetLoadAddress, METH_VARARGS, (char *)"SBValue_GetLoadAddress(SBValue self) -> lldb::addr_t"},
-	 { "SBValue_GetAddress", _wrap_SBValue_GetAddress, METH_VARARGS, (char *)"SBValue_GetAddress(SBValue self) -> SBAddress"},
-	 { "SBValue_Persist", _wrap_SBValue_Persist, METH_VARARGS, (char *)"SBValue_Persist(SBValue self) -> SBValue"},
-	 { "SBValue_GetExpressionPath", _wrap_SBValue_GetExpressionPath, METH_VARARGS, (char *)"\n"
-		"GetExpressionPath(SBStream description) -> bool\n"
-		"SBValue_GetExpressionPath(SBValue self, SBStream description, bool qualify_cxx_base_classes) -> bool\n"
-		""},
-	 { "SBValue___str__", _wrap_SBValue___str__, METH_VARARGS, (char *)"SBValue___str__(SBValue self) -> PyObject *"},
-	 { "SBValue_swigregister", SBValue_swigregister, METH_VARARGS, NULL},
-	 { "new_SBValueList", _wrap_new_SBValueList, METH_VARARGS, (char *)"\n"
-		"SBValueList()\n"
-		"new_SBValueList(SBValueList rhs) -> SBValueList\n"
-		""},
-	 { "delete_SBValueList", _wrap_delete_SBValueList, METH_VARARGS, (char *)"delete_SBValueList(SBValueList self)"},
-	 { "SBValueList_IsValid", _wrap_SBValueList_IsValid, METH_VARARGS, (char *)"SBValueList_IsValid(SBValueList self) -> bool"},
-	 { "SBValueList___nonzero__", _wrap_SBValueList___nonzero__, METH_VARARGS, (char *)"SBValueList___nonzero__(SBValueList self) -> bool"},
-	 { "SBValueList_Clear", _wrap_SBValueList_Clear, METH_VARARGS, (char *)"SBValueList_Clear(SBValueList self)"},
-	 { "SBValueList_Append", _wrap_SBValueList_Append, METH_VARARGS, (char *)"\n"
-		"Append(SBValue val_obj)\n"
-		"SBValueList_Append(SBValueList self, SBValueList value_list)\n"
-		""},
-	 { "SBValueList_GetSize", _wrap_SBValueList_GetSize, METH_VARARGS, (char *)"SBValueList_GetSize(SBValueList self) -> uint32_t"},
-	 { "SBValueList_GetValueAtIndex", _wrap_SBValueList_GetValueAtIndex, METH_VARARGS, (char *)"SBValueList_GetValueAtIndex(SBValueList self, uint32_t idx) -> SBValue"},
-	 { "SBValueList_FindValueObjectByUID", _wrap_SBValueList_FindValueObjectByUID, METH_VARARGS, (char *)"SBValueList_FindValueObjectByUID(SBValueList self, lldb::user_id_t uid) -> SBValue"},
-	 { "SBValueList_GetFirstValueByName", _wrap_SBValueList_GetFirstValueByName, METH_VARARGS, (char *)"SBValueList_GetFirstValueByName(SBValueList self, char const * name) -> SBValue"},
-	 { "SBValueList___str__", _wrap_SBValueList___str__, METH_VARARGS, (char *)"SBValueList___str__(SBValueList self) -> PyObject *"},
-	 { "SBValueList_swigregister", SBValueList_swigregister, METH_VARARGS, NULL},
-	 { "new_SBVariablesOptions", _wrap_new_SBVariablesOptions, METH_VARARGS, (char *)"\n"
-		"SBVariablesOptions()\n"
-		"new_SBVariablesOptions(SBVariablesOptions options) -> SBVariablesOptions\n"
-		""},
-	 { "delete_SBVariablesOptions", _wrap_delete_SBVariablesOptions, METH_VARARGS, (char *)"delete_SBVariablesOptions(SBVariablesOptions self)"},
-	 { "SBVariablesOptions_IsValid", _wrap_SBVariablesOptions_IsValid, METH_VARARGS, (char *)"SBVariablesOptions_IsValid(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions___nonzero__", _wrap_SBVariablesOptions___nonzero__, METH_VARARGS, (char *)"SBVariablesOptions___nonzero__(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions_GetIncludeArguments", _wrap_SBVariablesOptions_GetIncludeArguments, METH_VARARGS, (char *)"SBVariablesOptions_GetIncludeArguments(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions_SetIncludeArguments", _wrap_SBVariablesOptions_SetIncludeArguments, METH_VARARGS, (char *)"SBVariablesOptions_SetIncludeArguments(SBVariablesOptions self, bool arg3)"},
-	 { "SBVariablesOptions_GetIncludeRecognizedArguments", _wrap_SBVariablesOptions_GetIncludeRecognizedArguments, METH_VARARGS, (char *)"SBVariablesOptions_GetIncludeRecognizedArguments(SBVariablesOptions self, SBTarget arg3) -> bool"},
-	 { "SBVariablesOptions_SetIncludeRecognizedArguments", _wrap_SBVariablesOptions_SetIncludeRecognizedArguments, METH_VARARGS, (char *)"SBVariablesOptions_SetIncludeRecognizedArguments(SBVariablesOptions self, bool arg3)"},
-	 { "SBVariablesOptions_GetIncludeLocals", _wrap_SBVariablesOptions_GetIncludeLocals, METH_VARARGS, (char *)"SBVariablesOptions_GetIncludeLocals(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions_SetIncludeLocals", _wrap_SBVariablesOptions_SetIncludeLocals, METH_VARARGS, (char *)"SBVariablesOptions_SetIncludeLocals(SBVariablesOptions self, bool arg3)"},
-	 { "SBVariablesOptions_GetIncludeStatics", _wrap_SBVariablesOptions_GetIncludeStatics, METH_VARARGS, (char *)"SBVariablesOptions_GetIncludeStatics(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions_SetIncludeStatics", _wrap_SBVariablesOptions_SetIncludeStatics, METH_VARARGS, (char *)"SBVariablesOptions_SetIncludeStatics(SBVariablesOptions self, bool arg3)"},
-	 { "SBVariablesOptions_GetInScopeOnly", _wrap_SBVariablesOptions_GetInScopeOnly, METH_VARARGS, (char *)"SBVariablesOptions_GetInScopeOnly(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions_SetInScopeOnly", _wrap_SBVariablesOptions_SetInScopeOnly, METH_VARARGS, (char *)"SBVariablesOptions_SetInScopeOnly(SBVariablesOptions self, bool arg3)"},
-	 { "SBVariablesOptions_GetIncludeRuntimeSupportValues", _wrap_SBVariablesOptions_GetIncludeRuntimeSupportValues, METH_VARARGS, (char *)"SBVariablesOptions_GetIncludeRuntimeSupportValues(SBVariablesOptions self) -> bool"},
-	 { "SBVariablesOptions_SetIncludeRuntimeSupportValues", _wrap_SBVariablesOptions_SetIncludeRuntimeSupportValues, METH_VARARGS, (char *)"SBVariablesOptions_SetIncludeRuntimeSupportValues(SBVariablesOptions self, bool arg3)"},
-	 { "SBVariablesOptions_GetUseDynamic", _wrap_SBVariablesOptions_GetUseDynamic, METH_VARARGS, (char *)"SBVariablesOptions_GetUseDynamic(SBVariablesOptions self) -> lldb::DynamicValueType"},
-	 { "SBVariablesOptions_SetUseDynamic", _wrap_SBVariablesOptions_SetUseDynamic, METH_VARARGS, (char *)"SBVariablesOptions_SetUseDynamic(SBVariablesOptions self, lldb::DynamicValueType arg3)"},
-	 { "SBVariablesOptions_swigregister", SBVariablesOptions_swigregister, METH_VARARGS, NULL},
-	 { "new_SBWatchpoint", _wrap_new_SBWatchpoint, METH_VARARGS, (char *)"\n"
-		"SBWatchpoint()\n"
-		"new_SBWatchpoint(SBWatchpoint rhs) -> SBWatchpoint\n"
-		""},
-	 { "delete_SBWatchpoint", _wrap_delete_SBWatchpoint, METH_VARARGS, (char *)"delete_SBWatchpoint(SBWatchpoint self)"},
-	 { "SBWatchpoint_IsValid", _wrap_SBWatchpoint_IsValid, METH_VARARGS, (char *)"SBWatchpoint_IsValid(SBWatchpoint self) -> bool"},
-	 { "SBWatchpoint___nonzero__", _wrap_SBWatchpoint___nonzero__, METH_VARARGS, (char *)"SBWatchpoint___nonzero__(SBWatchpoint self) -> bool"},
-	 { "SBWatchpoint_GetError", _wrap_SBWatchpoint_GetError, METH_VARARGS, (char *)"SBWatchpoint_GetError(SBWatchpoint self) -> SBError"},
-	 { "SBWatchpoint_GetID", _wrap_SBWatchpoint_GetID, METH_VARARGS, (char *)"SBWatchpoint_GetID(SBWatchpoint self) -> lldb::watch_id_t"},
-	 { "SBWatchpoint_GetHardwareIndex", _wrap_SBWatchpoint_GetHardwareIndex, METH_VARARGS, (char *)"\n"
-		"SBWatchpoint_GetHardwareIndex(SBWatchpoint self) -> int32_t\n"
-		"\n"
-		"\n"
-		"//------------------------------------------------------------------\n"
-		"/// With -1 representing an invalid hardware index.\n"
-		"//------------------------------------------------------------------\n"
-=======
 	 { (char *)"SBValue_SetData", _wrap_SBValue_SetData, METH_VARARGS, (char *)"SBValue_SetData(SBValue self, SBData data, SBError error) -> bool"},
 	 { (char *)"SBValue_GetLoadAddress", _wrap_SBValue_GetLoadAddress, METH_VARARGS, (char *)"SBValue_GetLoadAddress(SBValue self) -> lldb::addr_t"},
 	 { (char *)"SBValue_GetAddress", _wrap_SBValue_GetAddress, METH_VARARGS, (char *)"SBValue_GetAddress(SBValue self) -> SBAddress"},
@@ -86159,22 +82964,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBWatchpoint_GetHardwareIndex", _wrap_SBWatchpoint_GetHardwareIndex, METH_VARARGS, (char *)"\n"
 		"SBWatchpoint_GetHardwareIndex(SBWatchpoint self) -> int32_t\n"
 		"\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"With -1 representing an invalid hardware index.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBWatchpoint_GetWatchAddress", _wrap_SBWatchpoint_GetWatchAddress, METH_VARARGS, (char *)"SBWatchpoint_GetWatchAddress(SBWatchpoint self) -> lldb::addr_t"},
-	 { "SBWatchpoint_GetWatchSize", _wrap_SBWatchpoint_GetWatchSize, METH_VARARGS, (char *)"SBWatchpoint_GetWatchSize(SBWatchpoint self) -> size_t"},
-	 { "SBWatchpoint_SetEnabled", _wrap_SBWatchpoint_SetEnabled, METH_VARARGS, (char *)"SBWatchpoint_SetEnabled(SBWatchpoint self, bool enabled)"},
-	 { "SBWatchpoint_IsEnabled", _wrap_SBWatchpoint_IsEnabled, METH_VARARGS, (char *)"SBWatchpoint_IsEnabled(SBWatchpoint self) -> bool"},
-	 { "SBWatchpoint_GetHitCount", _wrap_SBWatchpoint_GetHitCount, METH_VARARGS, (char *)"SBWatchpoint_GetHitCount(SBWatchpoint self) -> uint32_t"},
-	 { "SBWatchpoint_GetIgnoreCount", _wrap_SBWatchpoint_GetIgnoreCount, METH_VARARGS, (char *)"SBWatchpoint_GetIgnoreCount(SBWatchpoint self) -> uint32_t"},
-	 { "SBWatchpoint_SetIgnoreCount", _wrap_SBWatchpoint_SetIgnoreCount, METH_VARARGS, (char *)"SBWatchpoint_SetIgnoreCount(SBWatchpoint self, uint32_t n)"},
-	 { "SBWatchpoint_GetCondition", _wrap_SBWatchpoint_GetCondition, METH_VARARGS, (char *)"\n"
-		"SBWatchpoint_GetCondition(SBWatchpoint self) -> char const *\n"
-		"\n"
-=======
 	 { (char *)"SBWatchpoint_GetWatchAddress", _wrap_SBWatchpoint_GetWatchAddress, METH_VARARGS, (char *)"SBWatchpoint_GetWatchAddress(SBWatchpoint self) -> lldb::addr_t"},
 	 { (char *)"SBWatchpoint_GetWatchSize", _wrap_SBWatchpoint_GetWatchSize, METH_VARARGS, (char *)"SBWatchpoint_GetWatchSize(SBWatchpoint self) -> size_t"},
 	 { (char *)"SBWatchpoint_SetEnabled", _wrap_SBWatchpoint_SetEnabled, METH_VARARGS, (char *)"SBWatchpoint_SetEnabled(SBWatchpoint self, bool enabled)"},
@@ -86184,50 +82976,16 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBWatchpoint_SetIgnoreCount", _wrap_SBWatchpoint_SetIgnoreCount, METH_VARARGS, (char *)"SBWatchpoint_SetIgnoreCount(SBWatchpoint self, uint32_t n)"},
 	 { (char *)"SBWatchpoint_GetCondition", _wrap_SBWatchpoint_GetCondition, METH_VARARGS, (char *)"\n"
 		"SBWatchpoint_GetCondition(SBWatchpoint self) -> char const *\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"Get the condition expression for the watchpoint.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBWatchpoint_SetCondition", _wrap_SBWatchpoint_SetCondition, METH_VARARGS, (char *)"\n"
-		"SBWatchpoint_SetCondition(SBWatchpoint self, char const * condition)\n"
-		"\n"
-=======
 	 { (char *)"SBWatchpoint_SetCondition", _wrap_SBWatchpoint_SetCondition, METH_VARARGS, (char *)"\n"
 		"SBWatchpoint_SetCondition(SBWatchpoint self, char const * condition)\n"
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 		"\n"
 		"\n"
 		"The watchpoint stops only if the condition expression evaluates to true.\n"
 		""},
-<<<<<<< HEAD
-	 { "SBWatchpoint_GetDescription", _wrap_SBWatchpoint_GetDescription, METH_VARARGS, (char *)"SBWatchpoint_GetDescription(SBWatchpoint self, SBStream description, lldb::DescriptionLevel level) -> bool"},
-	 { "SBWatchpoint_EventIsWatchpointEvent", _wrap_SBWatchpoint_EventIsWatchpointEvent, METH_VARARGS, (char *)"SBWatchpoint_EventIsWatchpointEvent(SBEvent event) -> bool"},
-	 { "SBWatchpoint_GetWatchpointEventTypeFromEvent", _wrap_SBWatchpoint_GetWatchpointEventTypeFromEvent, METH_VARARGS, (char *)"SBWatchpoint_GetWatchpointEventTypeFromEvent(SBEvent event) -> lldb::WatchpointEventType"},
-	 { "SBWatchpoint_GetWatchpointFromEvent", _wrap_SBWatchpoint_GetWatchpointFromEvent, METH_VARARGS, (char *)"SBWatchpoint_GetWatchpointFromEvent(SBEvent event) -> SBWatchpoint"},
-	 { "SBWatchpoint___str__", _wrap_SBWatchpoint___str__, METH_VARARGS, (char *)"SBWatchpoint___str__(SBWatchpoint self) -> PyObject *"},
-	 { "SBWatchpoint_swigregister", SBWatchpoint_swigregister, METH_VARARGS, NULL},
-	 { "new_SBUnixSignals", _wrap_new_SBUnixSignals, METH_VARARGS, (char *)"\n"
-		"SBUnixSignals()\n"
-		"new_SBUnixSignals(SBUnixSignals rhs) -> SBUnixSignals\n"
-		""},
-	 { "delete_SBUnixSignals", _wrap_delete_SBUnixSignals, METH_VARARGS, (char *)"delete_SBUnixSignals(SBUnixSignals self)"},
-	 { "SBUnixSignals_Clear", _wrap_SBUnixSignals_Clear, METH_VARARGS, (char *)"SBUnixSignals_Clear(SBUnixSignals self)"},
-	 { "SBUnixSignals_IsValid", _wrap_SBUnixSignals_IsValid, METH_VARARGS, (char *)"SBUnixSignals_IsValid(SBUnixSignals self) -> bool"},
-	 { "SBUnixSignals___nonzero__", _wrap_SBUnixSignals___nonzero__, METH_VARARGS, (char *)"SBUnixSignals___nonzero__(SBUnixSignals self) -> bool"},
-	 { "SBUnixSignals_GetSignalAsCString", _wrap_SBUnixSignals_GetSignalAsCString, METH_VARARGS, (char *)"SBUnixSignals_GetSignalAsCString(SBUnixSignals self, int32_t signo) -> char const *"},
-	 { "SBUnixSignals_GetSignalNumberFromName", _wrap_SBUnixSignals_GetSignalNumberFromName, METH_VARARGS, (char *)"SBUnixSignals_GetSignalNumberFromName(SBUnixSignals self, char const * name) -> int32_t"},
-	 { "SBUnixSignals_GetShouldSuppress", _wrap_SBUnixSignals_GetShouldSuppress, METH_VARARGS, (char *)"SBUnixSignals_GetShouldSuppress(SBUnixSignals self, int32_t signo) -> bool"},
-	 { "SBUnixSignals_SetShouldSuppress", _wrap_SBUnixSignals_SetShouldSuppress, METH_VARARGS, (char *)"SBUnixSignals_SetShouldSuppress(SBUnixSignals self, int32_t signo, bool value) -> bool"},
-	 { "SBUnixSignals_GetShouldStop", _wrap_SBUnixSignals_GetShouldStop, METH_VARARGS, (char *)"SBUnixSignals_GetShouldStop(SBUnixSignals self, int32_t signo) -> bool"},
-	 { "SBUnixSignals_SetShouldStop", _wrap_SBUnixSignals_SetShouldStop, METH_VARARGS, (char *)"SBUnixSignals_SetShouldStop(SBUnixSignals self, int32_t signo, bool value) -> bool"},
-	 { "SBUnixSignals_GetShouldNotify", _wrap_SBUnixSignals_GetShouldNotify, METH_VARARGS, (char *)"SBUnixSignals_GetShouldNotify(SBUnixSignals self, int32_t signo) -> bool"},
-	 { "SBUnixSignals_SetShouldNotify", _wrap_SBUnixSignals_SetShouldNotify, METH_VARARGS, (char *)"SBUnixSignals_SetShouldNotify(SBUnixSignals self, int32_t signo, bool value) -> bool"},
-	 { "SBUnixSignals_GetNumSignals", _wrap_SBUnixSignals_GetNumSignals, METH_VARARGS, (char *)"SBUnixSignals_GetNumSignals(SBUnixSignals self) -> int32_t"},
-	 { "SBUnixSignals_GetSignalAtIndex", _wrap_SBUnixSignals_GetSignalAtIndex, METH_VARARGS, (char *)"SBUnixSignals_GetSignalAtIndex(SBUnixSignals self, int32_t index) -> int32_t"},
-	 { "SBUnixSignals_swigregister", SBUnixSignals_swigregister, METH_VARARGS, NULL},
-=======
 	 { (char *)"SBWatchpoint_GetDescription", _wrap_SBWatchpoint_GetDescription, METH_VARARGS, (char *)"SBWatchpoint_GetDescription(SBWatchpoint self, SBStream description, lldb::DescriptionLevel level) -> bool"},
 	 { (char *)"SBWatchpoint_EventIsWatchpointEvent", _wrap_SBWatchpoint_EventIsWatchpointEvent, METH_VARARGS, (char *)"SBWatchpoint_EventIsWatchpointEvent(SBEvent event) -> bool"},
 	 { (char *)"SBWatchpoint_GetWatchpointEventTypeFromEvent", _wrap_SBWatchpoint_GetWatchpointEventTypeFromEvent, METH_VARARGS, (char *)"SBWatchpoint_GetWatchpointEventTypeFromEvent(SBEvent event) -> lldb::WatchpointEventType"},
@@ -86253,7 +83011,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SBUnixSignals_GetNumSignals", _wrap_SBUnixSignals_GetNumSignals, METH_VARARGS, (char *)"SBUnixSignals_GetNumSignals(SBUnixSignals self) -> int32_t"},
 	 { (char *)"SBUnixSignals_GetSignalAtIndex", _wrap_SBUnixSignals_GetSignalAtIndex, METH_VARARGS, (char *)"SBUnixSignals_GetSignalAtIndex(SBUnixSignals self, int32_t index) -> int32_t"},
 	 { (char *)"SBUnixSignals_swigregister", SBUnixSignals_swigregister, METH_VARARGS, NULL},
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 	 { NULL, NULL, 0, NULL }
 };
 
@@ -87838,13 +84595,9 @@ extern "C" {
             char *ndoc = (char*)malloc(ldoc + lptr + 10);
             if (ndoc) {
               char *buff = ndoc;
-<<<<<<< HEAD
-              memcpy(buff, methods[i].ml_doc, ldoc);
-=======
               strncpy(buff, methods[i].ml_doc, ldoc);
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
               buff += ldoc;
-              memcpy(buff, "swig_ptr: ", 10);
+              strncpy(buff, "swig_ptr: ", 10);
               buff += 10;
               SWIG_PackVoidPtr(buff, ptr, ty->name, lptr);
               methods[i].ml_doc = ndoc;
@@ -87906,13 +84659,8 @@ SWIG_init(void) {
     (char *)"this", &SwigPyBuiltin_ThisClosure, NULL, NULL, NULL
   };
   static SwigPyGetSet thisown_getset_closure = {
-<<<<<<< HEAD
-    SwigPyObject_own,
-    SwigPyObject_own
-=======
     (PyCFunction) SwigPyObject_own,
     (PyCFunction) SwigPyObject_own
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
   };
   static PyGetSetDef thisown_getset_def = {
     (char *)"thisown", SwigPyBuiltin_GetterClosure, SwigPyBuiltin_SetterClosure, NULL, &thisown_getset_closure

--- a/scripts/Python/static-binding/lldb.py
+++ b/scripts/Python/static-binding/lldb.py
@@ -120,16 +120,6 @@ def lldb_iter(obj, getsize, getelem):
     for i in range(size()):
         yield elem(i)
 
-<<<<<<< HEAD
-# ==============================================================================
-# The modify-python-lldb.py script is responsible for post-processing this SWIG-
-# generated lldb.py module.  It is responsible for adding support for: iteration
-# protocol: __iter__, rich comparison methods: __eq__ and __ne__, and built-in
-# function len(): __len__.
-# ==============================================================================
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 INT32_MAX = _lldb.INT32_MAX
 UINT32_MAX = _lldb.UINT32_MAX
 UINT64_MAX = _lldb.UINT64_MAX
@@ -863,11 +853,6 @@ class SBAddress(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBAddress, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __eq__(self, other): return isinstance(other, SBAddress) and self.GetFileAddress() == other.GetFileAddress() and self.GetModule() == other.GetModule()
-    def __ne__(self, other): return not self.__eq__(other)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBAddress self) -> SBAddress
@@ -897,8 +882,6 @@ class SBAddress(_object):
 
 
 
-<<<<<<< HEAD
-=======
     def __eq__(self, other):
       return not self.__ne__(other)
 
@@ -908,7 +891,6 @@ class SBAddress(_object):
         return _lldb.SBAddress___ne__(self, rhs)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def Clear(self):
         """Clear(SBAddress self)"""
         return _lldb.SBAddress_Clear(self)
@@ -1046,7 +1028,6 @@ class SBAddress(_object):
     load_addr = property(__get_load_addr_property__, __set_load_addr_property__, doc='''A read/write property that gets/sets the SBAddress using load address. The setter resolves SBAddress using the SBTarget from lldb.target so this property can ONLY be used in the interactive script interpreter (i.e. under the lldb script command) and not in Python based commands, or breakpoint commands.''')
 
 
-
     def __str__(self):
         """__str__(SBAddress self) -> PyObject *"""
         return _lldb.SBAddress___str__(self)
@@ -1067,13 +1048,8 @@ class SBAttachInfo(_object):
         """
         __init__(lldb::SBAttachInfo self) -> SBAttachInfo
         __init__(lldb::SBAttachInfo self, lldb::pid_t pid) -> SBAttachInfo
-<<<<<<< HEAD
-        __init__(lldb::SBAttachInfo self, str const * path, bool wait_for) -> SBAttachInfo
-        __init__(lldb::SBAttachInfo self, str const * path, bool wait_for, bool async) -> SBAttachInfo
-=======
         __init__(lldb::SBAttachInfo self, char const * path, bool wait_for) -> SBAttachInfo
         __init__(lldb::SBAttachInfo self, char const * path, bool wait_for, bool async) -> SBAttachInfo
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBAttachInfo self, SBAttachInfo rhs) -> SBAttachInfo
         """
         this = _lldb.new_SBAttachInfo(*args)
@@ -1094,11 +1070,7 @@ class SBAttachInfo(_object):
 
     def SetExecutable(self, *args):
         """
-<<<<<<< HEAD
-        SetExecutable(SBAttachInfo self, str const * path)
-=======
         SetExecutable(SBAttachInfo self, char const * path)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         SetExecutable(SBAttachInfo self, SBFileSpec exe_file)
         """
         return _lldb.SBAttachInfo_SetExecutable(self, *args)
@@ -1138,20 +1110,12 @@ class SBAttachInfo(_object):
 
 
     def GetProcessPluginName(self):
-<<<<<<< HEAD
-        """GetProcessPluginName(SBAttachInfo self) -> str const *"""
-=======
         """GetProcessPluginName(SBAttachInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBAttachInfo_GetProcessPluginName(self)
 
 
     def SetProcessPluginName(self, plugin_name):
-<<<<<<< HEAD
-        """SetProcessPluginName(SBAttachInfo self, str const * plugin_name)"""
-=======
         """SetProcessPluginName(SBAttachInfo self, char const * plugin_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBAttachInfo_SetProcessPluginName(self, plugin_name)
 
 
@@ -1288,11 +1252,7 @@ class SBBlock(_object):
 
     def GetInlinedName(self):
         """
-<<<<<<< HEAD
-        GetInlinedName(SBBlock self) -> str const *
-=======
         GetInlinedName(SBBlock self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Get the function name if this block represents an inlined function;
@@ -1456,7 +1416,6 @@ class SBBlock(_object):
     num_ranges = property(GetNumRanges, None, doc='''A read only property that returns the same result as GetNumRanges().''')
 
 
-
     def __str__(self):
         """__str__(SBBlock self) -> PyObject *"""
         return _lldb.SBBlock___str__(self)
@@ -1540,13 +1499,6 @@ class SBBreakpoint(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBBreakpoint, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumLocations', 'GetLocationAtIndex')
-    def __len__(self): return self.GetNumLocations()
-    def __eq__(self, other): return isinstance(other, SBBreakpoint) and self.GetID() == other.GetID()
-    def __ne__(self, other): return not self.__eq__(other)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBBreakpoint self) -> SBBreakpoint
@@ -1560,8 +1512,6 @@ class SBBreakpoint(_object):
     __swig_destroy__ = _lldb.delete_SBBreakpoint
     __del__ = lambda self: None
 
-<<<<<<< HEAD
-=======
     def __eq__(self, rhs):
         """__eq__(SBBreakpoint self, SBBreakpoint rhs) -> bool"""
         return _lldb.SBBreakpoint___eq__(self, rhs)
@@ -1572,7 +1522,6 @@ class SBBreakpoint(_object):
         return _lldb.SBBreakpoint___ne__(self, rhs)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetID(self):
         """GetID(SBBreakpoint self) -> lldb::break_id_t"""
         return _lldb.SBBreakpoint_GetID(self)
@@ -1656,11 +1605,7 @@ class SBBreakpoint(_object):
 
     def SetCondition(self, condition):
         """
-<<<<<<< HEAD
-        SetCondition(SBBreakpoint self, str const * condition)
-=======
         SetCondition(SBBreakpoint self, char const * condition)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         The breakpoint stops only if the condition expression evaluates to true.
@@ -1670,11 +1615,7 @@ class SBBreakpoint(_object):
 
     def GetCondition(self):
         """
-<<<<<<< HEAD
-        GetCondition(SBBreakpoint self) -> str const *
-=======
         GetCondition(SBBreakpoint self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Get the condition expression for the breakpoint.
@@ -1713,48 +1654,28 @@ class SBBreakpoint(_object):
 
 
     def SetThreadName(self, thread_name):
-<<<<<<< HEAD
-        """SetThreadName(SBBreakpoint self, str const * thread_name)"""
-=======
         """SetThreadName(SBBreakpoint self, char const * thread_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpoint_SetThreadName(self, thread_name)
 
 
     def GetThreadName(self):
-<<<<<<< HEAD
-        """GetThreadName(SBBreakpoint self) -> str const *"""
-=======
         """GetThreadName(SBBreakpoint self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpoint_GetThreadName(self)
 
 
     def SetQueueName(self, queue_name):
-<<<<<<< HEAD
-        """SetQueueName(SBBreakpoint self, str const * queue_name)"""
-=======
         """SetQueueName(SBBreakpoint self, char const * queue_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpoint_SetQueueName(self, queue_name)
 
 
     def GetQueueName(self):
-<<<<<<< HEAD
-        """GetQueueName(SBBreakpoint self) -> str const *"""
-=======
         """GetQueueName(SBBreakpoint self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpoint_GetQueueName(self)
 
 
     def SetScriptCallbackFunction(self, callback_function_name):
         """
-<<<<<<< HEAD
-        SetScriptCallbackFunction(SBBreakpoint self, str const * callback_function_name)
-=======
         SetScriptCallbackFunction(SBBreakpoint self, char const * callback_function_name)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Set the name of the script function to be called when the breakpoint is hit.
@@ -1764,11 +1685,7 @@ class SBBreakpoint(_object):
 
     def SetScriptCallbackBody(self, script_body_text):
         """
-<<<<<<< HEAD
-        SetScriptCallbackBody(SBBreakpoint self, str const * script_body_text) -> SBError
-=======
         SetScriptCallbackBody(SBBreakpoint self, char const * script_body_text) -> SBError
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Provide the body for the script function to be called when the breakpoint is hit.
@@ -1794,26 +1711,6 @@ class SBBreakpoint(_object):
 
 
     def AddName(self, new_name):
-<<<<<<< HEAD
-        """AddName(SBBreakpoint self, str const * new_name) -> bool"""
-        return _lldb.SBBreakpoint_AddName(self, new_name)
-
-
-    def RemoveName(self, name_to_remove):
-        """RemoveName(SBBreakpoint self, str const * name_to_remove)"""
-        return _lldb.SBBreakpoint_RemoveName(self, name_to_remove)
-
-
-    def MatchesName(self, name):
-        """MatchesName(SBBreakpoint self, str const * name) -> bool"""
-        return _lldb.SBBreakpoint_MatchesName(self, name)
-
-
-    def GetNames(self, names):
-        """GetNames(SBBreakpoint self, SBStringList names)"""
-        return _lldb.SBBreakpoint_GetNames(self, names)
-
-=======
         """AddName(SBBreakpoint self, char const * new_name) -> bool"""
         return _lldb.SBBreakpoint_AddName(self, new_name)
 
@@ -1832,7 +1729,6 @@ class SBBreakpoint(_object):
         """GetNames(SBBreakpoint self, SBStringList names)"""
         return _lldb.SBBreakpoint_GetNames(self, names)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetNumResolvedLocations(self):
         """GetNumResolvedLocations(SBBreakpoint self) -> size_t"""
@@ -1855,25 +1751,11 @@ class SBBreakpoint(_object):
     def AddLocation(self, address):
         """AddLocation(SBBreakpoint self, SBAddress address) -> SBError"""
         return _lldb.SBBreakpoint_AddLocation(self, address)
-<<<<<<< HEAD
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBBreakpoint self, SBBreakpoint rhs) -> bool"""
-        return _lldb.SBBreakpoint___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBBreakpoint self, SBBreakpoint rhs) -> bool"""
-        return _lldb.SBBreakpoint___ne__(self, rhs)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def EventIsBreakpointEvent(event):
         """EventIsBreakpointEvent(SBEvent event) -> bool"""
         return _lldb.SBBreakpoint_EventIsBreakpointEvent(event)
-<<<<<<< HEAD
 
     EventIsBreakpointEvent = staticmethod(EventIsBreakpointEvent)
 
@@ -1881,21 +1763,11 @@ class SBBreakpoint(_object):
         """GetBreakpointEventTypeFromEvent(SBEvent event) -> lldb::BreakpointEventType"""
         return _lldb.SBBreakpoint_GetBreakpointEventTypeFromEvent(event)
 
-=======
-
-    EventIsBreakpointEvent = staticmethod(EventIsBreakpointEvent)
-
-    def GetBreakpointEventTypeFromEvent(event):
-        """GetBreakpointEventTypeFromEvent(SBEvent event) -> lldb::BreakpointEventType"""
-        return _lldb.SBBreakpoint_GetBreakpointEventTypeFromEvent(event)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     GetBreakpointEventTypeFromEvent = staticmethod(GetBreakpointEventTypeFromEvent)
 
     def GetBreakpointFromEvent(event):
         """GetBreakpointFromEvent(SBEvent event) -> SBBreakpoint"""
         return _lldb.SBBreakpoint_GetBreakpointFromEvent(event)
-<<<<<<< HEAD
 
     GetBreakpointFromEvent = staticmethod(GetBreakpointFromEvent)
 
@@ -1905,17 +1777,6 @@ class SBBreakpoint(_object):
 
     GetBreakpointLocationAtIndexFromEvent = staticmethod(GetBreakpointLocationAtIndexFromEvent)
 
-=======
-
-    GetBreakpointFromEvent = staticmethod(GetBreakpointFromEvent)
-
-    def GetBreakpointLocationAtIndexFromEvent(event, loc_idx):
-        """GetBreakpointLocationAtIndexFromEvent(SBEvent event, uint32_t loc_idx) -> SBBreakpointLocation"""
-        return _lldb.SBBreakpoint_GetBreakpointLocationAtIndexFromEvent(event, loc_idx)
-
-    GetBreakpointLocationAtIndexFromEvent = staticmethod(GetBreakpointLocationAtIndexFromEvent)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetNumBreakpointLocationsFromEvent(event_sp):
         """GetNumBreakpointLocationsFromEvent(SBEvent event_sp) -> uint32_t"""
         return _lldb.SBBreakpoint_GetNumBreakpointLocationsFromEvent(event_sp)
@@ -1960,21 +1821,6 @@ class SBBreakpoint(_object):
         object.'''
         return lldb_iter(self, 'GetNumLocations', 'GetLocationAtIndex')
 
-<<<<<<< HEAD
-    __swig_getmethods__["id"] = GetID
-    if _newclass: id = property(GetID, None, doc='''A read only property that returns the ID of this breakpoint.''')
-
-    __swig_getmethods__["enabled"] = IsEnabled
-    __swig_setmethods__["enabled"] = SetEnabled
-    if _newclass: enabled = property(IsEnabled, SetEnabled, doc='''A read/write property that configures whether this breakpoint is enabled or not.''')
-
-    __swig_getmethods__["one_shot"] = IsOneShot
-    __swig_setmethods__["one_shot"] = SetOneShot
-    if _newclass: one_shot = property(IsOneShot, SetOneShot, doc='''A read/write property that configures whether this breakpoint is one-shot (deleted when hit) or not.''')
-
-    __swig_getmethods__["num_locations"] = GetNumLocations
-    if _newclass: num_locations = property(GetNumLocations, None, doc='''A read only property that returns the count of locations of this breakpoint.''')
-=======
     def __len__(self):
         '''Return the number of breakpoint locations in a lldb.SBBreakpoint
         object.'''
@@ -1986,8 +1832,6 @@ class SBBreakpoint(_object):
     enabled = property(IsEnabled, SetEnabled, doc='''A read/write property that configures whether this breakpoint is enabled or not.''')
     one_shot = property(IsOneShot, SetOneShot, doc='''A read/write property that configures whether this breakpoint is one-shot (deleted when hit) or not.''')
     num_locations = property(GetNumLocations, None, doc='''A read only property that returns the count of locations of this breakpoint.''')
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
-
 
 
     def __str__(self):
@@ -2057,7 +1901,6 @@ class SBBreakpointList(_object):
     def GetBreakpointAtIndex(self, idx):
         """GetBreakpointAtIndex(SBBreakpointList self, size_t idx) -> SBBreakpoint"""
         return _lldb.SBBreakpointList_GetBreakpointAtIndex(self, idx)
-<<<<<<< HEAD
 
 
     def FindBreakpointByID(self, arg2):
@@ -2075,25 +1918,6 @@ class SBBreakpointList(_object):
         return _lldb.SBBreakpointList_AppendIfUnique(self, sb_bkpt)
 
 
-=======
-
-
-    def FindBreakpointByID(self, arg2):
-        """FindBreakpointByID(SBBreakpointList self, lldb::break_id_t arg2) -> SBBreakpoint"""
-        return _lldb.SBBreakpointList_FindBreakpointByID(self, arg2)
-
-
-    def Append(self, sb_bkpt):
-        """Append(SBBreakpointList self, SBBreakpoint sb_bkpt)"""
-        return _lldb.SBBreakpointList_Append(self, sb_bkpt)
-
-
-    def AppendIfUnique(self, sb_bkpt):
-        """AppendIfUnique(SBBreakpointList self, SBBreakpoint sb_bkpt) -> bool"""
-        return _lldb.SBBreakpointList_AppendIfUnique(self, sb_bkpt)
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def AppendByID(self, id):
         """AppendByID(SBBreakpointList self, lldb::break_id_t id)"""
         return _lldb.SBBreakpointList_AppendByID(self, id)
@@ -2190,11 +2014,7 @@ class SBBreakpointLocation(_object):
 
     def SetCondition(self, condition):
         """
-<<<<<<< HEAD
-        SetCondition(SBBreakpointLocation self, str const * condition)
-=======
         SetCondition(SBBreakpointLocation self, char const * condition)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         The breakpoint location stops only if the condition expression evaluates
@@ -2205,11 +2025,7 @@ class SBBreakpointLocation(_object):
 
     def GetCondition(self):
         """
-<<<<<<< HEAD
-        GetCondition(SBBreakpointLocation self) -> str const *
-=======
         GetCondition(SBBreakpointLocation self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Get the condition expression for the breakpoint location.
@@ -2229,11 +2045,7 @@ class SBBreakpointLocation(_object):
 
     def SetScriptCallbackFunction(self, callback_function_name):
         """
-<<<<<<< HEAD
-        SetScriptCallbackFunction(SBBreakpointLocation self, str const * callback_function_name)
-=======
         SetScriptCallbackFunction(SBBreakpointLocation self, char const * callback_function_name)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Set the callback to the given Python function name.
@@ -2243,11 +2055,7 @@ class SBBreakpointLocation(_object):
 
     def SetScriptCallbackBody(self, script_body_text):
         """
-<<<<<<< HEAD
-        SetScriptCallbackBody(SBBreakpointLocation self, str const * script_body_text) -> SBError
-=======
         SetScriptCallbackBody(SBBreakpointLocation self, char const * script_body_text) -> SBError
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Provide the body for the script function to be called when the breakpoint location is hit.
@@ -2265,7 +2073,6 @@ class SBBreakpointLocation(_object):
     def SetCommandLineCommands(self, commands):
         """SetCommandLineCommands(SBBreakpointLocation self, SBStringList commands)"""
         return _lldb.SBBreakpointLocation_SetCommandLineCommands(self, commands)
-<<<<<<< HEAD
 
 
     def GetCommandLineCommands(self, commands):
@@ -2277,19 +2084,6 @@ class SBBreakpointLocation(_object):
         """SetThreadID(SBBreakpointLocation self, lldb::tid_t sb_thread_id)"""
         return _lldb.SBBreakpointLocation_SetThreadID(self, sb_thread_id)
 
-=======
-
-
-    def GetCommandLineCommands(self, commands):
-        """GetCommandLineCommands(SBBreakpointLocation self, SBStringList commands) -> bool"""
-        return _lldb.SBBreakpointLocation_GetCommandLineCommands(self, commands)
-
-
-    def SetThreadID(self, sb_thread_id):
-        """SetThreadID(SBBreakpointLocation self, lldb::tid_t sb_thread_id)"""
-        return _lldb.SBBreakpointLocation_SetThreadID(self, sb_thread_id)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetThreadID(self):
         """GetThreadID(SBBreakpointLocation self) -> lldb::tid_t"""
@@ -2307,38 +2101,22 @@ class SBBreakpointLocation(_object):
 
 
     def SetThreadName(self, thread_name):
-<<<<<<< HEAD
-        """SetThreadName(SBBreakpointLocation self, str const * thread_name)"""
-=======
         """SetThreadName(SBBreakpointLocation self, char const * thread_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointLocation_SetThreadName(self, thread_name)
 
 
     def GetThreadName(self):
-<<<<<<< HEAD
-        """GetThreadName(SBBreakpointLocation self) -> str const *"""
-=======
         """GetThreadName(SBBreakpointLocation self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointLocation_GetThreadName(self)
 
 
     def SetQueueName(self, queue_name):
-<<<<<<< HEAD
-        """SetQueueName(SBBreakpointLocation self, str const * queue_name)"""
-=======
         """SetQueueName(SBBreakpointLocation self, char const * queue_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointLocation_SetQueueName(self, queue_name)
 
 
     def GetQueueName(self):
-<<<<<<< HEAD
-        """GetQueueName(SBBreakpointLocation self) -> str const *"""
-=======
         """GetQueueName(SBBreakpointLocation self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointLocation_GetQueueName(self)
 
 
@@ -2390,13 +2168,8 @@ class SBBreakpointName(_object):
     def __init__(self, *args):
         """
         __init__(lldb::SBBreakpointName self) -> SBBreakpointName
-<<<<<<< HEAD
-        __init__(lldb::SBBreakpointName self, SBTarget target, str const * name) -> SBBreakpointName
-        __init__(lldb::SBBreakpointName self, SBBreakpoint bkpt, str const * name) -> SBBreakpointName
-=======
         __init__(lldb::SBBreakpointName self, SBTarget target, char const * name) -> SBBreakpointName
         __init__(lldb::SBBreakpointName self, SBBreakpoint bkpt, char const * name) -> SBBreakpointName
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBBreakpointName self, SBBreakpointName rhs) -> SBBreakpointName
         """
         this = _lldb.new_SBBreakpointName(*args)
@@ -2406,32 +2179,6 @@ class SBBreakpointName(_object):
             self.this = this
     __swig_destroy__ = _lldb.delete_SBBreakpointName
     __del__ = lambda self: None
-<<<<<<< HEAD
-
-    def __eq__(self, rhs):
-        """__eq__(SBBreakpointName self, SBBreakpointName rhs) -> bool"""
-        return _lldb.SBBreakpointName___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBBreakpointName self, SBBreakpointName rhs) -> bool"""
-        return _lldb.SBBreakpointName___ne__(self, rhs)
-
-
-    def __nonzero__(self):
-        return _lldb.SBBreakpointName___nonzero__(self)
-    __bool__ = __nonzero__
-
-
-
-    def IsValid(self):
-        """IsValid(SBBreakpointName self) -> bool"""
-        return _lldb.SBBreakpointName_IsValid(self)
-
-
-    def GetName(self):
-        """GetName(SBBreakpointName self) -> str const *"""
-=======
 
     def __eq__(self, rhs):
         """__eq__(SBBreakpointName self, SBBreakpointName rhs) -> bool"""
@@ -2456,7 +2203,6 @@ class SBBreakpointName(_object):
 
     def GetName(self):
         """GetName(SBBreakpointName self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_GetName(self)
 
 
@@ -2491,20 +2237,12 @@ class SBBreakpointName(_object):
 
 
     def SetCondition(self, condition):
-<<<<<<< HEAD
-        """SetCondition(SBBreakpointName self, str const * condition)"""
-=======
         """SetCondition(SBBreakpointName self, char const * condition)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_SetCondition(self, condition)
 
 
     def GetCondition(self):
-<<<<<<< HEAD
-        """GetCondition(SBBreakpointName self) -> str const *"""
-=======
         """GetCondition(SBBreakpointName self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_GetCondition(self)
 
 
@@ -2539,53 +2277,26 @@ class SBBreakpointName(_object):
 
 
     def SetThreadName(self, thread_name):
-<<<<<<< HEAD
-        """SetThreadName(SBBreakpointName self, str const * thread_name)"""
-=======
         """SetThreadName(SBBreakpointName self, char const * thread_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_SetThreadName(self, thread_name)
 
 
     def GetThreadName(self):
-<<<<<<< HEAD
-        """GetThreadName(SBBreakpointName self) -> str const *"""
-=======
         """GetThreadName(SBBreakpointName self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_GetThreadName(self)
 
 
     def SetQueueName(self, queue_name):
-<<<<<<< HEAD
-        """SetQueueName(SBBreakpointName self, str const * queue_name)"""
-=======
         """SetQueueName(SBBreakpointName self, char const * queue_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_SetQueueName(self, queue_name)
 
 
     def GetQueueName(self):
-<<<<<<< HEAD
-        """GetQueueName(SBBreakpointName self) -> str const *"""
-=======
         """GetQueueName(SBBreakpointName self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_GetQueueName(self)
 
 
     def SetScriptCallbackFunction(self, callback_function_name):
-<<<<<<< HEAD
-        """SetScriptCallbackFunction(SBBreakpointName self, str const * callback_function_name)"""
-        return _lldb.SBBreakpointName_SetScriptCallbackFunction(self, callback_function_name)
-
-
-    def SetCommandLineCommands(self, commands):
-        """SetCommandLineCommands(SBBreakpointName self, SBStringList commands)"""
-        return _lldb.SBBreakpointName_SetCommandLineCommands(self, commands)
-
-
-=======
         """SetScriptCallbackFunction(SBBreakpointName self, char const * callback_function_name)"""
         return _lldb.SBBreakpointName_SetScriptCallbackFunction(self, callback_function_name)
 
@@ -2595,36 +2306,23 @@ class SBBreakpointName(_object):
         return _lldb.SBBreakpointName_SetCommandLineCommands(self, commands)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetCommandLineCommands(self, commands):
         """GetCommandLineCommands(SBBreakpointName self, SBStringList commands) -> bool"""
         return _lldb.SBBreakpointName_GetCommandLineCommands(self, commands)
 
 
     def SetScriptCallbackBody(self, script_body_text):
-<<<<<<< HEAD
-        """SetScriptCallbackBody(SBBreakpointName self, str const * script_body_text) -> SBError"""
-=======
         """SetScriptCallbackBody(SBBreakpointName self, char const * script_body_text) -> SBError"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_SetScriptCallbackBody(self, script_body_text)
 
 
     def GetHelpString(self):
-<<<<<<< HEAD
-        """GetHelpString(SBBreakpointName self) -> str const *"""
-=======
         """GetHelpString(SBBreakpointName self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_GetHelpString(self)
 
 
     def SetHelpString(self, help_string):
-<<<<<<< HEAD
-        """SetHelpString(SBBreakpointName self, str const * help_string)"""
-=======
         """SetHelpString(SBBreakpointName self, char const * help_string)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBreakpointName_SetHelpString(self, help_string)
 
 
@@ -2692,11 +2390,7 @@ class SBBroadcaster(_object):
     def __init__(self, *args):
         """
         __init__(lldb::SBBroadcaster self) -> SBBroadcaster
-<<<<<<< HEAD
-        __init__(lldb::SBBroadcaster self, str const * name) -> SBBroadcaster
-=======
         __init__(lldb::SBBroadcaster self, char const * name) -> SBBroadcaster
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBBroadcaster self, SBBroadcaster rhs) -> SBBroadcaster
         """
         this = _lldb.new_SBBroadcaster(*args)
@@ -2742,17 +2436,6 @@ class SBBroadcaster(_object):
     def AddInitialEventsToListener(self, listener, requested_events):
         """AddInitialEventsToListener(SBBroadcaster self, SBListener listener, uint32_t requested_events)"""
         return _lldb.SBBroadcaster_AddInitialEventsToListener(self, listener, requested_events)
-<<<<<<< HEAD
-
-
-    def AddListener(self, listener, event_mask):
-        """AddListener(SBBroadcaster self, SBListener listener, uint32_t event_mask) -> uint32_t"""
-        return _lldb.SBBroadcaster_AddListener(self, listener, event_mask)
-
-
-    def GetName(self):
-        """GetName(SBBroadcaster self) -> str const *"""
-=======
 
 
     def AddListener(self, listener, event_mask):
@@ -2762,7 +2445,6 @@ class SBBroadcaster(_object):
 
     def GetName(self):
         """GetName(SBBroadcaster self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBBroadcaster_GetName(self)
 
 
@@ -2777,7 +2459,6 @@ class SBBroadcaster(_object):
         RemoveListener(SBBroadcaster self, SBListener listener) -> bool
         """
         return _lldb.SBBroadcaster_RemoveListener(self, listener, event_mask)
-<<<<<<< HEAD
 
 
     def __eq__(self, rhs):
@@ -2789,19 +2470,6 @@ class SBBroadcaster(_object):
         """__ne__(SBBroadcaster self, SBBroadcaster rhs) -> bool"""
         return _lldb.SBBroadcaster___ne__(self, rhs)
 
-=======
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBBroadcaster self, SBBroadcaster rhs) -> bool"""
-        return _lldb.SBBroadcaster___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBBroadcaster self, SBBroadcaster rhs) -> bool"""
-        return _lldb.SBBroadcaster___ne__(self, rhs)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __eq__(self, rhs):
         if not isinstance(rhs, type(self)):
@@ -2978,21 +2646,13 @@ class SBCommandInterpreter(_object):
     __del__ = lambda self: None
 
     def GetArgumentTypeAsCString(arg_type):
-<<<<<<< HEAD
-        """GetArgumentTypeAsCString(lldb::CommandArgumentType const arg_type) -> str const *"""
-=======
         """GetArgumentTypeAsCString(lldb::CommandArgumentType const arg_type) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_GetArgumentTypeAsCString(arg_type)
 
     GetArgumentTypeAsCString = staticmethod(GetArgumentTypeAsCString)
 
     def GetArgumentDescriptionAsCString(arg_type):
-<<<<<<< HEAD
-        """GetArgumentDescriptionAsCString(lldb::CommandArgumentType const arg_type) -> str const *"""
-=======
         """GetArgumentDescriptionAsCString(lldb::CommandArgumentType const arg_type) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_GetArgumentDescriptionAsCString(arg_type)
 
     GetArgumentDescriptionAsCString = staticmethod(GetArgumentDescriptionAsCString)
@@ -3015,11 +2675,7 @@ class SBCommandInterpreter(_object):
 
 
     def GetIOHandlerControlSequence(self, ch):
-<<<<<<< HEAD
-        """GetIOHandlerControlSequence(SBCommandInterpreter self, str ch) -> str const *"""
-=======
         """GetIOHandlerControlSequence(SBCommandInterpreter self, char ch) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_GetIOHandlerControlSequence(self, ch)
 
 
@@ -3049,29 +2705,17 @@ class SBCommandInterpreter(_object):
 
 
     def ResolveCommand(self, command_line, result):
-<<<<<<< HEAD
-        """ResolveCommand(SBCommandInterpreter self, str const * command_line, SBCommandReturnObject result)"""
-=======
         """ResolveCommand(SBCommandInterpreter self, char const * command_line, SBCommandReturnObject result)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_ResolveCommand(self, command_line, result)
 
 
     def CommandExists(self, cmd):
-<<<<<<< HEAD
-        """CommandExists(SBCommandInterpreter self, str const * cmd) -> bool"""
-=======
         """CommandExists(SBCommandInterpreter self, char const * cmd) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_CommandExists(self, cmd)
 
 
     def AliasExists(self, cmd):
-<<<<<<< HEAD
-        """AliasExists(SBCommandInterpreter self, str const * cmd) -> bool"""
-=======
         """AliasExists(SBCommandInterpreter self, char const * cmd) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_AliasExists(self, cmd)
 
 
@@ -3081,11 +2725,7 @@ class SBCommandInterpreter(_object):
 
 
     def GetBroadcasterClass():
-<<<<<<< HEAD
-        """GetBroadcasterClass() -> str const *"""
-=======
         """GetBroadcasterClass() -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_GetBroadcasterClass()
 
     GetBroadcasterClass = staticmethod(GetBroadcasterClass)
@@ -3127,17 +2767,10 @@ class SBCommandInterpreter(_object):
 
     def HandleCommand(self, *args):
         """
-<<<<<<< HEAD
-        HandleCommand(SBCommandInterpreter self, str const * command_line, SBCommandReturnObject result, bool add_to_history=False) -> lldb::ReturnStatus
-        HandleCommand(SBCommandInterpreter self, str const * command_line, SBCommandReturnObject result) -> lldb::ReturnStatus
-        HandleCommand(SBCommandInterpreter self, str const * command_line, SBExecutionContext exe_ctx, SBCommandReturnObject result, bool add_to_history=False) -> lldb::ReturnStatus
-        HandleCommand(SBCommandInterpreter self, str const * command_line, SBExecutionContext exe_ctx, SBCommandReturnObject result) -> lldb::ReturnStatus
-=======
         HandleCommand(SBCommandInterpreter self, char const * command_line, SBCommandReturnObject result, bool add_to_history=False) -> lldb::ReturnStatus
         HandleCommand(SBCommandInterpreter self, char const * command_line, SBCommandReturnObject result) -> lldb::ReturnStatus
         HandleCommand(SBCommandInterpreter self, char const * command_line, SBExecutionContext exe_ctx, SBCommandReturnObject result, bool add_to_history=False) -> lldb::ReturnStatus
         HandleCommand(SBCommandInterpreter self, char const * command_line, SBExecutionContext exe_ctx, SBCommandReturnObject result) -> lldb::ReturnStatus
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBCommandInterpreter_HandleCommand(self, *args)
 
@@ -3148,20 +2781,12 @@ class SBCommandInterpreter(_object):
 
 
     def HandleCompletion(self, current_line, cursor_pos, match_start_point, max_return_elements, matches):
-<<<<<<< HEAD
-        """HandleCompletion(SBCommandInterpreter self, str const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches) -> int"""
-=======
         """HandleCompletion(SBCommandInterpreter self, char const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches) -> int"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_HandleCompletion(self, current_line, cursor_pos, match_start_point, max_return_elements, matches)
 
 
     def HandleCompletionWithDescriptions(self, current_line, cursor_pos, match_start_point, max_return_elements, matches, descriptions):
-<<<<<<< HEAD
-        """HandleCompletionWithDescriptions(SBCommandInterpreter self, str const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches, SBStringList descriptions) -> int"""
-=======
         """HandleCompletionWithDescriptions(SBCommandInterpreter self, char const * current_line, uint32_t cursor_pos, int match_start_point, int max_return_elements, SBStringList matches, SBStringList descriptions) -> int"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandInterpreter_HandleCompletionWithDescriptions(self, current_line, cursor_pos, match_start_point, max_return_elements, matches, descriptions)
 
 
@@ -3244,26 +2869,16 @@ class SBCommandReturnObject(_object):
 
     def GetOutput(self, *args):
         """
-<<<<<<< HEAD
-        GetOutput(SBCommandReturnObject self) -> str const
-        GetOutput(SBCommandReturnObject self, bool only_if_no_immediate) -> str const *
-=======
         GetOutput(SBCommandReturnObject self) -> char const
         GetOutput(SBCommandReturnObject self, bool only_if_no_immediate) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBCommandReturnObject_GetOutput(self, *args)
 
 
     def GetError(self, *args):
         """
-<<<<<<< HEAD
-        GetError(SBCommandReturnObject self) -> str const
-        GetError(SBCommandReturnObject self, bool if_no_immediate) -> str const *
-=======
         GetError(SBCommandReturnObject self) -> char const
         GetError(SBCommandReturnObject self, bool if_no_immediate) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBCommandReturnObject_GetError(self, *args)
 
@@ -3290,15 +2905,9 @@ class SBCommandReturnObject(_object):
 
     def SetError(self, *args):
         """
-<<<<<<< HEAD
-        SetError(SBCommandReturnObject self, SBError error, str const * fallback_error_cstr=None)
-        SetError(SBCommandReturnObject self, SBError error)
-        SetError(SBCommandReturnObject self, str const * error_cstr)
-=======
         SetError(SBCommandReturnObject self, SBError error, char const * fallback_error_cstr=None)
         SetError(SBCommandReturnObject self, SBError error)
         SetError(SBCommandReturnObject self, char const * error_cstr)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBCommandReturnObject_SetError(self, *args)
 
@@ -3319,45 +2928,11 @@ class SBCommandReturnObject(_object):
 
 
     def AppendMessage(self, message):
-<<<<<<< HEAD
-        """AppendMessage(SBCommandReturnObject self, str const * message)"""
-=======
         """AppendMessage(SBCommandReturnObject self, char const * message)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandReturnObject_AppendMessage(self, message)
 
 
     def AppendWarning(self, message):
-<<<<<<< HEAD
-        """AppendWarning(SBCommandReturnObject self, str const * message)"""
-        return _lldb.SBCommandReturnObject_AppendWarning(self, message)
-
-
-    def GetDescription(self, description):
-        """GetDescription(SBCommandReturnObject self, SBStream description) -> bool"""
-        return _lldb.SBCommandReturnObject_GetDescription(self, description)
-
-
-    def SetImmediateOutputFile(self, fh):
-        """SetImmediateOutputFile(SBCommandReturnObject self, FILE * fh)"""
-        return _lldb.SBCommandReturnObject_SetImmediateOutputFile(self, fh)
-
-
-    def SetImmediateErrorFile(self, fh):
-        """SetImmediateErrorFile(SBCommandReturnObject self, FILE * fh)"""
-        return _lldb.SBCommandReturnObject_SetImmediateErrorFile(self, fh)
-
-
-    def PutCString(self, string):
-        """PutCString(SBCommandReturnObject self, str const * string)"""
-        return _lldb.SBCommandReturnObject_PutCString(self, string)
-
-
-    def Print(self, str):
-        """Print(SBCommandReturnObject self, str const * str)"""
-        return _lldb.SBCommandReturnObject_Print(self, str)
-
-=======
         """AppendWarning(SBCommandReturnObject self, char const * message)"""
         return _lldb.SBCommandReturnObject_AppendWarning(self, message)
 
@@ -3386,7 +2961,6 @@ class SBCommandReturnObject(_object):
         """Print(SBCommandReturnObject self, char const * str)"""
         return _lldb.SBCommandReturnObject_Print(self, str)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __str__(self):
         """__str__(SBCommandReturnObject self) -> PyObject *"""
@@ -3394,11 +2968,7 @@ class SBCommandReturnObject(_object):
 
 
     def write(self, str):
-<<<<<<< HEAD
-        """write(SBCommandReturnObject self, str const * str)"""
-=======
         """write(SBCommandReturnObject self, char const * str)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommandReturnObject_write(self, str)
 
 
@@ -3427,11 +2997,7 @@ class SBCommunication(_object):
     def __init__(self, *args):
         """
         __init__(lldb::SBCommunication self) -> SBCommunication
-<<<<<<< HEAD
-        __init__(lldb::SBCommunication self, str const * broadcaster_name) -> SBCommunication
-=======
         __init__(lldb::SBCommunication self, char const * broadcaster_name) -> SBCommunication
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         this = _lldb.new_SBCommunication(*args)
         try:
@@ -3458,11 +3024,7 @@ class SBCommunication(_object):
 
 
     def GetBroadcasterClass():
-<<<<<<< HEAD
-        """GetBroadcasterClass() -> str const *"""
-=======
         """GetBroadcasterClass() -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommunication_GetBroadcasterClass()
 
     GetBroadcasterClass = staticmethod(GetBroadcasterClass)
@@ -3473,11 +3035,7 @@ class SBCommunication(_object):
 
 
     def Connect(self, url):
-<<<<<<< HEAD
-        """Connect(SBCommunication self, str const * url) -> lldb::ConnectionStatus"""
-=======
         """Connect(SBCommunication self, char const * url) -> lldb::ConnectionStatus"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBCommunication_Connect(self, url)
 
 
@@ -3580,11 +3138,6 @@ class SBCompileUnit(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBCompileUnit, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumLineEntries', 'GetLineEntryAtIndex')
-    def __len__(self): return self.GetNumLineEntries()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBCompileUnit self) -> SBCompileUnit
@@ -3669,345 +3222,6 @@ class SBCompileUnit(_object):
         """
         return _lldb.SBCompileUnit_GetTypes(self, *args)
 
-<<<<<<< HEAD
-
-    def GetLanguage(self):
-        """GetLanguage(SBCompileUnit self) -> lldb::LanguageType"""
-        return _lldb.SBCompileUnit_GetLanguage(self)
-
-
-    def GetDescription(self, description):
-        """GetDescription(SBCompileUnit self, SBStream description) -> bool"""
-        return _lldb.SBCompileUnit_GetDescription(self, description)
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBCompileUnit self, SBCompileUnit rhs) -> bool"""
-        return _lldb.SBCompileUnit___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBCompileUnit self, SBCompileUnit rhs) -> bool"""
-        return _lldb.SBCompileUnit___ne__(self, rhs)
-
-
-    __swig_getmethods__["file"] = GetFileSpec
-    if _newclass: file = property(GetFileSpec, None, doc='''A read only property that returns the same result an lldb object that represents the source file (lldb.SBFileSpec) for the compile unit.''')
-
-    __swig_getmethods__["num_line_entries"] = GetNumLineEntries
-    if _newclass: num_line_entries = property(GetNumLineEntries, None, doc='''A read only property that returns the number of line entries in a compile unit as an integer.''')
-
-
-    def __str__(self):
-        """__str__(SBCompileUnit self) -> PyObject *"""
-        return _lldb.SBCompileUnit___str__(self)
-
-
-    def __eq__(self, rhs):
-        if not isinstance(rhs, type(self)):
-            return False
-
-        return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-
-    def __ne__(self, rhs):
-        if not isinstance(rhs, type(self)):
-            return True
-
-        return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
-
-SBCompileUnit_swigregister = _lldb.SBCompileUnit_swigregister
-SBCompileUnit_swigregister(SBCompileUnit)
-
-class SBCompletionMatch(_object):
-    """
-
-    Represents a single possible completion.
-
-    """
-
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, SBCompletionMatch, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, SBCompletionMatch, name)
-    __repr__ = _swig_repr
-
-    def GetDisplay(self):
-        """
-        GetDisplay(SBCompletionMatch self) -> str const *
-
-
-        Returns a detailed string describing this completion that is suitable for
-        displaying to a user in a list of completion possibilities. This string
-        is not suitable for inserting into the code because it may contain
-        information about the match (like type information) that doesn't go in
-        code.
-        """
-        return _lldb.SBCompletionMatch_GetDisplay(self)
-
-
-    def GetInsertable(self):
-        """
-        GetInsertable(SBCompletionMatch self) -> str const *
-
-
-        Returns a string that can be inserted into the code.
-        """
-        return _lldb.SBCompletionMatch_GetInsertable(self)
-
-
-    def __init__(self):
-        """__init__(lldb::SBCompletionMatch self) -> SBCompletionMatch"""
-        this = _lldb.new_SBCompletionMatch()
-        try:
-            self.this.append(this)
-        except __builtin__.Exception:
-            self.this = this
-    __swig_destroy__ = _lldb.delete_SBCompletionMatch
-    __del__ = lambda self: None
-SBCompletionMatch_swigregister = _lldb.SBCompletionMatch_swigregister
-SBCompletionMatch_swigregister(SBCompletionMatch)
-
-class SBCompletionResponse(_object):
-    """
-
-    Represents a set of completions, or an error describing why completions could
-    not be calculated.
-    """
-
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, SBCompletionResponse, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, SBCompletionResponse, name)
-    __repr__ = _swig_repr
-
-    def GetErrorMessage(self):
-        """
-        GetErrorMessage(SBCompletionResponse self) -> str const *
-
-
-        Return the error message, if any. The length is 0 if and only if the
-        completion calculation was a success.
-        """
-        return _lldb.SBCompletionResponse_GetErrorMessage(self)
-
-
-    def GetPrefix(self):
-        """
-        GetPrefix(SBCompletionResponse self) -> str const *
-
-
-        Returns a common prefix of all the matches. This prefix is present in the
-        code for which the completion was requested.
-        """
-        return _lldb.SBCompletionResponse_GetPrefix(self)
-
-
-    def GetNumMatches(self):
-        """
-        GetNumMatches(SBCompletionResponse self) -> uint32_t
-
-
-        Returns the number of matches that this response contains.
-        """
-        return _lldb.SBCompletionResponse_GetNumMatches(self)
-
-
-    def GetMatchAtIndex(self, idx):
-        """GetMatchAtIndex(SBCompletionResponse self, size_t idx) -> SBCompletionMatch"""
-        return _lldb.SBCompletionResponse_GetMatchAtIndex(self, idx)
-
-
-    def __init__(self):
-        """__init__(lldb::SBCompletionResponse self) -> SBCompletionResponse"""
-        this = _lldb.new_SBCompletionResponse()
-        try:
-            self.this.append(this)
-        except __builtin__.Exception:
-            self.this = this
-    __swig_destroy__ = _lldb.delete_SBCompletionResponse
-    __del__ = lambda self: None
-SBCompletionResponse_swigregister = _lldb.SBCompletionResponse_swigregister
-SBCompletionResponse_swigregister(SBCompletionResponse)
-
-class SBData(_object):
-    """Proxy of C++ lldb::SBData class."""
-
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, SBData, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, SBData, name)
-    __repr__ = _swig_repr
-
-    def __init__(self, *args):
-        """
-        __init__(lldb::SBData self) -> SBData
-        __init__(lldb::SBData self, SBData rhs) -> SBData
-        """
-        this = _lldb.new_SBData(*args)
-        try:
-            self.this.append(this)
-        except __builtin__.Exception:
-            self.this = this
-    __swig_destroy__ = _lldb.delete_SBData
-    __del__ = lambda self: None
-
-    def GetAddressByteSize(self):
-        """GetAddressByteSize(SBData self) -> uint8_t"""
-        return _lldb.SBData_GetAddressByteSize(self)
-
-
-    def SetAddressByteSize(self, addr_byte_size):
-        """SetAddressByteSize(SBData self, uint8_t addr_byte_size)"""
-        return _lldb.SBData_SetAddressByteSize(self, addr_byte_size)
-
-
-    def Clear(self):
-        """Clear(SBData self)"""
-        return _lldb.SBData_Clear(self)
-
-
-    def IsValid(self):
-        """IsValid(SBData self) -> bool"""
-        return _lldb.SBData_IsValid(self)
-
-
-    def __nonzero__(self):
-        return _lldb.SBData___nonzero__(self)
-    __bool__ = __nonzero__
-
-
-
-    def GetByteSize(self):
-        """GetByteSize(SBData self) -> size_t"""
-        return _lldb.SBData_GetByteSize(self)
-
-
-    def GetByteOrder(self):
-        """GetByteOrder(SBData self) -> lldb::ByteOrder"""
-        return _lldb.SBData_GetByteOrder(self)
-
-
-    def SetByteOrder(self, endian):
-        """SetByteOrder(SBData self, lldb::ByteOrder endian)"""
-        return _lldb.SBData_SetByteOrder(self, endian)
-
-
-    def GetFloat(self, error, offset):
-        """GetFloat(SBData self, SBError error, lldb::offset_t offset) -> float"""
-        return _lldb.SBData_GetFloat(self, error, offset)
-
-
-    def GetDouble(self, error, offset):
-        """GetDouble(SBData self, SBError error, lldb::offset_t offset) -> double"""
-        return _lldb.SBData_GetDouble(self, error, offset)
-
-
-    def GetLongDouble(self, error, offset):
-        """GetLongDouble(SBData self, SBError error, lldb::offset_t offset) -> long double"""
-        return _lldb.SBData_GetLongDouble(self, error, offset)
-
-
-    def GetAddress(self, error, offset):
-        """GetAddress(SBData self, SBError error, lldb::offset_t offset) -> lldb::addr_t"""
-        return _lldb.SBData_GetAddress(self, error, offset)
-
-
-    def GetUnsignedInt8(self, error, offset):
-        """GetUnsignedInt8(SBData self, SBError error, lldb::offset_t offset) -> uint8_t"""
-        return _lldb.SBData_GetUnsignedInt8(self, error, offset)
-
-
-    def GetUnsignedInt16(self, error, offset):
-        """GetUnsignedInt16(SBData self, SBError error, lldb::offset_t offset) -> uint16_t"""
-        return _lldb.SBData_GetUnsignedInt16(self, error, offset)
-
-
-    def GetUnsignedInt32(self, error, offset):
-        """GetUnsignedInt32(SBData self, SBError error, lldb::offset_t offset) -> uint32_t"""
-        return _lldb.SBData_GetUnsignedInt32(self, error, offset)
-
-
-    def GetUnsignedInt64(self, error, offset):
-        """GetUnsignedInt64(SBData self, SBError error, lldb::offset_t offset) -> uint64_t"""
-        return _lldb.SBData_GetUnsignedInt64(self, error, offset)
-
-
-    def GetSignedInt8(self, error, offset):
-        """GetSignedInt8(SBData self, SBError error, lldb::offset_t offset) -> int8_t"""
-        return _lldb.SBData_GetSignedInt8(self, error, offset)
-
-
-    def GetSignedInt16(self, error, offset):
-        """GetSignedInt16(SBData self, SBError error, lldb::offset_t offset) -> int16_t"""
-        return _lldb.SBData_GetSignedInt16(self, error, offset)
-
-
-    def GetSignedInt32(self, error, offset):
-        """GetSignedInt32(SBData self, SBError error, lldb::offset_t offset) -> int32_t"""
-        return _lldb.SBData_GetSignedInt32(self, error, offset)
-
-
-    def GetSignedInt64(self, error, offset):
-        """GetSignedInt64(SBData self, SBError error, lldb::offset_t offset) -> int64_t"""
-        return _lldb.SBData_GetSignedInt64(self, error, offset)
-
-
-    def GetString(self, error, offset):
-        """GetString(SBData self, SBError error, lldb::offset_t offset) -> str const *"""
-        return _lldb.SBData_GetString(self, error, offset)
-
-
-    def GetDescription(self, description, base_addr):
-        """GetDescription(SBData self, SBStream description, lldb::addr_t base_addr) -> bool"""
-        return _lldb.SBData_GetDescription(self, description, base_addr)
-
-
-    def ReadRawData(self, error, offset, buf):
-        """ReadRawData(SBData self, SBError error, lldb::offset_t offset, void * buf) -> size_t"""
-        return _lldb.SBData_ReadRawData(self, error, offset, buf)
-
-
-    def SetData(self, error, buf, endian, addr_size):
-        """SetData(SBData self, SBError error, void const * buf, lldb::ByteOrder endian, uint8_t addr_size)"""
-        return _lldb.SBData_SetData(self, error, buf, endian, addr_size)
-
-
-    def Append(self, rhs):
-        """Append(SBData self, SBData rhs) -> bool"""
-        return _lldb.SBData_Append(self, rhs)
-
-
-    def CreateDataFromCString(endian, addr_byte_size, data):
-        """CreateDataFromCString(lldb::ByteOrder endian, uint32_t addr_byte_size, str const * data) -> SBData"""
-        return _lldb.SBData_CreateDataFromCString(endian, addr_byte_size, data)
-
-    CreateDataFromCString = staticmethod(CreateDataFromCString)
-
-    def CreateDataFromUInt64Array(endian, addr_byte_size, array):
-        """CreateDataFromUInt64Array(lldb::ByteOrder endian, uint32_t addr_byte_size, uint64_t * array) -> SBData"""
-        return _lldb.SBData_CreateDataFromUInt64Array(endian, addr_byte_size, array)
-
-    CreateDataFromUInt64Array = staticmethod(CreateDataFromUInt64Array)
-
-    def CreateDataFromUInt32Array(endian, addr_byte_size, array):
-        """CreateDataFromUInt32Array(lldb::ByteOrder endian, uint32_t addr_byte_size, uint32_t * array) -> SBData"""
-        return _lldb.SBData_CreateDataFromUInt32Array(endian, addr_byte_size, array)
-
-    CreateDataFromUInt32Array = staticmethod(CreateDataFromUInt32Array)
-
-    def CreateDataFromSInt64Array(endian, addr_byte_size, array):
-        """CreateDataFromSInt64Array(lldb::ByteOrder endian, uint32_t addr_byte_size, int64_t * array) -> SBData"""
-        return _lldb.SBData_CreateDataFromSInt64Array(endian, addr_byte_size, array)
-
-    CreateDataFromSInt64Array = staticmethod(CreateDataFromSInt64Array)
-
-    def CreateDataFromSInt32Array(endian, addr_byte_size, array):
-        """CreateDataFromSInt32Array(lldb::ByteOrder endian, uint32_t addr_byte_size, int32_t * array) -> SBData"""
-        return _lldb.SBData_CreateDataFromSInt32Array(endian, addr_byte_size, array)
-
-    CreateDataFromSInt32Array = staticmethod(CreateDataFromSInt32Array)
-
-=======
 
     def GetLanguage(self):
         """GetLanguage(SBCompileUnit self) -> lldb::LanguageType"""
@@ -4061,6 +3275,122 @@ class SBData(_object):
 
 SBCompileUnit_swigregister = _lldb.SBCompileUnit_swigregister
 SBCompileUnit_swigregister(SBCompileUnit)
+
+class SBCompletionMatch(_object):
+    """
+
+    Represents a single possible completion.
+
+    """
+
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, SBCompletionMatch, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, SBCompletionMatch, name)
+    __repr__ = _swig_repr
+
+    def GetDisplay(self):
+        """
+        GetDisplay(SBCompletionMatch self) -> char const *
+
+
+        Returns a detailed string describing this completion that is suitable for
+        displaying to a user in a list of completion possibilities. This string
+        is not suitable for inserting into the code because it may contain
+        information about the match (like type information) that doesn't go in
+        code.
+
+        """
+        return _lldb.SBCompletionMatch_GetDisplay(self)
+
+
+    def GetInsertable(self):
+        """
+        GetInsertable(SBCompletionMatch self) -> char const *
+
+
+        Returns a string that can be inserted into the code.
+
+        """
+        return _lldb.SBCompletionMatch_GetInsertable(self)
+
+
+    def __init__(self):
+        """__init__(lldb::SBCompletionMatch self) -> SBCompletionMatch"""
+        this = _lldb.new_SBCompletionMatch()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _lldb.delete_SBCompletionMatch
+    __del__ = lambda self: None
+SBCompletionMatch_swigregister = _lldb.SBCompletionMatch_swigregister
+SBCompletionMatch_swigregister(SBCompletionMatch)
+
+class SBCompletionResponse(_object):
+    """
+
+    Represents a set of completions, or an error describing why completions could
+    not be calculated.
+    """
+
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, SBCompletionResponse, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, SBCompletionResponse, name)
+    __repr__ = _swig_repr
+
+    def GetErrorMessage(self):
+        """
+        GetErrorMessage(SBCompletionResponse self) -> char const *
+
+
+        Return the error message, if any. The length is 0 if and only if the
+        completion calculation was a success.
+
+        """
+        return _lldb.SBCompletionResponse_GetErrorMessage(self)
+
+
+    def GetPrefix(self):
+        """
+        GetPrefix(SBCompletionResponse self) -> char const *
+
+
+        Returns a common prefix of all the matches. This prefix is present in the
+        code for which the completion was requested.
+
+        """
+        return _lldb.SBCompletionResponse_GetPrefix(self)
+
+
+    def GetNumMatches(self):
+        """
+        GetNumMatches(SBCompletionResponse self) -> uint32_t
+
+
+        Returns the number of matches that this response contains.
+
+        """
+        return _lldb.SBCompletionResponse_GetNumMatches(self)
+
+
+    def GetMatchAtIndex(self, idx):
+        """GetMatchAtIndex(SBCompletionResponse self, size_t idx) -> SBCompletionMatch"""
+        return _lldb.SBCompletionResponse_GetMatchAtIndex(self, idx)
+
+
+    def __init__(self):
+        """__init__(lldb::SBCompletionResponse self) -> SBCompletionResponse"""
+        this = _lldb.new_SBCompletionResponse()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _lldb.delete_SBCompletionResponse
+    __del__ = lambda self: None
+SBCompletionResponse_swigregister = _lldb.SBCompletionResponse_swigregister
+SBCompletionResponse_swigregister(SBCompletionResponse)
 
 class SBData(_object):
     """Proxy of C++ lldb::SBData class."""
@@ -4240,7 +3570,6 @@ class SBData(_object):
 
     CreateDataFromSInt32Array = staticmethod(CreateDataFromSInt32Array)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def CreateDataFromDoubleArray(endian, addr_byte_size, array):
         """CreateDataFromDoubleArray(lldb::ByteOrder endian, uint32_t addr_byte_size, double * array) -> SBData"""
         return _lldb.SBData_CreateDataFromDoubleArray(endian, addr_byte_size, array)
@@ -4248,11 +3577,7 @@ class SBData(_object):
     CreateDataFromDoubleArray = staticmethod(CreateDataFromDoubleArray)
 
     def SetDataFromCString(self, data):
-<<<<<<< HEAD
-        """SetDataFromCString(SBData self, str const * data) -> bool"""
-=======
         """SetDataFromCString(SBData self, char const * data) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBData_SetDataFromCString(self, data)
 
 
@@ -4410,76 +3735,6 @@ class SBData(_object):
     def _read_all_double(self):
         return self._make_helper_double().all()
 
-<<<<<<< HEAD
-    __swig_getmethods__["uint8"] = _make_helper_uint8
-    if _newclass: uint8 = property(_make_helper_uint8, None, doc='''A read only property that returns an array-like object out of which you can read uint8 values.''')
-
-    __swig_getmethods__["uint16"] = _make_helper_uint16
-    if _newclass: uint16 = property(_make_helper_uint16, None, doc='''A read only property that returns an array-like object out of which you can read uint16 values.''')
-
-    __swig_getmethods__["uint32"] = _make_helper_uint32
-    if _newclass: uint32 = property(_make_helper_uint32, None, doc='''A read only property that returns an array-like object out of which you can read uint32 values.''')
-
-    __swig_getmethods__["uint64"] = _make_helper_uint64
-    if _newclass: uint64 = property(_make_helper_uint64, None, doc='''A read only property that returns an array-like object out of which you can read uint64 values.''')
-
-    __swig_getmethods__["sint8"] = _make_helper_sint8
-    if _newclass: sint8 = property(_make_helper_sint8, None, doc='''A read only property that returns an array-like object out of which you can read sint8 values.''')
-
-    __swig_getmethods__["sint16"] = _make_helper_sint16
-    if _newclass: sint16 = property(_make_helper_sint16, None, doc='''A read only property that returns an array-like object out of which you can read sint16 values.''')
-
-    __swig_getmethods__["sint32"] = _make_helper_sint32
-    if _newclass: sint32 = property(_make_helper_sint32, None, doc='''A read only property that returns an array-like object out of which you can read sint32 values.''')
-
-    __swig_getmethods__["sint64"] = _make_helper_sint64
-    if _newclass: sint64 = property(_make_helper_sint64, None, doc='''A read only property that returns an array-like object out of which you can read sint64 values.''')
-
-    __swig_getmethods__["float"] = _make_helper_float
-    if _newclass: float = property(_make_helper_float, None, doc='''A read only property that returns an array-like object out of which you can read float values.''')
-
-    __swig_getmethods__["double"] = _make_helper_double
-    if _newclass: double = property(_make_helper_double, None, doc='''A read only property that returns an array-like object out of which you can read double values.''')
-
-    __swig_getmethods__["uint8s"] = _read_all_uint8
-    if _newclass: uint8s = property(_read_all_uint8, None, doc='''A read only property that returns an array with all the contents of this SBData represented as uint8 values.''')
-
-    __swig_getmethods__["uint16s"] = _read_all_uint16
-    if _newclass: uint16s = property(_read_all_uint16, None, doc='''A read only property that returns an array with all the contents of this SBData represented as uint16 values.''')
-
-    __swig_getmethods__["uint32s"] = _read_all_uint32
-    if _newclass: uint32s = property(_read_all_uint32, None, doc='''A read only property that returns an array with all the contents of this SBData represented as uint32 values.''')
-
-    __swig_getmethods__["uint64s"] = _read_all_uint64
-    if _newclass: uint64s = property(_read_all_uint64, None, doc='''A read only property that returns an array with all the contents of this SBData represented as uint64 values.''')
-
-    __swig_getmethods__["sint8s"] = _read_all_sint8
-    if _newclass: sint8s = property(_read_all_sint8, None, doc='''A read only property that returns an array with all the contents of this SBData represented as sint8 values.''')
-
-    __swig_getmethods__["sint16s"] = _read_all_sint16
-    if _newclass: sint16s = property(_read_all_sint16, None, doc='''A read only property that returns an array with all the contents of this SBData represented as sint16 values.''')
-
-    __swig_getmethods__["sint32s"] = _read_all_sint32
-    if _newclass: sint32s = property(_read_all_sint32, None, doc='''A read only property that returns an array with all the contents of this SBData represented as sint32 values.''')
-
-    __swig_getmethods__["sint64s"] = _read_all_sint64
-    if _newclass: sint64s = property(_read_all_sint64, None, doc='''A read only property that returns an array with all the contents of this SBData represented as sint64 values.''')
-
-    __swig_getmethods__["floats"] = _read_all_float
-    if _newclass: floats = property(_read_all_float, None, doc='''A read only property that returns an array with all the contents of this SBData represented as float values.''')
-
-    __swig_getmethods__["doubles"] = _read_all_double
-    if _newclass: doubles = property(_read_all_double, None, doc='''A read only property that returns an array with all the contents of this SBData represented as double values.''')
-
-
-
-    __swig_getmethods__["byte_order"] = GetByteOrder
-    __swig_setmethods__["byte_order"] = SetByteOrder
-    if _newclass: byte_order = property(GetByteOrder, SetByteOrder, doc='''A read/write property getting and setting the endianness of this SBData (data.byte_order = lldb.eByteOrderLittle).''')
-
-    __swig_getmethods__["size"] = GetByteSize
-    if _newclass: size = property(GetByteSize, None, doc='''A read only property that returns the size the same result as GetByteSize().''')
-=======
     uint8 = property(_make_helper_uint8, None, doc='''A read only property that returns an array-like object out of which you can read uint8 values.''')
     uint16 = property(_make_helper_uint16, None, doc='''A read only property that returns an array-like object out of which you can read uint16 values.''')
     uint32 = property(_make_helper_uint32, None, doc='''A read only property that returns an array-like object out of which you can read uint32 values.''')
@@ -4502,8 +3757,6 @@ class SBData(_object):
     doubles = property(_read_all_double, None, doc='''A read only property that returns an array with all the contents of this SBData represented as double values.''')
     byte_order = property(GetByteOrder, SetByteOrder, doc='''A read/write property getting and setting the endianness of this SBData (data.byte_order = lldb.eByteOrderLittle).''')
     size = property(GetByteSize, None, doc='''A read only property that returns the size the same result as GetByteSize().''')
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
-
 
 
     def __str__(self):
@@ -4693,11 +3946,6 @@ class SBDebugger(_object):
 
     MemoryPressureDetected = staticmethod(MemoryPressureDetected)
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumTargets', 'GetTargetAtIndex')
-    def __len__(self): return self.GetNumTargets()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBDebugger self) -> SBDebugger
@@ -4745,7 +3993,6 @@ class SBDebugger(_object):
     def SetInputFileHandle(self, f, transfer_ownership):
         """SetInputFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"""
         return _lldb.SBDebugger_SetInputFileHandle(self, f, transfer_ownership)
-<<<<<<< HEAD
 
 
     def SetOutputFileHandle(self, f, transfer_ownership):
@@ -4757,19 +4004,6 @@ class SBDebugger(_object):
         """SetErrorFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"""
         return _lldb.SBDebugger_SetErrorFileHandle(self, f, transfer_ownership)
 
-=======
-
-
-    def SetOutputFileHandle(self, f, transfer_ownership):
-        """SetOutputFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"""
-        return _lldb.SBDebugger_SetOutputFileHandle(self, f, transfer_ownership)
-
-
-    def SetErrorFileHandle(self, f, transfer_ownership):
-        """SetErrorFileHandle(SBDebugger self, FILE * f, bool transfer_ownership)"""
-        return _lldb.SBDebugger_SetErrorFileHandle(self, f, transfer_ownership)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetInputFileHandle(self):
         """GetInputFileHandle(SBDebugger self) -> FILE *"""
@@ -4792,11 +4026,7 @@ class SBDebugger(_object):
 
 
     def HandleCommand(self, command):
-<<<<<<< HEAD
-        """HandleCommand(SBDebugger self, str const * command)"""
-=======
         """HandleCommand(SBDebugger self, char const * command)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_HandleCommand(self, command)
 
 
@@ -4811,32 +4041,19 @@ class SBDebugger(_object):
 
 
     def CreateTargetWithFileAndTargetTriple(self, filename, target_triple):
-<<<<<<< HEAD
-        """CreateTargetWithFileAndTargetTriple(SBDebugger self, str const * filename, str const * target_triple) -> SBTarget"""
-=======
         """CreateTargetWithFileAndTargetTriple(SBDebugger self, char const * filename, char const * target_triple) -> SBTarget"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_CreateTargetWithFileAndTargetTriple(self, filename, target_triple)
 
 
     def CreateTargetWithFileAndArch(self, filename, archname):
-<<<<<<< HEAD
-        """CreateTargetWithFileAndArch(SBDebugger self, str const * filename, str const * archname) -> SBTarget"""
-=======
         """CreateTargetWithFileAndArch(SBDebugger self, char const * filename, char const * archname) -> SBTarget"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_CreateTargetWithFileAndArch(self, filename, archname)
 
 
     def CreateTarget(self, *args):
         """
-<<<<<<< HEAD
-        CreateTarget(SBDebugger self, str const * filename, str const * target_triple, str const * platform_name, bool add_dependent_modules, SBError sb_error) -> SBTarget
-        CreateTarget(SBDebugger self, str const * filename) -> SBTarget
-=======
         CreateTarget(SBDebugger self, char const * filename, char const * target_triple, char const * platform_name, bool add_dependent_modules, SBError sb_error) -> SBTarget
         CreateTarget(SBDebugger self, char const * filename) -> SBTarget
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBDebugger_CreateTarget(self, *args)
 
@@ -4867,19 +4084,6 @@ class SBDebugger(_object):
     def GetIndexOfTarget(self, target):
         """GetIndexOfTarget(SBDebugger self, SBTarget target) -> uint32_t"""
         return _lldb.SBDebugger_GetIndexOfTarget(self, target)
-<<<<<<< HEAD
-
-
-    def FindTargetWithProcessID(self, pid):
-        """FindTargetWithProcessID(SBDebugger self, lldb::pid_t pid) -> SBTarget"""
-        return _lldb.SBDebugger_FindTargetWithProcessID(self, pid)
-
-
-    def FindTargetWithFileAndArch(self, filename, arch):
-        """FindTargetWithFileAndArch(SBDebugger self, str const * filename, str const * arch) -> SBTarget"""
-        return _lldb.SBDebugger_FindTargetWithFileAndArch(self, filename, arch)
-
-=======
 
 
     def FindTargetWithProcessID(self, pid):
@@ -4891,7 +4095,6 @@ class SBDebugger(_object):
         """FindTargetWithFileAndArch(SBDebugger self, char const * filename, char const * arch) -> SBTarget"""
         return _lldb.SBDebugger_FindTargetWithFileAndArch(self, filename, arch)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetNumTargets(self):
         """GetNumTargets(SBDebugger self) -> uint32_t"""
@@ -4965,20 +4168,12 @@ class SBDebugger(_object):
 
 
     def SetCurrentPlatform(self, platform_name):
-<<<<<<< HEAD
-        """SetCurrentPlatform(SBDebugger self, str const * platform_name) -> SBError"""
-=======
         """SetCurrentPlatform(SBDebugger self, char const * platform_name) -> SBError"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_SetCurrentPlatform(self, platform_name)
 
 
     def SetCurrentPlatformSDKRoot(self, sysroot):
-<<<<<<< HEAD
-        """SetCurrentPlatformSDKRoot(SBDebugger self, str const * sysroot) -> bool"""
-=======
         """SetCurrentPlatformSDKRoot(SBDebugger self, char const * sysroot) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_SetCurrentPlatformSDKRoot(self, sysroot)
 
 
@@ -5003,50 +4198,30 @@ class SBDebugger(_object):
 
 
     def GetDefaultArchitecture(arch_name, arch_name_len):
-<<<<<<< HEAD
-        """GetDefaultArchitecture(str * arch_name, size_t arch_name_len) -> bool"""
-=======
         """GetDefaultArchitecture(char * arch_name, size_t arch_name_len) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetDefaultArchitecture(arch_name, arch_name_len)
 
     GetDefaultArchitecture = staticmethod(GetDefaultArchitecture)
 
     def SetDefaultArchitecture(arch_name):
-<<<<<<< HEAD
-        """SetDefaultArchitecture(str const * arch_name) -> bool"""
-=======
         """SetDefaultArchitecture(char const * arch_name) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_SetDefaultArchitecture(arch_name)
 
     SetDefaultArchitecture = staticmethod(SetDefaultArchitecture)
 
     def GetScriptingLanguage(self, script_language_name):
-<<<<<<< HEAD
-        """GetScriptingLanguage(SBDebugger self, str const * script_language_name) -> lldb::ScriptLanguage"""
-=======
         """GetScriptingLanguage(SBDebugger self, char const * script_language_name) -> lldb::ScriptLanguage"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetScriptingLanguage(self, script_language_name)
 
 
     def GetVersionString():
-<<<<<<< HEAD
-        """GetVersionString() -> str const *"""
-=======
         """GetVersionString() -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetVersionString()
 
     GetVersionString = staticmethod(GetVersionString)
 
     def StateAsCString(state):
-<<<<<<< HEAD
-        """StateAsCString(lldb::StateType state) -> str const *"""
-=======
         """StateAsCString(lldb::StateType state) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_StateAsCString(state)
 
     StateAsCString = staticmethod(StateAsCString)
@@ -5060,19 +4235,6 @@ class SBDebugger(_object):
     def StateIsRunningState(state):
         """StateIsRunningState(lldb::StateType state) -> bool"""
         return _lldb.SBDebugger_StateIsRunningState(state)
-<<<<<<< HEAD
-
-    StateIsRunningState = staticmethod(StateIsRunningState)
-
-    def StateIsStoppedState(state):
-        """StateIsStoppedState(lldb::StateType state) -> bool"""
-        return _lldb.SBDebugger_StateIsStoppedState(state)
-
-    StateIsStoppedState = staticmethod(StateIsStoppedState)
-
-    def EnableLog(self, channel, types):
-        """EnableLog(SBDebugger self, str const * channel, str const ** types) -> bool"""
-=======
 
     StateIsRunningState = staticmethod(StateIsRunningState)
 
@@ -5084,7 +4246,6 @@ class SBDebugger(_object):
 
     def EnableLog(self, channel, types):
         """EnableLog(SBDebugger self, char const * channel, char const ** types) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_EnableLog(self, channel, types)
 
 
@@ -5109,11 +4270,7 @@ class SBDebugger(_object):
 
 
     def GetInstanceName(self):
-<<<<<<< HEAD
-        """GetInstanceName(SBDebugger self) -> str const *"""
-=======
         """GetInstanceName(SBDebugger self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetInstanceName(self)
 
 
@@ -5124,21 +4281,13 @@ class SBDebugger(_object):
     FindDebuggerWithID = staticmethod(FindDebuggerWithID)
 
     def SetInternalVariable(var_name, value, debugger_instance_name):
-<<<<<<< HEAD
-        """SetInternalVariable(str const * var_name, str const * value, str const * debugger_instance_name) -> SBError"""
-=======
         """SetInternalVariable(char const * var_name, char const * value, char const * debugger_instance_name) -> SBError"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_SetInternalVariable(var_name, value, debugger_instance_name)
 
     SetInternalVariable = staticmethod(SetInternalVariable)
 
     def GetInternalVariableValue(var_name, debugger_instance_name):
-<<<<<<< HEAD
-        """GetInternalVariableValue(str const * var_name, str const * debugger_instance_name) -> SBStringList"""
-=======
         """GetInternalVariableValue(char const * var_name, char const * debugger_instance_name) -> SBStringList"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetInternalVariableValue(var_name, debugger_instance_name)
 
     GetInternalVariableValue = staticmethod(GetInternalVariableValue)
@@ -5164,29 +4313,17 @@ class SBDebugger(_object):
 
 
     def GetPrompt(self):
-<<<<<<< HEAD
-        """GetPrompt(SBDebugger self) -> str const *"""
-=======
         """GetPrompt(SBDebugger self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetPrompt(self)
 
 
     def SetPrompt(self, prompt):
-<<<<<<< HEAD
-        """SetPrompt(SBDebugger self, str const * prompt)"""
-=======
         """SetPrompt(SBDebugger self, char const * prompt)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_SetPrompt(self, prompt)
 
 
     def GetReproducerPath(self):
-<<<<<<< HEAD
-        """GetReproducerPath(SBDebugger self) -> str const *"""
-=======
         """GetReproducerPath(SBDebugger self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_GetReproducerPath(self)
 
 
@@ -5212,31 +4349,19 @@ class SBDebugger(_object):
 
     def GetCategory(self, *args):
         """
-<<<<<<< HEAD
-        GetCategory(SBDebugger self, str const * category_name) -> SBTypeCategory
-=======
         GetCategory(SBDebugger self, char const * category_name) -> SBTypeCategory
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         GetCategory(SBDebugger self, lldb::LanguageType lang_type) -> SBTypeCategory
         """
         return _lldb.SBDebugger_GetCategory(self, *args)
 
 
     def CreateCategory(self, category_name):
-<<<<<<< HEAD
-        """CreateCategory(SBDebugger self, str const * category_name) -> SBTypeCategory"""
-=======
         """CreateCategory(SBDebugger self, char const * category_name) -> SBTypeCategory"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_CreateCategory(self, category_name)
 
 
     def DeleteCategory(self, category_name):
-<<<<<<< HEAD
-        """DeleteCategory(SBDebugger self, str const * category_name) -> bool"""
-=======
         """DeleteCategory(SBDebugger self, char const * category_name) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBDebugger_DeleteCategory(self, category_name)
 
 
@@ -5258,34 +4383,6 @@ class SBDebugger(_object):
     def GetFormatForType(self, arg2):
         """GetFormatForType(SBDebugger self, SBTypeNameSpecifier arg2) -> SBTypeFormat"""
         return _lldb.SBDebugger_GetFormatForType(self, arg2)
-<<<<<<< HEAD
-
-
-    def GetSummaryForType(self, arg2):
-        """GetSummaryForType(SBDebugger self, SBTypeNameSpecifier arg2) -> SBTypeSummary"""
-        return _lldb.SBDebugger_GetSummaryForType(self, arg2)
-
-
-    def GetFilterForType(self, arg2):
-        """GetFilterForType(SBDebugger self, SBTypeNameSpecifier arg2) -> SBTypeFilter"""
-        return _lldb.SBDebugger_GetFilterForType(self, arg2)
-
-
-    def GetSyntheticForType(self, arg2):
-        """GetSyntheticForType(SBDebugger self, SBTypeNameSpecifier arg2) -> SBTypeSynthetic"""
-        return _lldb.SBDebugger_GetSyntheticForType(self, arg2)
-
-
-    def RunCommandInterpreter(self, auto_handle_events, spawn_thread, options, num_errors, quit_requested, stopped_for_crash):
-        """RunCommandInterpreter(SBDebugger self, bool auto_handle_events, bool spawn_thread, SBCommandInterpreterRunOptions options, int & num_errors, bool & quit_requested, bool & stopped_for_crash)"""
-        return _lldb.SBDebugger_RunCommandInterpreter(self, auto_handle_events, spawn_thread, options, num_errors, quit_requested, stopped_for_crash)
-
-
-    def RunREPL(self, language, repl_options):
-        """RunREPL(SBDebugger self, lldb::LanguageType language, str const * repl_options) -> SBError"""
-        return _lldb.SBDebugger_RunREPL(self, language, repl_options)
-
-=======
 
 
     def GetSummaryForType(self, arg2):
@@ -5346,7 +4443,6 @@ class SBDebugger(_object):
         '''Return the number of targets in a lldb.SBDebugger object.'''
         return self.GetNumTargets()
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __str__(self):
         """__str__(SBDebugger self) -> PyObject *"""
@@ -5489,19 +4585,6 @@ class SBDeclaration(_object):
     def SetColumn(self, column):
         """SetColumn(SBDeclaration self, uint32_t column)"""
         return _lldb.SBDeclaration_SetColumn(self, column)
-<<<<<<< HEAD
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBDeclaration self, SBDeclaration rhs) -> bool"""
-        return _lldb.SBDeclaration___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBDeclaration self, SBDeclaration rhs) -> bool"""
-        return _lldb.SBDeclaration___ne__(self, rhs)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -5517,7 +4600,6 @@ class SBDeclaration(_object):
     file = property(GetFileSpec, None, doc='''A read only property that returns an lldb object that represents the file (lldb.SBFileSpec) for this line entry.''')
     line = property(GetLine, None, doc='''A read only property that returns the 1 based line number for this line entry, a return value of zero indicates that no line information is available.''')
     column = property(GetColumn, None, doc='''A read only property that returns the 1 based column number for this line entry, a return value of zero indicates that no column information is available.''')
-
 
 
     def __str__(self):
@@ -5609,11 +4691,7 @@ class SBError(_object):
     __del__ = lambda self: None
 
     def GetCString(self):
-<<<<<<< HEAD
-        """GetCString(SBError self) -> str const *"""
-=======
         """GetCString(SBError self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBError_GetCString(self)
 
 
@@ -5658,27 +4736,16 @@ class SBError(_object):
 
 
     def SetErrorString(self, err_str):
-<<<<<<< HEAD
-        """SetErrorString(SBError self, str const * err_str)"""
-=======
         """SetErrorString(SBError self, char const * err_str)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBError_SetErrorString(self, err_str)
 
 
     def SetErrorStringWithFormat(self, format, str1=None, str2=None, str3=None):
         """
-<<<<<<< HEAD
-        SetErrorStringWithFormat(SBError self, str const * format, str * str1=None, str * str2=None, str * str3=None) -> int
-        SetErrorStringWithFormat(SBError self, str const * format, str * str1=None, str * str2=None) -> int
-        SetErrorStringWithFormat(SBError self, str const * format, str * str1=None) -> int
-        SetErrorStringWithFormat(SBError self, str const * format) -> int
-=======
         SetErrorStringWithFormat(SBError self, char const * format, char * str1=None, char * str2=None, char * str3=None) -> int
         SetErrorStringWithFormat(SBError self, char const * format, char * str1=None, char * str2=None) -> int
         SetErrorStringWithFormat(SBError self, char const * format, char * str1=None) -> int
         SetErrorStringWithFormat(SBError self, char const * format) -> int
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBError_SetErrorStringWithFormat(self, format, str1, str2, str3)
 
@@ -5687,20 +4754,6 @@ class SBError(_object):
         """IsValid(SBError self) -> bool"""
         return _lldb.SBError_IsValid(self)
 
-<<<<<<< HEAD
-
-    def __nonzero__(self):
-        return _lldb.SBError___nonzero__(self)
-    __bool__ = __nonzero__
-
-
-
-    def GetDescription(self, description):
-        """GetDescription(SBError self, SBStream description) -> bool"""
-        return _lldb.SBError_GetDescription(self, description)
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __nonzero__(self):
         return _lldb.SBError___nonzero__(self)
@@ -5718,7 +4771,6 @@ class SBError(_object):
     success = property(Success, None, doc='''A read only property that returns the same result as Success().''')
     description = property(GetCString, None, doc='''A read only property that returns the same result as GetCString().''')
     type = property(GetType, None, doc='''A read only property that returns the same result as GetType().''')
-
 
 
     def __str__(self):
@@ -5859,11 +4911,7 @@ class SBEvent(_object):
 
 
     def GetDataFlavor(self):
-<<<<<<< HEAD
-        """GetDataFlavor(SBEvent self) -> str const *"""
-=======
         """GetDataFlavor(SBEvent self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBEvent_GetDataFlavor(self)
 
 
@@ -5878,11 +4926,7 @@ class SBEvent(_object):
 
 
     def GetBroadcasterClass(self):
-<<<<<<< HEAD
-        """GetBroadcasterClass(SBEvent self) -> str const *"""
-=======
         """GetBroadcasterClass(SBEvent self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBEvent_GetBroadcasterClass(self)
 
 
@@ -5897,11 +4941,7 @@ class SBEvent(_object):
 
 
     def GetCStringFromEvent(event):
-<<<<<<< HEAD
-        """GetCStringFromEvent(SBEvent event) -> str const *"""
-=======
         """GetCStringFromEvent(SBEvent event) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBEvent_GetCStringFromEvent(event)
 
     GetCStringFromEvent = staticmethod(GetCStringFromEvent)
@@ -5962,26 +5002,11 @@ class SBExecutionContext(_object):
         """GetFrame(SBExecutionContext self) -> SBFrame"""
         return _lldb.SBExecutionContext_GetFrame(self)
 
-<<<<<<< HEAD
-
-    __swig_getmethods__["target"] = GetTarget
-    if _newclass: target = property(GetTarget, None, doc='''A read only property that returns the same result as GetTarget().''')
-
-    __swig_getmethods__["process"] = GetProcess
-    if _newclass: process = property(GetProcess, None, doc='''A read only property that returns the same result as GetProcess().''')
-
-    __swig_getmethods__["thread"] = GetThread
-    if _newclass: thread = property(GetThread, None, doc='''A read only property that returns the same result as GetThread().''')
-
-    __swig_getmethods__["frame"] = GetFrame
-    if _newclass: frame = property(GetFrame, None, doc='''A read only property that returns the same result as GetFrame().''')
-=======
 
     target = property(GetTarget, None, doc='''A read only property that returns the same result as GetTarget().''')
     process = property(GetProcess, None, doc='''A read only property that returns the same result as GetProcess().''')
     thread = property(GetThread, None, doc='''A read only property that returns the same result as GetThread().''')
     frame = property(GetFrame, None, doc='''A read only property that returns the same result as GetFrame().''')
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 SBExecutionContext_swigregister = _lldb.SBExecutionContext_swigregister
 SBExecutionContext_swigregister(SBExecutionContext)
@@ -6202,11 +5227,7 @@ class SBExpressionOptions(_object):
 
     def GetPrefix(self):
         """
-<<<<<<< HEAD
-        GetPrefix(SBExpressionOptions self) -> str const *
-=======
         GetPrefix(SBExpressionOptions self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         Gets the prefix to use for this expression.
         """
@@ -6215,11 +5236,7 @@ class SBExpressionOptions(_object):
 
     def SetPrefix(self, prefix):
         """
-<<<<<<< HEAD
-        SetPrefix(SBExpressionOptions self, str const * prefix)
-=======
         SetPrefix(SBExpressionOptions self, char const * prefix)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         Sets the prefix to use for this expression. This prefix gets inserted after the 'target.expr-prefix' prefix contents, but before the wrapped expression function body.
         """
@@ -6307,22 +5324,12 @@ class SBFileSpec(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBFileSpec, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __eq__(self, other): return isinstance(other, SBFileSpec) and self.GetFilename() == other.GetFilename() and self.GetDirectory() == other.GetDirectory()
-    def __ne__(self, other): return not self.__eq__(other)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBFileSpec self) -> SBFileSpec
         __init__(lldb::SBFileSpec self, SBFileSpec rhs) -> SBFileSpec
-<<<<<<< HEAD
-        __init__(lldb::SBFileSpec self, str const * path) -> SBFileSpec
-        __init__(lldb::SBFileSpec self, str const * path, bool resolve) -> SBFileSpec
-=======
         __init__(lldb::SBFileSpec self, char const * path) -> SBFileSpec
         __init__(lldb::SBFileSpec self, char const * path, bool resolve) -> SBFileSpec
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         this = _lldb.new_SBFileSpec(*args)
         try:
@@ -6332,8 +5339,6 @@ class SBFileSpec(_object):
     __swig_destroy__ = _lldb.delete_SBFileSpec
     __del__ = lambda self: None
 
-<<<<<<< HEAD
-=======
     def __eq__(self, rhs):
         """__eq__(SBFileSpec self, SBFileSpec rhs) -> bool"""
         return _lldb.SBFileSpec___eq__(self, rhs)
@@ -6344,7 +5349,6 @@ class SBFileSpec(_object):
         return _lldb.SBFileSpec___ne__(self, rhs)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def IsValid(self):
         """IsValid(SBFileSpec self) -> bool"""
         return _lldb.SBFileSpec_IsValid(self)
@@ -6367,46 +5371,21 @@ class SBFileSpec(_object):
 
 
     def GetFilename(self):
-<<<<<<< HEAD
-        """GetFilename(SBFileSpec self) -> str const *"""
-=======
         """GetFilename(SBFileSpec self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFileSpec_GetFilename(self)
 
 
     def GetDirectory(self):
-<<<<<<< HEAD
-        """GetDirectory(SBFileSpec self) -> str const *"""
-=======
         """GetDirectory(SBFileSpec self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFileSpec_GetDirectory(self)
 
 
     def SetFilename(self, filename):
-<<<<<<< HEAD
-        """SetFilename(SBFileSpec self, str const * filename)"""
-=======
         """SetFilename(SBFileSpec self, char const * filename)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFileSpec_SetFilename(self, filename)
 
 
     def SetDirectory(self, directory):
-<<<<<<< HEAD
-        """SetDirectory(SBFileSpec self, str const * directory)"""
-        return _lldb.SBFileSpec_SetDirectory(self, directory)
-
-
-    def GetPath(self, dst_path, dst_len):
-        """GetPath(SBFileSpec self, str * dst_path, size_t dst_len) -> uint32_t"""
-        return _lldb.SBFileSpec_GetPath(self, dst_path, dst_len)
-
-
-    def ResolvePath(src_path, dst_path, dst_len):
-        """ResolvePath(str const * src_path, str * dst_path, size_t dst_len) -> int"""
-=======
         """SetDirectory(SBFileSpec self, char const * directory)"""
         return _lldb.SBFileSpec_SetDirectory(self, directory)
 
@@ -6418,7 +5397,6 @@ class SBFileSpec(_object):
 
     def ResolvePath(src_path, dst_path, dst_len):
         """ResolvePath(char const * src_path, char * dst_path, size_t dst_len) -> int"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFileSpec_ResolvePath(src_path, dst_path, dst_len)
 
     ResolvePath = staticmethod(ResolvePath)
@@ -6429,11 +5407,7 @@ class SBFileSpec(_object):
 
 
     def AppendPathComponent(self, file_or_directory):
-<<<<<<< HEAD
-        """AppendPathComponent(SBFileSpec self, str const * file_or_directory)"""
-=======
         """AppendPathComponent(SBFileSpec self, char const * file_or_directory)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFileSpec_AppendPathComponent(self, file_or_directory)
 
 
@@ -6452,7 +5426,6 @@ class SBFileSpec(_object):
     basename = property(GetFilename, None, doc='''A read only property that returns the path basename as a python string.''')
     dirname = property(GetDirectory, None, doc='''A read only property that returns the path directory name as a python string.''')
     exists = property(Exists, None, doc='''A read only property that returns a boolean value that indicates if the file exists.''')
-
 
 
     def __str__(self):
@@ -6680,23 +5653,14 @@ class SBFrame(_object):
 
 
     def GetDisplayFunctionName(self):
-<<<<<<< HEAD
-        """GetDisplayFunctionName(SBFrame self) -> str const *"""
-=======
         """GetDisplayFunctionName(SBFrame self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFrame_GetDisplayFunctionName(self)
 
 
     def GetFunctionName(self, *args):
         """
-<<<<<<< HEAD
-        GetFunctionName(SBFrame self) -> str const
-        GetFunctionName(SBFrame self) -> str const *
-=======
         GetFunctionName(SBFrame self) -> char const
         GetFunctionName(SBFrame self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Get the appropriate function name for this frame. Inlined functions in
@@ -6761,17 +5725,10 @@ class SBFrame(_object):
 
     def EvaluateExpression(self, *args):
         """
-<<<<<<< HEAD
-        EvaluateExpression(SBFrame self, str const * expr) -> SBValue
-        EvaluateExpression(SBFrame self, str const * expr, lldb::DynamicValueType use_dynamic) -> SBValue
-        EvaluateExpression(SBFrame self, str const * expr, lldb::DynamicValueType use_dynamic, bool unwind_on_error) -> SBValue
-        EvaluateExpression(SBFrame self, str const * expr, SBExpressionOptions options) -> SBValue
-=======
         EvaluateExpression(SBFrame self, char const * expr) -> SBValue
         EvaluateExpression(SBFrame self, char const * expr, lldb::DynamicValueType use_dynamic) -> SBValue
         EvaluateExpression(SBFrame self, char const * expr, lldb::DynamicValueType use_dynamic, bool unwind_on_error) -> SBValue
         EvaluateExpression(SBFrame self, char const * expr, SBExpressionOptions options) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         The version that doesn't supply a 'use_dynamic' value will use the
@@ -6812,11 +5769,7 @@ class SBFrame(_object):
 
 
     def Disassemble(self):
-<<<<<<< HEAD
-        """Disassemble(SBFrame self) -> str const *"""
-=======
         """Disassemble(SBFrame self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFrame_Disassemble(self)
 
 
@@ -6825,8 +5778,6 @@ class SBFrame(_object):
         return _lldb.SBFrame_Clear(self)
 
 
-<<<<<<< HEAD
-=======
     def __eq__(self, rhs):
         """__eq__(SBFrame self, SBFrame rhs) -> bool"""
         return _lldb.SBFrame___eq__(self, rhs)
@@ -6837,7 +5788,6 @@ class SBFrame(_object):
         return _lldb.SBFrame___ne__(self, rhs)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetVariables(self, *args):
         """
         GetVariables(SBFrame self, bool arguments, bool locals, bool statics, bool in_scope_only) -> SBValueList
@@ -6858,13 +5808,8 @@ class SBFrame(_object):
 
     def FindVariable(self, *args):
         """
-<<<<<<< HEAD
-        FindVariable(SBFrame self, str const * var_name) -> SBValue
-        FindVariable(SBFrame self, str const * var_name, lldb::DynamicValueType use_dynamic) -> SBValue
-=======
         FindVariable(SBFrame self, char const * var_name) -> SBValue
         FindVariable(SBFrame self, char const * var_name, lldb::DynamicValueType use_dynamic) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         The version that doesn't supply a 'use_dynamic' value will use the
@@ -6874,27 +5819,17 @@ class SBFrame(_object):
 
 
     def FindRegister(self, name):
-<<<<<<< HEAD
-        """FindRegister(SBFrame self, str const * name) -> SBValue"""
-=======
         """FindRegister(SBFrame self, char const * name) -> SBValue"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFrame_FindRegister(self, name)
 
 
     def GetValueForVariablePath(self, *args):
         """
-<<<<<<< HEAD
-        GetValueForVariablePath(SBFrame self, str const * var_path) -> SBValue
-        GetValueForVariablePath(SBFrame self, str const * var_path, lldb::DynamicValueType use_dynamic) -> SBValue
-
-=======
         GetValueForVariablePath(SBFrame self, char const * var_path) -> SBValue
         GetValueForVariablePath(SBFrame self, char const * var_path, lldb::DynamicValueType use_dynamic) -> SBValue
 
 
         Get a lldb.SBValue for a variable path.
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         Variable paths can include access to pointer or instance members:
             rect_ptr->origin.y
@@ -6920,13 +5855,8 @@ class SBFrame(_object):
 
     def FindValue(self, *args):
         """
-<<<<<<< HEAD
-        FindValue(SBFrame self, str const * name, lldb::ValueType value_type) -> SBValue
-        FindValue(SBFrame self, str const * name, lldb::ValueType value_type, lldb::DynamicValueType use_dynamic) -> SBValue
-=======
         FindValue(SBFrame self, char const * name, lldb::ValueType value_type) -> SBValue
         FindValue(SBFrame self, char const * name, lldb::ValueType value_type, lldb::DynamicValueType use_dynamic) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find variables, register sets, registers, or persistent variables using
@@ -7013,7 +5943,6 @@ class SBFrame(_object):
     parent = property(get_parent_frame, None, doc='''A read only property that returns the parent (caller) frame of the current frame.''')
 
 
-
     def __str__(self):
         """__str__(SBFrame self) -> PyObject *"""
         return _lldb.SBFrame___str__(self)
@@ -7088,40 +6017,24 @@ class SBFunction(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBFunction self) -> str const *"""
-=======
         """GetName(SBFunction self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFunction_GetName(self)
 
 
     def GetDisplayName(self):
-<<<<<<< HEAD
-        """GetDisplayName(SBFunction self) -> str const *"""
-=======
         """GetDisplayName(SBFunction self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFunction_GetDisplayName(self)
 
 
     def GetMangledName(self):
-<<<<<<< HEAD
-        """GetMangledName(SBFunction self) -> str const *"""
-=======
         """GetMangledName(SBFunction self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFunction_GetMangledName(self)
 
 
     def GetInstructions(self, *args):
         """
         GetInstructions(SBFunction self, SBTarget target) -> SBInstructionList
-<<<<<<< HEAD
-        GetInstructions(SBFunction self, SBTarget target, str const * flavor) -> SBInstructionList
-=======
         GetInstructions(SBFunction self, SBTarget target, char const * flavor) -> SBInstructionList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBFunction_GetInstructions(self, *args)
 
@@ -7137,11 +6050,7 @@ class SBFunction(_object):
 
 
     def GetArgumentName(self, arg_idx):
-<<<<<<< HEAD
-        """GetArgumentName(SBFunction self, uint32_t arg_idx) -> str const *"""
-=======
         """GetArgumentName(SBFunction self, uint32_t arg_idx) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBFunction_GetArgumentName(self, arg_idx)
 
 
@@ -7184,7 +6093,6 @@ class SBFunction(_object):
         """GetCanThrow(SBFunction self) -> bool"""
         return _lldb.SBFunction_GetCanThrow(self)
 
-<<<<<<< HEAD
 
     def GetDescription(self, description):
         """GetDescription(SBFunction self, SBStream description) -> bool"""
@@ -7195,31 +6103,6 @@ class SBFunction(_object):
         """__eq__(SBFunction self, SBFunction rhs) -> bool"""
         return _lldb.SBFunction___eq__(self, rhs)
 
-
-    def __ne__(self, rhs):
-        """__ne__(SBFunction self, SBFunction rhs) -> bool"""
-        return _lldb.SBFunction___ne__(self, rhs)
-
-=======
-
-    def GetDescription(self, description):
-        """GetDescription(SBFunction self, SBStream description) -> bool"""
-        return _lldb.SBFunction_GetDescription(self, description)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBFunction self, SBFunction rhs) -> bool"""
-        return _lldb.SBFunction___eq__(self, rhs)
-
-<<<<<<< HEAD
-    __swig_getmethods__["end_addr"] = GetEndAddress
-    if _newclass: end_addr = property(GetEndAddress, None, doc='''A read only property that returns an lldb object that represents the end address (lldb.SBAddress) for this function.''')
-
-    __swig_getmethods__["block"] = GetBlock
-    if _newclass: block = property(GetBlock, None, doc='''A read only property that returns an lldb object that represents the top level lexical block (lldb.SBBlock) for this function.''')
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __ne__(self, rhs):
         """__ne__(SBFunction self, SBFunction rhs) -> bool"""
@@ -7237,7 +6120,6 @@ class SBFunction(_object):
     name = property(GetName, None, doc='''A read only property that returns the name for this function as a string.''')
     prologue_size = property(GetPrologueByteSize, None, doc='''A read only property that returns the size in bytes of the prologue instructions as an unsigned integer.''')
     type = property(GetType, None, doc='''A read only property that returns an lldb object that represents the return type (lldb.SBType) for this function.''')
-
 
 
     def __str__(self):
@@ -7294,21 +6176,13 @@ class SBHostOS(_object):
     GetUserHomeDirectory = staticmethod(GetUserHomeDirectory)
 
     def ThreadCreated(name):
-<<<<<<< HEAD
-        """ThreadCreated(str const * name)"""
-=======
         """ThreadCreated(char const * name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBHostOS_ThreadCreated(name)
 
     ThreadCreated = staticmethod(ThreadCreated)
 
     def ThreadCreate(name, arg2, thread_arg, err):
-<<<<<<< HEAD
-        """ThreadCreate(str const * name, lldb::thread_func_t arg2, void * thread_arg, SBError err) -> lldb::thread_t"""
-=======
         """ThreadCreate(char const * name, lldb::thread_func_t arg2, void * thread_arg, SBError err) -> lldb::thread_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBHostOS_ThreadCreate(name, arg2, thread_arg, err)
 
     ThreadCreate = staticmethod(ThreadCreate)
@@ -7418,26 +6292,11 @@ class SBInstruction(_object):
 
 
     def GetMnemonic(self, target):
-<<<<<<< HEAD
-        """GetMnemonic(SBInstruction self, SBTarget target) -> str const *"""
-=======
         """GetMnemonic(SBInstruction self, SBTarget target) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBInstruction_GetMnemonic(self, target)
 
 
     def GetOperands(self, target):
-<<<<<<< HEAD
-        """GetOperands(SBInstruction self, SBTarget target) -> str const *"""
-        return _lldb.SBInstruction_GetOperands(self, target)
-
-
-    def GetComment(self, target):
-        """GetComment(SBInstruction self, SBTarget target) -> str const *"""
-        return _lldb.SBInstruction_GetComment(self, target)
-
-
-=======
         """GetOperands(SBInstruction self, SBTarget target) -> char const *"""
         return _lldb.SBInstruction_GetOperands(self, target)
 
@@ -7447,7 +6306,6 @@ class SBInstruction(_object):
         return _lldb.SBInstruction_GetComment(self, target)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetData(self, target):
         """GetData(SBInstruction self, SBTarget target) -> SBData"""
         return _lldb.SBInstruction_GetData(self, target)
@@ -7477,21 +6335,6 @@ class SBInstruction(_object):
         """Print(SBInstruction self, FILE * out)"""
         return _lldb.SBInstruction_Print(self, out)
 
-<<<<<<< HEAD
-
-    def GetDescription(self, description):
-        """GetDescription(SBInstruction self, SBStream description) -> bool"""
-        return _lldb.SBInstruction_GetDescription(self, description)
-
-
-    def EmulateWithFrame(self, frame, evaluate_options):
-        """EmulateWithFrame(SBInstruction self, SBFrame frame, uint32_t evaluate_options) -> bool"""
-        return _lldb.SBInstruction_EmulateWithFrame(self, frame, evaluate_options)
-
-
-    def DumpEmulation(self, triple):
-        """DumpEmulation(SBInstruction self, str const * triple) -> bool"""
-=======
 
     def GetDescription(self, description):
         """GetDescription(SBInstruction self, SBStream description) -> bool"""
@@ -7505,16 +6348,11 @@ class SBInstruction(_object):
 
     def DumpEmulation(self, triple):
         """DumpEmulation(SBInstruction self, char const * triple) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBInstruction_DumpEmulation(self, triple)
 
 
     def TestEmulation(self, output_stream, test_file):
-<<<<<<< HEAD
-        """TestEmulation(SBInstruction self, SBStream output_stream, str const * test_file) -> bool"""
-=======
         """TestEmulation(SBInstruction self, SBStream output_stream, char const * test_file) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBInstruction_TestEmulation(self, output_stream, test_file)
 
 
@@ -7535,7 +6373,6 @@ class SBInstruction(_object):
     addr = property(GetAddress, None, doc='''A read only property that returns an lldb object that represents the address (lldb.SBAddress) for this instruction.''')
     size = property(GetByteSize, None, doc='''A read only property that returns the size in bytes for this instruction as an integer.''')
     is_branch = property(DoesBranch, None, doc='''A read only property that returns a boolean value that indicates if this instruction is a branch instruction.''')
-
 
 
     def __str__(self):
@@ -7567,11 +6404,6 @@ class SBInstructionList(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBInstructionList, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetSize', 'GetInstructionAtIndex')
-    def __len__(self): return self.GetSize()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBInstructionList self) -> SBInstructionList
@@ -7619,7 +6451,6 @@ class SBInstructionList(_object):
     def AppendInstruction(self, inst):
         """AppendInstruction(SBInstructionList self, SBInstruction inst)"""
         return _lldb.SBInstructionList_AppendInstruction(self, inst)
-<<<<<<< HEAD
 
 
     def Print(self, out):
@@ -7627,26 +6458,12 @@ class SBInstructionList(_object):
         return _lldb.SBInstructionList_Print(self, out)
 
 
-=======
-
-
-    def Print(self, out):
-        """Print(SBInstructionList self, FILE * out)"""
-        return _lldb.SBInstructionList_Print(self, out)
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetDescription(self, description):
         """GetDescription(SBInstructionList self, SBStream description) -> bool"""
         return _lldb.SBInstructionList_GetDescription(self, description)
 
 
     def DumpEmulationForAllInstructions(self, triple):
-<<<<<<< HEAD
-        """DumpEmulationForAllInstructions(SBInstructionList self, str const * triple) -> bool"""
-        return _lldb.SBInstructionList_DumpEmulationForAllInstructions(self, triple)
-
-=======
         """DumpEmulationForAllInstructions(SBInstructionList self, char const * triple) -> bool"""
         return _lldb.SBInstructionList_DumpEmulationForAllInstructions(self, triple)
 
@@ -7655,7 +6472,6 @@ class SBInstructionList(_object):
         '''Iterate over all instructions in a lldb.SBInstructionList
         object.'''
         return lldb_iter(self, 'GetSize', 'GetInstructionAtIndex')
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __len__(self):
         '''Access len of the instruction list.'''
@@ -7683,7 +6499,6 @@ class SBInstructionList(_object):
         return None
 
 
-
     def __str__(self):
         """__str__(SBInstructionList self) -> PyObject *"""
         return _lldb.SBInstructionList___str__(self)
@@ -7701,21 +6516,13 @@ class SBLanguageRuntime(_object):
     __repr__ = _swig_repr
 
     def GetLanguageTypeFromString(string):
-<<<<<<< HEAD
-        """GetLanguageTypeFromString(str const * string) -> lldb::LanguageType"""
-=======
         """GetLanguageTypeFromString(char const * string) -> lldb::LanguageType"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLanguageRuntime_GetLanguageTypeFromString(string)
 
     GetLanguageTypeFromString = staticmethod(GetLanguageTypeFromString)
 
     def GetNameForLanguageType(language):
-<<<<<<< HEAD
-        """GetNameForLanguageType(lldb::LanguageType language) -> str const *"""
-=======
         """GetNameForLanguageType(lldb::LanguageType language) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLanguageRuntime_GetNameForLanguageType(language)
 
     GetNameForLanguageType = staticmethod(GetNameForLanguageType)
@@ -7750,11 +6557,7 @@ class SBLaunchInfo(_object):
     __repr__ = _swig_repr
 
     def __init__(self, argv):
-<<<<<<< HEAD
-        """__init__(lldb::SBLaunchInfo self, str const ** argv) -> SBLaunchInfo"""
-=======
         """__init__(lldb::SBLaunchInfo self, char const ** argv) -> SBLaunchInfo"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         this = _lldb.new_SBLaunchInfo(argv)
         try:
             self.this.append(this)
@@ -7822,20 +6625,12 @@ class SBLaunchInfo(_object):
 
 
     def GetArgumentAtIndex(self, idx):
-<<<<<<< HEAD
-        """GetArgumentAtIndex(SBLaunchInfo self, uint32_t idx) -> str const *"""
-=======
         """GetArgumentAtIndex(SBLaunchInfo self, uint32_t idx) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_GetArgumentAtIndex(self, idx)
 
 
     def SetArguments(self, argv, append):
-<<<<<<< HEAD
-        """SetArguments(SBLaunchInfo self, str const ** argv, bool append)"""
-=======
         """SetArguments(SBLaunchInfo self, char const ** argv, bool append)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_SetArguments(self, argv, append)
 
 
@@ -7845,20 +6640,12 @@ class SBLaunchInfo(_object):
 
 
     def GetEnvironmentEntryAtIndex(self, idx):
-<<<<<<< HEAD
-        """GetEnvironmentEntryAtIndex(SBLaunchInfo self, uint32_t idx) -> str const *"""
-=======
         """GetEnvironmentEntryAtIndex(SBLaunchInfo self, uint32_t idx) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_GetEnvironmentEntryAtIndex(self, idx)
 
 
     def SetEnvironmentEntries(self, envp, append):
-<<<<<<< HEAD
-        """SetEnvironmentEntries(SBLaunchInfo self, str const ** envp, bool append)"""
-=======
         """SetEnvironmentEntries(SBLaunchInfo self, char const ** envp, bool append)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_SetEnvironmentEntries(self, envp, append)
 
 
@@ -7868,20 +6655,12 @@ class SBLaunchInfo(_object):
 
 
     def GetWorkingDirectory(self):
-<<<<<<< HEAD
-        """GetWorkingDirectory(SBLaunchInfo self) -> str const *"""
-=======
         """GetWorkingDirectory(SBLaunchInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_GetWorkingDirectory(self)
 
 
     def SetWorkingDirectory(self, working_dir):
-<<<<<<< HEAD
-        """SetWorkingDirectory(SBLaunchInfo self, str const * working_dir)"""
-=======
         """SetWorkingDirectory(SBLaunchInfo self, char const * working_dir)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_SetWorkingDirectory(self, working_dir)
 
 
@@ -7896,38 +6675,22 @@ class SBLaunchInfo(_object):
 
 
     def GetProcessPluginName(self):
-<<<<<<< HEAD
-        """GetProcessPluginName(SBLaunchInfo self) -> str const *"""
-=======
         """GetProcessPluginName(SBLaunchInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_GetProcessPluginName(self)
 
 
     def SetProcessPluginName(self, plugin_name):
-<<<<<<< HEAD
-        """SetProcessPluginName(SBLaunchInfo self, str const * plugin_name)"""
-=======
         """SetProcessPluginName(SBLaunchInfo self, char const * plugin_name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_SetProcessPluginName(self, plugin_name)
 
 
     def GetShell(self):
-<<<<<<< HEAD
-        """GetShell(SBLaunchInfo self) -> str const *"""
-=======
         """GetShell(SBLaunchInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_GetShell(self)
 
 
     def SetShell(self, path):
-<<<<<<< HEAD
-        """SetShell(SBLaunchInfo self, str const * path)"""
-=======
         """SetShell(SBLaunchInfo self, char const * path)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_SetShell(self, path)
 
 
@@ -7962,11 +6725,7 @@ class SBLaunchInfo(_object):
 
 
     def AddOpenFileAction(self, fd, path, read, write):
-<<<<<<< HEAD
-        """AddOpenFileAction(SBLaunchInfo self, int fd, str const * path, bool read, bool write) -> bool"""
-=======
         """AddOpenFileAction(SBLaunchInfo self, int fd, char const * path, bool read, bool write) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_AddOpenFileAction(self, fd, path, read, write)
 
 
@@ -7976,20 +6735,12 @@ class SBLaunchInfo(_object):
 
 
     def SetLaunchEventData(self, data):
-<<<<<<< HEAD
-        """SetLaunchEventData(SBLaunchInfo self, str const * data)"""
-=======
         """SetLaunchEventData(SBLaunchInfo self, char const * data)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_SetLaunchEventData(self, data)
 
 
     def GetLaunchEventData(self):
-<<<<<<< HEAD
-        """GetLaunchEventData(SBLaunchInfo self) -> str const *"""
-=======
         """GetLaunchEventData(SBLaunchInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBLaunchInfo_GetLaunchEventData(self)
 
 
@@ -8110,19 +6861,6 @@ class SBLineEntry(_object):
     def SetColumn(self, column):
         """SetColumn(SBLineEntry self, uint32_t column)"""
         return _lldb.SBLineEntry_SetColumn(self, column)
-<<<<<<< HEAD
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBLineEntry self, SBLineEntry rhs) -> bool"""
-        return _lldb.SBLineEntry___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBLineEntry self, SBLineEntry rhs) -> bool"""
-        return _lldb.SBLineEntry___ne__(self, rhs)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -8140,7 +6878,6 @@ class SBLineEntry(_object):
     column = property(GetColumn, None, doc='''A read only property that returns the 1 based column number for this line entry, a return value of zero indicates that no column information is available.''')
     addr = property(GetStartAddress, None, doc='''A read only property that returns an lldb object that represents the start address (lldb.SBAddress) for this line entry.''')
     end_addr = property(GetEndAddress, None, doc='''A read only property that returns an lldb object that represents the end address (lldb.SBAddress) for this line entry.''')
-
 
 
     def __str__(self):
@@ -8179,11 +6916,7 @@ class SBListener(_object):
     def __init__(self, *args):
         """
         __init__(lldb::SBListener self) -> SBListener
-<<<<<<< HEAD
-        __init__(lldb::SBListener self, str const * name) -> SBListener
-=======
         __init__(lldb::SBListener self, char const * name) -> SBListener
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBListener self, SBListener rhs) -> SBListener
         """
         this = _lldb.new_SBListener(*args)
@@ -8216,20 +6949,12 @@ class SBListener(_object):
 
 
     def StartListeningForEventClass(self, debugger, broadcaster_class, event_mask):
-<<<<<<< HEAD
-        """StartListeningForEventClass(SBListener self, SBDebugger debugger, str const * broadcaster_class, uint32_t event_mask) -> uint32_t"""
-=======
         """StartListeningForEventClass(SBListener self, SBDebugger debugger, char const * broadcaster_class, uint32_t event_mask) -> uint32_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBListener_StartListeningForEventClass(self, debugger, broadcaster_class, event_mask)
 
 
     def StopListeningForEventClass(self, debugger, broadcaster_class, event_mask):
-<<<<<<< HEAD
-        """StopListeningForEventClass(SBListener self, SBDebugger debugger, str const * broadcaster_class, uint32_t event_mask) -> uint32_t"""
-=======
         """StopListeningForEventClass(SBListener self, SBDebugger debugger, char const * broadcaster_class, uint32_t event_mask) -> uint32_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBListener_StopListeningForEventClass(self, debugger, broadcaster_class, event_mask)
 
 
@@ -8353,11 +7078,7 @@ class SBMemoryRegionInfo(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBMemoryRegionInfo self) -> str const *"""
-=======
         """GetName(SBMemoryRegionInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBMemoryRegionInfo_GetName(self)
 
 
@@ -8540,23 +7261,6 @@ class SBModule(_object):
     __swig_getmethods__ = {}
     __getattr__ = lambda self, name: _swig_getattr(self, SBModule, name)
     __repr__ = _swig_repr
-<<<<<<< HEAD
-
-    def __iter__(self): return lldb_iter(self, 'GetNumSymbols', 'GetSymbolAtIndex')
-    def __len__(self): return self.GetNumSymbols()
-    def __eq__(self, other): return isinstance(other, SBModule) and self.GetFileSpec() == other.GetFileSpec() and self.GetUUIDString() == other.GetUUIDString()
-    def __ne__(self, other): return not self.__eq__(other)
-    def section_iter(self): return lldb_iter(self, 'GetNumSections', 'GetSectionAtIndex')
-    def compile_unit_iter(self): return lldb_iter(self, 'GetNumCompileUnits', 'GetCompileUnitAtIndex')
-
-    def symbol_in_section_iter(self, section):
-        """Given a module and its contained section, returns an iterator on the
-        symbols within the section."""
-        for sym in self:
-            if in_range(sym, section):
-                yield sym
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __init__(self, *args):
         """
@@ -8645,24 +7349,13 @@ class SBModule(_object):
 
     def GetUUIDString(self):
         """
-<<<<<<< HEAD
-        GetUUIDString(SBModule self) -> str const *
-=======
         GetUUIDString(SBModule self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         Returns the UUID of the module as a Python string.
         """
         return _lldb.SBModule_GetUUIDString(self)
 
 
-<<<<<<< HEAD
-    def FindSection(self, sect_name):
-        """FindSection(SBModule self, str const * sect_name) -> SBSection"""
-        return _lldb.SBModule_FindSection(self, sect_name)
-
-
-=======
     def __eq__(self, rhs):
         """__eq__(SBModule self, SBModule rhs) -> bool"""
         return _lldb.SBModule___eq__(self, rhs)
@@ -8678,7 +7371,6 @@ class SBModule(_object):
         return _lldb.SBModule_FindSection(self, sect_name)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def ResolveFileAddress(self, vm_addr):
         """ResolveFileAddress(SBModule self, lldb::addr_t vm_addr) -> SBAddress"""
         return _lldb.SBModule_ResolveFileAddress(self, vm_addr)
@@ -8735,26 +7427,16 @@ class SBModule(_object):
 
     def FindSymbol(self, *args):
         """
-<<<<<<< HEAD
-        FindSymbol(SBModule self, str const * name, lldb::SymbolType type) -> SBSymbol
-        FindSymbol(SBModule self, str const * name) -> SBSymbol
-=======
         FindSymbol(SBModule self, char const * name, lldb::SymbolType type) -> SBSymbol
         FindSymbol(SBModule self, char const * name) -> SBSymbol
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBModule_FindSymbol(self, *args)
 
 
     def FindSymbols(self, *args):
         """
-<<<<<<< HEAD
-        FindSymbols(SBModule self, str const * name, lldb::SymbolType type) -> SBSymbolContextList
-        FindSymbols(SBModule self, str const * name) -> SBSymbolContextList
-=======
         FindSymbols(SBModule self, char const * name, lldb::SymbolType type) -> SBSymbolContextList
         FindSymbols(SBModule self, char const * name) -> SBSymbolContextList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBModule_FindSymbols(self, *args)
 
@@ -8771,13 +7453,8 @@ class SBModule(_object):
 
     def FindFunctions(self, *args):
         """
-<<<<<<< HEAD
-        FindFunctions(SBModule self, str const * name, uint32_t name_type_mask) -> SBSymbolContextList
-        FindFunctions(SBModule self, str const * name) -> SBSymbolContextList
-=======
         FindFunctions(SBModule self, char const * name, uint32_t name_type_mask) -> SBSymbolContextList
         FindFunctions(SBModule self, char const * name) -> SBSymbolContextList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find functions by name.
@@ -8800,20 +7477,12 @@ class SBModule(_object):
 
 
     def FindFirstType(self, name):
-<<<<<<< HEAD
-        """FindFirstType(SBModule self, str const * name) -> SBType"""
-=======
         """FindFirstType(SBModule self, char const * name) -> SBType"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModule_FindFirstType(self, name)
 
 
     def FindTypes(self, type):
-<<<<<<< HEAD
-        """FindTypes(SBModule self, str const * type) -> SBTypeList"""
-=======
         """FindTypes(SBModule self, char const * type) -> SBTypeList"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModule_FindTypes(self, type)
 
 
@@ -8851,11 +7520,7 @@ class SBModule(_object):
 
     def FindGlobalVariables(self, target, name, max_matches):
         """
-<<<<<<< HEAD
-        FindGlobalVariables(SBModule self, SBTarget target, str const * name, uint32_t max_matches) -> SBValueList
-=======
         FindGlobalVariables(SBModule self, SBTarget target, char const * name, uint32_t max_matches) -> SBValueList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find global and static variables by name.
@@ -8878,11 +7543,7 @@ class SBModule(_object):
 
     def FindFirstGlobalVariable(self, target, name):
         """
-<<<<<<< HEAD
-        FindFirstGlobalVariable(SBModule self, SBTarget target, str const * name) -> SBValue
-=======
         FindFirstGlobalVariable(SBModule self, SBTarget target, char const * name) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find the first global (or static) variable by name.
@@ -8911,11 +7572,7 @@ class SBModule(_object):
 
 
     def GetTriple(self):
-<<<<<<< HEAD
-        """GetTriple(SBModule self) -> str const *"""
-=======
         """GetTriple(SBModule self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModule_GetTriple(self)
 
 
@@ -8944,17 +7601,6 @@ class SBModule(_object):
         return _lldb.SBModule_GetObjectFileEntryPointAddress(self)
 
 
-<<<<<<< HEAD
-    def __eq__(self, rhs):
-        """__eq__(SBModule self, SBModule rhs) -> bool"""
-        return _lldb.SBModule___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBModule self, SBModule rhs) -> bool"""
-        return _lldb.SBModule___ne__(self, rhs)
-
-=======
     def __len__(self):
         '''Return the number of symbols in a lldb.SBModule object.'''
         return self.GetNumSymbols()
@@ -8977,7 +7623,6 @@ class SBModule(_object):
         for sym in self:
             if in_range(sym, section):
                 yield sym
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     class symbols_access(object):
         re_compile_type = type(re.compile('.'))
@@ -9156,7 +7801,6 @@ class SBModule(_object):
 
 
 
-
     def __str__(self):
         """__str__(SBModule self) -> PyObject *"""
         return _lldb.SBModule___str__(self)
@@ -9216,9 +7860,6 @@ class SBModuleSpec(_object):
 
 
     def GetFileSpec(self):
-<<<<<<< HEAD
-        """GetFileSpec(SBModuleSpec self) -> SBFileSpec"""
-=======
         """
         GetFileSpec(SBModuleSpec self) -> SBFileSpec
 
@@ -9232,7 +7873,6 @@ class SBModuleSpec(_object):
         @return
             A const reference to the file specification object.
         """
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpec_GetFileSpec(self)
 
 
@@ -9242,9 +7882,6 @@ class SBModuleSpec(_object):
 
 
     def GetPlatformFileSpec(self):
-<<<<<<< HEAD
-        """GetPlatformFileSpec(SBModuleSpec self) -> SBFileSpec"""
-=======
         """
         GetPlatformFileSpec(SBModuleSpec self) -> SBFileSpec
 
@@ -9263,7 +7900,6 @@ class SBModuleSpec(_object):
         @return
             A const reference to the file specification object.
         """
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpec_GetPlatformFileSpec(self)
 
 
@@ -9283,38 +7919,22 @@ class SBModuleSpec(_object):
 
 
     def GetObjectName(self):
-<<<<<<< HEAD
-        """GetObjectName(SBModuleSpec self) -> str const *"""
-=======
         """GetObjectName(SBModuleSpec self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpec_GetObjectName(self)
 
 
     def SetObjectName(self, name):
-<<<<<<< HEAD
-        """SetObjectName(SBModuleSpec self, str const * name)"""
-=======
         """SetObjectName(SBModuleSpec self, char const * name)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpec_SetObjectName(self, name)
 
 
     def GetTriple(self):
-<<<<<<< HEAD
-        """GetTriple(SBModuleSpec self) -> str const *"""
-=======
         """GetTriple(SBModuleSpec self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpec_GetTriple(self)
 
 
     def SetTriple(self, triple):
-<<<<<<< HEAD
-        """SetTriple(SBModuleSpec self, str const * triple)"""
-=======
         """SetTriple(SBModuleSpec self, char const * triple)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpec_SetTriple(self, triple)
 
 
@@ -9368,11 +7988,7 @@ class SBModuleSpecList(_object):
     __del__ = lambda self: None
 
     def GetModuleSpecifications(path):
-<<<<<<< HEAD
-        """GetModuleSpecifications(str const * path) -> SBModuleSpecList"""
-=======
         """GetModuleSpecifications(char const * path) -> SBModuleSpecList"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBModuleSpecList_GetModuleSpecifications(path)
 
     GetModuleSpecifications = staticmethod(GetModuleSpecifications)
@@ -9432,11 +8048,7 @@ class SBPlatformConnectOptions(_object):
 
     def __init__(self, *args):
         """
-<<<<<<< HEAD
-        __init__(lldb::SBPlatformConnectOptions self, str const * url) -> SBPlatformConnectOptions
-=======
         __init__(lldb::SBPlatformConnectOptions self, char const * url) -> SBPlatformConnectOptions
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBPlatformConnectOptions self, SBPlatformConnectOptions rhs) -> SBPlatformConnectOptions
         """
         this = _lldb.new_SBPlatformConnectOptions(*args)
@@ -9448,20 +8060,12 @@ class SBPlatformConnectOptions(_object):
     __del__ = lambda self: None
 
     def GetURL(self):
-<<<<<<< HEAD
-        """GetURL(SBPlatformConnectOptions self) -> str const *"""
-=======
         """GetURL(SBPlatformConnectOptions self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformConnectOptions_GetURL(self)
 
 
     def SetURL(self, url):
-<<<<<<< HEAD
-        """SetURL(SBPlatformConnectOptions self, str const * url)"""
-=======
         """SetURL(SBPlatformConnectOptions self, char const * url)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformConnectOptions_SetURL(self, url)
 
 
@@ -9471,11 +8075,7 @@ class SBPlatformConnectOptions(_object):
 
 
     def EnableRsync(self, options, remote_path_prefix, omit_remote_hostname):
-<<<<<<< HEAD
-        """EnableRsync(SBPlatformConnectOptions self, str const * options, str const * remote_path_prefix, bool omit_remote_hostname)"""
-=======
         """EnableRsync(SBPlatformConnectOptions self, char const * options, char const * remote_path_prefix, bool omit_remote_hostname)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformConnectOptions_EnableRsync(self, options, remote_path_prefix, omit_remote_hostname)
 
 
@@ -9485,20 +8085,12 @@ class SBPlatformConnectOptions(_object):
 
 
     def GetLocalCacheDirectory(self):
-<<<<<<< HEAD
-        """GetLocalCacheDirectory(SBPlatformConnectOptions self) -> str const *"""
-=======
         """GetLocalCacheDirectory(SBPlatformConnectOptions self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformConnectOptions_GetLocalCacheDirectory(self)
 
 
     def SetLocalCacheDirectory(self, path):
-<<<<<<< HEAD
-        """SetLocalCacheDirectory(SBPlatformConnectOptions self, str const * path)"""
-=======
         """SetLocalCacheDirectory(SBPlatformConnectOptions self, char const * path)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformConnectOptions_SetLocalCacheDirectory(self, path)
 
 SBPlatformConnectOptions_swigregister = _lldb.SBPlatformConnectOptions_swigregister
@@ -9515,11 +8107,7 @@ class SBPlatformShellCommand(_object):
 
     def __init__(self, *args):
         """
-<<<<<<< HEAD
-        __init__(lldb::SBPlatformShellCommand self, str const * shell_command) -> SBPlatformShellCommand
-=======
         __init__(lldb::SBPlatformShellCommand self, char const * shell_command) -> SBPlatformShellCommand
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBPlatformShellCommand self, SBPlatformShellCommand rhs) -> SBPlatformShellCommand
         """
         this = _lldb.new_SBPlatformShellCommand(*args)
@@ -9536,38 +8124,22 @@ class SBPlatformShellCommand(_object):
 
 
     def GetCommand(self):
-<<<<<<< HEAD
-        """GetCommand(SBPlatformShellCommand self) -> str const *"""
-=======
         """GetCommand(SBPlatformShellCommand self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformShellCommand_GetCommand(self)
 
 
     def SetCommand(self, shell_command):
-<<<<<<< HEAD
-        """SetCommand(SBPlatformShellCommand self, str const * shell_command)"""
-=======
         """SetCommand(SBPlatformShellCommand self, char const * shell_command)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformShellCommand_SetCommand(self, shell_command)
 
 
     def GetWorkingDirectory(self):
-<<<<<<< HEAD
-        """GetWorkingDirectory(SBPlatformShellCommand self) -> str const *"""
-=======
         """GetWorkingDirectory(SBPlatformShellCommand self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformShellCommand_GetWorkingDirectory(self)
 
 
     def SetWorkingDirectory(self, path):
-<<<<<<< HEAD
-        """SetWorkingDirectory(SBPlatformShellCommand self, str const * path)"""
-=======
         """SetWorkingDirectory(SBPlatformShellCommand self, char const * path)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformShellCommand_SetWorkingDirectory(self, path)
 
 
@@ -9592,11 +8164,7 @@ class SBPlatformShellCommand(_object):
 
 
     def GetOutput(self):
-<<<<<<< HEAD
-        """GetOutput(SBPlatformShellCommand self) -> str const *"""
-=======
         """GetOutput(SBPlatformShellCommand self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatformShellCommand_GetOutput(self)
 
 SBPlatformShellCommand_swigregister = _lldb.SBPlatformShellCommand_swigregister
@@ -9635,11 +8203,7 @@ class SBPlatform(_object):
     def __init__(self, *args):
         """
         __init__(lldb::SBPlatform self) -> SBPlatform
-<<<<<<< HEAD
-        __init__(lldb::SBPlatform self, str const * arg2) -> SBPlatform
-=======
         __init__(lldb::SBPlatform self, char const * arg2) -> SBPlatform
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         this = _lldb.new_SBPlatform(*args)
         try:
@@ -9666,29 +8230,17 @@ class SBPlatform(_object):
 
 
     def GetWorkingDirectory(self):
-<<<<<<< HEAD
-        """GetWorkingDirectory(SBPlatform self) -> str const *"""
-=======
         """GetWorkingDirectory(SBPlatform self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetWorkingDirectory(self)
 
 
     def SetWorkingDirectory(self, arg2):
-<<<<<<< HEAD
-        """SetWorkingDirectory(SBPlatform self, str const * arg2) -> bool"""
-=======
         """SetWorkingDirectory(SBPlatform self, char const * arg2) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_SetWorkingDirectory(self, arg2)
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBPlatform self) -> str const *"""
-=======
         """GetName(SBPlatform self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetName(self)
 
 
@@ -9708,38 +8260,22 @@ class SBPlatform(_object):
 
 
     def GetTriple(self):
-<<<<<<< HEAD
-        """GetTriple(SBPlatform self) -> str const *"""
-=======
         """GetTriple(SBPlatform self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetTriple(self)
 
 
     def GetHostname(self):
-<<<<<<< HEAD
-        """GetHostname(SBPlatform self) -> str const *"""
-=======
         """GetHostname(SBPlatform self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetHostname(self)
 
 
     def GetOSBuild(self):
-<<<<<<< HEAD
-        """GetOSBuild(SBPlatform self) -> str const *"""
-=======
         """GetOSBuild(SBPlatform self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetOSBuild(self)
 
 
     def GetOSDescription(self):
-<<<<<<< HEAD
-        """GetOSDescription(SBPlatform self) -> str const *"""
-=======
         """GetOSDescription(SBPlatform self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetOSDescription(self)
 
 
@@ -9790,32 +8326,19 @@ class SBPlatform(_object):
 
     def MakeDirectory(self, *args):
         """
-<<<<<<< HEAD
-        MakeDirectory(SBPlatform self, str const * path, uint32_t file_permissions) -> SBError
-        MakeDirectory(SBPlatform self, str const * path) -> SBError
-=======
         MakeDirectory(SBPlatform self, char const * path, uint32_t file_permissions) -> SBError
         MakeDirectory(SBPlatform self, char const * path) -> SBError
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBPlatform_MakeDirectory(self, *args)
 
 
     def GetFilePermissions(self, path):
-<<<<<<< HEAD
-        """GetFilePermissions(SBPlatform self, str const * path) -> uint32_t"""
-=======
         """GetFilePermissions(SBPlatform self, char const * path) -> uint32_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_GetFilePermissions(self, path)
 
 
     def SetFilePermissions(self, path, file_permissions):
-<<<<<<< HEAD
-        """SetFilePermissions(SBPlatform self, str const * path, uint32_t file_permissions) -> SBError"""
-=======
         """SetFilePermissions(SBPlatform self, char const * path, uint32_t file_permissions) -> SBError"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBPlatform_SetFilePermissions(self, path, file_permissions)
 
 
@@ -9863,11 +8386,6 @@ class SBProcess(_object):
     eBroadcastBitProfileData = _lldb.SBProcess_eBroadcastBitProfileData
     eBroadcastBitStructuredData = _lldb.SBProcess_eBroadcastBitStructuredData
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumThreads', 'GetThreadAtIndex')
-    def __len__(self): return self.GetNumThreads()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBProcess self) -> SBProcess
@@ -9882,30 +8400,18 @@ class SBProcess(_object):
     __del__ = lambda self: None
 
     def GetBroadcasterClassName():
-<<<<<<< HEAD
-        """GetBroadcasterClassName() -> str const *"""
-=======
         """GetBroadcasterClassName() -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcess_GetBroadcasterClassName()
 
     GetBroadcasterClassName = staticmethod(GetBroadcasterClassName)
 
     def GetPluginName(self):
-<<<<<<< HEAD
-        """GetPluginName(SBProcess self) -> str const *"""
-=======
         """GetPluginName(SBProcess self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcess_GetPluginName(self)
 
 
     def GetShortPluginName(self):
-<<<<<<< HEAD
-        """GetShortPluginName(SBProcess self) -> str const *"""
-=======
         """GetShortPluginName(SBProcess self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcess_GetShortPluginName(self)
 
 
@@ -9965,11 +8471,7 @@ class SBProcess(_object):
 
 
     def GetAsyncProfileData(self, dst):
-<<<<<<< HEAD
-        """GetAsyncProfileData(SBProcess self, str * dst) -> size_t"""
-=======
         """GetAsyncProfileData(SBProcess self, char * dst) -> size_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcess_GetAsyncProfileData(self, dst)
 
 
@@ -9997,11 +8499,7 @@ class SBProcess(_object):
 
     def RemoteLaunch(self, argv, envp, stdin_path, stdout_path, stderr_path, working_directory, launch_flags, stop_at_entry, error):
         """
-<<<<<<< HEAD
-        RemoteLaunch(SBProcess self, str const ** argv, str const ** envp, str const * stdin_path, str const * stdout_path, str const * stderr_path, str const * working_directory, uint32_t launch_flags, bool stop_at_entry, SBError error) -> bool
-=======
         RemoteLaunch(SBProcess self, char const ** argv, char const ** envp, char const * stdin_path, char const * stdout_path, char const * stderr_path, char const * working_directory, uint32_t launch_flags, bool stop_at_entry, SBError error) -> bool
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         See SBTarget.Launch for argument description and usage.
         """
@@ -10092,11 +8590,7 @@ class SBProcess(_object):
 
 
     def GetExitDescription(self):
-<<<<<<< HEAD
-        """GetExitDescription(SBProcess self) -> str const *"""
-=======
         """GetExitDescription(SBProcess self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcess_GetExitDescription(self)
 
 
@@ -10236,11 +8730,7 @@ class SBProcess(_object):
     def ReadUnsignedFromMemory(self, addr, byte_size, error):
         """
 
-<<<<<<< HEAD
-        Reads an unsigned integer from memory given a byte size and an address. 
-=======
         Reads an unsigned integer from memory given a byte size and an address.
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         Returns the unsigned integer that was read. Example:
 
         # Read a 4 byte unsigned integer from address 0x1000
@@ -10252,13 +8742,8 @@ class SBProcess(_object):
             print('error: ', error)
         """
         return _lldb.SBProcess_ReadUnsignedFromMemory(self, addr, byte_size, error)
-<<<<<<< HEAD
 
 
-=======
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def ReadPointerFromMemory(self, addr, error):
         """
 
@@ -10290,17 +8775,6 @@ class SBProcess(_object):
     def GetNumRestartedReasonsFromEvent(event):
         """GetNumRestartedReasonsFromEvent(SBEvent event) -> size_t"""
         return _lldb.SBProcess_GetNumRestartedReasonsFromEvent(event)
-<<<<<<< HEAD
-
-    GetNumRestartedReasonsFromEvent = staticmethod(GetNumRestartedReasonsFromEvent)
-
-    def GetRestartedReasonAtIndexFromEvent(event, idx):
-        """GetRestartedReasonAtIndexFromEvent(SBEvent event, size_t idx) -> str const *"""
-        return _lldb.SBProcess_GetRestartedReasonAtIndexFromEvent(event, idx)
-
-    GetRestartedReasonAtIndexFromEvent = staticmethod(GetRestartedReasonAtIndexFromEvent)
-
-=======
 
     GetNumRestartedReasonsFromEvent = staticmethod(GetNumRestartedReasonsFromEvent)
 
@@ -10310,7 +8784,6 @@ class SBProcess(_object):
 
     GetRestartedReasonAtIndexFromEvent = staticmethod(GetRestartedReasonAtIndexFromEvent)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetProcessFromEvent(event):
         """GetProcessFromEvent(SBEvent event) -> SBProcess"""
         return _lldb.SBProcess_GetProcessFromEvent(event)
@@ -10354,7 +8827,6 @@ class SBProcess(_object):
     def GetNumSupportedHardwareWatchpoints(self, error):
         """GetNumSupportedHardwareWatchpoints(SBProcess self, SBError error) -> uint32_t"""
         return _lldb.SBProcess_GetNumSupportedHardwareWatchpoints(self, error)
-<<<<<<< HEAD
 
 
     def LoadImage(self, image_spec, error):
@@ -10362,15 +8834,6 @@ class SBProcess(_object):
         return _lldb.SBProcess_LoadImage(self, image_spec, error)
 
 
-=======
-
-
-    def LoadImage(self, image_spec, error):
-        """LoadImage(SBProcess self, SBFileSpec image_spec, SBError error) -> uint32_t"""
-        return _lldb.SBProcess_LoadImage(self, image_spec, error)
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def LoadImageUsingPaths(self, image_spec, paths, loaded_path, error):
         """
 
@@ -10382,16 +8845,6 @@ class SBProcess(_object):
         """
         return _lldb.SBProcess_LoadImageUsingPaths(self, image_spec, paths, loaded_path, error)
 
-<<<<<<< HEAD
-
-    def UnloadImage(self, image_token):
-        """UnloadImage(SBProcess self, uint32_t image_token) -> SBError"""
-        return _lldb.SBProcess_UnloadImage(self, image_token)
-
-
-    def SendEventData(self, event_data):
-        """SendEventData(SBProcess self, str const * event_data) -> SBError"""
-=======
 
     def UnloadImage(self, image_token):
         """UnloadImage(SBProcess self, uint32_t image_token) -> SBError"""
@@ -10400,7 +8853,6 @@ class SBProcess(_object):
 
     def SendEventData(self, event_data):
         """SendEventData(SBProcess self, char const * event_data) -> SBError"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcess_SendEventData(self, event_data)
 
 
@@ -10420,33 +8872,11 @@ class SBProcess(_object):
     def GetExtendedBacktraceTypeAtIndex(self, idx):
         """
 
-<<<<<<< HEAD
-        Takes an index argument, returns the name of one of the thread-origin 
-=======
         Takes an index argument, returns the name of one of the thread-origin
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         extended backtrace methods as a str.
         """
         return _lldb.SBProcess_GetExtendedBacktraceTypeAtIndex(self, idx)
 
-<<<<<<< HEAD
-
-    def GetHistoryThreads(self, addr):
-        """GetHistoryThreads(SBProcess self, lldb::addr_t addr) -> SBThreadCollection"""
-        return _lldb.SBProcess_GetHistoryThreads(self, addr)
-
-
-    def IsInstrumentationRuntimePresent(self, type):
-        """IsInstrumentationRuntimePresent(SBProcess self, lldb::InstrumentationRuntimeType type) -> bool"""
-        return _lldb.SBProcess_IsInstrumentationRuntimePresent(self, type)
-
-
-    def SaveCore(self, file_name):
-        """SaveCore(SBProcess self, str const * file_name) -> SBError"""
-        return _lldb.SBProcess_SaveCore(self, file_name)
-
-
-=======
 
     def GetHistoryThreads(self, addr):
         """GetHistoryThreads(SBProcess self, lldb::addr_t addr) -> SBThreadCollection"""
@@ -10463,7 +8893,6 @@ class SBProcess(_object):
         return _lldb.SBProcess_SaveCore(self, file_name)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def StartTrace(self, options, error):
         """StartTrace(SBProcess self, SBTraceOptions options, SBError error) -> SBTrace"""
         return _lldb.SBProcess_StartTrace(self, options, error)
@@ -10571,7 +9000,6 @@ class SBProcess(_object):
     broadcaster = property(GetBroadcaster, None, doc='''A read only property that an lldb object that represents the broadcaster (lldb.SBBroadcaster) for this process.''')
 
 
-
     def __str__(self):
         """__str__(SBProcess self) -> PyObject *"""
         return _lldb.SBProcess___str__(self)
@@ -10656,11 +9084,7 @@ class SBProcessInfo(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBProcessInfo self) -> str const *"""
-=======
         """GetName(SBProcessInfo self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBProcessInfo_GetName(self)
 
 
@@ -10776,22 +9200,14 @@ class SBQueue(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBQueue self) -> str const *"""
-=======
         """GetName(SBQueue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBQueue_GetName(self)
 
 
     def GetKind(self):
         """
 
-<<<<<<< HEAD
-        Returns an lldb::QueueKind enumerated value (e.g. eQueueKindUnknown, 
-=======
         Returns an lldb::QueueKind enumerated value (e.g. eQueueKindUnknown,
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         eQueueKindSerial, eQueueKindConcurrent) describing the type of this
         queue.
         """
@@ -10891,17 +9307,10 @@ class SBQueueItem(_object):
     def SetQueueItem(self, queue_item_sp):
         """SetQueueItem(SBQueueItem self, lldb::QueueItemSP const & queue_item_sp)"""
         return _lldb.SBQueueItem_SetQueueItem(self, queue_item_sp)
-<<<<<<< HEAD
-
-
-    def GetExtendedBacktraceThread(self, type):
-        """GetExtendedBacktraceThread(SBQueueItem self, str const * type) -> SBThread"""
-=======
 
 
     def GetExtendedBacktraceThread(self, type):
         """GetExtendedBacktraceThread(SBQueueItem self, char const * type) -> SBThread"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBQueueItem_GetExtendedBacktraceThread(self, type)
 
 SBQueueItem_swigregister = _lldb.SBQueueItem_swigregister
@@ -10942,11 +9351,6 @@ class SBSection(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBSection, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumSubSections', 'GetSubSectionAtIndex')
-    def __len__(self): return self.GetNumSubSections()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBSection self) -> SBSection
@@ -10972,11 +9376,7 @@ class SBSection(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBSection self) -> str const *"""
-=======
         """GetName(SBSection self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBSection_GetName(self)
 
 
@@ -10986,11 +9386,7 @@ class SBSection(_object):
 
 
     def FindSubSection(self, sect_name):
-<<<<<<< HEAD
-        """FindSubSection(SBSection self, str const * sect_name) -> SBSection"""
-=======
         """FindSubSection(SBSection self, char const * sect_name) -> SBSection"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBSection_FindSubSection(self, sect_name)
 
 
@@ -11062,31 +9458,10 @@ class SBSection(_object):
         """
         return _lldb.SBSection_GetTargetByteSize(self)
 
-<<<<<<< HEAD
 
     def GetDescription(self, description):
         """GetDescription(SBSection self, SBStream description) -> bool"""
         return _lldb.SBSection_GetDescription(self, description)
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBSection self, SBSection rhs) -> bool"""
-        return _lldb.SBSection___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBSection self, SBSection rhs) -> bool"""
-        return _lldb.SBSection___ne__(self, rhs)
-
-
-    def get_addr(self):
-        return SBAddress(self, 0)
-=======
-
-    def GetDescription(self, description):
-        """GetDescription(SBSection self, SBStream description) -> bool"""
-        return _lldb.SBSection_GetDescription(self, description)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -11119,7 +9494,6 @@ class SBSection(_object):
     data = property(GetSectionData, None, doc='''A read only property that returns an lldb object that represents the bytes for this section (lldb.SBData) for this section.''')
     type = property(GetSectionType, None, doc='''A read only property that returns an lldb enumeration value (see enumerations that start with "lldb.eSectionType") that represents the type of this section (code, data, etc.).''')
     target_byte_size = property(GetTargetByteSize, None, doc='''A read only property that returns the size of a target byte represented by this section as a number of host bytes.''')
-
 
 
     def __str__(self):
@@ -11185,16 +9559,6 @@ class SBSourceManager(_object):
             self.this = this
     __swig_destroy__ = _lldb.delete_SBSourceManager
     __del__ = lambda self: None
-<<<<<<< HEAD
-
-    def DisplaySourceLinesWithLineNumbers(self, file, line, context_before, context_after, current_line_cstr, s):
-        """DisplaySourceLinesWithLineNumbers(SBSourceManager self, SBFileSpec file, uint32_t line, uint32_t context_before, uint32_t context_after, str const * current_line_cstr, SBStream s) -> size_t"""
-        return _lldb.SBSourceManager_DisplaySourceLinesWithLineNumbers(self, file, line, context_before, context_after, current_line_cstr, s)
-
-
-    def DisplaySourceLinesWithLineNumbersAndColumn(self, file, line, column, context_before, context_after, current_line_cstr, s):
-        """DisplaySourceLinesWithLineNumbersAndColumn(SBSourceManager self, SBFileSpec file, uint32_t line, uint32_t column, uint32_t context_before, uint32_t context_after, str const * current_line_cstr, SBStream s) -> size_t"""
-=======
 
     def DisplaySourceLinesWithLineNumbers(self, file, line, context_before, context_after, current_line_cstr, s):
         """DisplaySourceLinesWithLineNumbers(SBSourceManager self, SBFileSpec file, uint32_t line, uint32_t context_before, uint32_t context_after, char const * current_line_cstr, SBStream s) -> size_t"""
@@ -11203,7 +9567,6 @@ class SBSourceManager(_object):
 
     def DisplaySourceLinesWithLineNumbersAndColumn(self, file, line, column, context_before, context_after, current_line_cstr, s):
         """DisplaySourceLinesWithLineNumbersAndColumn(SBSourceManager self, SBFileSpec file, uint32_t line, uint32_t column, uint32_t context_before, uint32_t context_after, char const * current_line_cstr, SBStream s) -> size_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBSourceManager_DisplaySourceLinesWithLineNumbersAndColumn(self, file, line, column, context_before, context_after, current_line_cstr, s)
 
 SBSourceManager_swigregister = _lldb.SBSourceManager_swigregister
@@ -11267,11 +9630,7 @@ class SBStream(_object):
 
     def GetData(self):
         """
-<<<<<<< HEAD
-        GetData(SBStream self) -> str const *
-=======
         GetData(SBStream self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         If this stream is not redirected to a file, it will maintain a local
@@ -11293,26 +9652,11 @@ class SBStream(_object):
 
 
     def Print(self, str):
-<<<<<<< HEAD
-        """Print(SBStream self, str const * str)"""
-=======
         """Print(SBStream self, char const * str)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBStream_Print(self, str)
 
 
     def RedirectToFile(self, path, append):
-<<<<<<< HEAD
-        """RedirectToFile(SBStream self, str const * path, bool append)"""
-        return _lldb.SBStream_RedirectToFile(self, path, append)
-
-
-    def RedirectToFileHandle(self, fh, transfer_fh_ownership):
-        """RedirectToFileHandle(SBStream self, FILE * fh, bool transfer_fh_ownership)"""
-        return _lldb.SBStream_RedirectToFileHandle(self, fh, transfer_fh_ownership)
-
-
-=======
         """RedirectToFile(SBStream self, char const * path, bool append)"""
         return _lldb.SBStream_RedirectToFile(self, path, append)
 
@@ -11322,7 +9666,6 @@ class SBStream(_object):
         return _lldb.SBStream_RedirectToFileHandle(self, fh, transfer_fh_ownership)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def RedirectToFileDescriptor(self, fd, transfer_fh_ownership):
         """RedirectToFileDescriptor(SBStream self, int fd, bool transfer_fh_ownership)"""
         return _lldb.SBStream_RedirectToFileDescriptor(self, fd, transfer_fh_ownership)
@@ -11341,11 +9684,7 @@ class SBStream(_object):
 
 
     def write(self, str):
-<<<<<<< HEAD
-        """write(SBStream self, str const * str)"""
-=======
         """write(SBStream self, char const * str)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBStream_write(self, str)
 
 
@@ -11365,11 +9704,6 @@ class SBStringList(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBStringList, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetSize', 'GetStringAtIndex')
-    def __len__(self): return self.GetSize()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBStringList self) -> SBStringList
@@ -11395,21 +9729,13 @@ class SBStringList(_object):
 
 
     def AppendString(self, str):
-<<<<<<< HEAD
-        """AppendString(SBStringList self, str const * str)"""
-=======
         """AppendString(SBStringList self, char const * str)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBStringList_AppendString(self, str)
 
 
     def AppendList(self, *args):
         """
-<<<<<<< HEAD
-        AppendList(SBStringList self, str const ** strv, int strc)
-=======
         AppendList(SBStringList self, char const ** strv, int strc)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         AppendList(SBStringList self, SBStringList strings)
         """
         return _lldb.SBStringList_AppendList(self, *args)
@@ -11421,11 +9747,7 @@ class SBStringList(_object):
 
 
     def GetStringAtIndex(self, idx):
-<<<<<<< HEAD
-        """GetStringAtIndex(SBStringList self, size_t idx) -> str const *"""
-=======
         """GetStringAtIndex(SBStringList self, size_t idx) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBStringList_GetStringAtIndex(self, idx)
 
 
@@ -11505,16 +9827,6 @@ class SBStructuredData(_object):
 
 
     def GetValueForKey(self, key):
-<<<<<<< HEAD
-        """GetValueForKey(SBStructuredData self, str const * key) -> SBStructuredData"""
-        return _lldb.SBStructuredData_GetValueForKey(self, key)
-
-
-    def GetItemAtIndex(self, idx):
-        """GetItemAtIndex(SBStructuredData self, size_t idx) -> SBStructuredData"""
-        return _lldb.SBStructuredData_GetItemAtIndex(self, idx)
-
-=======
         """GetValueForKey(SBStructuredData self, char const * key) -> SBStructuredData"""
         return _lldb.SBStructuredData_GetValueForKey(self, key)
 
@@ -11523,7 +9835,6 @@ class SBStructuredData(_object):
         """GetItemAtIndex(SBStructuredData self, size_t idx) -> SBStructuredData"""
         return _lldb.SBStructuredData_GetItemAtIndex(self, idx)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetIntegerValue(self, fail_value=0):
         """
@@ -11550,11 +9861,7 @@ class SBStructuredData(_object):
 
 
     def GetStringValue(self, dst):
-<<<<<<< HEAD
-        """GetStringValue(SBStructuredData self, str * dst) -> size_t"""
-=======
         """GetStringValue(SBStructuredData self, char * dst) -> size_t"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBStructuredData_GetStringValue(self, dst)
 
 
@@ -11614,40 +9921,24 @@ class SBSymbol(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBSymbol self) -> str const *"""
-=======
         """GetName(SBSymbol self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBSymbol_GetName(self)
 
 
     def GetDisplayName(self):
-<<<<<<< HEAD
-        """GetDisplayName(SBSymbol self) -> str const *"""
-=======
         """GetDisplayName(SBSymbol self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBSymbol_GetDisplayName(self)
 
 
     def GetMangledName(self):
-<<<<<<< HEAD
-        """GetMangledName(SBSymbol self) -> str const *"""
-=======
         """GetMangledName(SBSymbol self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBSymbol_GetMangledName(self)
 
 
     def GetInstructions(self, *args):
         """
         GetInstructions(SBSymbol self, SBTarget target) -> SBInstructionList
-<<<<<<< HEAD
-        GetInstructions(SBSymbol self, SBTarget target, str const * flavor_string) -> SBInstructionList
-=======
         GetInstructions(SBSymbol self, SBTarget target, char const * flavor_string) -> SBInstructionList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBSymbol_GetInstructions(self, *args)
 
@@ -11686,34 +9977,6 @@ class SBSymbol(_object):
         """IsSynthetic(SBSymbol self) -> bool"""
         return _lldb.SBSymbol_IsSynthetic(self)
 
-<<<<<<< HEAD
-
-    def __eq__(self, rhs):
-        """__eq__(SBSymbol self, SBSymbol rhs) -> bool"""
-        return _lldb.SBSymbol___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBSymbol self, SBSymbol rhs) -> bool"""
-        return _lldb.SBSymbol___ne__(self, rhs)
-
-
-    def get_instructions_from_current_target (self):
-        return self.GetInstructions (target)
-
-    __swig_getmethods__["name"] = GetName
-    if _newclass: name = property(GetName, None, doc='''A read only property that returns the name for this symbol as a string.''')
-
-    __swig_getmethods__["mangled"] = GetMangledName
-    if _newclass: mangled = property(GetMangledName, None, doc='''A read only property that returns the mangled (linkage) name for this symbol as a string.''')
-
-    __swig_getmethods__["type"] = GetType
-    if _newclass: type = property(GetType, None, doc='''A read only property that returns an lldb enumeration value (see enumerations that start with "lldb.eSymbolType") that represents the type of this symbol.''')
-
-    __swig_getmethods__["addr"] = GetStartAddress
-    if _newclass: addr = property(GetStartAddress, None, doc='''A read only property that returns an lldb object that represents the start address (lldb.SBAddress) for this symbol.''')
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __eq__(self, rhs):
         """__eq__(SBSymbol self, SBSymbol rhs) -> bool"""
@@ -11737,7 +10000,6 @@ class SBSymbol(_object):
     instructions = property(get_instructions_from_current_target, None, doc='''A read only property that returns an lldb object that represents the instructions (lldb.SBInstructionList) for this symbol.''')
     external = property(IsExternal, None, doc='''A read only property that returns a boolean value that indicates if this symbol is externally visiable (exported) from the module that contains it.''')
     synthetic = property(IsSynthetic, None, doc='''A read only property that returns a boolean value that indicates if this symbol was synthetically created from information in module that contains it.''')
-
 
 
     def __str__(self):
@@ -11832,10 +10094,6 @@ class SBSymbolContext(_object):
     def GetModule(self):
         """GetModule(SBSymbolContext self) -> SBModule"""
         return _lldb.SBSymbolContext_GetModule(self)
-<<<<<<< HEAD
-=======
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def GetCompileUnit(self):
@@ -11887,7 +10145,6 @@ class SBSymbolContext(_object):
         """SetLineEntry(SBSymbolContext self, SBLineEntry line_entry)"""
         return _lldb.SBSymbolContext_SetLineEntry(self, line_entry)
 
-<<<<<<< HEAD
 
     def SetSymbol(self, symbol):
         """SetSymbol(SBSymbolContext self, SBSymbol symbol)"""
@@ -11898,33 +10155,6 @@ class SBSymbolContext(_object):
         """GetParentOfInlinedScope(SBSymbolContext self, SBAddress curr_frame_pc, SBAddress parent_frame_addr) -> SBSymbolContext"""
         return _lldb.SBSymbolContext_GetParentOfInlinedScope(self, curr_frame_pc, parent_frame_addr)
 
-
-    def GetDescription(self, description):
-        """GetDescription(SBSymbolContext self, SBStream description) -> bool"""
-        return _lldb.SBSymbolContext_GetDescription(self, description)
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
-
-    def SetSymbol(self, symbol):
-        """SetSymbol(SBSymbolContext self, SBSymbol symbol)"""
-        return _lldb.SBSymbolContext_SetSymbol(self, symbol)
-
-
-    def GetParentOfInlinedScope(self, curr_frame_pc, parent_frame_addr):
-        """GetParentOfInlinedScope(SBSymbolContext self, SBAddress curr_frame_pc, SBAddress parent_frame_addr) -> SBSymbolContext"""
-        return _lldb.SBSymbolContext_GetParentOfInlinedScope(self, curr_frame_pc, parent_frame_addr)
-
-<<<<<<< HEAD
-    __swig_getmethods__["block"] = GetBlock
-    __swig_setmethods__["block"] = SetBlock
-    if _newclass: block = property(GetBlock, SetBlock, doc='''A read/write property that allows the getting/setting of the block (lldb.SBBlock) in this symbol context.''')
-
-    __swig_getmethods__["symbol"] = GetSymbol
-    __swig_setmethods__["symbol"] = SetSymbol
-    if _newclass: symbol = property(GetSymbol, SetSymbol, doc='''A read/write property that allows the getting/setting of the symbol (lldb.SBSymbol) in this symbol context.''')
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetDescription(self, description):
         """GetDescription(SBSymbolContext self, SBStream description) -> bool"""
@@ -11937,7 +10167,6 @@ class SBSymbolContext(_object):
     block = property(GetBlock, SetBlock, doc='''A read/write property that allows the getting/setting of the block (lldb.SBBlock) in this symbol context.''')
     symbol = property(GetSymbol, SetSymbol, doc='''A read/write property that allows the getting/setting of the symbol (lldb.SBSymbol) in this symbol context.''')
     line_entry = property(GetLineEntry, SetLineEntry, doc='''A read/write property that allows the getting/setting of the line entry (lldb.SBLineEntry) in this symbol context.''')
-
 
 
     def __str__(self):
@@ -11976,11 +10205,6 @@ class SBSymbolContextList(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBSymbolContextList, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetSize', 'GetContextAtIndex')
-    def __len__(self): return self.GetSize()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBSymbolContextList self) -> SBSymbolContextList
@@ -12033,14 +10257,11 @@ class SBSymbolContextList(_object):
         return _lldb.SBSymbolContextList_Clear(self)
 
 
-<<<<<<< HEAD
-=======
     def __iter__(self):
         '''Iterate over all symbol contexts in a lldb.SBSymbolContextList
         object.'''
         return lldb_iter(self, 'GetSize', 'GetContextAtIndex')
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __len__(self):
         return int(self.GetSize())
 
@@ -12105,7 +10326,6 @@ class SBSymbolContextList(_object):
     symbols = property(get_symbol_array, None, doc='''Returns a list() of lldb.SBSymbol objects, one for each symbol in each SBSymbolContext object in this list.''')
 
 
-
     def __str__(self):
         """__str__(SBSymbolContextList self) -> PyObject *"""
         return _lldb.SBSymbolContextList___str__(self)
@@ -12164,12 +10384,6 @@ class SBTarget(_object):
     eBroadcastBitWatchpointChanged = _lldb.SBTarget_eBroadcastBitWatchpointChanged
     eBroadcastBitSymbolsLoaded = _lldb.SBTarget_eBroadcastBitSymbolsLoaded
 
-<<<<<<< HEAD
-    def module_iter(self): return lldb_iter(self, 'GetNumModules', 'GetModuleAtIndex')
-    def breakpoint_iter(self): return lldb_iter(self, 'GetNumBreakpoints', 'GetBreakpointAtIndex')
-    def watchpoint_iter(self): return lldb_iter(self, 'GetNumWatchpoints', 'GetWatchpointAtIndex')
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBTarget self) -> SBTarget
@@ -12184,11 +10398,7 @@ class SBTarget(_object):
     __del__ = lambda self: None
 
     def GetBroadcasterClassName():
-<<<<<<< HEAD
-        """GetBroadcasterClassName() -> str const *"""
-=======
         """GetBroadcasterClassName() -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_GetBroadcasterClassName()
 
     GetBroadcasterClassName = staticmethod(GetBroadcasterClassName)
@@ -12272,11 +10482,7 @@ class SBTarget(_object):
 
     def LaunchSimple(self, argv, envp, working_directory):
         """
-<<<<<<< HEAD
-        LaunchSimple(SBTarget self, str const ** argv, str const ** envp, str const * working_directory) -> SBProcess
-=======
         LaunchSimple(SBTarget self, char const ** argv, char const ** envp, char const * working_directory) -> SBProcess
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Launch a new process with sensible defaults.
@@ -12316,11 +10522,7 @@ class SBTarget(_object):
 
     def Launch(self, *args):
         """
-<<<<<<< HEAD
-        Launch(SBTarget self, SBListener listener, str const ** argv, str const ** envp, str const * stdin_path, str const * stdout_path, str const * stderr_path, str const * working_directory, uint32_t launch_flags, bool stop_at_entry, SBError error) -> SBProcess
-=======
         Launch(SBTarget self, SBListener listener, char const ** argv, char const ** envp, char const * stdin_path, char const * stdout_path, char const * stderr_path, char const * working_directory, uint32_t launch_flags, bool stop_at_entry, SBError error) -> SBProcess
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         Launch(SBTarget self, SBLaunchInfo launch_info, SBError error) -> SBProcess
 
 
@@ -12398,13 +10600,8 @@ class SBTarget(_object):
 
     def LoadCore(self, *args):
         """
-<<<<<<< HEAD
-        LoadCore(SBTarget self, str const * core_file) -> SBProcess
-        LoadCore(SBTarget self, str const * core_file, SBError error) -> SBProcess
-=======
         LoadCore(SBTarget self, char const * core_file) -> SBProcess
         LoadCore(SBTarget self, char const * core_file, SBError error) -> SBProcess
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Load a core file
@@ -12456,19 +10653,11 @@ class SBTarget(_object):
              A process object for the attached process.
         """
         return _lldb.SBTarget_AttachToProcessWithID(self, listener, pid, error)
-<<<<<<< HEAD
-
-
-    def AttachToProcessWithName(self, listener, name, wait_for, error):
-        """
-        AttachToProcessWithName(SBTarget self, SBListener listener, str const * name, bool wait_for, SBError error) -> SBProcess
-=======
 
 
     def AttachToProcessWithName(self, listener, name, wait_for, error):
         """
         AttachToProcessWithName(SBTarget self, SBListener listener, char const * name, bool wait_for, SBError error) -> SBProcess
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Attach to process with name.
@@ -12496,11 +10685,7 @@ class SBTarget(_object):
 
     def ConnectRemote(self, listener, url, plugin_name, error):
         """
-<<<<<<< HEAD
-        ConnectRemote(SBTarget self, SBListener listener, str const * url, str const * plugin_name, SBError error) -> SBProcess
-=======
         ConnectRemote(SBTarget self, SBListener listener, char const * url, char const * plugin_name, SBError error) -> SBProcess
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Connect to a remote debug server with url.
@@ -12533,11 +10718,7 @@ class SBTarget(_object):
 
     def AppendImageSearchPath(self, arg2, to, error):
         """
-<<<<<<< HEAD
-        AppendImageSearchPath(SBTarget self, str const * arg2, str const * to, SBError error)
-=======
         AppendImageSearchPath(SBTarget self, char const * arg2, char const * to, SBError error)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Append the path mapping (from -> to) to the target's paths mapping list.
@@ -12548,13 +10729,8 @@ class SBTarget(_object):
     def AddModule(self, *args):
         """
         AddModule(SBTarget self, SBModule module) -> bool
-<<<<<<< HEAD
-        AddModule(SBTarget self, str const * path, str const * triple, str const * uuid) -> SBModule
-        AddModule(SBTarget self, str const * path, str const * triple, str const * uuid_cstr, str const * symfile) -> SBModule
-=======
         AddModule(SBTarget self, char const * path, char const * triple, char const * uuid) -> SBModule
         AddModule(SBTarget self, char const * path, char const * triple, char const * uuid_cstr, char const * symfile) -> SBModule
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         AddModule(SBTarget self, SBModuleSpec module_spec) -> SBModule
         """
         return _lldb.SBTarget_AddModule(self, *args)
@@ -12615,11 +10791,7 @@ class SBTarget(_object):
 
 
     def GetTriple(self):
-<<<<<<< HEAD
-        """GetTriple(SBTarget self) -> str const *"""
-=======
         """GetTriple(SBTarget self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_GetTriple(self)
 
 
@@ -12655,28 +10827,6 @@ class SBTarget(_object):
         """SetSectionLoadAddress(SBTarget self, SBSection section, lldb::addr_t section_base_addr) -> SBError"""
         return _lldb.SBTarget_SetSectionLoadAddress(self, section, section_base_addr)
 
-<<<<<<< HEAD
-
-    def ClearSectionLoadAddress(self, section):
-        """ClearSectionLoadAddress(SBTarget self, SBSection section) -> SBError"""
-        return _lldb.SBTarget_ClearSectionLoadAddress(self, section)
-
-
-    def SetModuleLoadAddress(self, module, sections_offset):
-        """SetModuleLoadAddress(SBTarget self, SBModule module, int64_t sections_offset) -> SBError"""
-        return _lldb.SBTarget_SetModuleLoadAddress(self, module, sections_offset)
-
-
-    def ClearModuleLoadAddress(self, module):
-        """ClearModuleLoadAddress(SBTarget self, SBModule module) -> SBError"""
-        return _lldb.SBTarget_ClearModuleLoadAddress(self, module)
-
-
-    def FindFunctions(self, *args):
-        """
-        FindFunctions(SBTarget self, str const * name, uint32_t name_type_mask) -> SBSymbolContextList
-        FindFunctions(SBTarget self, str const * name) -> SBSymbolContextList
-=======
 
     def ClearSectionLoadAddress(self, section):
         """ClearSectionLoadAddress(SBTarget self, SBSection section) -> SBError"""
@@ -12697,7 +10847,6 @@ class SBTarget(_object):
         """
         FindFunctions(SBTarget self, char const * name, uint32_t name_type_mask) -> SBSymbolContextList
         FindFunctions(SBTarget self, char const * name) -> SBSymbolContextList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find functions by name.
@@ -12720,20 +10869,12 @@ class SBTarget(_object):
 
 
     def FindFirstType(self, type):
-<<<<<<< HEAD
-        """FindFirstType(SBTarget self, str const * type) -> SBType"""
-=======
         """FindFirstType(SBTarget self, char const * type) -> SBType"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_FindFirstType(self, type)
 
 
     def FindTypes(self, type):
-<<<<<<< HEAD
-        """FindTypes(SBTarget self, str const * type) -> SBTypeList"""
-=======
         """FindTypes(SBTarget self, char const * type) -> SBTypeList"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_FindTypes(self, type)
 
 
@@ -12749,11 +10890,7 @@ class SBTarget(_object):
 
     def FindFirstGlobalVariable(self, name):
         """
-<<<<<<< HEAD
-        FindFirstGlobalVariable(SBTarget self, str const * name) -> SBValue
-=======
         FindFirstGlobalVariable(SBTarget self, char const * name) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find the first global (or static) variable by name.
@@ -12770,13 +10907,8 @@ class SBTarget(_object):
 
     def FindGlobalVariables(self, *args):
         """
-<<<<<<< HEAD
-        FindGlobalVariables(SBTarget self, str const * name, uint32_t max_matches) -> SBValueList
-        FindGlobalVariables(SBTarget self, str const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBValueList
-=======
         FindGlobalVariables(SBTarget self, char const * name, uint32_t max_matches) -> SBValueList
         FindGlobalVariables(SBTarget self, char const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBValueList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Find global and static variables by name.
@@ -12795,11 +10927,7 @@ class SBTarget(_object):
 
 
     def FindGlobalFunctions(self, name, max_matches, matchtype):
-<<<<<<< HEAD
-        """FindGlobalFunctions(SBTarget self, str const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBSymbolContextList"""
-=======
         """FindGlobalFunctions(SBTarget self, char const * name, uint32_t max_matches, lldb::MatchType matchtype) -> SBSymbolContextList"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_FindGlobalFunctions(self, name, max_matches, matchtype)
 
 
@@ -12827,7 +10955,6 @@ class SBTarget(_object):
         """ResolveLoadAddress(SBTarget self, lldb::addr_t vm_addr) -> SBAddress"""
         return _lldb.SBTarget_ResolveLoadAddress(self, vm_addr)
 
-<<<<<<< HEAD
 
     def ResolvePastLoadAddress(self, stop_id, vm_addr):
         """ResolvePastLoadAddress(SBTarget self, uint32_t stop_id, lldb::addr_t vm_addr) -> SBAddress"""
@@ -12839,19 +10966,6 @@ class SBTarget(_object):
         return _lldb.SBTarget_ResolveSymbolContextForAddress(self, addr, resolve_scope)
 
 
-=======
-
-    def ResolvePastLoadAddress(self, stop_id, vm_addr):
-        """ResolvePastLoadAddress(SBTarget self, uint32_t stop_id, lldb::addr_t vm_addr) -> SBAddress"""
-        return _lldb.SBTarget_ResolvePastLoadAddress(self, stop_id, vm_addr)
-
-
-    def ResolveSymbolContextForAddress(self, addr, resolve_scope):
-        """ResolveSymbolContextForAddress(SBTarget self, SBAddress addr, uint32_t resolve_scope) -> SBSymbolContext"""
-        return _lldb.SBTarget_ResolveSymbolContextForAddress(self, addr, resolve_scope)
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def ReadMemory(self, addr, buf, error):
         """
         ReadMemory(SBTarget self, SBAddress addr, void * buf, SBError error) -> size_t
@@ -12883,11 +10997,7 @@ class SBTarget(_object):
 
     def BreakpointCreateByLocation(self, *args):
         """
-<<<<<<< HEAD
-        BreakpointCreateByLocation(SBTarget self, str const * file, uint32_t line) -> SBBreakpoint
-=======
         BreakpointCreateByLocation(SBTarget self, char const * file, uint32_t line) -> SBBreakpoint
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         BreakpointCreateByLocation(SBTarget self, SBFileSpec file_spec, uint32_t line) -> SBBreakpoint
         BreakpointCreateByLocation(SBTarget self, SBFileSpec file_spec, uint32_t line, lldb::addr_t offset) -> SBBreakpoint
         BreakpointCreateByLocation(SBTarget self, SBFileSpec file_spec, uint32_t line, lldb::addr_t offset, SBFileSpecList module_list) -> SBBreakpoint
@@ -12898,64 +11008,38 @@ class SBTarget(_object):
 
     def BreakpointCreateByName(self, *args):
         """
-<<<<<<< HEAD
-        BreakpointCreateByName(SBTarget self, str const * symbol_name, str const * module_name=None) -> SBBreakpoint
-        BreakpointCreateByName(SBTarget self, str const * symbol_name) -> SBBreakpoint
-        BreakpointCreateByName(SBTarget self, str const * symbol_name, uint32_t func_name_type, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
-        BreakpointCreateByName(SBTarget self, str const * symbol_name, uint32_t func_name_type, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
-=======
         BreakpointCreateByName(SBTarget self, char const * symbol_name, char const * module_name=None) -> SBBreakpoint
         BreakpointCreateByName(SBTarget self, char const * symbol_name) -> SBBreakpoint
         BreakpointCreateByName(SBTarget self, char const * symbol_name, uint32_t func_name_type, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
         BreakpointCreateByName(SBTarget self, char const * symbol_name, uint32_t func_name_type, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBTarget_BreakpointCreateByName(self, *args)
 
 
     def BreakpointCreateByNames(self, *args):
         """
-<<<<<<< HEAD
-        BreakpointCreateByNames(SBTarget self, str const ** symbol_name, uint32_t name_type_mask, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
-        BreakpointCreateByNames(SBTarget self, str const ** symbol_name, uint32_t name_type_mask, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
-        BreakpointCreateByNames(SBTarget self, str const ** symbol_name, uint32_t name_type_mask, lldb::LanguageType symbol_language, lldb::addr_t offset, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
-=======
         BreakpointCreateByNames(SBTarget self, char const ** symbol_name, uint32_t name_type_mask, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
         BreakpointCreateByNames(SBTarget self, char const ** symbol_name, uint32_t name_type_mask, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
         BreakpointCreateByNames(SBTarget self, char const ** symbol_name, uint32_t name_type_mask, lldb::LanguageType symbol_language, lldb::addr_t offset, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBTarget_BreakpointCreateByNames(self, *args)
 
 
     def BreakpointCreateByRegex(self, *args):
         """
-<<<<<<< HEAD
-        BreakpointCreateByRegex(SBTarget self, str const * symbol_name_regex, str const * module_name=None) -> SBBreakpoint
-        BreakpointCreateByRegex(SBTarget self, str const * symbol_name_regex) -> SBBreakpoint
-        BreakpointCreateByRegex(SBTarget self, str const * symbol_name_regex, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
-=======
         BreakpointCreateByRegex(SBTarget self, char const * symbol_name_regex, char const * module_name=None) -> SBBreakpoint
         BreakpointCreateByRegex(SBTarget self, char const * symbol_name_regex) -> SBBreakpoint
         BreakpointCreateByRegex(SBTarget self, char const * symbol_name_regex, lldb::LanguageType symbol_language, SBFileSpecList module_list, SBFileSpecList comp_unit_list) -> SBBreakpoint
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBTarget_BreakpointCreateByRegex(self, *args)
 
 
     def BreakpointCreateBySourceRegex(self, *args):
         """
-<<<<<<< HEAD
-        BreakpointCreateBySourceRegex(SBTarget self, str const * source_regex, SBFileSpec source_file, str const * module_name=None) -> SBBreakpoint
-        BreakpointCreateBySourceRegex(SBTarget self, str const * source_regex, SBFileSpec source_file) -> SBBreakpoint
-        BreakpointCreateBySourceRegex(SBTarget self, str const * source_regex, SBFileSpecList module_list, SBFileSpecList file_list) -> SBBreakpoint
-        BreakpointCreateBySourceRegex(SBTarget self, str const * source_regex, SBFileSpecList module_list, SBFileSpecList source_file, SBStringList func_names) -> SBBreakpoint
-=======
         BreakpointCreateBySourceRegex(SBTarget self, char const * source_regex, SBFileSpec source_file, char const * module_name=None) -> SBBreakpoint
         BreakpointCreateBySourceRegex(SBTarget self, char const * source_regex, SBFileSpec source_file) -> SBBreakpoint
         BreakpointCreateBySourceRegex(SBTarget self, char const * source_regex, SBFileSpecList module_list, SBFileSpecList file_list) -> SBBreakpoint
         BreakpointCreateBySourceRegex(SBTarget self, char const * source_regex, SBFileSpecList module_list, SBFileSpecList source_file, SBStringList func_names) -> SBBreakpoint
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBTarget_BreakpointCreateBySourceRegex(self, *args)
 
@@ -12980,13 +11064,8 @@ class SBTarget(_object):
 
     def BreakpointCreateFromScript(self, class_name, extra_args, module_list, file_list, request_hardware=False):
         """
-<<<<<<< HEAD
-        BreakpointCreateFromScript(SBTarget self, str const * class_name, SBStructuredData extra_args, SBFileSpecList module_list, SBFileSpecList file_list, bool request_hardware=False) -> SBBreakpoint
-        BreakpointCreateFromScript(SBTarget self, str const * class_name, SBStructuredData extra_args, SBFileSpecList module_list, SBFileSpecList file_list) -> SBBreakpoint
-=======
         BreakpointCreateFromScript(SBTarget self, char const * class_name, SBStructuredData extra_args, SBFileSpecList module_list, SBFileSpecList file_list, bool request_hardware=False) -> SBBreakpoint
         BreakpointCreateFromScript(SBTarget self, char const * class_name, SBStructuredData extra_args, SBFileSpecList module_list, SBFileSpecList file_list) -> SBBreakpoint
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Create a breakpoint using a scripted resolver.
@@ -13064,24 +11143,6 @@ class SBTarget(_object):
         """BreakpointDelete(SBTarget self, lldb::break_id_t break_id) -> bool"""
         return _lldb.SBTarget_BreakpointDelete(self, break_id)
 
-<<<<<<< HEAD
-
-    def FindBreakpointByID(self, break_id):
-        """FindBreakpointByID(SBTarget self, lldb::break_id_t break_id) -> SBBreakpoint"""
-        return _lldb.SBTarget_FindBreakpointByID(self, break_id)
-
-
-    def FindBreakpointsByName(self, name, bkpt_list):
-        """FindBreakpointsByName(SBTarget self, str const * name, SBBreakpointList bkpt_list) -> bool"""
-        return _lldb.SBTarget_FindBreakpointsByName(self, name, bkpt_list)
-
-
-    def DeleteBreakpointName(self, name):
-        """DeleteBreakpointName(SBTarget self, str const * name)"""
-        return _lldb.SBTarget_DeleteBreakpointName(self, name)
-
-
-=======
 
     def FindBreakpointByID(self, break_id):
         """FindBreakpointByID(SBTarget self, lldb::break_id_t break_id) -> SBBreakpoint"""
@@ -13098,7 +11159,6 @@ class SBTarget(_object):
         return _lldb.SBTarget_DeleteBreakpointName(self, name)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetBreakpointNames(self, names):
         """GetBreakpointNames(SBTarget self, SBStringList names)"""
         return _lldb.SBTarget_GetBreakpointNames(self, names)
@@ -13200,11 +11260,7 @@ class SBTarget(_object):
 
     def CreateValueFromAddress(self, name, addr, type):
         """
-<<<<<<< HEAD
-        CreateValueFromAddress(SBTarget self, str const * name, SBAddress addr, SBType type) -> SBValue
-=======
         CreateValueFromAddress(SBTarget self, char const * name, SBAddress addr, SBType type) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Create an SBValue with the given name by treating the memory starting at addr as an entity of type.
@@ -13226,31 +11282,19 @@ class SBTarget(_object):
 
 
     def CreateValueFromData(self, name, data, type):
-<<<<<<< HEAD
-        """CreateValueFromData(SBTarget self, str const * name, SBData data, SBType type) -> SBValue"""
-=======
         """CreateValueFromData(SBTarget self, char const * name, SBData data, SBType type) -> SBValue"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_CreateValueFromData(self, name, data, type)
 
 
     def CreateValueFromExpression(self, name, expr):
-<<<<<<< HEAD
-        """CreateValueFromExpression(SBTarget self, str const * name, str const * expr) -> SBValue"""
-=======
         """CreateValueFromExpression(SBTarget self, char const * name, char const * expr) -> SBValue"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTarget_CreateValueFromExpression(self, name, expr)
 
 
     def ReadInstructions(self, *args):
         """
         ReadInstructions(SBTarget self, SBAddress base_addr, uint32_t count) -> SBInstructionList
-<<<<<<< HEAD
-        ReadInstructions(SBTarget self, SBAddress base_addr, uint32_t count, str const * flavor_string) -> SBInstructionList
-=======
         ReadInstructions(SBTarget self, SBAddress base_addr, uint32_t count, char const * flavor_string) -> SBInstructionList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Disassemble a specified number of instructions starting at an address.
@@ -13280,11 +11324,7 @@ class SBTarget(_object):
 
     def GetInstructionsWithFlavor(self, base_addr, flavor_string, buf):
         """
-<<<<<<< HEAD
-        GetInstructionsWithFlavor(SBTarget self, SBAddress base_addr, str const * flavor_string, void const * buf) -> SBInstructionList
-=======
         GetInstructionsWithFlavor(SBTarget self, SBAddress base_addr, char const * flavor_string, void const * buf) -> SBInstructionList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Disassemble the bytes in a buffer and return them in an SBInstructionList, with a supplied flavor.
@@ -13300,13 +11340,8 @@ class SBTarget(_object):
 
     def FindSymbols(self, *args):
         """
-<<<<<<< HEAD
-        FindSymbols(SBTarget self, str const * name, lldb::SymbolType type) -> SBSymbolContextList
-        FindSymbols(SBTarget self, str const * name) -> SBSymbolContextList
-=======
         FindSymbols(SBTarget self, char const * name, lldb::SymbolType type) -> SBSymbolContextList
         FindSymbols(SBTarget self, char const * name) -> SBSymbolContextList
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBTarget_FindSymbols(self, *args)
 
@@ -13358,21 +11393,15 @@ class SBTarget(_object):
 
     def EvaluateExpression(self, *args):
         """
-<<<<<<< HEAD
-        EvaluateExpression(SBTarget self, str const * expr) -> SBValue
-        EvaluateExpression(SBTarget self, str const * expr, SBExpressionOptions options) -> SBValue
-=======
         EvaluateExpression(SBTarget self, char const * expr) -> SBValue
         EvaluateExpression(SBTarget self, char const * expr, SBExpressionOptions options) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBTarget_EvaluateExpression(self, *args)
 
 
-<<<<<<< HEAD
     def CompleteCode(self, language, symbol_context, current_code):
         """
-        CompleteCode(SBTarget self, lldb::LanguageType language, SBSymbolContext symbol_context, str const * current_code) -> SBCompletionResponse
+        CompleteCode(SBTarget self, lldb::LanguageType language, SBSymbolContext symbol_context, char const * current_code) -> SBCompletionResponse
 
 
         Complete code.
@@ -13381,13 +11410,12 @@ class SBTarget(_object):
           symbol_context    -- the context in which to do the completion
           current_code      -- the code to complete
         Returns an SBCompletionResponse with completions that fit immediately after
-        the last stracter of `current_code`.
+        the last character of `current_code`.
+
         """
         return _lldb.SBTarget_CompleteCode(self, language, symbol_context, current_code)
 
 
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     class modules_access(object):
         '''A helper object that will lazily hand out lldb.SBModule objects for a target when supplied an index, or by full or partial path.'''
         def __init__(self, sbtarget):
@@ -13498,46 +11526,6 @@ class SBTarget(_object):
         if not isinstance(rhs, type(self)):
             return True
 
-<<<<<<< HEAD
-    __swig_getmethods__["broadcaster"] = GetBroadcaster
-    if _newclass: broadcaster = property(GetBroadcaster, None, doc='''A read only property that an lldb object that represents the broadcaster (lldb.SBBroadcaster) for this target.''')
-
-    __swig_getmethods__["byte_order"] = GetByteOrder
-    if _newclass: byte_order = property(GetByteOrder, None, doc='''A read only property that returns an lldb enumeration value (lldb.eByteOrderLittle, lldb.eByteOrderBig, lldb.eByteOrderInvalid) that represents the byte order for this target.''')
-
-    __swig_getmethods__["addr_size"] = GetAddressByteSize
-    if _newclass: addr_size = property(GetAddressByteSize, None, doc='''A read only property that returns the size in bytes of an address for this target.''')
-
-    __swig_getmethods__["triple"] = GetTriple
-    if _newclass: triple = property(GetTriple, None, doc='''A read only property that returns the target triple (arch-vendor-os) for this target as a string.''')
-
-    __swig_getmethods__["data_byte_size"] = GetDataByteSize
-    if _newclass: data_byte_size = property(GetDataByteSize, None, doc='''A read only property that returns the size in host bytes of a byte in the data address space for this target.''')
-
-    __swig_getmethods__["code_byte_size"] = GetCodeByteSize
-    if _newclass: code_byte_size = property(GetCodeByteSize, None, doc='''A read only property that returns the size in host bytes of a byte in the code address space for this target.''')
-
-    __swig_getmethods__["platform"] = GetPlatform
-    if _newclass: platform = property(GetPlatform, None, doc='''A read only property that returns the platform associated with with this target.''')
-
-
-    def __str__(self):
-        """__str__(SBTarget self) -> PyObject *"""
-        return _lldb.SBTarget___str__(self)
-
-
-    def __eq__(self, rhs):
-        if not isinstance(rhs, type(self)):
-            return False
-
-        return getattr(_lldb,self.__class__.__name__+"___eq__")(self, rhs)
-
-    def __ne__(self, rhs):
-        if not isinstance(rhs, type(self)):
-            return True
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return getattr(_lldb,self.__class__.__name__+"___ne__")(self, rhs)
 
 SBTarget_swigregister = _lldb.SBTarget_swigregister
@@ -13605,11 +11593,6 @@ class SBThread(_object):
     eBroadcastBitSelectedFrameChanged = _lldb.SBThread_eBroadcastBitSelectedFrameChanged
     eBroadcastBitThreadSelected = _lldb.SBThread_eBroadcastBitThreadSelected
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumFrames', 'GetFrameAtIndex')
-    def __len__(self): return self.GetNumFrames()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBThread self) -> SBThread
@@ -13624,11 +11607,7 @@ class SBThread(_object):
     __del__ = lambda self: None
 
     def GetBroadcasterClassName():
-<<<<<<< HEAD
-        """GetBroadcasterClassName() -> str const *"""
-=======
         """GetBroadcasterClassName() -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBThread_GetBroadcasterClassName()
 
     GetBroadcasterClassName = staticmethod(GetBroadcasterClassName)
@@ -13636,7 +11615,6 @@ class SBThread(_object):
     def EventIsThreadEvent(event):
         """EventIsThreadEvent(SBEvent event) -> bool"""
         return _lldb.SBThread_EventIsThreadEvent(event)
-<<<<<<< HEAD
 
     EventIsThreadEvent = staticmethod(EventIsThreadEvent)
 
@@ -13646,17 +11624,6 @@ class SBThread(_object):
 
     GetStackFrameFromEvent = staticmethod(GetStackFrameFromEvent)
 
-=======
-
-    EventIsThreadEvent = staticmethod(EventIsThreadEvent)
-
-    def GetStackFrameFromEvent(event):
-        """GetStackFrameFromEvent(SBEvent event) -> SBFrame"""
-        return _lldb.SBThread_GetStackFrameFromEvent(event)
-
-    GetStackFrameFromEvent = staticmethod(GetStackFrameFromEvent)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetThreadFromEvent(event):
         """GetThreadFromEvent(SBEvent event) -> SBThread"""
         return _lldb.SBThread_GetThreadFromEvent(event)
@@ -13718,13 +11685,8 @@ class SBThread(_object):
         eStopReasonPlanComplete  0
         """
         return _lldb.SBThread_GetStopReasonDataAtIndex(self, idx)
-<<<<<<< HEAD
 
 
-=======
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetStopReasonExtendedInfoAsJSON(self, stream):
         """
 
@@ -13733,13 +11695,8 @@ class SBThread(_object):
         on the stop reason and is currently used only for instrumentation plugins.
         """
         return _lldb.SBThread_GetStopReasonExtendedInfoAsJSON(self, stream)
-<<<<<<< HEAD
 
 
-=======
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetStopReasonExtendedBacktraces(self, type):
         """
 
@@ -13748,13 +11705,8 @@ class SBThread(_object):
         traces that were involved in a data race or other type of detected issue.
         """
         return _lldb.SBThread_GetStopReasonExtendedBacktraces(self, type)
-<<<<<<< HEAD
 
 
-=======
-
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetStopDescription(self, dst):
         """
 
@@ -13814,11 +11766,7 @@ class SBThread(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBThread self) -> str const *"""
-=======
         """GetName(SBThread self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBThread_GetName(self)
 
 
@@ -13842,11 +11790,7 @@ class SBThread(_object):
 
     def GetInfoItemByPathAsString(self, path, strm):
         """
-<<<<<<< HEAD
-        GetInfoItemByPathAsString(SBThread self, str const * path, SBStream strm) -> bool
-=======
         GetInfoItemByPathAsString(SBThread self, char const * path, SBStream strm) -> bool
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Takes a path string and a SBStream reference as parameters, returns a bool.
@@ -13885,21 +11829,12 @@ class SBThread(_object):
         """
         StepInto(SBThread self, lldb::RunMode stop_other_threads)
         StepInto(SBThread self)
-<<<<<<< HEAD
-        StepInto(SBThread self, str const * target_name, lldb::RunMode stop_other_threads)
-        StepInto(SBThread self, str const * target_name)
-=======
         StepInto(SBThread self, char const * target_name, lldb::RunMode stop_other_threads)
         StepInto(SBThread self, char const * target_name)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
             Step the current thread from the current source line to the line given by end_line, stopping if
             the thread steps into the function given by target_name.  If target_name is None, then stepping will stop
             in any of the places we would normally stop.
-<<<<<<< HEAD
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
             Step the current thread from the current source line to the line given by end_line, stopping if
             the thread steps into the function given by target_name.  If target_name is None, then stepping will stop
@@ -13939,13 +11874,8 @@ class SBThread(_object):
 
     def StepUsingScriptedThreadPlan(self, *args):
         """
-<<<<<<< HEAD
-        StepUsingScriptedThreadPlan(SBThread self, str const * script_class_name) -> SBError
-        StepUsingScriptedThreadPlan(SBThread self, str const * script_class_name, bool resume_immediately) -> SBError
-=======
         StepUsingScriptedThreadPlan(SBThread self, char const * script_class_name) -> SBError
         StepUsingScriptedThreadPlan(SBThread self, char const * script_class_name, bool resume_immediately) -> SBError
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBThread_StepUsingScriptedThreadPlan(self, *args)
 
@@ -14146,8 +12076,6 @@ class SBThread(_object):
         return _lldb.SBThread_SafeToCallFunctions(self)
 
 
-<<<<<<< HEAD
-=======
     def __iter__(self):
         '''Iterate over all frames in a lldb.SBThread object.'''
         return lldb_iter(self, 'GetNumFrames', 'GetFrameAtIndex')
@@ -14156,7 +12084,6 @@ class SBThread(_object):
         '''Return the number of frames in a lldb.SBThread object.'''
         return self.GetNumFrames()
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     class frames_access(object):
         '''A helper object that will lazily hand out frames for a thread when supplied an index.'''
         def __init__(self, sbthread):
@@ -14196,7 +12123,6 @@ class SBThread(_object):
     stop_reason = property(GetStopReason, None, doc='''A read only property that returns an lldb enumeration value (see enumerations that start with "lldb.eStopReason") that represents the reason this thread stopped.''')
     is_suspended = property(IsSuspended, None, doc='''A read only property that returns a boolean value that indicates if this thread is suspended.''')
     is_stopped = property(IsStopped, None, doc='''A read only property that returns a boolean value that indicates if this thread is stopped but not exited.''')
-
 
 
     def __str__(self):
@@ -14294,11 +12220,7 @@ class SBThreadPlan(_object):
         __init__(lldb::SBThreadPlan self) -> SBThreadPlan
         __init__(lldb::SBThreadPlan self, SBThreadPlan threadPlan) -> SBThreadPlan
         __init__(lldb::SBThreadPlan self, lldb::ThreadPlanSP const & lldb_object_sp) -> SBThreadPlan
-<<<<<<< HEAD
-        __init__(lldb::SBThreadPlan self, SBThread thread, str const * class_name) -> SBThreadPlan
-=======
         __init__(lldb::SBThreadPlan self, SBThread thread, char const * class_name) -> SBThreadPlan
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         this = _lldb.new_SBThreadPlan(*args)
         try:
@@ -14325,9 +12247,6 @@ class SBThreadPlan(_object):
 
 
     def GetStopReasonDataCount(self):
-<<<<<<< HEAD
-        """GetStopReasonDataCount(SBThreadPlan self) -> size_t"""
-=======
         """
         GetStopReasonDataCount(SBThreadPlan self) -> size_t
 
@@ -14335,14 +12254,10 @@ class SBThreadPlan(_object):
         Get the number of words associated with the stop reason.
         See also GetStopReasonDataAtIndex().
         """
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBThreadPlan_GetStopReasonDataCount(self)
 
 
     def GetStopReasonDataAtIndex(self, idx):
-<<<<<<< HEAD
-        """GetStopReasonDataAtIndex(SBThreadPlan self, uint32_t idx) -> uint64_t"""
-=======
         """
         GetStopReasonDataAtIndex(SBThreadPlan self, uint32_t idx) -> uint64_t
 
@@ -14364,7 +12279,6 @@ class SBThreadPlan(_object):
         eStopReasonExec          0
         eStopReasonPlanComplete  0
         """
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBThreadPlan_GetStopReasonDataAtIndex(self, idx)
 
 
@@ -14425,11 +12339,7 @@ class SBThreadPlan(_object):
 
 
     def QueueThreadPlanForStepScripted(self, script_class_name):
-<<<<<<< HEAD
-        """QueueThreadPlanForStepScripted(SBThreadPlan self, str const * script_class_name) -> SBThreadPlan"""
-=======
         """QueueThreadPlanForStepScripted(SBThreadPlan self, char const * script_class_name) -> SBThreadPlan"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBThreadPlan_QueueThreadPlanForStepScripted(self, script_class_name)
 
 SBThreadPlan_swigregister = _lldb.SBThreadPlan_swigregister
@@ -14577,11 +12487,6 @@ SBTraceOptions_swigregister(SBTraceOptions)
 class SBTypeMember(_object):
     """Represents a member of a type in lldb."""
 
-<<<<<<< HEAD
-    """
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeMember, name, value)
     __swig_getmethods__ = {}
@@ -14613,11 +12518,7 @@ class SBTypeMember(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBTypeMember self) -> str const *"""
-=======
         """GetName(SBTypeMember self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeMember_GetName(self)
 
 
@@ -14645,24 +12546,6 @@ class SBTypeMember(_object):
         """GetBitfieldSizeInBits(SBTypeMember self) -> uint32_t"""
         return _lldb.SBTypeMember_GetBitfieldSizeInBits(self)
 
-<<<<<<< HEAD
-
-    __swig_getmethods__["name"] = GetName
-    if _newclass: name = property(GetName, None, doc='''A read only property that returns the name for this member as a string.''')
-
-    __swig_getmethods__["type"] = GetType
-    if _newclass: type = property(GetType, None, doc='''A read only property that returns an lldb object that represents the type (lldb.SBType) for this member.''')
-
-    __swig_getmethods__["byte_offset"] = GetOffsetInBytes
-    if _newclass: byte_offset = property(GetOffsetInBytes, None, doc='''A read only property that returns offset in bytes for this member as an integer.''')
-
-    __swig_getmethods__["bit_offset"] = GetOffsetInBits
-    if _newclass: bit_offset = property(GetOffsetInBits, None, doc='''A read only property that returns offset in bits for this member as an integer.''')
-
-    __swig_getmethods__["is_bitfield"] = IsBitfield
-    if _newclass: is_bitfield = property(IsBitfield, None, doc='''A read only property that returns true if this member is a bitfield.''')
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     name = property(GetName, None, doc='''A read only property that returns the name for this member as a string.''')
     type = property(GetType, None, doc='''A read only property that returns an lldb object that represents the type (lldb.SBType) for this member.''')
@@ -14670,7 +12553,6 @@ class SBTypeMember(_object):
     bit_offset = property(GetOffsetInBits, None, doc='''A read only property that returns offset in bits for this member as an integer.''')
     is_bitfield = property(IsBitfield, None, doc='''A read only property that returns true if this member is a bitfield.''')
     bitfield_bit_size = property(GetBitfieldSizeInBits, None, doc='''A read only property that returns the bitfield size in bits for this member as an integer, or zero if this member is not a bitfield.''')
-
 
 
     def __str__(self):
@@ -14714,29 +12596,17 @@ class SBTypeMemberFunction(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBTypeMemberFunction self) -> str const *"""
-=======
         """GetName(SBTypeMemberFunction self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeMemberFunction_GetName(self)
 
 
     def GetDemangledName(self):
-<<<<<<< HEAD
-        """GetDemangledName(SBTypeMemberFunction self) -> str const *"""
-=======
         """GetDemangledName(SBTypeMemberFunction self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeMemberFunction_GetDemangledName(self)
 
 
     def GetMangledName(self):
-<<<<<<< HEAD
-        """GetMangledName(SBTypeMemberFunction self) -> str const *"""
-=======
         """GetMangledName(SBTypeMemberFunction self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeMemberFunction_GetMangledName(self)
 
 
@@ -14858,13 +12728,6 @@ class SBType(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBType, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetNumberChildren', 'GetChildAtIndex')
-    def __len__(self): return self.GetNumberChildren()
-    def __eq__(self, other): return isinstance(other, SBType) and self.GetByteSize() == other.GetByteSize() and self.GetName() == other.GetName()
-    def __ne__(self, other): return not self.__eq__(other)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBType self) -> SBType
@@ -15028,20 +12891,12 @@ class SBType(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBType self) -> str const *"""
-=======
         """GetName(SBType self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBType_GetName(self)
 
 
     def GetDisplayTypeName(self):
-<<<<<<< HEAD
-        """GetDisplayTypeName(SBType self) -> str const *"""
-=======
         """GetDisplayTypeName(SBType self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBType_GetDisplayTypeName(self)
 
 
@@ -15095,8 +12950,6 @@ class SBType(_object):
         return _lldb.SBType_GetTypeFlags(self)
 
 
-<<<<<<< HEAD
-=======
     def __eq__(self, rhs):
         """__eq__(SBType self, SBType rhs) -> bool"""
         return _lldb.SBType___eq__(self, rhs)
@@ -15107,7 +12960,6 @@ class SBType(_object):
         return _lldb.SBType___ne__(self, rhs)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def template_arg_array(self):
         num_args = self.num_template_args
         if num_args:
@@ -15116,36 +12968,6 @@ class SBType(_object):
                 template_args.append(self.GetTemplateArgumentType(i))
             return template_args
         return None
-<<<<<<< HEAD
-
-    __swig_getmethods__["name"] = GetName
-    if _newclass: name = property(GetName, None, doc='''A read only property that returns the name for this type as a string.''')
-
-    __swig_getmethods__["size"] = GetByteSize
-    if _newclass: size = property(GetByteSize, None, doc='''A read only property that returns size in bytes for this type as an integer.''')
-
-    __swig_getmethods__["is_pointer"] = IsPointerType
-    if _newclass: is_pointer = property(IsPointerType, None, doc='''A read only property that returns a boolean value that indicates if this type is a pointer type.''')
-
-    __swig_getmethods__["is_reference"] = IsReferenceType
-    if _newclass: is_reference = property(IsReferenceType, None, doc='''A read only property that returns a boolean value that indicates if this type is a reference type.''')
-
-    __swig_getmethods__["is_function"] = IsFunctionType
-    if _newclass: is_reference = property(IsReferenceType, None, doc='''A read only property that returns a boolean value that indicates if this type is a function type.''')
-
-    __swig_getmethods__["num_fields"] = GetNumberOfFields
-    if _newclass: num_fields = property(GetNumberOfFields, None, doc='''A read only property that returns number of fields in this type as an integer.''')
-
-    __swig_getmethods__["num_bases"] = GetNumberOfDirectBaseClasses
-    if _newclass: num_bases = property(GetNumberOfDirectBaseClasses, None, doc='''A read only property that returns number of direct base classes in this type as an integer.''')
-
-    __swig_getmethods__["num_vbases"] = GetNumberOfVirtualBaseClasses
-    if _newclass: num_vbases = property(GetNumberOfVirtualBaseClasses, None, doc='''A read only property that returns number of virtual base classes in this type as an integer.''')
-
-    __swig_getmethods__["num_template_args"] = GetNumberOfTemplateArguments
-    if _newclass: num_template_args = property(GetNumberOfTemplateArguments, None, doc='''A read only property that returns number of template arguments in this type as an integer.''')
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     name = property(GetName, None, doc='''A read only property that returns the name for this type as a string.''')
     size = property(GetByteSize, None, doc='''A read only property that returns size in bytes for this type as an integer.''')
@@ -15234,7 +13056,6 @@ class SBType(_object):
     enum_members = property(get_enum_members_array, None, doc='''A read only property that returns a list() of all lldb.SBTypeEnumMember objects that represent the enum members for this type.''')
 
 
-
     def __str__(self):
         """__str__(SBType self) -> PyObject *"""
         return _lldb.SBType___str__(self)
@@ -15281,11 +13102,6 @@ class SBTypeList(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBTypeList, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetSize', 'GetTypeAtIndex')
-    def __len__(self): return self.GetSize()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self):
         """__init__(lldb::SBTypeList self) -> SBTypeList"""
         this = _lldb.new_SBTypeList()
@@ -15321,8 +13137,6 @@ class SBTypeList(_object):
 
     __swig_destroy__ = _lldb.delete_SBTypeList
     __del__ = lambda self: None
-<<<<<<< HEAD
-=======
 
     def __iter__(self):
         '''Iterate over all types in a lldb.SBTypeList object.'''
@@ -15332,19 +13146,11 @@ class SBTypeList(_object):
         '''Return the number of types in a lldb.SBTypeList object.'''
         return self.GetSize()
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 SBTypeList_swigregister = _lldb.SBTypeList_swigregister
 SBTypeList_swigregister(SBTypeList)
 
 class SBTypeCategory(_object):
-<<<<<<< HEAD
-    """
-    Represents a category that can contain formatters for types.
-
-    """
-=======
     """Represents a category that can contain formatters for types."""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeCategory, name, value)
@@ -15387,11 +13193,7 @@ class SBTypeCategory(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBTypeCategory self) -> str const *"""
-=======
         """GetName(SBTypeCategory self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeCategory_GetName(self)
 
 
@@ -15624,7 +13426,6 @@ class SBTypeCategory(_object):
     enabled = property(GetEnabled, SetEnabled)
 
 
-
     def __str__(self):
         """__str__(SBTypeCategory self) -> PyObject *"""
         return _lldb.SBTypeCategory___str__(self)
@@ -15676,11 +13477,7 @@ class SBTypeEnumMember(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBTypeEnumMember self) -> str const *"""
-=======
         """GetName(SBTypeEnumMember self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeEnumMember_GetName(self)
 
 
@@ -15688,14 +13485,6 @@ class SBTypeEnumMember(_object):
         """GetType(SBTypeEnumMember self) -> SBType"""
         return _lldb.SBTypeEnumMember_GetType(self)
 
-<<<<<<< HEAD
-
-    def GetDescription(self, description, description_level):
-        """GetDescription(SBTypeEnumMember self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
-        return _lldb.SBTypeEnumMember_GetDescription(self, description, description_level)
-
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def GetDescription(self, description, description_level):
         """GetDescription(SBTypeEnumMember self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
@@ -15706,7 +13495,6 @@ class SBTypeEnumMember(_object):
     type = property(GetType, None, doc='''A read only property that returns an lldb object that represents the type (lldb.SBType) for this enum member.''')
     signed = property(GetValueAsSigned, None, doc='''A read only property that returns the value of this enum member as a signed integer.''')
     unsigned = property(GetValueAsUnsigned, None, doc='''A read only property that returns the value of this enum member as a unsigned integer.''')
-
 
 
     def __str__(self):
@@ -15767,14 +13555,7 @@ SBTypeEnumMemberList_swigregister = _lldb.SBTypeEnumMemberList_swigregister
 SBTypeEnumMemberList_swigregister(SBTypeEnumMemberList)
 
 class SBTypeFilter(_object):
-<<<<<<< HEAD
-    """
-    Represents a filter that can be associated to one or more types.
-
-    """
-=======
     """Represents a filter that can be associated to one or more types."""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeFilter, name, value)
@@ -15818,29 +13599,17 @@ class SBTypeFilter(_object):
 
 
     def GetExpressionPathAtIndex(self, i):
-<<<<<<< HEAD
-        """GetExpressionPathAtIndex(SBTypeFilter self, uint32_t i) -> str const *"""
-=======
         """GetExpressionPathAtIndex(SBTypeFilter self, uint32_t i) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeFilter_GetExpressionPathAtIndex(self, i)
 
 
     def ReplaceExpressionPathAtIndex(self, i, item):
-<<<<<<< HEAD
-        """ReplaceExpressionPathAtIndex(SBTypeFilter self, uint32_t i, str const * item) -> bool"""
-=======
         """ReplaceExpressionPathAtIndex(SBTypeFilter self, uint32_t i, char const * item) -> bool"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeFilter_ReplaceExpressionPathAtIndex(self, i, item)
 
 
     def AppendExpressionPath(self, item):
-<<<<<<< HEAD
-        """AppendExpressionPath(SBTypeFilter self, str const * item)"""
-=======
         """AppendExpressionPath(SBTypeFilter self, char const * item)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeFilter_AppendExpressionPath(self, item)
 
 
@@ -15858,27 +13627,10 @@ class SBTypeFilter(_object):
         """SetOptions(SBTypeFilter self, uint32_t arg2)"""
         return _lldb.SBTypeFilter_SetOptions(self, arg2)
 
-<<<<<<< HEAD
 
     def GetDescription(self, description, description_level):
         """GetDescription(SBTypeFilter self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
         return _lldb.SBTypeFilter_GetDescription(self, description, description_level)
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBTypeFilter self, SBTypeFilter rhs) -> bool"""
-        return _lldb.SBTypeFilter___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBTypeFilter self, SBTypeFilter rhs) -> bool"""
-        return _lldb.SBTypeFilter___ne__(self, rhs)
-=======
-
-    def GetDescription(self, description, description_level):
-        """GetDescription(SBTypeFilter self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
-        return _lldb.SBTypeFilter_GetDescription(self, description, description_level)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -15893,7 +13645,6 @@ class SBTypeFilter(_object):
 
     options = property(GetOptions, SetOptions)
     count = property(GetNumberOfExpressionPaths)
-
 
 
     def __str__(self):
@@ -15917,14 +13668,7 @@ SBTypeFilter_swigregister = _lldb.SBTypeFilter_swigregister
 SBTypeFilter_swigregister(SBTypeFilter)
 
 class SBTypeFormat(_object):
-<<<<<<< HEAD
-    """
-    Represents a format that can be associated to one or more types.
-
-    """
-=======
     """Represents a format that can be associated to one or more types."""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeFormat, name, value)
@@ -15937,13 +13681,8 @@ class SBTypeFormat(_object):
         __init__(lldb::SBTypeFormat self) -> SBTypeFormat
         __init__(lldb::SBTypeFormat self, lldb::Format format, uint32_t options=0) -> SBTypeFormat
         __init__(lldb::SBTypeFormat self, lldb::Format format) -> SBTypeFormat
-<<<<<<< HEAD
-        __init__(lldb::SBTypeFormat self, str const * type, uint32_t options=0) -> SBTypeFormat
-        __init__(lldb::SBTypeFormat self, str const * type) -> SBTypeFormat
-=======
         __init__(lldb::SBTypeFormat self, char const * type, uint32_t options=0) -> SBTypeFormat
         __init__(lldb::SBTypeFormat self, char const * type) -> SBTypeFormat
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBTypeFormat self, SBTypeFormat rhs) -> SBTypeFormat
         """
         this = _lldb.new_SBTypeFormat(*args)
@@ -15976,11 +13715,7 @@ class SBTypeFormat(_object):
 
 
     def GetTypeName(self):
-<<<<<<< HEAD
-        """GetTypeName(SBTypeFormat self) -> str const *"""
-=======
         """GetTypeName(SBTypeFormat self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeFormat_GetTypeName(self)
 
 
@@ -15995,11 +13730,7 @@ class SBTypeFormat(_object):
 
 
     def SetTypeName(self, arg2):
-<<<<<<< HEAD
-        """SetTypeName(SBTypeFormat self, str const * arg2)"""
-=======
         """SetTypeName(SBTypeFormat self, char const * arg2)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeFormat_SetTypeName(self, arg2)
 
 
@@ -16007,29 +13738,11 @@ class SBTypeFormat(_object):
         """SetOptions(SBTypeFormat self, uint32_t arg2)"""
         return _lldb.SBTypeFormat_SetOptions(self, arg2)
 
-<<<<<<< HEAD
 
     def GetDescription(self, description, description_level):
         """GetDescription(SBTypeFormat self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
         return _lldb.SBTypeFormat_GetDescription(self, description, description_level)
 
-
-    def __eq__(self, rhs):
-        """__eq__(SBTypeFormat self, SBTypeFormat rhs) -> bool"""
-        return _lldb.SBTypeFormat___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBTypeFormat self, SBTypeFormat rhs) -> bool"""
-        return _lldb.SBTypeFormat___ne__(self, rhs)
-
-=======
-
-    def GetDescription(self, description, description_level):
-        """GetDescription(SBTypeFormat self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
-        return _lldb.SBTypeFormat_GetDescription(self, description, description_level)
-
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __eq__(self, rhs):
         """__eq__(SBTypeFormat self, SBTypeFormat rhs) -> bool"""
@@ -16045,7 +13758,6 @@ class SBTypeFormat(_object):
     options = property(GetOptions, SetOptions)
 
 
-
     def __str__(self):
         """__str__(SBTypeFormat self) -> PyObject *"""
         return _lldb.SBTypeFormat___str__(self)
@@ -16054,14 +13766,7 @@ SBTypeFormat_swigregister = _lldb.SBTypeFormat_swigregister
 SBTypeFormat_swigregister(SBTypeFormat)
 
 class SBTypeNameSpecifier(_object):
-<<<<<<< HEAD
-    """
-    Represents a general way to provide a type name to LLDB APIs.
-
-    """
-=======
     """Represents a general way to provide a type name to LLDB APIs."""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeNameSpecifier, name, value)
@@ -16072,13 +13777,8 @@ class SBTypeNameSpecifier(_object):
     def __init__(self, *args):
         """
         __init__(lldb::SBTypeNameSpecifier self) -> SBTypeNameSpecifier
-<<<<<<< HEAD
-        __init__(lldb::SBTypeNameSpecifier self, str const * name, bool is_regex=False) -> SBTypeNameSpecifier
-        __init__(lldb::SBTypeNameSpecifier self, str const * name) -> SBTypeNameSpecifier
-=======
         __init__(lldb::SBTypeNameSpecifier self, char const * name, bool is_regex=False) -> SBTypeNameSpecifier
         __init__(lldb::SBTypeNameSpecifier self, char const * name) -> SBTypeNameSpecifier
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBTypeNameSpecifier self, SBType type) -> SBTypeNameSpecifier
         __init__(lldb::SBTypeNameSpecifier self, SBTypeNameSpecifier rhs) -> SBTypeNameSpecifier
         """
@@ -16107,11 +13807,7 @@ class SBTypeNameSpecifier(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBTypeNameSpecifier self) -> str const *"""
-=======
         """GetName(SBTypeNameSpecifier self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeNameSpecifier_GetName(self)
 
 
@@ -16128,19 +13824,6 @@ class SBTypeNameSpecifier(_object):
     def GetDescription(self, description, description_level):
         """GetDescription(SBTypeNameSpecifier self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
         return _lldb.SBTypeNameSpecifier_GetDescription(self, description, description_level)
-<<<<<<< HEAD
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBTypeNameSpecifier self, SBTypeNameSpecifier rhs) -> bool"""
-        return _lldb.SBTypeNameSpecifier___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBTypeNameSpecifier self, SBTypeNameSpecifier rhs) -> bool"""
-        return _lldb.SBTypeNameSpecifier___ne__(self, rhs)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -16155,7 +13838,6 @@ class SBTypeNameSpecifier(_object):
 
     name = property(GetName)
     is_regex = property(IsRegex)
-
 
 
     def __str__(self):
@@ -16234,14 +13916,7 @@ SBTypeSummaryOptions_swigregister = _lldb.SBTypeSummaryOptions_swigregister
 SBTypeSummaryOptions_swigregister(SBTypeSummaryOptions)
 
 class SBTypeSummary(_object):
-<<<<<<< HEAD
-    """
-    Represents a summary that can be associated to one or more types.
-
-    """
-=======
     """Represents a summary that can be associated to one or more types."""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeSummary, name, value)
@@ -16251,33 +13926,6 @@ class SBTypeSummary(_object):
 
     def CreateWithSummaryString(data, options=0):
         """
-<<<<<<< HEAD
-        CreateWithSummaryString(str const * data, uint32_t options=0) -> SBTypeSummary
-        CreateWithSummaryString(str const * data) -> SBTypeSummary
-        """
-        return _lldb.SBTypeSummary_CreateWithSummaryString(data, options)
-
-    CreateWithSummaryString = staticmethod(CreateWithSummaryString)
-
-    def CreateWithFunctionName(data, options=0):
-        """
-        CreateWithFunctionName(str const * data, uint32_t options=0) -> SBTypeSummary
-        CreateWithFunctionName(str const * data) -> SBTypeSummary
-        """
-        return _lldb.SBTypeSummary_CreateWithFunctionName(data, options)
-
-    CreateWithFunctionName = staticmethod(CreateWithFunctionName)
-
-    def CreateWithScriptCode(data, options=0):
-        """
-        CreateWithScriptCode(str const * data, uint32_t options=0) -> SBTypeSummary
-        CreateWithScriptCode(str const * data) -> SBTypeSummary
-        """
-        return _lldb.SBTypeSummary_CreateWithScriptCode(data, options)
-
-    CreateWithScriptCode = staticmethod(CreateWithScriptCode)
-
-=======
         CreateWithSummaryString(char const * data, uint32_t options=0) -> SBTypeSummary
         CreateWithSummaryString(char const * data) -> SBTypeSummary
         """
@@ -16303,7 +13951,6 @@ class SBTypeSummary(_object):
 
     CreateWithScriptCode = staticmethod(CreateWithScriptCode)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBTypeSummary self) -> SBTypeSummary
@@ -16349,38 +13996,22 @@ class SBTypeSummary(_object):
 
 
     def GetData(self):
-<<<<<<< HEAD
-        """GetData(SBTypeSummary self) -> str const *"""
-=======
         """GetData(SBTypeSummary self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSummary_GetData(self)
 
 
     def SetSummaryString(self, data):
-<<<<<<< HEAD
-        """SetSummaryString(SBTypeSummary self, str const * data)"""
-=======
         """SetSummaryString(SBTypeSummary self, char const * data)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSummary_SetSummaryString(self, data)
 
 
     def SetFunctionName(self, data):
-<<<<<<< HEAD
-        """SetFunctionName(SBTypeSummary self, str const * data)"""
-=======
         """SetFunctionName(SBTypeSummary self, char const * data)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSummary_SetFunctionName(self, data)
 
 
     def SetFunctionCode(self, data):
-<<<<<<< HEAD
-        """SetFunctionCode(SBTypeSummary self, str const * data)"""
-=======
         """SetFunctionCode(SBTypeSummary self, char const * data)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSummary_SetFunctionCode(self, data)
 
 
@@ -16392,30 +14023,11 @@ class SBTypeSummary(_object):
     def SetOptions(self, arg2):
         """SetOptions(SBTypeSummary self, uint32_t arg2)"""
         return _lldb.SBTypeSummary_SetOptions(self, arg2)
-<<<<<<< HEAD
 
 
     def GetDescription(self, description, description_level):
         """GetDescription(SBTypeSummary self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
         return _lldb.SBTypeSummary_GetDescription(self, description, description_level)
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBTypeSummary self, SBTypeSummary rhs) -> bool"""
-        return _lldb.SBTypeSummary___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBTypeSummary self, SBTypeSummary rhs) -> bool"""
-        return _lldb.SBTypeSummary___ne__(self, rhs)
-
-=======
-
-
-    def GetDescription(self, description, description_level):
-        """GetDescription(SBTypeSummary self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
-        return _lldb.SBTypeSummary_GetDescription(self, description, description_level)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -16433,7 +14045,6 @@ class SBTypeSummary(_object):
     is_function_name = property(IsFunctionName)
     is_function_name = property(IsFunctionCode)
     summary_data = property(GetData)
-
 
 
     def __str__(self):
@@ -16460,7 +14071,6 @@ def SBTypeSummary_CreateWithSummaryString(data, options=0):
     """
     CreateWithSummaryString(char const * data, uint32_t options=0) -> SBTypeSummary
     SBTypeSummary_CreateWithSummaryString(char const * data) -> SBTypeSummary
-<<<<<<< HEAD
     """
     return _lldb.SBTypeSummary_CreateWithSummaryString(data, options)
 
@@ -16473,29 +14083,6 @@ def SBTypeSummary_CreateWithFunctionName(data, options=0):
 
 def SBTypeSummary_CreateWithScriptCode(data, options=0):
     """
-    CreateWithScriptCode(char const * data, uint32_t options=0) -> SBTypeSummary
-    SBTypeSummary_CreateWithScriptCode(char const * data) -> SBTypeSummary
-    """
-    return _lldb.SBTypeSummary_CreateWithScriptCode(data, options)
-=======
-    """
-    return _lldb.SBTypeSummary_CreateWithSummaryString(data, options)
-
-def SBTypeSummary_CreateWithFunctionName(data, options=0):
-    """
-    CreateWithFunctionName(char const * data, uint32_t options=0) -> SBTypeSummary
-    SBTypeSummary_CreateWithFunctionName(char const * data) -> SBTypeSummary
-    """
-    return _lldb.SBTypeSummary_CreateWithFunctionName(data, options)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
-
-def SBTypeSummary_CreateWithScriptCode(data, options=0):
-    """
-<<<<<<< HEAD
-    Represents a summary that can be associated to one or more types.
-
-    """
-=======
     CreateWithScriptCode(char const * data, uint32_t options=0) -> SBTypeSummary
     SBTypeSummary_CreateWithScriptCode(char const * data) -> SBTypeSummary
     """
@@ -16503,7 +14090,6 @@ def SBTypeSummary_CreateWithScriptCode(data, options=0):
 
 class SBTypeSynthetic(_object):
     """Represents a summary that can be associated to one or more types."""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     __swig_setmethods__ = {}
     __setattr__ = lambda self, name, value: _swig_setattr(self, SBTypeSynthetic, name, value)
@@ -16513,24 +14099,6 @@ class SBTypeSynthetic(_object):
 
     def CreateWithClassName(data, options=0):
         """
-<<<<<<< HEAD
-        CreateWithClassName(str const * data, uint32_t options=0) -> SBTypeSynthetic
-        CreateWithClassName(str const * data) -> SBTypeSynthetic
-        """
-        return _lldb.SBTypeSynthetic_CreateWithClassName(data, options)
-
-    CreateWithClassName = staticmethod(CreateWithClassName)
-
-    def CreateWithScriptCode(data, options=0):
-        """
-        CreateWithScriptCode(str const * data, uint32_t options=0) -> SBTypeSynthetic
-        CreateWithScriptCode(str const * data) -> SBTypeSynthetic
-        """
-        return _lldb.SBTypeSynthetic_CreateWithScriptCode(data, options)
-
-    CreateWithScriptCode = staticmethod(CreateWithScriptCode)
-
-=======
         CreateWithClassName(char const * data, uint32_t options=0) -> SBTypeSynthetic
         CreateWithClassName(char const * data) -> SBTypeSynthetic
         """
@@ -16547,7 +14115,6 @@ class SBTypeSynthetic(_object):
 
     CreateWithScriptCode = staticmethod(CreateWithScriptCode)
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBTypeSynthetic self) -> SBTypeSynthetic
@@ -16583,29 +14150,17 @@ class SBTypeSynthetic(_object):
 
 
     def GetData(self):
-<<<<<<< HEAD
-        """GetData(SBTypeSynthetic self) -> str const *"""
-=======
         """GetData(SBTypeSynthetic self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSynthetic_GetData(self)
 
 
     def SetClassName(self, data):
-<<<<<<< HEAD
-        """SetClassName(SBTypeSynthetic self, str const * data)"""
-=======
         """SetClassName(SBTypeSynthetic self, char const * data)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSynthetic_SetClassName(self, data)
 
 
     def SetClassCode(self, data):
-<<<<<<< HEAD
-        """SetClassCode(SBTypeSynthetic self, str const * data)"""
-=======
         """SetClassCode(SBTypeSynthetic self, char const * data)"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBTypeSynthetic_SetClassCode(self, data)
 
 
@@ -16618,27 +14173,10 @@ class SBTypeSynthetic(_object):
         """SetOptions(SBTypeSynthetic self, uint32_t arg2)"""
         return _lldb.SBTypeSynthetic_SetOptions(self, arg2)
 
-<<<<<<< HEAD
 
     def GetDescription(self, description, description_level):
         """GetDescription(SBTypeSynthetic self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
         return _lldb.SBTypeSynthetic_GetDescription(self, description, description_level)
-
-
-    def __eq__(self, rhs):
-        """__eq__(SBTypeSynthetic self, SBTypeSynthetic rhs) -> bool"""
-        return _lldb.SBTypeSynthetic___eq__(self, rhs)
-
-
-    def __ne__(self, rhs):
-        """__ne__(SBTypeSynthetic self, SBTypeSynthetic rhs) -> bool"""
-        return _lldb.SBTypeSynthetic___ne__(self, rhs)
-=======
-
-    def GetDescription(self, description, description_level):
-        """GetDescription(SBTypeSynthetic self, SBStream description, lldb::DescriptionLevel description_level) -> bool"""
-        return _lldb.SBTypeSynthetic_GetDescription(self, description, description_level)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
     def __eq__(self, rhs):
@@ -16654,7 +14192,6 @@ class SBTypeSynthetic(_object):
     options = property(GetOptions, SetOptions)
     contains_code = property(IsClassCode, None)
     synthetic_data = property(GetData, None)
-
 
 
     def __str__(self):
@@ -16678,7 +14215,6 @@ SBTypeSynthetic_swigregister = _lldb.SBTypeSynthetic_swigregister
 SBTypeSynthetic_swigregister(SBTypeSynthetic)
 
 def SBTypeSynthetic_CreateWithClassName(data, options=0):
-<<<<<<< HEAD
     """
     CreateWithClassName(char const * data, uint32_t options=0) -> SBTypeSynthetic
     SBTypeSynthetic_CreateWithClassName(char const * data) -> SBTypeSynthetic
@@ -16690,19 +14226,6 @@ def SBTypeSynthetic_CreateWithScriptCode(data, options=0):
     CreateWithScriptCode(char const * data, uint32_t options=0) -> SBTypeSynthetic
     SBTypeSynthetic_CreateWithScriptCode(char const * data) -> SBTypeSynthetic
     """
-=======
-    """
-    CreateWithClassName(char const * data, uint32_t options=0) -> SBTypeSynthetic
-    SBTypeSynthetic_CreateWithClassName(char const * data) -> SBTypeSynthetic
-    """
-    return _lldb.SBTypeSynthetic_CreateWithClassName(data, options)
-
-def SBTypeSynthetic_CreateWithScriptCode(data, options=0):
-    """
-    CreateWithScriptCode(char const * data, uint32_t options=0) -> SBTypeSynthetic
-    SBTypeSynthetic_CreateWithScriptCode(char const * data) -> SBTypeSynthetic
-    """
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     return _lldb.SBTypeSynthetic_CreateWithScriptCode(data, options)
 
 class SBValue(_object):
@@ -16758,70 +14281,9 @@ class SBValue(_object):
     __swig_getmethods__ = {}
     __getattr__ = lambda self, name: _swig_getattr(self, SBValue, name)
     __repr__ = _swig_repr
-<<<<<<< HEAD
-
-    def __iter__(self): return lldb_iter(self, 'GetNumChildren', 'GetChildAtIndex')
-    def __len__(self): return self.GetNumChildren()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __init__(self, *args):
         """
-<<<<<<< HEAD
-        if not val or val.GetValueAsUnsigned() == 0:
-            return True
-        else:
-            return False
-
-    # ==================================================
-    # Iterator for lldb.SBValue treated as a linked list
-    # ==================================================
-    def linked_list_iter(self, next_item_name, end_of_list_test=__eol_test__):
-        """Generator adaptor to support iteration for SBValue as a linked list.
-
-        linked_list_iter() is a special purpose iterator to treat the SBValue as
-        the head of a list data structure, where you specify the child member
-        name which points to the next item on the list and you specify the
-        end-of-list test function which takes an SBValue for an item and returns
-        True if EOL is reached and False if not.
-
-        linked_list_iter() also detects infinite loop and bails out early.
-
-        The end_of_list_test arg, if omitted, defaults to the __eol_test__
-        function above.
-
-        For example,
-
-        # Get Frame #0.
-        ...
-
-        # Get variable 'task_head'.
-        task_head = frame0.FindVariable('task_head')
-        ...
-
-        for t in task_head.linked_list_iter('next'):
-            print t
-        """
-        if end_of_list_test(self):
-            return
-        item = self
-        visited = set()
-        try:
-            while not end_of_list_test(item) and not item.GetValueAsUnsigned() in visited:
-                visited.add(item.GetValueAsUnsigned())
-                yield item
-                # Prepare for the next iteration.
-                item = item.GetChildMemberWithName(next_item_name)
-        except:
-            # Exception occurred.  Stop the generator.
-            pass
-
-        return
-
-    def __init__(self, *args):
-        """
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         __init__(lldb::SBValue self) -> SBValue
         __init__(lldb::SBValue self, SBValue rhs) -> SBValue
         """
@@ -16860,29 +14322,17 @@ class SBValue(_object):
 
 
     def GetName(self):
-<<<<<<< HEAD
-        """GetName(SBValue self) -> str const *"""
-=======
         """GetName(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetName(self)
 
 
     def GetTypeName(self):
-<<<<<<< HEAD
-        """GetTypeName(SBValue self) -> str const *"""
-=======
         """GetTypeName(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetTypeName(self)
 
 
     def GetDisplayTypeName(self):
-<<<<<<< HEAD
-        """GetDisplayTypeName(SBValue self) -> str const *"""
-=======
         """GetDisplayTypeName(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetDisplayTypeName(self)
 
 
@@ -16907,11 +14357,7 @@ class SBValue(_object):
 
 
     def GetValue(self):
-<<<<<<< HEAD
-        """GetValue(SBValue self) -> str const *"""
-=======
         """GetValue(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetValue(self)
 
 
@@ -16947,32 +14393,19 @@ class SBValue(_object):
 
     def GetSummary(self, *args):
         """
-<<<<<<< HEAD
-        GetSummary(SBValue self) -> str const
-        GetSummary(SBValue self, SBStream stream, SBTypeSummaryOptions options) -> str const *
-=======
         GetSummary(SBValue self) -> char const
         GetSummary(SBValue self, SBStream stream, SBTypeSummaryOptions options) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBValue_GetSummary(self, *args)
 
 
     def GetObjectDescription(self):
-<<<<<<< HEAD
-        """GetObjectDescription(SBValue self) -> str const *"""
-=======
         """GetObjectDescription(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetObjectDescription(self)
 
 
     def GetTypeValidatorResult(self):
-<<<<<<< HEAD
-        """GetTypeValidatorResult(SBValue self) -> str const *"""
-=======
         """GetTypeValidatorResult(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetTypeValidatorResult(self)
 
 
@@ -17032,23 +14465,14 @@ class SBValue(_object):
 
 
     def GetLocation(self):
-<<<<<<< HEAD
-        """GetLocation(SBValue self) -> str const *"""
-=======
         """GetLocation(SBValue self) -> char const *"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_GetLocation(self)
 
 
     def SetValueFromCString(self, *args):
         """
-<<<<<<< HEAD
-        SetValueFromCString(SBValue self, str const * value_str) -> bool
-        SetValueFromCString(SBValue self, str const * value_str, SBError error) -> bool
-=======
         SetValueFromCString(SBValue self, char const * value_str) -> bool
         SetValueFromCString(SBValue self, char const * value_str, SBError error) -> bool
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBValue_SetValueFromCString(self, *args)
 
@@ -17137,11 +14561,7 @@ class SBValue(_object):
 
 
     def CreateChildAtOffset(self, name, offset, type):
-<<<<<<< HEAD
-        """CreateChildAtOffset(SBValue self, str const * name, uint32_t offset, SBType type) -> SBValue"""
-=======
         """CreateChildAtOffset(SBValue self, char const * name, uint32_t offset, SBType type) -> SBValue"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_CreateChildAtOffset(self, name, offset, type)
 
 
@@ -17152,32 +14572,19 @@ class SBValue(_object):
 
     def CreateValueFromExpression(self, *args):
         """
-<<<<<<< HEAD
-        CreateValueFromExpression(SBValue self, str const * name, str const * expression) -> SBValue
-        CreateValueFromExpression(SBValue self, str const * name, str const * expression, SBExpressionOptions options) -> SBValue
-=======
         CreateValueFromExpression(SBValue self, char const * name, char const * expression) -> SBValue
         CreateValueFromExpression(SBValue self, char const * name, char const * expression, SBExpressionOptions options) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBValue_CreateValueFromExpression(self, *args)
 
 
     def CreateValueFromAddress(self, name, address, type):
-<<<<<<< HEAD
-        """CreateValueFromAddress(SBValue self, str const * name, lldb::addr_t address, SBType type) -> SBValue"""
-=======
         """CreateValueFromAddress(SBValue self, char const * name, lldb::addr_t address, SBType type) -> SBValue"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_CreateValueFromAddress(self, name, address, type)
 
 
     def CreateValueFromData(self, name, data, type):
-<<<<<<< HEAD
-        """CreateValueFromData(SBValue self, str const * name, SBData data, SBType type) -> SBValue"""
-=======
         """CreateValueFromData(SBValue self, char const * name, SBData data, SBType type) -> SBValue"""
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         return _lldb.SBValue_CreateValueFromData(self, name, data, type)
 
 
@@ -17188,11 +14595,7 @@ class SBValue(_object):
 
     def GetIndexOfChildWithName(self, name):
         """
-<<<<<<< HEAD
-        GetIndexOfChildWithName(SBValue self, str const * name) -> uint32_t
-=======
         GetIndexOfChildWithName(SBValue self, char const * name) -> uint32_t
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Returns the child member index.
@@ -17211,13 +14614,8 @@ class SBValue(_object):
 
     def GetChildMemberWithName(self, *args):
         """
-<<<<<<< HEAD
-        GetChildMemberWithName(SBValue self, str const * name) -> SBValue
-        GetChildMemberWithName(SBValue self, str const * name, lldb::DynamicValueType use_dynamic) -> SBValue
-=======
         GetChildMemberWithName(SBValue self, char const * name) -> SBValue
         GetChildMemberWithName(SBValue self, char const * name, lldb::DynamicValueType use_dynamic) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Returns the child member value.
@@ -17241,11 +14639,7 @@ class SBValue(_object):
 
     def GetValueForExpressionPath(self, expr_path):
         """
-<<<<<<< HEAD
-        GetValueForExpressionPath(SBValue self, str const * expr_path) -> SBValue
-=======
         GetValueForExpressionPath(SBValue self, char const * expr_path) -> SBValue
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         Expands nested expressions like .a->b[0].c[1]->d.
         """
@@ -17349,27 +14743,6 @@ class SBValue(_object):
         GetPointeeData(SBValue self) -> SBData
 
 
-<<<<<<< HEAD
-          Get an SBData wrapping what this SBValue points to.
-          
-          This method will dereference the current SBValue, if its
-          data type is a T* or T[], and extract item_count elements
-          of type T from it, copying their contents in an SBData. 
-          
-          @param[in] item_idx
-              The index of the first item to retrieve. For an array
-              this is equivalent to array[item_idx], for a pointer
-              to *(pointer + item_idx). In either case, the measurement
-              unit for item_idx is the sizeof(T) rather than the byte
-          
-          @param[in] item_count
-              How many items should be copied into the output. By default
-              only one item is copied, but more can be asked for.
-          
-          @return
-              An SBData with the contents of the copied items, on success.
-              An empty SBData otherwise.
-=======
         Get an SBData wrapping what this SBValue points to.
 
         This method will dereference the current SBValue, if its
@@ -17389,7 +14762,6 @@ class SBValue(_object):
         @return
             An SBData with the contents of the copied items, on success.
             An empty SBData otherwise.
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         """
         return _lldb.SBValue_GetPointeeData(self, item_idx, item_count)
 
@@ -17398,11 +14770,8 @@ class SBValue(_object):
         """
         GetData(SBValue self) -> SBData
 
-<<<<<<< HEAD
-=======
 
         Get an SBData wrapping the contents of this SBValue.
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
         This method will read the contents of this object in memory
         and copy them into an SBData for future use.
@@ -17444,8 +14813,6 @@ class SBValue(_object):
         return _lldb.SBValue_GetExpressionPath(self, *args)
 
 
-<<<<<<< HEAD
-=======
     def EvaluateExpression(self, *args):
         """
         EvaluateExpression(SBValue self, char const * expr) -> SBValue
@@ -17455,7 +14822,6 @@ class SBValue(_object):
         return _lldb.SBValue_EvaluateExpression(self, *args)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __get_dynamic__ (self):
         '''Helper function for the "SBValue.dynamic" property.'''
         return self.GetDynamicValue (eDynamicCanRunTarget)
@@ -17604,7 +14970,6 @@ class SBValue(_object):
         return
 
 
-
     def __str__(self):
         """__str__(SBValue self) -> PyObject *"""
         return _lldb.SBValue___str__(self)
@@ -17677,11 +15042,6 @@ class SBValueList(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBValueList, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __iter__(self): return lldb_iter(self, 'GetSize', 'GetValueAtIndex')
-    def __len__(self): return self.GetSize()
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBValueList self) -> SBValueList
@@ -17728,18 +15088,6 @@ class SBValueList(_object):
         """GetValueAtIndex(SBValueList self, uint32_t idx) -> SBValue"""
         return _lldb.SBValueList_GetValueAtIndex(self, idx)
 
-<<<<<<< HEAD
-
-    def FindValueObjectByUID(self, uid):
-        """FindValueObjectByUID(SBValueList self, lldb::user_id_t uid) -> SBValue"""
-        return _lldb.SBValueList_FindValueObjectByUID(self, uid)
-
-
-    def GetFirstValueByName(self, name):
-        """GetFirstValueByName(SBValueList self, str const * name) -> SBValue"""
-        return _lldb.SBValueList_GetFirstValueByName(self, name)
-
-=======
 
     def FindValueObjectByUID(self, uid):
         """FindValueObjectByUID(SBValueList self, lldb::user_id_t uid) -> SBValue"""
@@ -17754,7 +15102,6 @@ class SBValueList(_object):
     def __iter__(self):
         '''Iterate over all values in a lldb.SBValueList object.'''
         return lldb_iter(self, 'GetSize', 'GetValueAtIndex')
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
     def __len__(self):
         return int(self.GetSize())
@@ -17920,11 +15267,6 @@ class SBWatchpoint(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, SBWatchpoint, name)
     __repr__ = _swig_repr
 
-<<<<<<< HEAD
-    def __eq__(self, other): return isinstance(other, SBWatchpoint) and self.GetID() == other.GetID()
-    def __ne__(self, other): return not self.__eq__(other)
-=======
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self, *args):
         """
         __init__(lldb::SBWatchpoint self) -> SBWatchpoint
@@ -17949,8 +15291,6 @@ class SBWatchpoint(_object):
 
 
 
-<<<<<<< HEAD
-=======
     def __eq__(self, rhs):
         """__eq__(SBWatchpoint self, SBWatchpoint rhs) -> bool"""
         return _lldb.SBWatchpoint___eq__(self, rhs)
@@ -17961,7 +15301,6 @@ class SBWatchpoint(_object):
         return _lldb.SBWatchpoint___ne__(self, rhs)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def GetError(self):
         """GetError(SBWatchpoint self) -> SBError"""
         return _lldb.SBWatchpoint_GetError(self)
@@ -18019,11 +15358,7 @@ class SBWatchpoint(_object):
 
     def GetCondition(self):
         """
-<<<<<<< HEAD
-        GetCondition(SBWatchpoint self) -> str const *
-=======
         GetCondition(SBWatchpoint self) -> char const *
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         Get the condition expression for the watchpoint.
@@ -18033,11 +15368,7 @@ class SBWatchpoint(_object):
 
     def SetCondition(self, condition):
         """
-<<<<<<< HEAD
-        SetCondition(SBWatchpoint self, str const * condition)
-=======
         SetCondition(SBWatchpoint self, char const * condition)
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
 
 
         The watchpoint stops only if the condition expression evaluates to true.
@@ -18126,32 +15457,6 @@ class SBUnixSignals(_object):
 
 
     def GetSignalAsCString(self, signo):
-<<<<<<< HEAD
-        """GetSignalAsCString(SBUnixSignals self, int32_t signo) -> str const *"""
-        return _lldb.SBUnixSignals_GetSignalAsCString(self, signo)
-
-
-    def GetSignalNumberFromName(self, name):
-        """GetSignalNumberFromName(SBUnixSignals self, str const * name) -> int32_t"""
-        return _lldb.SBUnixSignals_GetSignalNumberFromName(self, name)
-
-
-    def GetShouldSuppress(self, signo):
-        """GetShouldSuppress(SBUnixSignals self, int32_t signo) -> bool"""
-        return _lldb.SBUnixSignals_GetShouldSuppress(self, signo)
-
-
-    def SetShouldSuppress(self, signo, value):
-        """SetShouldSuppress(SBUnixSignals self, int32_t signo, bool value) -> bool"""
-        return _lldb.SBUnixSignals_SetShouldSuppress(self, signo, value)
-
-
-    def GetShouldStop(self, signo):
-        """GetShouldStop(SBUnixSignals self, int32_t signo) -> bool"""
-        return _lldb.SBUnixSignals_GetShouldStop(self, signo)
-
-
-=======
         """GetSignalAsCString(SBUnixSignals self, int32_t signo) -> char const *"""
         return _lldb.SBUnixSignals_GetSignalAsCString(self, signo)
 
@@ -18176,7 +15481,6 @@ class SBUnixSignals(_object):
         return _lldb.SBUnixSignals_GetShouldStop(self, signo)
 
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def SetShouldStop(self, signo, value):
         """SetShouldStop(SBUnixSignals self, int32_t signo, bool value) -> bool"""
         return _lldb.SBUnixSignals_SetShouldStop(self, signo, value)
@@ -18240,23 +15544,16 @@ class value_iter(object):
     def __iter__(self):
         return self
 
-<<<<<<< HEAD
-    def next(self):
-=======
     def __next__(self):
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
         if self.index >= self.length:
             raise StopIteration()
         child_sbvalue = self.sbvalue.GetChildAtIndex(self.index)
         self.index += 1
         return value(child_sbvalue)
 
-<<<<<<< HEAD
-=======
     def next(self):
         return self.__next__()
 
->>>>>>> swift-DEVELOPMENT-SNAPSHOT-2019-10-08-a
     def __init__(self,value):
         self.index = 0
         self.sbvalue = value
@@ -18542,7 +15839,6 @@ def is_numeric_type(basic_type):
     return (False,False)
 
 
-# This file is compatible with both classic and new-style classes.
 
 debugger_unique_id = 0
 SBDebugger.Initialize()


### PR DESCRIPTION
Regenerate Swig bindings with Swig 3.0.12.

Bindings on `master` branch seem to be generated with Swig 1.3.40, but `tensorflow` branch last used Swig 3.0.12 (https://github.com/apple/swift-lldb/pull/1989).