### PR TITLE
[CMake] Make it possible to set the RPATH in add_lldb_exectable.

### DIFF
--- a/cmake/modules/AddLLDB.cmake
+++ b/cmake/modules/AddLLDB.cmake
@@ -142,7 +142,7 @@ function(add_lldb_executable name)
   cmake_parse_arguments(ARG
     "GENERATE_INSTALL"
     "INSTALL_PREFIX;ENTITLEMENTS"
-    "LINK_LIBS;LINK_COMPONENTS"
+    "LINK_LIBS;LINK_COMPONENTS;BUILD_RPATH;INSTALL_RPATH"
     ${ARGN}
     )
 
@@ -164,13 +164,26 @@ function(add_lldb_executable name)
   target_link_libraries(${name} PRIVATE ${ARG_LINK_LIBS})
   set_target_properties(${name} PROPERTIES FOLDER "lldb executables")
 
+  if (ARG_BUILD_RPATH)
+    set_target_properties(${name} PROPERTIES BUILD_RPATH "${ARG_BUILD_RPATH}")
+  endif()
+
+  if (ARG_INSTALL_RPATH)
+    set_target_properties(${name} PROPERTIES
+      BUILD_WITH_INSTALL_RPATH OFF
+      INSTALL_RPATH "${ARG_INSTALL_RPATH}")
+  endif()
+
   if(ARG_GENERATE_INSTALL)
     set(install_dest bin)
     if(ARG_INSTALL_PREFIX)
       set(install_dest ${ARG_INSTALL_PREFIX})
     endif()
     install(TARGETS ${name} COMPONENT ${name}
-            RUNTIME DESTINATION ${install_dest})
+            RUNTIME DESTINATION ${install_dest}
+            LIBRARY DESTINATION ${install_dest}
+            BUNDLE DESTINATION ${install_dest}
+            FRAMEWORK DESTINATION ${install_dest})
     if (NOT CMAKE_CONFIGURATION_TYPES)
       add_llvm_install_targets(install-${name}
                                DEPENDS ${name}


### PR DESCRIPTION
Make it possible to pass a build and install RPATH to
add_lldb_executable instead of having to call lldb_setup_rpaths after
the fact.

This fixes a real issue where setting an install RPATH with
lldb_setup_rpaths would only affect the symroot installation component.
Given that lldb_setup_rpaths sets a target property I would expect this
to be orthogonal to installation components. Regardless, it makes sense
to integrate this functionality in add_lldb_exectable.

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@375068 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 0f53352cb22da3e0bd5e4d4272e9849e9883f11e)