### PR TITLE
[CMake] Use variables exported by SwiftConfig to compose LLDB variables.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,8 +29,8 @@ set(LLDB_TEST_ARCH
 option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 
 if(LLDB_TEST_SWIFT)
-  set(LLDB_SWIFTC ${LLVM_RUNTIME_OUTPUT_INTDIR}/swiftc CACHE STRING "Path to swift compiler")
-  set(LLDB_SWIFT_LIBS ${LLVM_LIBRARY_OUTPUT_INTDIR}/swift CACHE STRING "Path to swift libraries")
+  set(LLDB_SWIFTC ${SWIFT_BINARY_DIR}/bin/swiftc CACHE STRING "Path to swift compiler")
+  set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift CACHE STRING "Path to swift libraries")
   set(SWIFT_TEST_ARGS
     --swift-compiler ${LLDB_SWIFTC}
     --swift-library ${LLDB_SWIFT_LIBS}


### PR DESCRIPTION
The SwiftConfig.cmake file exports variables that point to the swift
binary and library directory. Use those instead of going through the
LLVM_LIBRARY_OUTPUT_INTDIR indirection, which might be incorrect, for
example for out-of-tree builds with the Xcode generator.