### PR TITLE
[CMake] Move LLDB_SWIFT_LIBS and LLDB_SWIFTC into test.

### DIFF
--- a/cmake/modules/LLDBConfig.cmake
+++ b/cmake/modules/LLDBConfig.cmake
@@ -54,15 +54,7 @@ option(LLDB_USE_SYSTEM_DEBUGSERVER "Use the system's debugserver for testing (Da
 
 # BEGIN SWIFT MOD
 option(LLDB_ENABLE_SWIFT_SUPPORT "Enable swift support" ON)
-# END SWIFT MOD
-
-# BEGIN SWIFT CODE
 option(LLDB_ALLOW_STATIC_BINDINGS "Enable using static/baked language bindings if swig is not present." OFF)
-
-if(swift IN_LIST LLVM_EXTERNAL_PROJECTS)
-  set(LLDB_SWIFTC ${LLVM_RUNTIME_OUTPUT_INTDIR}/swiftc CACHE STRING "Path to swift compiler")
-  set(LLDB_SWIFT_LIBS ${LLVM_LIBRARY_OUTPUT_INTDIR}/swift CACHE STRING "Path to swift libraries")
-endif()
 # END SWIFT CODE
 
 if(LLDB_BUILD_FRAMEWORK)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,8 @@ set(LLDB_TEST_ARCH
 option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 
 if(LLDB_TEST_SWIFT)
+  set(LLDB_SWIFTC ${LLVM_RUNTIME_OUTPUT_INTDIR}/swiftc CACHE STRING "Path to swift compiler")
+  set(LLDB_SWIFT_LIBS ${LLVM_LIBRARY_OUTPUT_INTDIR}/swift CACHE STRING "Path to swift libraries")
   set(SWIFT_TEST_ARGS
     --swift-compiler ${LLDB_SWIFTC}
     --swift-library ${LLDB_SWIFT_LIBS}


### PR DESCRIPTION
This moves the LLDB_SWIFT_LIBS and LLDB_SWIFTC variables to where they
are actually used.