### PR TITLE
Backport "[lldb] Don't emit artificial constructor declarations as global functions"

### DIFF
--- a/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
+++ b/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/TestCallOverriddenMethod.py
@@ -46,4 +46,11 @@ class ExprCommandCallOverriddenMethod(TestBase):
         # Test call to overridden method in derived class (this will fail if the
         # overrides table is not correctly set up, as Derived::foo will be assigned
         # a vtable entry that does not exist in the compiled program).
-        self.expect("expr d.foo()")
+        self.expect("expr d.foo()", substrs=["2"])
+
+        # Test calling the base class.
+        self.expect("expr realbase.foo()", substrs=["1"])
+
+        # Test with locally constructed instances.
+        self.expect("expr Base().foo()", substrs=["1"])
+        self.expect("expr Derived().foo()", substrs=["2"])

--- a/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/main.cpp
+++ b/packages/Python/lldbsuite/test/commands/expression/call-overridden-method/main.cpp
@@ -10,6 +10,8 @@ public:
 };
 
 int main() {
+  Base realbase;
+  realbase.foo();
   Derived d;
   Base *b = &d;
   return 0; // Set breakpoint here

--- a/packages/Python/lldbsuite/test/commands/expression/ignore-artificial-constructors/TestIgnoreArtificialConstructors.py
+++ b/packages/Python/lldbsuite/test/commands/expression/ignore-artificial-constructors/TestIgnoreArtificialConstructors.py
@@ -1,0 +1,4 @@
+from lldbsuite.test import lldbinline
+from lldbsuite.test import decorators
+
+lldbinline.MakeInlineTest(__file__, globals(), None)

--- a/packages/Python/lldbsuite/test/commands/expression/ignore-artificial-constructors/main.cpp
+++ b/packages/Python/lldbsuite/test/commands/expression/ignore-artificial-constructors/main.cpp
@@ -1,0 +1,10 @@
+struct Foo {
+  // Triggers that we emit an artificial constructor for Foo.
+  virtual ~Foo() = default;
+};
+
+int main() {
+  Foo f;
+  // Try to construct foo in our expression.
+  return 0; //%self.expect("expr Foo()", substrs=["(Foo) $0 = {}"])
+}

--- a/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1398,8 +1398,11 @@ TypeSP DWARFASTParserClang::ParseTypeFromDWARF(const SymbolContext &sc,
                               is_attr_used, attrs.is_artificial);
 
                       type_handled = cxx_method_decl != NULL;
+                      // Artificial methods are always handled even when don't
+                      // create a new declaration for them.
+                      type_handled |= attrs.is_artificial;
 
-                      if (type_handled) {
+                      if (cxx_method_decl) {
                         LinkDeclContextToDIE(
                             ClangASTContext::GetAsDeclContext(cxx_method_decl),
                             die);


### PR DESCRIPTION

Summary:
When we have a artificial constructor DIE, we currently create from that a global function with the name of that class.
That ends up causing a bunch of funny errors such as "must use 'struct' tag to refer to type 'Foo' in this scope" when
doing `Foo f`. Also causes that constructing a class via `Foo()` actually just calls that global function.

The fix is that when we have an artificial method decl, we always treat it as handled even if we don't create a CXXMethodDecl
for it (which we never do for artificial methods at the moment).

Fixes rdar://55757491 and probably some other radars.

Reviewers: aprantl, vsk, shafik

Reviewed By: aprantl

Subscribers: jingham, shafik, labath, JDevlieghere, lldb-commits

Tags: #lldb

Differential Revision: https://reviews.llvm.org/D68130

git-svn-id: https://llvm.org/svn/llvm-project/lldb/trunk@375151 91177308-0d34-0410-b5e6-96231b3b80d8